### PR TITLE
adding two way engagement detected callback in nfc engagement helper

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -45,6 +45,10 @@ class NfcEngagementHandler : HostApduService() {
 
     private val nfcEngagementListener = object : NfcEngagementHelper.Listener {
 
+        override fun onTwoWayEngagementDetected() {
+            log("Engagement Listener: Two Way Engagement Detected.")
+        }
+
         override fun onDeviceConnecting() {
             log("Engagement Listener: Device Connecting. Launching Transfer Screen")
             val launchAppIntent = Intent(applicationContext, MainActivity::class.java)

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.java
@@ -593,6 +593,7 @@ public class NfcEngagementHelper {
         }
 
         Logger.d(TAG, "Service Select NDEF message has been validated");
+        reportTwoWayEngagementDetected();
 
         // From NDEF Exchange Protocol 1.0: 4.3 TNEP Status Message
         // If the NFC Tag Device has received a Service Select Message with a known
@@ -743,6 +744,16 @@ public class NfcEngagementHelper {
 
     // Note: The report*() methods are safe to call from any thread.
 
+    void reportTwoWayEngagementDetected() {
+        Logger.d(TAG, "reportTwoWayEngagementDetected");
+        final Listener listener = mListener;
+        final Executor executor = mExecutor;
+        if (!mInhibitCallbacks && listener != null && executor != null) {
+            executor.execute(listener::onTwoWayEngagementDetected);
+        }
+    }
+
+
     void reportDeviceConnecting() {
         Logger.d(TAG, "reportDeviceConnecting");
         final Listener listener = mListener;
@@ -771,6 +782,7 @@ public class NfcEngagementHelper {
     }
 
     public interface Listener {
+        void onTwoWayEngagementDetected();
         void onDeviceConnecting();
         void onDeviceConnected(DataTransport transport);
         void onError(@NonNull Throwable error);


### PR DESCRIPTION
this is useful for users to be able to make actions as soon as we have confidence that this is a two way engagement...

currently callback is only triggered in negotiated NFC when we see the ServiceSelect NDEF with the `urn:nfc:sn:handover` service.