### PR TITLE
Handle OpenId Credential Offer Urls for dynamic Issuing Authorities.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletServer.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletServer.kt
@@ -38,4 +38,16 @@ interface WalletServer: FlowBase {
      */
     @FlowMethod
     suspend fun getIssuingAuthority(identifier: String): IssuingAuthority
+
+    /**
+     * Create the Issuing Authority from the payload of an OpenId Credential Offer (OID4VCI) that
+     * produces a credential issuer Uri and Credential config Id (such as pid-mso-mdoc or pid-sd-jwt).
+     *
+     * Like above, do not call this method directly, use WalletServerProvider that maintains a cache.
+     */
+    @FlowMethod
+    suspend fun createIssuingAuthorityByUri(
+        credentialIssuerUri: String,
+        credentialConfigurationId: String
+    ): IssuingAuthority
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
@@ -46,7 +46,8 @@ class FunkeProofingState(
     var secureAreaIdentifier: String? = null,
     var secureAreaSetupDone: Boolean = false,
     var tosAcknowleged: Boolean = false,
-    var notificationPermissonRequested: Boolean = false
+    var notificationPermissonRequested: Boolean = false,
+    val credentialIssuerUri:String,
 ) {
     companion object {
         private const val TAG = "FunkeProofingState"
@@ -195,7 +196,7 @@ class FunkeProofingState(
         val code = location.substring(index + 5)
         this.access = FunkeUtil.obtainToken(
             env = env,
-            tokenUrl = "${FunkeUtil.BASE_URL}/token",
+            tokenUrl = "${credentialIssuerUri}/token",
             clientId = clientId,
             issuanceClientId = issuanceClientId,
             authorizationCode = code,

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
@@ -26,7 +26,8 @@ class FunkeRequestCredentialsState(
     val credentialConfiguration: CredentialConfiguration,
     val nonce: String,
     var format: CredentialFormat? = null,
-    var credentialRequests: List<FunkeCredentialRequest>? = null
+    var credentialRequests: List<FunkeCredentialRequest>? = null,
+    val credentialIssuerUri:String,
 ) {
     companion object
 
@@ -55,7 +56,7 @@ class FunkeRequestCredentialsState(
             )).toString().toByteArray().toBase64Url()
             val body = JsonObject(mapOf(
                 "iss" to JsonPrimitive(issuanceClientId),
-                "aud" to JsonPrimitive(FunkeUtil.BASE_URL),
+                "aud" to JsonPrimitive(credentialIssuerUri),
                 "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
                 "nonce" to JsonPrimitive(nonce)
             )).toString().toByteArray().toBase64Url()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -23,11 +23,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlin.random.Random
 
 internal object FunkeUtil {
-    // To use generic OpenID4VCI issuer, switch USE_AUSWEIS_SDK to false
-    //const val BASE_URL = "http://localhost:8080/server/openid4vci"
-
-    const val BASE_URL = "https://demo.pid-issuer.bundesdruckerei.de/c"
-
     const val TAG = "FunkeUtil"
 
     const val EU_PID_MDOC_DOCTYPE = "eu.europa.ec.eudi.pid.1"

--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         tools:replace="android:name">
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTop"
             android:exported="true"
             android:label="@string/app_name"
             android:windowSoftInputMode="adjustResize"
@@ -49,7 +50,14 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="openwallet" android:host="callback" />
+                <!-- Wallet server callback scheme "openwallet://" for handling callbacks from the
+                Wallet server via Url format "openwallet://callback" that is paired with host "*"
+                declared below -->
+                <data android:scheme="openwallet"/>
+                <!--  OpenId Credential Offer scheme (OID4VCI) -->
+                <data android:scheme="openid-credential-offer"/>
+                <!-- Accept all hosts for any of the defined schemes above -->
+                <data android:host="*"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
@@ -202,6 +202,22 @@ class WalletServerProvider(
     }
 
     /**
+     * Creates an Issuing Authority by the [credentialIssuerUri] and [credentialConfigurationId],
+     * caching instances. If unable to connect, suspend and wait until connecting is possible.
+     */
+    suspend fun createIssuingAuthorityByUri(credentialIssuerUri:String, credentialConfigurationId: String): IssuingAuthority {
+        val instance = waitForWalletServer()
+        instanceLock.withLock {
+            var issuingAuthority = issuingAuthorityMap[credentialConfigurationId]
+            if (issuingAuthority == null) {
+                issuingAuthority = instance.createIssuingAuthorityByUri(credentialIssuerUri, credentialConfigurationId)
+                issuingAuthorityMap[credentialConfigurationId] = issuingAuthority
+            }
+            return issuingAuthority
+        }
+    }
+
+    /**
      * Gets ApplicationSupport object. It always comes from the server (either full wallet server
      * or minimal wallet server).
      */

--- a/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
@@ -17,6 +17,7 @@
 package com.android.identity_credential.wallet
 
 import android.Manifest
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -24,11 +25,18 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.compose.rememberNavController
+import com.android.identity_credential.wallet.credentialoffer.extractCredentialIssuerData
+import com.android.identity_credential.wallet.credentialoffer.initiateCredentialOfferIssuance
 import com.android.identity_credential.wallet.navigation.WalletNavigation
+import com.android.identity_credential.wallet.navigation.navigateTo
 import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+import com.android.identity_credential.wallet.util.getUrlQueryFromCustomSchemeUrl
 
 class MainActivity : FragmentActivity() {
     companion object {
@@ -68,10 +76,10 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         application = getApplication() as WalletApplication
-
         permissionTracker.updatePermissions()
+        // handle intents with schema openid-credential-offer://
+        handleOid4vciCredentialOfferIntent(intent)
 
         setContent {
             IdentityCredentialTheme {
@@ -81,6 +89,30 @@ class MainActivity : FragmentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     val navController = rememberNavController()
+                    // observe whether a new intent was received with credential offer url
+                    val credentialOfferIntentPayload by provisioningViewModel.newCredentialOfferIntentReceived.collectAsState()
+                    // if not null, execute once
+                    LaunchedEffect(credentialOfferIntentPayload) {
+                        if (credentialOfferIntentPayload != null) {
+                            val credentialIssuerUri = credentialOfferIntentPayload!!.first
+                            val credentialIssuerConfigurationId =
+                                credentialOfferIntentPayload!!.second
+
+                            initiateCredentialOfferIssuance(
+                                walletServerProvider = application.walletServerProvider,
+                                provisioningViewModel = provisioningViewModel,
+                                settingsModel = application.settingsModel,
+                                documentStore = application.documentStore,
+                                onNavigate = { routeWithArgs ->
+                                    navigateTo(navController, routeWithArgs)
+                                },
+                                credentialIssuerUri = credentialIssuerUri,
+                                credentialIssuerConfigurationId = credentialIssuerConfigurationId,
+                            )
+                            // reset the state (consume the Url)
+                            provisioningViewModel.onNewCredentialOfferIntent(null, null)
+                        }
+                    }
 
                     WalletNavigation(
                         navController,
@@ -91,6 +123,40 @@ class MainActivity : FragmentActivity() {
                         qrEngagementViewModel = qrEngagementViewModel,
                         documentModel = application.documentModel,
                         readerModel = application.readerModel,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Intercept deep links when the Activity is backgrounded (has previously run).
+     *
+     * Handle OID4VCI openid-credential-offer deep links.
+     */
+    override fun onNewIntent(intent: Intent) {
+        // super class handles intent internally
+        super.onNewIntent(intent)
+        // calls to getIntent() return the new intent
+        setIntent(intent)
+        // handle OID4VCI deep links starting with scheme "openid-credential-offer://"
+        handleOid4vciCredentialOfferIntent(intent)
+    }
+
+    /**
+     * Handle incoming Intents from deep links emanating from onCreate() or onNewIntent() and
+     * notifies Compose to initiate the provisioning flow (via [ProvisioningViewModel]) for
+     * obtaining an Issuing Authority from a Uri (that is found in the deep link's payload).
+     */
+    private fun handleOid4vciCredentialOfferIntent(intent: Intent) {
+        if (intent.action == Intent.ACTION_VIEW) {
+            // perform recomposition only if deep link url starts with oid4vci credential offer scheme
+            if (intent.dataString?.startsWith(WalletApplication.OID4VCI_CREDENTIAL_OFFER_URL_SCHEME) == true) {
+                val decodedQuery = getUrlQueryFromCustomSchemeUrl(intent.dataString!!)
+                extractCredentialIssuerData(decodedQuery).let { (credentialIssuerUri, credentialConfigurationId) ->
+                    provisioningViewModel.onNewCredentialOfferIntent(
+                        credentialIssuerUri,
+                        credentialConfigurationId
                     )
                 }
             }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -75,6 +75,8 @@ class WalletApplication : Application() {
         const val CREDENTIAL_DOMAIN_MDOC = "mdoc/MSO"
         const val CREDENTIAL_DOMAIN_SD_JWT_VC = "SD-JWT"
 
+        // OID4VCI url scheme used for filtering OID4VCI Urls from all incoming URLs (deep links or QR)
+        const val OID4VCI_CREDENTIAL_OFFER_URL_SCHEME = "openid-credential-offer://"
         // The permissions needed to perform 18013-5 presentations. This only include the
         // BLE permissions because that's the only transport we currently support in the
         // application.

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credentialoffer/CredentialOfferIssuance.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credentialoffer/CredentialOfferIssuance.kt
@@ -1,0 +1,50 @@
+package com.android.identity_credential.wallet.credentialoffer
+
+import com.android.identity.document.DocumentStore
+import com.android.identity.issuance.remote.WalletServerProvider
+import com.android.identity_credential.wallet.ProvisioningViewModel
+import com.android.identity_credential.wallet.SettingsModel
+import com.android.identity_credential.wallet.navigation.WalletDestination
+import org.json.JSONObject
+
+/**
+ * Initiate the process of setting a dynamic Credential Issuer defined in the credential offer
+ * payload that produces [credentialIssuerUri] Url of Issuer for obtaining credentials and
+ * [credentialIssuerConfigurationId] for the Credential Id (such as "pid-mso-mdoc" or "pid-sd-jwt").
+ */
+fun initiateCredentialOfferIssuance(
+    walletServerProvider: WalletServerProvider,
+    provisioningViewModel: ProvisioningViewModel,
+    settingsModel: SettingsModel,
+    documentStore: DocumentStore,
+    onNavigate: (String) -> Unit,
+    credentialIssuerUri: String,
+    credentialIssuerConfigurationId: String,
+) {
+    provisioningViewModel.start(
+        walletServerProvider = walletServerProvider,
+        documentStore = documentStore,
+        settingsModel = settingsModel,
+        issuerIdentifier = null,
+        credentialIssuerUri = credentialIssuerUri,
+        credentialIssuerConfigurationId = credentialIssuerConfigurationId
+    )
+    onNavigate(WalletDestination.ProvisionDocument.route)
+}
+
+/**
+ * Parse the Url Query component of an OID4VCI credential offer Url (from a deep link or Qr scan)
+ * and return a [Pair] containing the Credential Issuer Uri and Credential (Config) Id that are
+ * used for initiating the OID4VCI Credential Offer Issuance flow above [initiateCredentialOfferIssuance].
+ */
+fun extractCredentialIssuerData(urlQueryComponent: String): Pair<String, String> {
+    val jsonPayload = JSONObject("{$urlQueryComponent}")
+    val credentialOffer = jsonPayload.getJSONObject("credential_offer")
+    // extract Credential Issuer Uri and Credential (Config) Id
+    val credentialIssuerUri = credentialOffer.getString("credential_issuer")
+    val credentialConfigurationIds =
+        credentialOffer.getJSONArray("credential_configuration_ids")
+    // TODO should there be a future implementation addressing all specified ids in credential_configuration_ids ?
+    val credentialConfigurationId = credentialConfigurationIds.getString(0)
+    return Pair(credentialIssuerUri, credentialConfigurationId)
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
@@ -6,7 +6,11 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 
 
-sealed class WalletDestination(val routeEnum: Route) : DestinationArguments() {
+sealed class WalletDestination(val routeEnum: Route) {
+    /**
+     * Can be overriden by any Destination's inner class using its Argument enum to return arguments.
+     */
+    open fun getArguments(): List<NamedNavArgument> = listOf()
 
     // String representation of this Destination's route
     val route = routeEnum.routeName
@@ -167,9 +171,6 @@ sealed class WalletDestination(val routeEnum: Route) : DestinationArguments() {
 }
 
 
-abstract class DestinationArguments {
-    open fun getArguments(): List<NamedNavArgument> = listOf()
-}
 
 /**
  * A Route is used to define identifiers of Screens that can be navigated to. A Route can also be used

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/qrscanner/ScanQrDialog.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/qrscanner/ScanQrDialog.kt
@@ -1,0 +1,173 @@
+package com.android.identity_credential.wallet.ui.qrscanner
+
+import android.Manifest
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.DialogProperties
+import com.android.identity.util.Logger
+import com.android.identity_credential.wallet.R
+import com.budiyev.android.codescanner.CodeScanner
+import com.budiyev.android.codescanner.CodeScannerView
+import com.budiyev.android.codescanner.DecodeCallback
+import com.budiyev.android.codescanner.ErrorCallback
+import com.budiyev.android.codescanner.ScanMode
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+
+const val TAG = "ScanQrDialog"
+
+/**
+ * Composable Dialog that shows a [title], [description], Qr scanner/camera surface, and close button.
+ * Issues callbacks to [onClose] for dismiss requests (from dialog or close button). When a Qr code
+ * is successfully scanned, the callback [onScannedQrCode] is invoked with the decoded text.
+ *
+ * A [modifier] can be passed for setting the Dialog's dimensions
+ */
+@Composable
+fun ScanQrDialog(
+    title: String,
+    description: String,
+    onClose: () -> Unit,
+    onScannedQrCode: (String) -> Unit,
+    modifier: Modifier? = null
+) {
+    // if provided, use the passed-in modifier and set dialog properties that allow for adjustment of dimensions
+    val (dialogModier: Modifier, dialogProperties: DialogProperties) =
+        if (modifier != null) {
+            Pair(
+                modifier, DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    decorFitsSystemWindows = false
+                )
+            )
+        } else {
+            Pair(Modifier, DialogProperties())
+        }
+
+    AlertDialog(
+        modifier = dialogModier,
+        properties = dialogProperties,
+        icon = {
+            Icon(
+                Icons.Filled.QrCode,
+                contentDescription = stringResource(R.string.reader_screen_qr_icon_content_description)
+            )
+        },
+        title = { Text(text = title) },
+        text = { QrScanner(description, onScannedQrCode) },
+        onDismissRequest = { onClose.invoke() },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(
+                onClick = {
+                    onClose.invoke()
+                }
+            ) {
+                Text(stringResource(R.string.reader_screen_scan_qr_dialog_dismiss_button))
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun QrScanner(
+    description: String,
+    onScannedQrCode: (String) -> Unit,
+) {
+    val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
+    if (!cameraPermissionState.status.isGranted) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    modifier = Modifier.padding(20.dp),
+                    text = stringResource(R.string.reader_screen_scan_qr_dialog_missing_permission_text)
+                )
+                Button(
+                    onClick = {
+                        cameraPermissionState.launchPermissionRequest()
+                    }
+                ) {
+                    Text(stringResource(R.string.reader_screen_scan_qr_dialog_request_permission_button))
+                }
+            }
+        }
+    } else {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    modifier = Modifier.padding(8.dp),
+                    text = description
+                )
+                Row(
+                    modifier = Modifier
+                        .width(300.dp)
+                        .height(300.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    AndroidView(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(32.dp),
+                        factory = { context ->
+                            CodeScannerView(context).apply {
+                                val codeScanner = CodeScanner(context, this).apply {
+                                    layoutParams = LinearLayout.LayoutParams(
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.MATCH_PARENT
+                                    )
+                                    isAutoFocusEnabled = true
+                                    isAutoFocusButtonVisible = false
+                                    scanMode = ScanMode.SINGLE
+                                    decodeCallback = DecodeCallback { result ->
+                                        releaseResources()
+                                        onScannedQrCode.invoke(result.text)
+                                    }
+                                    errorCallback = ErrorCallback { error ->
+                                        Logger.w(TAG, "Error scanning QR", error)
+                                        releaseResources()
+                                    }
+                                    camera = CodeScanner.CAMERA_BACK
+                                    isFlashEnabled = false
+                                }
+                                codeScanner.startPreview()
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -473,6 +473,11 @@
         <p>The PID is generated and signed on the government server. The created PID will be bound to
         this device.</p>
     ]]></string>
+
+    <!-- Credential Offer -->
+    <string name="credential_offer_scan">Scan Credential Offer</string>
+    <string name="credential_offer_details">QR code for OpenID for Verifiable Credential Issuance (draft #14)</string>
+
     <!-- Consent Prompt -->
     <string name="consent_prompt_button_cancel">Cancel</string>
     <string name="consent_prompt_button_confirm">Share</string>


### PR DESCRIPTION
WalletServer and WalletServerState can create an IssuingAuthority by Uri that impact Funke IssuingAuthorityState, ProofingState, RequestCredenti- als state. WalletServerProvider is used for obtaining IssuingAuthority's by Uri. Current PID-based approach Funke IssuingAuthority runs the same.

The function initiateCredentialOfferIssuance(.., issuer uri, config id) enables any part of the app to get credentials from any arbitrary Credential Issuer Uri as defined in the openid-credential-offer:// url.

Extracted ScanQrDialog into a standalone Composable that can be re-used anywhere and obtain the scanned text. Refactored ReaderScreen to use the new ScanQrDialog. AddToWallet also uses this dialog when user taps on the -Scan Credential Offer- button.

Tested by:
- Manual tests from a emulator
- Manual tests from a real device
- ./gradlew check



https://github.com/user-attachments/assets/3b8287a2-e62a-4db6-b612-f002c7f8ca1b

