### PR TITLE
feat(manifest): add custom URI scheme support in AndroidManifest.xml

### DIFF
--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -86,6 +86,14 @@
                 <data android:host="*"/>
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Custom URI scheme -->
+                <data android:scheme="multipaz-test-app"/>
+                <data android:host="landing"/>
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
feat(manifest): add custom URI scheme support in AndroidManifest.xml

(Depeends on discussion, we can add the code to handle custom urls logic in manifest, https://discord.com/channels/1022962884864643214/1179828955717574707/1390556276307787847   ,https://discord.com/channels/1022962884864643214/1179828955717574707/1389853010682974279 )


- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR