### PR TITLE
Add check to GattClient to make sure value of 0x01 is written before triggering the peer connected callback.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.java
@@ -470,7 +470,11 @@ class GattClient extends BluetoothGattCallback {
                 return;
             }
 
-            reportPeerConnected();
+            // Only report peer connected if start value was written to State characteristic.
+            // Should not trigger this callback if end value was written.
+            if (Arrays.equals(characteristic.getValue(), new byte[]{0x01})) {
+                reportPeerConnected();
+            }
 
         } else if (charUuid.equals(mCharacteristicClient2ServerUuid)) {
             if (status != BluetoothGatt.GATT_SUCCESS) {


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to README are included in PR