### PR TITLE
samples/testapp: More fixes for dealing with the world now being async.

### DIFF
--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/digitalcredentials/DigitalCredentials.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/digitalcredentials/DigitalCredentials.kt
@@ -15,7 +15,7 @@ interface DigitalCredentials {
     val available: Boolean
 
     /**
-     * Registers all credentials in the given [DocumentStore] with the platform.
+     * Registers all documents in the given [DocumentStore] with the platform.
      *
      * This also watches the store and updates the registration as documents and credentials
      * are added and removed.
@@ -29,11 +29,15 @@ interface DigitalCredentials {
     )
 
     /**
-     * Stops exporting credentials.
+     * Stops exporting documents.
+     *
+     * All documents from the given store are unregistered with the platform.
      *
      * @param documentStore the [DocumentStore] passed to [startExportingCredentials]
      */
-    suspend fun stopExportingCredentials(documentStore: DocumentStore)
+    suspend fun stopExportingCredentials(
+        documentStore: DocumentStore
+    )
 
     /**
      * The default implementation of the [DigitalCredentials] API on the platform.
@@ -47,8 +51,9 @@ interface DigitalCredentials {
             documentTypeRepository: DocumentTypeRepository,
         ) = defaultStartExportingCredentials(documentStore, documentTypeRepository)
 
-        override suspend fun stopExportingCredentials(documentStore: DocumentStore) =
-            defaultStopExportingCredentials(documentStore)
+        override suspend fun stopExportingCredentials(
+            documentStore: DocumentStore
+        ) = defaultStopExportingCredentials(documentStore)
     }
 }
 

--- a/identity-doctypes/src/commonTest/kotlin/com/android/identity/documenttype/TestDocumentTypeRepository.kt
+++ b/identity-doctypes/src/commonTest/kotlin/com/android/identity/documenttype/TestDocumentTypeRepository.kt
@@ -2,6 +2,7 @@ package com.android.identity.documenttype
 
 import com.android.identity.cbor.Bstr
 import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.Simple
 import com.android.identity.cbor.Tagged
 import com.android.identity.cbor.Tstr
@@ -122,21 +123,26 @@ class TestDocumentTypeRepository {
             mdlNs.dataElements["portrait"]?.renderValue(Bstr(byteArrayOf(1, 2, 3)))
         )
 
-        // CredentialAttributeType.DateTime - supports both tdate and full-date
+        // CredentialAttributeType.DateTime - supports both tdate, full-date, and ISO/IEC 23220-2 maps
         assertEquals(
             "1976-02-03T06:30:00",
             MdocDataElement(
-                DocumentAttribute(
-                    DocumentAttributeType.DateTime,
-                    "",
-                    "",
-                    "",
-                    null,
-                    null
-                ),
+                DocumentAttribute(DocumentAttributeType.DateTime, "", "", "", null, null),
                 false
             ).renderValue(
                 Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString(),
+                timeZone = TimeZone.of("Europe/Copenhagen")
+            )
+        )
+        assertEquals(
+            "1976-02-03T06:30:00",
+            MdocDataElement(
+                DocumentAttribute(DocumentAttributeType.DateTime, "", "", "", null, null),
+                false
+            ).renderValue(
+                CborMap.builder()
+                    .put("birth_date", Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString())
+                    .end().build(),
                 timeZone = TimeZone.of("Europe/Copenhagen")
             )
         )
@@ -146,24 +152,29 @@ class TestDocumentTypeRepository {
             assertEquals(
                 "1976-02-03T00:00:00",
                 MdocDataElement(
-                    DocumentAttribute(
-                        DocumentAttributeType.DateTime,
-                        "",
-                        "",
-                        "",
-                        null,
-                        null
-                    ),
+                    DocumentAttribute(DocumentAttributeType.DateTime, "", "", "", null, null),
                     false
                 ).renderValue(
                     LocalDate.parse("1976-02-03").toDataItemFullDate(),
                     timeZone = TimeZone.of(zoneId)
                 )
             )
+            assertEquals(
+                "1976-02-03T00:00:00",
+                MdocDataElement(
+                    DocumentAttribute(DocumentAttributeType.DateTime, "", "", "", null, null),
+                    false
+                ).renderValue(
+                    CborMap.builder()
+                        .put("birth_date", LocalDate.parse("1976-02-03").toDataItemFullDate())
+                        .end().build(),
+                    timeZone = TimeZone.of(zoneId)
+                )
+            )
         }
 
-        // CredentialAttributeType.Date - supports both tdate and full-date... for tdate
-        // the timezone is taken into account, for full-date it isn't.
+        // CredentialAttributeType.Date - supports both tdate, full-date, and ISO/IEC 23220-2 maps
+        // for tdate the timezone is taken into account, for full-date it isn't.
         assertEquals(
             "1976-02-03",
             mdlNs.dataElements["birth_date"]?.renderValue(
@@ -190,6 +201,24 @@ class TestDocumentTypeRepository {
             mdlNs.dataElements["birth_date"]?.renderValue(
                 LocalDate.parse("1976-02-03").toDataItemFullDate(),
                 timeZone = TimeZone.of("America/Los_Angeles")
+            )
+        )
+        assertEquals(
+            "1976-02-03",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                CborMap.builder()
+                    .put("birth_date", Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString())
+                    .end().build(),
+                timeZone = TimeZone.of("America/New_York")
+            )
+        )
+        assertEquals(
+            "1976-02-03",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                CborMap.builder()
+                    .put("birth_date", LocalDate.parse("1976-02-03").toDataItemFullDate())
+                    .end().build(),
+                timeZone = TimeZone.of("America/New_York")
             )
         )
 

--- a/identity/src/androidMain/kotlin/com/android/identity/util/AndroidContexts.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/util/AndroidContexts.kt
@@ -23,7 +23,7 @@ object AndroidContexts {
     val applicationContext: Context
         get() {
             return _applicationContext
-                ?: throw IllegalStateException("Application must use AndroidInitializer to set context")
+                ?: throw IllegalStateException("Application must use AndroidContexts to set context")
         }
     private var _applicationContext: Context? = null
 

--- a/identity/src/commonMain/kotlin/com/android/identity/document/DocumentStore.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/document/DocumentStore.kt
@@ -51,16 +51,17 @@ import kotlin.coroutines.CoroutineContext
  * For more details about documents stored in a [DocumentStore] see the
  * [Document] class.
  *
- * @param storage the [Storage] to use for storing/retrieving documents.
- * @param secureAreaRepository the repository of configured [SecureArea] that can
+ * @property storage the [Storage] to use for storing/retrieving documents.
+ * @property secureAreaRepository the repository of configured [SecureArea] that can
  * be used.
- * @param credentialFactory the [CredentialFactory] to use for retrieving serialized credentials
+ * @property credentialFactory the [CredentialFactory] to use for retrieving serialized credentials
  * associated with documents.
+ * @property coroutineScope the [CoroutineScope] to use.
  */
 class DocumentStore(
-    storage: Storage,
-    private val secureAreaRepository: SecureAreaRepository,
-    private val credentialFactory: CredentialFactory,
+    val storage: Storage,
+    val secureAreaRepository: SecureAreaRepository,
+    val credentialFactory: CredentialFactory,
     internal val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ) {
     // Use a cache so the same instance is returned by multiple lookupDocument() calls.

--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/MdocDataElement.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/MdocDataElement.kt
@@ -17,6 +17,7 @@
 package com.android.identity.documenttype
 
 import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.DataItem
 import com.android.identity.cbor.Tagged
 import com.android.identity.cbor.DiagnosticOption
@@ -81,17 +82,24 @@ data class MdocDataElement(
                 DocumentAttributeType.ComplexType -> Cbor.toDiagnostics(value)
 
                 DocumentAttributeType.Date -> {
-                    // value can be either tdate or full-date
-                    val tagNumber = (value as Tagged).tagNumber
+                    // value can be either tdate or full-date or a map as per ISO/IEC 23220-2
+                    // clause 6.3.1.1.3 Date of birth as uncertain or approximate, or both
+                    val taggedValue = if (value is CborMap) {
+                        value.get("birth_date")
+                        // TODO: if available, also use approximate_mask when rendering the value
+                    } else {
+                        value
+                    }
+                    val tagNumber = (taggedValue as Tagged).tagNumber
                     val dt = when (tagNumber) {
                         Tagged.FULL_DATE_STRING -> {
                             LocalDateTime(
-                                LocalDate.parse(value.asTagged.asTstr),
+                                LocalDate.parse(taggedValue.asTagged.asTstr),
                                 LocalTime(0, 0, 0)
                             )
                         }
                         Tagged.DATE_TIME_STRING -> {
-                            val pointInTime = Instant.parse(value.asTagged.asTstr)
+                            val pointInTime = Instant.parse(taggedValue.asTagged.asTstr)
                             pointInTime.toLocalDateTime(timeZone)
                         }
                         else -> {
@@ -102,17 +110,24 @@ data class MdocDataElement(
                 }
 
                 DocumentAttributeType.DateTime -> {
-                    // value can be either tdate or full-date
-                    val tagNumber = (value as Tagged).tagNumber
+                    // value can be either tdate or full-date or a map as per ISO/IEC 23220-2
+                    // clause 6.3.1.1.3 Date of birth as uncertain or approximate, or both
+                    val taggedValue = if (value is CborMap) {
+                        value.get("birth_date")
+                        // TODO: if available, also use approximate_mask when rendering the value
+                    } else {
+                        value
+                    }
+                    val tagNumber = (taggedValue as Tagged).tagNumber
                     val dt = when (tagNumber) {
                         Tagged.FULL_DATE_STRING -> {
                             LocalDateTime(
-                                LocalDate.parse(value.asTagged.asTstr),
+                                LocalDate.parse(taggedValue.asTagged.asTstr),
                                 LocalTime(0, 0, 0)
                             )
                         }
                         Tagged.DATE_TIME_STRING -> {
-                            val pointInTime = Instant.parse(value.asTagged.asTstr)
+                            val pointInTime = Instant.parse(taggedValue.asTagged.asTstr)
                             pointInTime.toLocalDateTime(timeZone)
                         }
                         else -> {

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -48,7 +48,7 @@
             android:name=".CredmanPresentmentActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"
             android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="androidx.credentials.registry.provider.action.GET_CREDENTIAL" />
@@ -67,7 +67,7 @@
             android:turnScreenOn="true"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"
             android:launchMode="singleInstance">
         </activity>
 

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MainActivity.kt
@@ -6,40 +6,17 @@ import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.util.AndroidContexts
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.security.Security
 
 class MainActivity : FragmentActivity() {
 
     companion object {
         private const val TAG = "MainActivity"
-
-        private var bcInitialized = false
-
-        fun initBouncyCastle() {
-            if (bcInitialized) {
-                return
-            }
-            // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-            // based implementation included in the OS itself.
-            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-            Security.addProvider(BouncyCastleProvider())
-            bcInitialized = true
-        }
-
-        init {
-            initBouncyCastle()
-        }
     }
-
-    private val app = App()
 
     override fun onResume() {
         super.onResume()
@@ -61,21 +38,12 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        initBouncyCastle()
-
         CoroutineScope(Dispatchers.Main).launch {
-            app.init()
+            val app = App.getInstance()
+            app.startExportDocumentsToDigitalCredentials()
             setContent {
                 app.Content()
             }
         }
     }
-}
-
-private val previewApp: App by lazy { App() }
-
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    previewApp.Content()
 }

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NfcPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NfcPresentmentActivity.kt
@@ -20,6 +20,9 @@ import com.android.identity.util.AndroidContexts
 import identitycredential.samples.testapp.generated.resources.Res
 import identitycredential.samples.testapp.generated.resources.app_icon
 import identitycredential.samples.testapp.generated.resources.app_name
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -32,14 +35,19 @@ class NfcPresentmentActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        CoroutineScope(Dispatchers.Main).launch {
+            startPresentment(App.getInstance())
+        }
+    }
 
+    private suspend fun startPresentment(app: App) {
         setContent {
             AppTheme {
                 Scaffold { innerPadding ->
                     Presentment(
                         presentmentModel = NdefService.presentmentModel,
-                        documentTypeRepository = TestAppUtils.documentTypeRepository,
-                        source = TestAppPresentmentSource(App.settingsModel),
+                        documentTypeRepository = app.documentTypeRepository,
+                        source = TestAppPresentmentSource(app),
                         onPresentmentComplete = { finish() },
                         appName = stringResource(Res.string.app_name),
                         appIconPainter = painterResource(Res.drawable.app_icon),

--- a/samples/testapp/src/commonMain/composeResources/values/strings.xml
+++ b/samples/testapp/src/commonMain/composeResources/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="back_button">Back</string>
 
     <string name="start_screen_title">Test App</string>
+    <string name="settings_screen_title">Settings</string>
     <string name="about_screen_title">About</string>
     <string name="software_secure_area_screen_title">Software Secure Area</string>
     <string name="android_keystore_secure_area_screen_title">Android Keystore Secure Area</string>

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Destinations.kt
@@ -21,6 +21,7 @@ import identitycredential.samples.testapp.generated.resources.secure_enclave_sec
 import identitycredential.samples.testapp.generated.resources.software_secure_area_screen_title
 import identitycredential.samples.testapp.generated.resources.start_screen_title
 import identitycredential.samples.testapp.generated.resources.certificate_viewer_title
+import identitycredential.samples.testapp.generated.resources.settings_screen_title
 import org.jetbrains.compose.resources.StringResource
 
 sealed interface Destination {
@@ -31,6 +32,11 @@ sealed interface Destination {
 data object StartDestination : Destination {
     override val route = "start"
     override val title = Res.string.start_screen_title
+}
+
+data object SettingsDestination : Destination {
+    override val route = "settings"
+    override val title = Res.string.settings_screen_title
 }
 
 data object AboutDestination : Destination {
@@ -132,6 +138,7 @@ data object CertificateViewerDestination : Destination {
 
 val appDestinations = listOf(
     StartDestination,
+    SettingsDestination,
     AboutDestination,
     SoftwareSecureAreaDestination,
     AndroidKeystoreSecureAreaDestination,

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
@@ -12,6 +12,8 @@ enum class Platform(val displayName: String) {
 
 expect val platform: Platform
 
+expect suspend fun platformInit()
+
 expect fun getLocalIpAddress(): String
 
 expect val platformIsEmulator: Boolean

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
@@ -1,61 +1,157 @@
 package com.android.identity.testapp
 
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.Tstr
+import com.android.identity.cbor.toDataItem
+import com.android.identity.storage.Storage
+import com.android.identity.storage.StorageTable
+import com.android.identity.storage.StorageTableSpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import kotlin.Boolean
 
 /**
  * A model for settings for samples/testapp.
  *
- * TODO: Use [Storage] to back this model, for persistence.
- *
  * TODO: Port [CloudSecureAreaScreen] and [ProvisioningTestScreen] to use this.
+ * @param storage the [Storage] to use for storing/retrieving documents.
  */
-class TestAppSettingsModel {
+class TestAppSettingsModel private constructor(
+    private val readOnly: Boolean
+) {
+
+    private lateinit var settingsTable: StorageTable
+
     companion object {
         private const val TAG = "TestAppSettingsModel"
+
+        private val tableSpec = StorageTableSpec(
+            name = "TestAppSettings",
+            supportPartitions = false,
+            supportExpiration = false
+        )
+
+        /**
+         * Asynchronous construction.
+         *
+         * @param storage the [Storage] backing the settings.
+         * @param readOnly if `false`, won't monitor all the settings and write to storage when they change.
+         */
+        suspend fun create(
+            storage: Storage,
+            readOnly: Boolean = false
+        ): TestAppSettingsModel {
+            val instance = TestAppSettingsModel(readOnly)
+            instance.settingsTable = storage.getTable(tableSpec)
+            instance.init()
+            return instance
+        }
     }
 
-    val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(true)
+    private data class BoundItem<T>(
+        val variable: MutableStateFlow<T>,
+        val defaultValue: T
+    ) {
+        fun resetValue() {
+            variable.value = defaultValue
+        }
+    }
+
+    private val boundItems = mutableListOf<BoundItem<*>>()
+
+    private suspend fun<T> bind(
+        variable: MutableStateFlow<T>,
+        key: String,
+        defaultValue: T
+    ) {
+        val value = settingsTable.get(key)?.let {
+            val dataItem = Cbor.decode(it.toByteArray())
+            when (defaultValue) {
+                is Boolean -> { dataItem.asBoolean as T }
+                is List<*> -> { dataItem.asArray.map { dataItem -> (dataItem as Tstr).value } as T}
+                else -> { throw IllegalStateException("Type not supported") }
+            }
+        } ?: defaultValue
+        variable.value = value
+
+        if (!readOnly) {
+            CoroutineScope(currentCoroutineContext()).launch {
+                variable.asStateFlow().collect { newValue ->
+                    val dataItem = when (defaultValue) {
+                        is Boolean -> {
+                            (newValue as Boolean).toDataItem()
+                        }
+
+                        is List<*> -> {
+                            val builder = CborArray.builder()
+                            (newValue as List<String>).forEach { builder.add(Tstr(it)) }
+                            builder.end().build()
+                        }
+
+                        else -> {
+                            throw IllegalStateException("Type not supported")
+                        }
+                    }
+                    if (settingsTable.get(key) == null) {
+                        settingsTable.insert(key, ByteString(Cbor.encode(dataItem)))
+                    } else {
+                        settingsTable.update(key, ByteString(Cbor.encode(dataItem)))
+                    }
+                }
+            }
+        }
+        boundItems.add(BoundItem(variable, defaultValue))
+    }
+
+    fun resetSettings() {
+        boundItems.forEach { it.resetValue() }
+    }
+
+    // TODO: use something like KSP to avoid having to repeat settings name three times..
+    //
+
+    private suspend fun init() {
+        bind(presentmentBleCentralClientModeEnabled, "presentmentBleCentralClientModeEnabled", true)
+        bind(presentmentBlePeripheralServerModeEnabled, "presentmentBlePeripheralServerModeEnabled", false)
+        bind(presentmentNfcDataTransferEnabled, "presentmentNfcDataTransferEnabled", false)
+        bind(presentmentBleL2CapEnabled, "presentmentBleL2CapEnabled", true)
+        bind(presentmentUseNegotiatedHandover, "presentmentUseNegotiatedHandover", true)
+        bind(presentmentAllowMultipleRequests, "presentmentAllowMultipleRequests", false)
+        bind(presentmentNegotiatedHandoverPreferredOrder, "presentmentNegotiatedHandoverPreferredOrder",
+            listOf(
+                "ble:central_client_mode:",
+                "ble:peripheral_server_mode:",
+                "nfc:"
+            )
+        )
+        bind(presentmentShowConsentPrompt, "presentmentShowConsentPrompt", true)
+
+        bind(readerBleCentralClientModeEnabled, "readerBleCentralClientModeEnabled", true)
+        bind(readerBlePeripheralServerModeEnabled, "readerBlePeripheralServerModeEnabled", true)
+        bind(readerNfcDataTransferEnabled, "readerNfcDataTransferEnabled", true)
+        bind(readerBleL2CapEnabled, "readerBleL2CapEnabled", true)
+        bind(readerAutomaticallySelectTransport, "readerAutomaticallySelectTransport", false)
+        bind(readerAllowMultipleRequests, "readerAllowMultipleRequests", false)
+    }
+
+    val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
     val presentmentBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(false)
     val presentmentNfcDataTransferEnabled = MutableStateFlow<Boolean>(false)
     val presentmentBleL2CapEnabled = MutableStateFlow<Boolean>(false)
-    val presentmentUseNegotiatedHandover = MutableStateFlow<Boolean>(true)
+    val presentmentUseNegotiatedHandover = MutableStateFlow<Boolean>(false)
     val presentmentAllowMultipleRequests = MutableStateFlow<Boolean>(false)
-    val presentmentNegotiatedHandoverPreferredOrder = MutableStateFlow<List<String>>(listOf(
-        "ble:central_client_mode:",
-        "ble:peripheral_server_mode:",
-        "nfc:"
-    ))
-    val presentmentShowConsentPrompt = MutableStateFlow<Boolean>(true)
+    val presentmentNegotiatedHandoverPreferredOrder = MutableStateFlow<List<String>>(listOf())
+    val presentmentShowConsentPrompt = MutableStateFlow<Boolean>(false)
 
-    fun resetPresentmentSettings() {
-        presentmentBleCentralClientModeEnabled.value = true
-        presentmentBlePeripheralServerModeEnabled.value = false
-        presentmentNfcDataTransferEnabled.value = false
-        presentmentBleL2CapEnabled.value = true
-        presentmentUseNegotiatedHandover.value = true
-        presentmentAllowMultipleRequests.value = false
-        presentmentNegotiatedHandoverPreferredOrder.value = listOf(
-            "ble:central_client_mode:",
-            "ble:peripheral_server_mode:",
-            "nfc:"
-        )
-        presentmentShowConsentPrompt.value = true
-    }
-
-    val readerBleCentralClientModeEnabled = MutableStateFlow<Boolean>(true)
-    val readerBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(true)
-    val readerNfcDataTransferEnabled = MutableStateFlow<Boolean>(true)
-    val readerBleL2CapEnabled = MutableStateFlow<Boolean>(true)
+    val readerBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
+    val readerBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(false)
+    val readerNfcDataTransferEnabled = MutableStateFlow<Boolean>(false)
+    val readerBleL2CapEnabled = MutableStateFlow<Boolean>(false)
     val readerAutomaticallySelectTransport = MutableStateFlow<Boolean>(false)
     val readerAllowMultipleRequests = MutableStateFlow<Boolean>(false)
-
-    fun resetReaderSettings() {
-        readerBleCentralClientModeEnabled.value = true
-        readerBlePeripheralServerModeEnabled.value = true
-        readerNfcDataTransferEnabled.value = true
-        readerBleL2CapEnabled.value = true
-        readerAutomaticallySelectTransport.value = false
-        readerAllowMultipleRequests.value = false
-    }
-
 }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -2,20 +2,12 @@ package com.android.identity.testapp.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDownward
-import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -24,9 +16,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.identity.appsupport.ui.permissions.rememberBluetoothPermissionState
+import com.android.identity.appsupport.ui.presentment.MdocPresentmentMechanism
+import com.android.identity.appsupport.ui.presentment.PresentmentModel
 import com.android.identity.appsupport.ui.qrcode.ShowQrCodeDialog
 import com.android.identity.cbor.DataItem
 import com.android.identity.cbor.Simple
@@ -34,17 +27,13 @@ import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 import com.android.identity.mdoc.engagement.EngagementGenerator
-import com.android.identity.appsupport.ui.presentment.MdocPresentmentMechanism
 import com.android.identity.mdoc.transport.MdocTransport
 import com.android.identity.mdoc.transport.MdocTransportFactory
 import com.android.identity.mdoc.transport.MdocTransportOptions
-import com.android.identity.appsupport.ui.presentment.PresentmentModel
 import com.android.identity.mdoc.transport.advertiseAndWait
-import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
-import com.android.identity.testapp.Platform
 import com.android.identity.testapp.TestAppSettingsModel
-import com.android.identity.testapp.platform
 import com.android.identity.util.Logger
 import com.android.identity.util.UUID
 import com.android.identity.util.toBase64Url
@@ -80,10 +69,6 @@ fun IsoMdocProximitySharingScreen(
         )
     }
 
-    // NFC engagment as an mdoc is only supported on Android.
-    //
-    val nfcAvailable = (platform == Platform.ANDROID)
-
     if (!blePermissionState.isGranted) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -97,145 +82,9 @@ fun IsoMdocProximitySharingScreen(
             }
         }
     } else {
-        val negotiatedHandoverOrder = settingsModel.presentmentNegotiatedHandoverPreferredOrder.collectAsState().value
         LazyColumn(
             modifier = Modifier.padding(8.dp)
         ) {
-            item { SettingHeadline("NFC Engagement Settings") }
-            item {
-                if (!nfcAvailable) {
-                    WarningCard("NFC Engagement as an mdoc is not supported on ${platform.displayName}")
-                }
-            }
-            item {
-                SettingToggle(
-                    title = "Use NFC Static Handover",
-                    isChecked = !settingsModel.presentmentUseNegotiatedHandover.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentUseNegotiatedHandover.value = !it },
-                    enabled = nfcAvailable
-                )
-            }
-            item {
-                SettingToggle(
-                    title = "Use NFC Negotiated Handover",
-                    isChecked = settingsModel.presentmentUseNegotiatedHandover.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentUseNegotiatedHandover.value = it },
-                    enabled = nfcAvailable
-                )
-            }
-            item {
-                SettingHeadline("Transports (QR and NFC Static Handover)")
-            }
-            item {
-                SettingToggle(
-                    title = "BLE (mdoc central client mode)",
-                    isChecked = settingsModel.presentmentBleCentralClientModeEnabled.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentBleCentralClientModeEnabled.value = it },
-                )
-            }
-            item {
-                SettingToggle(
-                    title = "BLE (mdoc peripheral server mode)",
-                    isChecked = settingsModel.presentmentBlePeripheralServerModeEnabled.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentBlePeripheralServerModeEnabled.value = it },
-                )
-            }
-            item {
-                SettingToggle(
-                    title = "NFC Data Transfer",
-                    isChecked = settingsModel.presentmentNfcDataTransferEnabled.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentNfcDataTransferEnabled.value = it },
-                )
-            }
-            item {
-                SettingHeadline("NFC Negotiated Handover Preferred Order")
-            }
-            for (n in negotiatedHandoverOrder.indices) {
-                val prefix = negotiatedHandoverOrder[n]
-                val isFirst = (n == 0)
-                val isLast = (n == negotiatedHandoverOrder.size - 1)
-                item {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = prefixToDisplayNameMap[prefix] ?: prefix,
-                                fontWeight = FontWeight.Normal,
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
-                        IconButton(
-                            onClick = { settingsModel.swapNegotiatedHandoverOrder(n, n - 1) },
-                            enabled = !isFirst
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.ArrowUpward,
-                                contentDescription = null,
-                            )
-                        }
-                        IconButton(
-                            onClick = { settingsModel.swapNegotiatedHandoverOrder(n, n + 1) },
-                            enabled = !isLast
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.ArrowDownward,
-                                contentDescription = null,
-                            )
-                        }
-                    }
-                }
-            }
-            item {
-                SettingHeadline("Transport Options")
-            }
-            item {
-                SettingToggle(
-                    title = "Use L2CAP if available",
-                    isChecked = settingsModel.presentmentBleL2CapEnabled.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentBleL2CapEnabled.value = it },
-                )
-            }
-            item {
-                SettingToggle(
-                    title = "Keep connection open after first request",
-                    isChecked = settingsModel.presentmentAllowMultipleRequests.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentAllowMultipleRequests.value = it },
-                )
-            }
-            item {
-                SettingHeadline("General Options")
-            }
-            item {
-                SettingToggle(
-                    title = "Skip consent prompt",
-                    isChecked = !settingsModel.presentmentShowConsentPrompt.collectAsState().value,
-                    onCheckedChange = { settingsModel.presentmentShowConsentPrompt.value = !it },
-                )
-            }
-            item {
-                HorizontalDivider(
-                    modifier = Modifier.padding(8.dp)
-                )
-            }
-            item {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Button(
-                        onClick = {
-                            settingsModel.resetPresentmentSettings()
-                        },
-                    ) {
-                        Text(text = "Reset Settings")
-                    }
-                }
-            }
-            item {
-                HorizontalDivider(
-                    modifier = Modifier.padding(8.dp)
-                )
-            }
             item {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
@@ -343,18 +192,4 @@ private suspend fun doHolderFlow(
     )
     showQrCode.value = null
     onNavigateToPresentationScreen()
-}
-
-private val prefixToDisplayNameMap = mapOf<String, String>(
-    "ble:central_client_mode:" to "BLE (mdoc central client mode)",
-    "ble:peripheral_server_mode:" to "BLE (mdoc peripheral server mode)",
-    "nfc:" to "NFC Data Transfer"
-)
-
-private fun TestAppSettingsModel.swapNegotiatedHandoverOrder(index1: Int, index2: Int) {
-    val list = presentmentNegotiatedHandoverPreferredOrder.value.toMutableList()
-    val tmp = list[index2]
-    list[index2] = list[index1]
-    list[index1] = tmp
-    presentmentNegotiatedHandoverPreferredOrder.value = list
 }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PresentmentScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PresentmentScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import com.android.identity.appsupport.ui.presentment.Presentment
 import com.android.identity.appsupport.ui.presentment.PresentmentModel
+import com.android.identity.testapp.App
 import com.android.identity.testapp.TestAppSettingsModel
 import com.android.identity.testapp.TestAppPresentmentSource
 import com.android.identity.testapp.TestAppUtils
@@ -18,14 +19,14 @@ private const val TAG = "PresentmentScreen"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PresentmentScreen(
+    app: App,
     presentmentModel: PresentmentModel,
-    settingsModel: TestAppSettingsModel,
     onPresentationComplete: () -> Unit,
 ) {
     Presentment(
         presentmentModel = presentmentModel,
-        documentTypeRepository = TestAppUtils.documentTypeRepository,
-        source = TestAppPresentmentSource(settingsModel),
+        documentTypeRepository = app.documentTypeRepository,
+        source = TestAppPresentmentSource(app),
         onPresentmentComplete = onPresentationComplete,
         appName = stringResource(Res.string.app_name),
         appIconPainter = painterResource(Res.drawable.app_icon),

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
@@ -1,0 +1,250 @@
+package com.android.identity.testapp.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.android.identity.testapp.App
+import com.android.identity.testapp.Platform
+import com.android.identity.testapp.TestAppSettingsModel
+import com.android.identity.testapp.platform
+
+@Composable
+fun SettingsScreen(
+    app: App,
+) {
+    // NFC engagement as an mdoc is only supported on Android.
+    //
+    val nfcAvailable = (platform == Platform.ANDROID)
+    val negotiatedHandoverOrder = app.settingsModel.presentmentNegotiatedHandoverPreferredOrder.collectAsState().value
+
+    LazyColumn(
+        modifier = Modifier.padding(8.dp)
+    ) {
+        item { SettingHeadline("ISO mdoc NFC Engagement Settings") }
+        item {
+            if (!nfcAvailable) {
+                WarningCard("NFC Engagement as an mdoc is not supported on ${platform.displayName}")
+            }
+        }
+        item {
+            SettingToggle(
+                title = "Use NFC Static Handover",
+                isChecked = !app.settingsModel.presentmentUseNegotiatedHandover.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentUseNegotiatedHandover.value = !it },
+                enabled = nfcAvailable
+            )
+        }
+        item {
+            SettingToggle(
+                title = "Use NFC Negotiated Handover",
+                isChecked = app.settingsModel.presentmentUseNegotiatedHandover.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentUseNegotiatedHandover.value = it },
+                enabled = nfcAvailable
+            )
+        }
+        item {
+            SettingHeadline("ISO mdoc Transports (QR and NFC Static Handover)")
+        }
+        item {
+            SettingToggle(
+                title = "BLE (mdoc central client mode)",
+                isChecked = app.settingsModel.presentmentBleCentralClientModeEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentBleCentralClientModeEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "BLE (mdoc peripheral server mode)",
+                isChecked = app.settingsModel.presentmentBlePeripheralServerModeEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentBlePeripheralServerModeEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "NFC Data Transfer",
+                isChecked = app.settingsModel.presentmentNfcDataTransferEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentNfcDataTransferEnabled.value = it },
+            )
+        }
+        item {
+            SettingHeadline("ISO mdoc NFC Negotiated Handover Preferred Order")
+        }
+        for (n in negotiatedHandoverOrder.indices) {
+            val prefix = negotiatedHandoverOrder[n]
+            val isFirst = (n == 0)
+            val isLast = (n == negotiatedHandoverOrder.size - 1)
+            item {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = prefixToDisplayNameMap[prefix] ?: prefix,
+                            fontWeight = FontWeight.Normal,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    IconButton(
+                        onClick = { app.settingsModel.swapNegotiatedHandoverOrder(n, n - 1) },
+                        enabled = !isFirst
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowUpward,
+                            contentDescription = null,
+                        )
+                    }
+                    IconButton(
+                        onClick = { app.settingsModel.swapNegotiatedHandoverOrder(n, n + 1) },
+                        enabled = !isLast
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowDownward,
+                            contentDescription = null,
+                        )
+                    }
+                }
+            }
+        }
+        item {
+            SettingHeadline("ISO mdoc Transport Options")
+        }
+        item {
+            SettingToggle(
+                title = "Use L2CAP if available",
+                isChecked = app.settingsModel.presentmentBleL2CapEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentBleL2CapEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "Keep connection open after first request",
+                isChecked = app.settingsModel.presentmentAllowMultipleRequests.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentAllowMultipleRequests.value = it },
+            )
+        }
+
+        item {
+            HorizontalDivider(
+                modifier = Modifier.padding(8.dp)
+            )
+        }
+
+        item {
+            SettingHeadline("ISO mdoc reader Transports (NFC Negotiated Handover)")
+        }
+        item {
+            SettingToggle(
+                title = "BLE (mdoc central client mode)",
+                isChecked = app.settingsModel.readerBleCentralClientModeEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerBleCentralClientModeEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "BLE (mdoc peripheral server mode)",
+                isChecked = app.settingsModel.readerBlePeripheralServerModeEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerBlePeripheralServerModeEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "NFC Data Transfer",
+                isChecked = app.settingsModel.readerNfcDataTransferEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerNfcDataTransferEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "Automatically select transport",
+                isChecked = app.settingsModel.readerAutomaticallySelectTransport.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerAutomaticallySelectTransport.value = it },
+            )
+        }
+        item {
+            SettingHeadline("ISO mdoc reader Transport Options")
+        }
+        item {
+            SettingToggle(
+                title = "Use L2CAP if available",
+                isChecked = app.settingsModel.readerBleL2CapEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerBleL2CapEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "Keep connection open after first request",
+                isChecked = app.settingsModel.readerAllowMultipleRequests.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerAllowMultipleRequests.value = it },
+            )
+        }
+
+        item {
+            HorizontalDivider(
+                modifier = Modifier.padding(8.dp)
+            )
+        }
+
+        item {
+            SettingHeadline("Wallet General Options")
+        }
+        item {
+            SettingToggle(
+                title = "Skip consent prompt",
+                isChecked = !app.settingsModel.presentmentShowConsentPrompt.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentShowConsentPrompt.value = !it },
+            )
+        }
+
+        item {
+            HorizontalDivider(
+                modifier = Modifier.padding(8.dp)
+            )
+        }
+
+        item {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    onClick = {
+                        app.settingsModel.resetSettings()
+                    },
+                ) {
+                    Text(text = "Reset Settings")
+                }
+            }
+        }
+
+    }
+}
+
+private val prefixToDisplayNameMap = mapOf<String, String>(
+    "ble:central_client_mode:" to "BLE (mdoc central client mode)",
+    "ble:peripheral_server_mode:" to "BLE (mdoc peripheral server mode)",
+    "nfc:" to "NFC Data Transfer"
+)
+
+private fun TestAppSettingsModel.swapNegotiatedHandoverOrder(index1: Int, index2: Int) {
+    val list = presentmentNegotiatedHandoverPreferredOrder.value.toMutableList()
+    val tmp = list[index2]
+    list[index2] = list[index1]
+    list[index1] = tmp
+    presentmentNegotiatedHandoverPreferredOrder.value = list
+}

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
@@ -41,6 +41,10 @@ import platform.posix.sockaddr_in6
 
 actual val platform = Platform.IOS
 
+actual suspend fun platformInit() {
+    // Nothing to do
+}
+
 @OptIn(ExperimentalForeignApi::class)
 actual fun getLocalIpAddress(): String {
     val (status, interfaces) = memScoped {


### PR DESCRIPTION
Move all dependencies used by TestApp in the `App` class and make it a singleton with asynchronous construction.

Use Storage in TestAppSettingsModel to make settings persistent and introduce a new SettingsScreen and move all settings there. Make this accessible through a gear icon in the app's top bar.

Startup performance is quite important, especially when the app is invoked from cold, for example as part of a Credman request or NFC tap.

We really need initialization of the document database, key material and certificates used, trust lists, and other items to be in the handful of milliseconds so add machinery to measure where the time goes. Use this to learn that generating keys and certificates or even parsing PEM at startup is prohibitively expensive. Fix this by serializing these objects in [Storage] so it's only expensive on first run and practically free for future runs. Ditto, only provision the documents on the first run of the application.

Make sure the app actually work in cases a Credman or NFC presentment happen and the app is not currently running. Also make sure it's performant.

For example for the NFC engagament path, defer `App` initialization until the NFC engagement is actually complete. This is quite important because timing is very sensitive because the holder's device is only going to be in the NFC field for so long.

For the Credman case, ensure we can handle the request without first having re-registered all our documents with Credman which is a costly affair. This implies storing the Credman registration ID -> Document mapping in persistent storage. It's tempting to use applicationData on Document for this but this is going to go away soon so use a separate database table instead. In order to do this, have `DocumentStore` expose the `Storage` it's using so we can piggyback and store this new database table in the same backing file.

Also fix `MdocDataElement.renderValue()` so it understands the ISO/IEC 23220-2 encoding of `birth_date` as used in PhotoID doctype. This takes care of a few noisy warnings which starting appear when we added support for PhotoID.

Test: Manually tested.
Test: New unit tests for `MdocDataElement.renderValue()`.