### PR TITLE
WalletApplicationCapabilities: Convey whether app is running on an emulator.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletApplicationCapabilities.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletApplicationCapabilities.kt
@@ -9,12 +9,14 @@ import kotlinx.datetime.Instant
  * @property generatedAt The point in time this data was generated.
  * @property androidKeystoreAttestKeyAvailable Whether Android Keystore supports attest keys.
  * @property androidKeystoreStrongBoxAvailable Whether StrongBox is available on the device.
+ * @property androidIsEmulator Whether the app is running on an emulator.
  */
 @CborSerializable
 data class WalletApplicationCapabilities(
     val generatedAt: Instant,
     val androidKeystoreAttestKeyAvailable: Boolean,
     val androidKeystoreStrongBoxAvailable: Boolean,
+    val androidIsEmulator: Boolean,
 ) {
     companion object
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -383,8 +383,45 @@ class WalletApplication : Application() {
         return WalletApplicationCapabilities(
             generatedAt = now,
             androidKeystoreAttestKeyAvailable = keystoreCapabilities.attestKeySupported,
-            androidKeystoreStrongBoxAvailable = keystoreCapabilities.strongBoxSupported
+            androidKeystoreStrongBoxAvailable = keystoreCapabilities.strongBoxSupported,
+            androidIsEmulator = isProbablyRunningOnEmulator
         )
+    }
+
+    // https://stackoverflow.com/a/21505193/878126
+    private val isProbablyRunningOnEmulator: Boolean by lazy {
+        // Android SDK emulator
+        return@lazy ((Build.MANUFACTURER == "Google" && Build.BRAND == "google" &&
+                ((Build.FINGERPRINT.startsWith("google/sdk_gphone_")
+                        && Build.FINGERPRINT.endsWith(":user/release-keys")
+                        && Build.PRODUCT.startsWith("sdk_gphone_")
+                        && Build.MODEL.startsWith("sdk_gphone_"))
+                        //alternative
+                        || (Build.FINGERPRINT.startsWith("google/sdk_gphone64_")
+                        && (Build.FINGERPRINT.endsWith(":userdebug/dev-keys") || Build.FINGERPRINT.endsWith(
+                    ":user/release-keys"
+                ))
+                        && Build.PRODUCT.startsWith("sdk_gphone64_")
+                        && Build.MODEL.startsWith("sdk_gphone64_"))))
+                //
+                || Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                //bluestacks
+                || "QC_Reference_Phone" == Build.BOARD && !"Xiaomi".equals(
+            Build.MANUFACTURER,
+            ignoreCase = true
+        )
+                //bluestacks
+                || Build.MANUFACTURER.contains("Genymotion")
+                || Build.HOST.startsWith("Build")
+                //MSI App Player
+                || Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
+                || Build.PRODUCT == "google_sdk")
+                // another Android SDK emulator check
+                /* || SystemProperties.getProp("ro.kernel.qemu") == "1") */
     }
 
     private fun isAusweisSdkProcess(): Boolean {


### PR DESCRIPTION
For example, the issuer may decide to not requie a selfie check under these conditions since this cannot be completed b/c the emulator doesn't have a real camera.

Of course this is just a heuristic and should not be used for security decisions (key/app attestation is the right tool for such a job).

Test: ./gradlew check
Test: ./gradlew connectedCheck
