### PR TITLE
ConnectionMethod: Properly convey PSM when disambiguating methods.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -40,6 +40,7 @@ import com.android.mdl.appreader.util.KeysAndCertificates
 import com.android.mdl.appreader.util.TransferStatus
 import com.android.mdl.appreader.util.logDebug
 import com.android.mdl.appreader.util.logError
+import org.multipaz.mdoc.transport.MdocTransport
 import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.Signature
@@ -221,7 +222,10 @@ class TransferManager private constructor(private val context: Context) {
             // if both BLE modes are available at the same time.
             mediaPlayer = mediaPlayer ?: MediaPlayer.create(context, R.raw.nfc_connected)
             mediaPlayer?.start()
-            setAvailableTransferMethods(ConnectionMethod.disambiguate(connectionMethods))
+            setAvailableTransferMethods(ConnectionMethod.disambiguate(
+                connectionMethods,
+                MdocTransport.Role.MDOC_READER
+            ))
             transferStatusLd.value = TransferStatus.ENGAGED
         }
 

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
@@ -45,6 +45,7 @@ import org.multipaz.mdoc.sessionencryption.SessionEncryption
 import org.multipaz.util.Constants
 import org.multipaz.util.Logger
 import kotlinx.datetime.Clock
+import org.multipaz.mdoc.transport.MdocTransport
 import java.io.IOException
 import java.util.Arrays
 import java.util.Locale
@@ -173,7 +174,8 @@ class VerificationHelper internal constructor(
         // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
         // if both BLE modes are available at the same time.
         val disambiguatedMethods = ConnectionMethod.disambiguate(
-            reverseEngagementConnectionMethods!!
+            reverseEngagementConnectionMethods!!,
+            MdocTransport.Role.MDOC_READER
         )
         for (cm in disambiguatedMethods) {
             val transport = DataTransport.fromConnectionMethod(

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.kt
@@ -19,6 +19,7 @@ import org.multipaz.mdoc.connectionmethod.ConnectionMethod
 import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.combine
 import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.disambiguate
 import org.multipaz.mdoc.engagement.EngagementGenerator
+import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -130,7 +131,7 @@ class NfcEngagementHelper private constructor(
 
         // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
         // if both BLE modes are available at the same time.
-        val disambiguatedMethods = disambiguate(connectionMethods)
+        val disambiguatedMethods = disambiguate(connectionMethods, MdocTransport.Role.MDOC)
         for (cm in disambiguatedMethods) {
             val transport = fromConnectionMethod(
                 context, cm, DataTransport.Role.MDOC, options
@@ -612,7 +613,7 @@ class NfcEngagementHelper private constructor(
             negotiatedHandoverState = NEGOTIATED_HANDOVER_STATE_NOT_STARTED
             return NfcUtil.STATUS_WORD_WRONG_PARAMETERS
         }
-        val disambiguatedCms = disambiguate(parsedCms)
+        val disambiguatedCms = disambiguate(parsedCms, MdocTransport.Role.MDOC)
         for (cm in disambiguatedCms) {
             Logger.d(TAG, "Have connectionMethod: $cm")
         }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
@@ -15,6 +15,7 @@ import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.ConnectionMethod
 import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.disambiguate
 import org.multipaz.mdoc.engagement.EngagementGenerator
+import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.util.Logger
 import java.util.concurrent.Executor
 
@@ -78,7 +79,7 @@ class QrEngagementHelper internal constructor(
         if (connectionMethods != null) {
             // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
             // if both BLE modes are available at the same time.
-            val disambiguatedMethods = disambiguate(connectionMethods)
+            val disambiguatedMethods = disambiguate(connectionMethods, MdocTransport.Role.MDOC)
             for (cm in disambiguatedMethods) {
                 val transport = fromConnectionMethod(
                     context, cm, DataTransport.Role.MDOC, options

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBle.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBle.kt
@@ -18,6 +18,7 @@ package com.android.identity.android.mdoc.transport
 import android.content.Context
 import android.nfc.NdefRecord
 import android.util.Pair
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.mdoc.connectionmethod.ConnectionMethod
 import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
 import org.multipaz.util.Logger
@@ -154,7 +155,7 @@ abstract class DataTransportBle(
                 if (centralClient) uuid else null
             )
             cm.peripheralServerModePsm = psm
-            cm.peripheralServerModeMacAddress = macAddress
+            cm.peripheralServerModeMacAddress = macAddress?.let { ByteString(it) }
             return cm
         }
 
@@ -259,7 +260,7 @@ abstract class DataTransportBle(
                 baos.write(0x07)
                 baos.write(0x1b) // MAC address
                 try {
-                    baos.write(macAddress)
+                    baos.write(macAddress.toByteArray())
                 } catch (e: IOException) {
                     throw IllegalStateException(e)
                 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
@@ -208,7 +208,7 @@ class DataTransportBleCentralClientMode(
         val macAddress = connectionMethod.peripheralServerModeMacAddress
         if (macAddress != null) {
             Logger.i(TAG, "MAC address provided, no scanning needed")
-            val device = bluetoothAdapter.getRemoteDevice(macAddress)
+            val device = bluetoothAdapter.getRemoteDevice(macAddress.toByteArray())
             connectToDevice(device)
             return
         }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
@@ -301,7 +301,7 @@ class DataTransportBlePeripheralServerMode(
         val macAddress = connectionMethod.peripheralServerModeMacAddress
         if (macAddress != null) {
             Logger.i(TAG, "MAC address provided, no scanning needed")
-            val device = bluetoothAdapter.getRemoteDevice(macAddress)
+            val device = bluetoothAdapter.getRemoteDevice(macAddress.toByteArray())
             connectToDevice(device)
             return
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
@@ -233,7 +233,10 @@ class MdocNfcEngagementHelper(
         if (availableConnectionMethods.isEmpty()) {
             throw Error("No supported connection methods found in Handover Request method")
         }
-        val disambiguatedConnectionMethods = ConnectionMethod.disambiguate(availableConnectionMethods)
+        val disambiguatedConnectionMethods = ConnectionMethod.disambiguate(
+            availableConnectionMethods,
+            MdocTransport.Role.MDOC
+        )
 
         val selectedMethod = negotiatedHandoverPicker!!(disambiguatedConnectionMethods)
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
@@ -91,9 +91,12 @@ suspend fun mdocReaderNfcHandover(
             add(initialNdefMessage.encode()) // Handover Select message
             add(Simple.NULL)                 // Handover Request message
         }
-
+        val disambiguatedConnectionMethods = ConnectionMethod.disambiguate(
+            connectionMethods,
+            MdocTransport.Role.MDOC_READER
+        )
         return MdocReaderNfcHandoverResult(
-            connectionMethods = ConnectionMethod.disambiguate(connectionMethods),
+            connectionMethods = disambiguatedConnectionMethods,
             encodedDeviceEngagement = ByteString(encodedDeviceEngagement),
             handover = handover,
         )
@@ -144,7 +147,10 @@ suspend fun mdocReaderNfcHandover(
     }
 
     return MdocReaderNfcHandoverResult(
-        connectionMethods = ConnectionMethod.disambiguate(connectionMethods),
+        connectionMethods = ConnectionMethod.disambiguate(
+            connectionMethods,
+            MdocTransport.Role.MDOC_READER
+        ),
         encodedDeviceEngagement = ByteString(encodedDeviceEngagement),
         handover = handover,
     )

--- a/samples/simple-verifier/build.gradle.kts
+++ b/samples/simple-verifier/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(project(":multipaz-android-legacy"))
 
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.io.core)
 
     implementation(compose.runtime)
     implementation(compose.foundation)
@@ -78,7 +79,6 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.code.scanner)
     implementation(libs.androidx.material)
-
     implementation(libs.bouncy.castle.bcprov)
 
     testImplementation(libs.kotlin.test)

--- a/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
+++ b/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
@@ -92,6 +92,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.multipaz.mdoc.transport.MdocTransport
 import java.security.Security
 
 class MdocReaderPrompt(
@@ -157,7 +158,10 @@ class MdocReaderPrompt(
                 Logger.d("Listener", "device engagement received")
                 navController.navigate("ReaderReady/Connecting")
                 vibrator.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK))
-                val availableMdocConnectionMethods = ConnectionMethod.disambiguate(connectionMethods)
+                val availableMdocConnectionMethods = ConnectionMethod.disambiguate(
+                    connectionMethods,
+                    MdocTransport.Role.MDOC_READER
+                )
                 if (availableMdocConnectionMethods.isNotEmpty()) {
                     this@MdocReaderPrompt.mdocConnectionMethod = availableMdocConnectionMethods.first()
                 }

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
@@ -195,6 +195,9 @@ class NdefService: HostApduService() {
             }
         }
 
+        // TODO: Listen on methods _before_ starting the engagement helper so we can send the PSM
+        //   for mdoc Peripheral Server mode when using NFC Static Handover.
+        //
         engagement = MdocNfcEngagementHelper(
             eDeviceKey = eDeviceKey.publicKey,
             onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -561,7 +561,10 @@ private suspend fun doReaderFlow(
     val transport = if (existingTransport != null) {
         existingTransport
     } else {
-        val connectionMethods = ConnectionMethod.disambiguate(deviceEngagement.connectionMethods)
+        val connectionMethods = ConnectionMethod.disambiguate(
+            deviceEngagement.connectionMethods,
+            MdocTransport.Role.MDOC_READER
+        )
         val connectionMethod = if (connectionMethods.size == 1) {
             connectionMethods[0]
         } else {


### PR DESCRIPTION
Commit e0d0f98 introduced a bug where when using NFC Negotiated Handover and the mdoc reader is offering mdoc BLE Central Client mode w/ the PSM set (default configuration for our proximity reader in samples/testapp), we weren't using the PSM from the engagement to connect directly.

Concretely this manifested itself in slower BLE connections because it then meant we had to go through the whole GATT dance which the PSM in the engagement was designed to avoid entirely.

The root problem is that when disambiguating the single received ConnectionMethodBle object, the PSM was only set on the instance created for mdoc BLE Peripheral Server mode. The solution to this problem is to add a new `role` parameter to the disambiguate() call and use this to control where to put the PSM.

Write unit tests to carefully test this and also test it in practice. Also tested NFC Static Handover w/ mdoc BLE Peripheral Server mode and noted that we don't currently convey the PSM in this case. This fix is more involved and only applies to samples/testapp so for now just add a TODO so we can revisit later.

Also for ConnectionMethodBle move PSM and MAC address properties into the constructor for easier access. And use ByteString for the MAC address.

Test: New unit tests and all unit tests pass.
Test: Manually tested.
