### PR TITLE
Updated fix for the issue where an NFC scan would cause following QR scans to fail.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiProviderAndroid.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiProviderAndroid.kt
@@ -72,9 +72,9 @@ actual fun UiProvider(lifecycleOwner: LifecycleOwner) {
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
+            if (event == Lifecycle.Event.ON_RESUME) {
                 UiModelAndroid.registerView(provider)
-            } else if (event == Lifecycle.Event.ON_STOP) {
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
                 UiModelAndroid.unregisterView(provider)
             }
         }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/UiProvider.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/UiProvider.kt
@@ -69,9 +69,9 @@ fun UiProviderCommon(lifecycleOwner: LifecycleOwner) {
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
+            if (event == Lifecycle.Event.ON_RESUME) {
                 UiModel.registerView(provider)
-            } else if (event == Lifecycle.Event.ON_STOP) {
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
                 UiModel.unregisterView(provider)
             }
         }


### PR DESCRIPTION
This is slightly simpler than https://github.com/openwallet-foundation-labs/identity-credential/pull/884: we register and unregister our views on the ON_PAUSE/ON_RESUME lifecycle events.

Tested by:
- Manual testing in testapp, where the bug occurred before.
