### PR TITLE
wallet: Fix crash in when doing QR presentation.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/qrengagement/QrEngagementScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/qrengagement/QrEngagementScreen.kt
@@ -106,15 +106,7 @@ fun QrEngagementScreen(
                 )
             }
 
-            // startQrEngagement is called before navigating to this compose, so let user know we're
-            // waiting (until the QR code is generated/errors out)
-            QrEngagementViewModel.State.IDLE -> {
-                CircularProgressIndicator(
-                    modifier = Modifier.width(64.dp),
-                    color = MaterialTheme.colorScheme.secondary,
-                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
-                )
-            }
+            QrEngagementViewModel.State.IDLE -> {}
 
             QrEngagementViewModel.State.ERROR -> {
                 Column {


### PR DESCRIPTION
This is crashing when showing a progress indicator and there's no reason we should be showing this in the first place since DeviceEngagement is creating synchronously nowadays.
