### PR TITLE
Android Keystore: Remove support for Curve448.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -800,7 +800,6 @@ class AndroidKeystoreSecureArea private constructor(
                 Algorithm.ES384, Algorithm.ESP384, Algorithm.ESB384, Algorithm.ESB320 -> "SHA384withECDSA"
                 Algorithm.ES512, Algorithm.ESP512, Algorithm.ESB512 -> "SHA512withECDSA"
                 Algorithm.ED25519 -> "Ed25519"
-                Algorithm.ED448 -> "Ed448"
                 Algorithm.EDDSA -> "Ed25519"
                 else -> throw IllegalArgumentException(
                     "Unsupported signing algorithm with id $signatureAlgorithm"

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -172,10 +172,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
             for (algorithm in listOf(
                 Algorithm.ESP256,
                 Algorithm.ED25519,
-                Algorithm.ED448,
                 Algorithm.ECDH_P256,
                 Algorithm.ECDH_X25519,
-                Algorithm.ECDH_X448,
             )) {
                 val AUTH_NONE = setOf<UserAuthenticationType>()
                 val AUTH_LSKF_OR_BIOMETRIC = setOf(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
@@ -361,7 +361,8 @@ private suspend fun provisionTestDocuments(
         showToast("Secure Area doesn't support algorithm $deviceKeyAlgorithm for DeviceKey")
         return
     }
-    if (secureArea.supportedAlgorithms.find { it == deviceKeyMacAlgorithm } == null) {
+    if (deviceKeyMacAlgorithm != Algorithm.UNSET &&
+        secureArea.supportedAlgorithms.find { it == deviceKeyMacAlgorithm } == null) {
         showToast("Secure Area doesn't support algorithm $deviceKeyMacAlgorithm for DeviceKey for MAC")
         return
     }


### PR DESCRIPTION
Remove support for Ed448 and X448 in AndroidKeystoreSecureArea since it's not supported, only Ed25519 and X25119 is, conditionally. Also fix a bug so choosing UNSET for DeviceKey MAC Algorithm in DocumentStoreScreen actually works.

Test: Manually tested.
