### PR TITLE
Add multiplatform QR code presentment UI

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/QrCodeDisplay.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/QrCodeDisplay.kt
@@ -1,0 +1,48 @@
+package org.multipaz.compose.qrcode
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.util.toBase64Url
+
+@Composable
+fun QrCodeDisplay(
+    deviceEngagement: MutableState<ByteString?>,
+    onCancel: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        deviceEngagement.value?.let { engagement ->
+            val qrCodeBitmap = remember(engagement) {
+                val mdocUrl = "mdoc:" + engagement.toByteArray().toBase64Url()
+                generateQrCode(mdocUrl)
+            }
+            Text(text = "Present QR code to mdoc reader")
+            Image(
+                modifier = Modifier.fillMaxWidth(),
+                bitmap = qrCodeBitmap,
+                contentDescription = "Device engagement QR code",
+                contentScale = ContentScale.FillWidth
+            )
+            Button(onClick = onCancel) {
+                Text("Cancel")
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/startQrPresentment.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/startQrPresentment.kt
@@ -1,0 +1,75 @@
+package org.multipaz.compose.qrcode
+
+import androidx.compose.runtime.MutableState
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Simple
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.engagement.EngagementGenerator
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.transport.MdocTransportFactory
+import org.multipaz.mdoc.transport.MdocTransportOptions
+import org.multipaz.mdoc.transport.advertise
+import org.multipaz.mdoc.transport.waitForConnection
+import org.multipaz.models.presentment.MdocPresentmentMechanism
+import org.multipaz.models.presentment.PresentmentModel
+import org.multipaz.util.UUID
+import kotlin.coroutines.cancellation.CancellationException
+
+fun startQrPresentment(
+    presentmentModel: PresentmentModel,
+    deviceEngagement: MutableState<ByteString?>
+) {
+    presentmentModel.reset()
+    presentmentModel.setConnecting()
+    presentmentModel.presentmentScope.launch {
+        try {
+            val connectionMethods = listOf(
+                MdocConnectionMethodBle(
+                    supportsPeripheralServerMode = false,
+                    supportsCentralClientMode = true,
+                    peripheralServerModeUuid = null,
+                    centralClientModeUuid = UUID.randomUUID(),
+                )
+            )
+            val eDeviceKey = Crypto.createEcPrivateKey(EcCurve.P256)
+            val advertisedTransports = connectionMethods.advertise(
+                role = MdocRole.MDOC,
+                transportFactory = MdocTransportFactory.Default,
+                options = MdocTransportOptions(bleUseL2CAP = true),
+            )
+            val engagementGenerator = EngagementGenerator(
+                eSenderKey = eDeviceKey.publicKey,
+                version = EngagementGenerator.ENGAGEMENT_VERSION_1_0
+            )
+            engagementGenerator.addConnectionMethods(advertisedTransports.map {
+                it.connectionMethod
+            })
+            val encodedDeviceEngagement = ByteString(engagementGenerator.generate())
+            deviceEngagement.value = encodedDeviceEngagement
+            val transport = advertisedTransports.waitForConnection(
+                eSenderKey = eDeviceKey.publicKey,
+                coroutineScope = presentmentModel.presentmentScope
+            )
+            presentmentModel.setMechanism(
+                MdocPresentmentMechanism(
+                    transport = transport,
+                    eDeviceKey = eDeviceKey,
+                    encodedDeviceEngagement = encodedDeviceEngagement,
+                    handover = Simple.NULL,
+                    engagementDuration = null,
+                    allowMultipleRequests = false
+                )
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            presentmentModel.setCompleted(e)
+        } finally {
+            // to ensure the QR code is hidden even on error or cancellation.
+            deviceEngagement.value = null
+        }
+    }
+}


### PR DESCRIPTION
Adds reusable QrCodeDisplay Composable and startQrPresentment in commonMain for use across Android and iOS.

Fixes MpzCmpWallet Composable boilerplate code used to render QR code. 

Changes in MpzCmpWallet to be submitted in a separate PR in that repo.

CC - @VishnuSanal 

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [N/A] Appropriate changes to README are included in PR