### PR TITLE
QrCodeScanner: Fix problem with onCodeScanned() being called multiple times.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.android.kt
@@ -22,7 +22,7 @@ actual fun QrCodeScanner(
     showCameraPreview: Boolean,
     onCodeScanned: (qrCode: String?) -> Unit
 ) {
-    var lastResult by remember { mutableStateOf<String?>(null) }
+    var lastCodeScanned by remember { mutableStateOf<String?>(null) }
     Camera(
         modifier = modifier,
         cameraSelection = cameraSelection,
@@ -50,14 +50,16 @@ actual fun QrCodeScanner(
             val bitmap = BinaryBitmap(HybridBinarizer(source));
             try {
                 val result = MultiFormatReader().decode(bitmap)
-                onCodeScanned(result.text)
-                lastResult = result.text
+                if (result.text != lastCodeScanned) {
+                    onCodeScanned(result.text)
+                    lastCodeScanned = result.text
+                }
             } catch (_ : Throwable) {
                 // QR code not found in this frame
-                if (lastResult != null) {
+                if (lastCodeScanned != null) {
                     onCodeScanned(null)
+                    lastCodeScanned = null
                 }
-                lastResult = null
             }
         }
     )

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.kt
@@ -11,6 +11,11 @@ import org.multipaz.compose.camera.CameraSelection
  * On iOS this is implemented using the platform Vision API and on Android it's using the
  * [ZXing](https://github.com/zxing/zxing) library.
  *
+ * This provides the guarantee that [onCodeScanned] will never be called with `null` multiple
+ * times in a row and will never be called with the same QR Code multiple times in a row. However
+ * do note that in some situations the underlying QR code scanner might flicker so [onCodeScanned]
+ * will be called with the QR code, then `null`, the QR code, then `null`, many times in a row.
+ *
  * This requires camera permission, see [org.multipaz.compose.permissions.rememberCameraPermissionState].
  *
  * @param modifier The composition modifier to apply to the composable.
@@ -19,7 +24,7 @@ import org.multipaz.compose.camera.CameraSelection
  * @param showCameraPreview Whether to show the preview of the captured frame within the composable.
  * @param onCodeScanned a callback which will be called when a QR code has been detected (in which
  *   case the contents are passed) and when a QR code is no longer detected (in which case `null`
- *   is passed). Will never be called with `null` multiple times in a row.
+ *   is passed).
  */
 @Composable
 expect fun QrCodeScanner(

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/Camera.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/Camera.ios.kt
@@ -445,6 +445,7 @@ private class CameraManager(
         GC.collect()
     }
 
+    var lastCodeScanned: String? = null
     override fun captureOutput(
         output: AVCaptureOutput,
         didOutputMetadataObjects: List<*>,
@@ -454,11 +455,17 @@ private class CameraManager(
             return
         }
         if (didOutputMetadataObjects.isEmpty()) {
-            onQrCodeScanned?.let { it(null) }
+            if (lastCodeScanned != null) {
+                onQrCodeScanned(null)
+                lastCodeScanned = null
+            }
         } else {
             val metadataObj = didOutputMetadataObjects[0] as AVMetadataMachineReadableCodeObject
             if (metadataObj.type == AVMetadataObjectTypeQRCode) {
-                onQrCodeScanned?.let { it(metadataObj.stringValue) }
+                if (lastCodeScanned != metadataObj.stringValue) {
+                    onQrCodeScanned(metadataObj.stringValue)
+                    lastCodeScanned = metadataObj.stringValue
+                }
             }
 
         }


### PR DESCRIPTION
This problem manifested itself in the _ISO mdoc Proximity Reading_ screen insofar that `doReaderFlow()` occasionally would be invoked multiple times leading to the wrong SessionTranscript to be used because a new ephemeral reader key was generated. This resulted in a "Device Authentication failed" warning when showing the result.

This problem was introduced in Commit fe28caf where we changed the QR code scanning library on Android to be ZXing.

Test: Manually tested and observed "Device Authentication failed" no longer is shown.
