### PR TITLE
UI Updates to Document Data Screen

### DIFF
--- a/wallet/src/main/res/drawable/warning.xml
+++ b/wallet/src/main/res/drawable/warning.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m40,840 l440,-760 440,760L40,840ZM178,760h604L480,240 178,760ZM480,720q17,0 28.5,-11.5T520,680q0,-17 -11.5,-28.5T480,640q-17,0 -28.5,11.5T440,680q0,17 11.5,28.5T480,720ZM440,600h80v-200h-80v200ZM480,500Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -271,13 +271,10 @@
     <!-- DocumentDetailsScreen -->
     <string name="document_details_screen_title">Document Data</string>
     <string name="document_details_screen_disclaimer">UNVERIFIED DATA\nDO NOT USE</string>
-    <string name="document_details_screen_flash_pass_lecture">
-        Showing this screen is not a secure way of sharing identity data because the verifier
-        has no way to confirm the authenticity of the data. Use NFC or QR to share identity
-        data in a secure and privacy-preserving manner.
-    </string>
+    <string name="document_details_screen_flash_pass_lecture">Do not share this screen. It is not secure for presenting info directly as authenticity cannot be verified.</string>
     <string name="document_details_boolean_true_value">True</string>
     <string name="document_details_boolean_false_value">False</string>
+    <string name="document_details_screen_warning_icon_unverified_data">Warning Icon</string>
 
     <!-- CredentialInfoScreen -->
     <string name="credential_info_screen_title">Credentials</string>


### PR DESCRIPTION
- Added warning message text, box, and icon
- Showing document data fields according to a specified order defined in the code that matches the slides. Shows remaining fields in an unordered fashion.

Tested by:
- Manual testing by adding Test eID-Karte Personalausweis
- ./gradlew check
- ./gradlew connectedCheck


![Screenshot 2024-11-22 at 6 21 20 PM](https://github.com/user-attachments/assets/3d178efa-d004-40a6-bc5d-3ad62d892bb3)

![Screenshot 2024-11-22 at 6 21 46 PM](https://github.com/user-attachments/assets/8d28db01-f365-4fd7-a4c7-9c1193dd09e9)
