### PR TITLE
Add a way to check for app updates.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,24 @@ val projectVersionCode: Int by extra {
     stdout.toString().trim().toInt()
 }
 
-// For versionName, we use the output of: git describe --tags --dirty
+// For versionName, we use the output of: 'git describe --tags --dirty' and replace
+// all but the first '-' with a '.' character. This ensures our version string is
+// compliant with Semantic Versioning, see https://semver.org/
+//
+// This yields version strings such as
+//
+//  "0.91.0"                     - for the release tagged 0.91.0
+//  "0.91.0-42.g12345678"        - for 42 commits past release 0.91.0
+//  "0.91.0-42.g12345678.dirty"  - for 42 commits past release 0.91.0 with local modifications
+//
 val projectVersionName: String by extra {
     val stdout = ByteArrayOutputStream()
     rootProject.exec {
-        commandLine("git", "describe", "--tags", "--dirty")
+        commandLine(
+            "bash",
+            "-c",
+            "git describe --tags --dirty | sed 's/-/@temp_dash@/1; s/-/./g; s/@temp_dash@/-/g'"
+        )
         standardOutput = stdout
     }
     @Suppress("DEPRECATION") // toString() is deprecated.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidx-credentials = "1.5.0-rc01"
 androidx-credentials-registry-provider = "1.0.0-alpha01"
 errorprone = "2.38.0"
 mlkit-barcode-scanning = "17.3.0"
+semver = "3.0.0"
 
 [libraries]
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "uiToolingPreview" }
@@ -146,6 +147,7 @@ androidx-credentials = { module = "androidx.credentials:credentials", version.re
 androidx-credentials-registry-provider = { module = "androidx.credentials.registry:registry-provider", version.ref = "androidx-credentials-registry-provider" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref="errorprone"}
 mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref="mlkit-barcode-scanning"}
+semver = { module = "io.github.z4kn4fein:semver", version.ref="semver" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -17,6 +17,8 @@ val projectVersionName: String by rootProject.extra
 buildConfig {
     packageName("org.multipaz.testapp")
     buildConfigField("VERSION", projectVersionName)
+    buildConfigField("TEST_APP_UPDATE_URL", System.getenv("TEST_APP_UPDATE_URL") ?: "")
+    buildConfigField("TEST_APP_UPDATE_WEBSITE_URL", System.getenv("TEST_APP_UPDATE_WEBSITE_URL") ?: "")
     useKotlinOutput { internalVisibility = false }
 }
 
@@ -92,6 +94,7 @@ kotlin {
                 implementation(libs.jetbrains.lifecycle.viewmodel.compose)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.network)
+                implementation(libs.semver)
 
                 implementation(project(":multipaz"))
                 implementation(project(":multipaz-models"))

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AppUpdateCard.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AppUpdateCard.kt
@@ -1,0 +1,77 @@
+package com.android.identity.testapp.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import io.github.z4kn4fein.semver.Version
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import org.multipaz.compose.cards.InfoCard
+import org.multipaz.testapp.BuildConfig
+import org.multipaz.testapp.platformHttpClientEngineFactory
+import org.multipaz.util.Logger
+
+private const val TAG = "AppUpdateCard"
+
+@Composable
+fun AppUpdateCard() {
+    if (BuildConfig.TEST_APP_UPDATE_URL.isEmpty()) {
+        return
+    }
+
+    val latestVersionString = remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(true) {
+        val httpClient = HttpClient(platformHttpClientEngineFactory().create())
+        val response = httpClient.get(BuildConfig.TEST_APP_UPDATE_URL)
+        if (response.status == HttpStatusCode.OK) {
+            latestVersionString.value = response.readBytes().decodeToString().trim()
+            Logger.i(TAG, "Latest available version from ${BuildConfig.TEST_APP_UPDATE_WEBSITE_URL} is ${latestVersionString.value}")
+        }
+    }
+
+
+    latestVersionString.value?.let {
+        val currentVersion = Version.parse(
+            versionString = BuildConfig.VERSION,
+            strict = false
+        )
+        val availableVersion = Version.parse(
+            versionString = it,
+            strict = false
+        )
+        if (currentVersion < availableVersion) {
+            InfoCard {
+                val str = buildAnnotatedString {
+                    append(
+                        "You are running version ${BuildConfig.VERSION} and version " +
+                                "${latestVersionString.value} is the latest available on "
+                    )
+                    withLink(
+                        LinkAnnotation.Url(
+                            BuildConfig.TEST_APP_UPDATE_WEBSITE_URL,
+                            TextLinkStyles(
+                                style = SpanStyle(color = Color.Blue, textDecoration = TextDecoration.Underline),
+                            )
+                        )
+                    ) {
+                        append(BuildConfig.TEST_APP_UPDATE_WEBSITE_URL)
+                    }
+                    append(".")
+                }
+                Text(text = str)
+            }
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.android.identity.testapp.ui.AppUpdateCard
 import org.multipaz.testapp.DocumentModel
 import org.multipaz.testapp.Platform
 import org.multipaz.testapp.platform
@@ -79,6 +80,7 @@ fun StartScreen(
             modifier = Modifier.padding(8.dp)
         ) {
             Column {
+                AppUpdateCard()
                 if (documentModel.documentInfos.isEmpty()) {
                     WarningCard(
                         modifier = Modifier.clickable() {


### PR DESCRIPTION
For APKs we distribute on https://apps.multipaz.org/ do a version check via https://apps.multipaz.org/testapp/LATEST-VERSION.txt and inform the user if a newer version is available. Also include a link to https://apps.multipaz.org/ so the user can easily install the new version.

This is implemented by defining two new BuildConfig variables which is set only by the build-script which builds/signs APKs for apps.multipaz.org.

Test: Manually tested.
