### PR TITLE
Disable strongbox on keystore writable IC

### DIFF
--- a/identity/src/main/java/com/android/identity/KeystoreWritableIdentityCredential.java
+++ b/identity/src/main/java/com/android/identity/KeystoreWritableIdentityCredential.java
@@ -122,12 +122,14 @@ class KeystoreWritableIdentityCredential extends WritableIdentityCredential {
 
             mKeyPair = null;
             boolean isStrongBoxBacked = false;
+            /* Disable StrongBox usage for now, see Issue #259 for details
             PackageManager pm = mContext.getPackageManager();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
                     pm.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)) {
                 isStrongBoxBacked = true;
                 builder.setIsStrongBoxBacked(true);
             }
+            */
             kpg.initialize(builder.build());
             mKeyPair = kpg.generateKeyPair();
             Log.i(TAG, "CredentialKey created, strongBoxBacked=" + isStrongBoxBacked);


### PR DESCRIPTION
Disable strongbox on KeystoreWritableIdentityCredential the use of strongbox is crashing the app in some Samsung devices.

Tested manually in one device.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR