### PR TITLE
multipaz-android-legacy: Add API needed to migrate to DocumentStore.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
@@ -60,6 +60,7 @@ import javax.crypto.SecretKey;
 import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import kotlin.Pair;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -321,6 +322,12 @@ public class DynamicAuthTest {
             assertTrue(false);
         }
         */
+
+        // Check we can get the authentication keys and associated auth data...
+        List<Pair<String, byte[]>> listOfAuthKeys = ((KeystoreIdentityCredential) credential).getAuthenticationKeys();
+        assertEquals(2, listOfAuthKeys.size());
+        assertArrayEquals(new byte[] {42, 43, 44}, listOfAuthKeys.get(0).getSecond());
+        assertArrayEquals(new byte[] {43, 44, 45}, listOfAuthKeys.get(1).getSecond());
 
         // Now use one of the keys...
         entriesToRequest = new LinkedHashMap<>();

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
@@ -1624,6 +1624,17 @@ class CredentialData {
         return checkUserAuthenticationTimeout(acpAlias);
     }
 
+    @NonNull
+    List<kotlin.Pair<String, byte[]>> getAuthenticationKeys() {
+        ArrayList<kotlin.Pair<String, byte[]>> ret = new ArrayList<>();
+        for (AuthKeyData data : mAuthKeyDatas) {
+            if (!data.mAlias.isEmpty()) {
+                ret.add(new kotlin.Pair<>(data.mAlias, data.mStaticAuthenticationData));
+            }
+        }
+        return ret;
+    }
+
     // Note that a dynamic authentication key may have two Android Keystore keys associated with
     // it.. the obvious one is for a previously certificated key. This key may possibly have an
     // use-count which is already exhausted. The other one is for a key yet pending certification.
@@ -1632,7 +1643,7 @@ class CredentialData {
     // That is, it's better to use a key with an exhausted use-count (slightly bad for user privacy
     // in terms of linkability between multiple presentations) than the user not being able to
     // present their credential at all...
-    private static class AuthKeyData {
+    static class AuthKeyData {
         // The mAlias for the key in Android Keystore. Is set to the empty string if the key has not
         // yet been created. This is set to the empty string if no key has been certified.
         String mAlias = "";

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
@@ -75,7 +75,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.UnicodeString;
 
-class KeystoreIdentityCredential extends IdentityCredential {
+public class KeystoreIdentityCredential extends IdentityCredential {
 
     private static final String TAG = "KSIdentityCredential"; // limit to <= 23 chars
     private final KeystorePresentationSession mPresentationSession;
@@ -851,6 +851,18 @@ class KeystoreIdentityCredential extends IdentityCredential {
             throw new IllegalStateException("Error loading data");
         }
         return mData.getCredentialKeyAlias();
+    }
+
+    /**
+     * Gets a list of certified authentication keys.
+     *
+     * @return the certified authentication keys aliases and associated issuer-provided data.
+     */
+    public @NonNull List<kotlin.Pair<String, byte[]>> getAuthenticationKeys() {
+        if (!loadData()) {
+            throw new IllegalStateException("Error loading data");
+        }
+        return mData.getAuthenticationKeys();
     }
 
     @Override

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -26,6 +26,7 @@ import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
 import org.multipaz.util.Logger
@@ -96,6 +97,17 @@ class MdocCredential : SecureAreaBoundCredential {
             return Pair(credentials, batchResult.openid4vciKeyAttestationJws)
         }
 
+        /**
+         * Create a [KeyBoundSdJwtVcCredential].
+         *
+         * @param document The document to add the credential to.
+         * @param asReplacementForIdentifier the identifier for the [Credential] this will replace when certified.
+         * @param domain The domain for the credential.
+         * @param secureArea The [SecureArea] to use for creating a key.
+         * @param docType The docType for the credential.
+         * @param createKeySettings The settings to use for key creation, including algorithm parameters.
+         * @return an uncertified [Credential] which has been added to [document].
+         */
         suspend fun create(
             document: Document,
             asReplacementForIdentifier: String?,
@@ -112,6 +124,36 @@ class MdocCredential : SecureAreaBoundCredential {
                 docType
             ).apply {
                 generateKey(createKeySettings)
+            }
+        }
+
+        /**
+         * Create a [MdocCredential] using a key that already exists.
+         *
+         * @param document The document to add the credential to.
+         * @param asReplacementForIdentifier the identifier for the [Credential] this will replace when certified.
+         * @param domain The domain for the credential.
+         * @param secureArea The [SecureArea] to use for creating a key.
+         * @param docType The docType for the credential.
+         * @param existingKeyAlias the alias for the existing key in [secureArea].
+         * @return an uncertified [Credential] which has been added to [document].
+         */
+        suspend fun createForExistingAlias(
+            document: Document,
+            asReplacementForIdentifier: String?,
+            domain: String,
+            secureArea: SecureArea,
+            docType: String,
+            existingKeyAlias: String,
+        ): MdocCredential {
+            return MdocCredential(
+                document,
+                asReplacementForIdentifier,
+                domain,
+                secureArea,
+                docType
+            ).apply {
+                useExistingKey(keyAlias = existingKeyAlias)
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
@@ -1,6 +1,5 @@
 package org.multipaz.sdjwt.credential
 
-import kotlinx.serialization.json.JsonObject
 import org.multipaz.cbor.CborBuilder
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.MapBuilder
@@ -67,6 +66,17 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
             return Pair(credentials, batchResult.openid4vciKeyAttestationJws)
         }
 
+        /**
+         * Create a [KeyBoundSdJwtVcCredential].
+         *
+         * @param document The document to add the credential to.
+         * @param asReplacementForIdentifier the identifier for the [Credential] this will replace when certified.
+         * @param domain The domain for the credential.
+         * @param secureArea The [SecureArea] to use for creating a key.
+         * @param vct The Verifiable Credential Type for the credential.
+         * @param createKeySettings The settings to use for key creation, including algorithm parameters.
+         * @return an uncertified [Credential] which has been added to [document].
+         */
         suspend fun create(
             document: Document,
             asReplacementForIdentifier: String?,
@@ -83,6 +93,36 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
                 vct
             ).apply {
                 generateKey(createKeySettings)
+            }
+        }
+
+        /**
+         * Create a [KeyBoundSdJwtVcCredential] using a key that already exists.
+         *
+         * @param document The document to add the credential to.
+         * @param asReplacementForIdentifier the identifier for the [Credential] this will replace when certified.
+         * @param domain The domain for the credential.
+         * @param secureArea The [SecureArea] to use for creating a key.
+         * @param vct The Verifiable Credential Type for the credential.
+         * @param existingKeyAlias the alias for the existing key in [secureArea].
+         * @return an uncertified [Credential] which has been added to [document].
+         */
+        suspend fun createForExistingAlias(
+            document: Document,
+            asReplacementForIdentifier: String?,
+            domain: String,
+            secureArea: SecureArea,
+            vct: String,
+            existingKeyAlias: String,
+        ): KeyBoundSdJwtVcCredential {
+            return KeyBoundSdJwtVcCredential(
+                document,
+                asReplacementForIdentifier,
+                domain,
+                secureArea,
+                vct
+            ).apply {
+                useExistingKey(keyAlias = existingKeyAlias)
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
@@ -7,6 +7,7 @@ import org.multipaz.claim.JsonClaim
 import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.securearea.SecureArea
 
 class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
     override lateinit var vct: String
@@ -57,6 +58,15 @@ class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
     companion object {
         const val CREDENTIAL_TYPE: String = "KeylessSdJwtVcCredential"
 
+        /**
+         * Create a [KeyBoundSdJwtVcCredential].
+         *
+         * @param document The document to add the credential to.
+         * @param asReplacementForIdentifier the identifier for the [Credential] this will replace when certified.
+         * @param domain The domain for the credential.
+         * @param vct The Verifiable Credential Type for the credential.
+         * @return an uncertified [Credential] which has been added to [document].
+         */
         suspend fun create(
             document: Document,
             asReplacementForIdentifier: String?,


### PR DESCRIPTION
This is needed for an existing Wallet app to migrate to DocumentStore from IdentityCredentialStore without losing authentication keys. This includes the ability to create a credential using an existing key in e.g. Android Keystore.

Test: New unit tests.
