### PR TITLE
Make everything but identifier optional for Google Account extension.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/certext/GoogleAccount.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/certext/GoogleAccount.kt
@@ -14,9 +14,9 @@ import org.multipaz.cbor.annotation.CborSerializable
  * ```
  * GoogleAccount = {
  *   "id": tstr,
- *   "emailAddress": tstr,
- *   "displayName": tstr,
- *   "profilePictureUri": tstr
+ *   ? "emailAddress": tstr,
+ *   ? "displayName": tstr,
+ *   ? "profilePictureUri": tstr
  * }
  * ```
  *
@@ -31,12 +31,12 @@ import org.multipaz.cbor.annotation.CborSerializable
  * @property displayName the user's name.
  * @property profilePictureUri an URI pointing to the profile picture for the user.
  */
-@CborSerializable(schemaHash = "E_Tpe6LHdAdxIOEetMiXdBodgOv1qiEHLKgkso12Aag")
+@CborSerializable(schemaHash = "7VrvNoArF_EU_LofYHBhcQnVb1kTsWs2zV22kx_K6Rc")
 data class GoogleAccount(
     val id: String,
-    val emailAddress: String,
-    val displayName: String,
-    val profilePictureUri: String
+    val emailAddress: String?,
+    val displayName: String?,
+    val profilePictureUri: String?
 ) {
     companion object
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -230,14 +230,16 @@ class App private constructor (val promptModel: PromptModel) {
             requester.certChain!!.certificates.last().ecPublicKey == MULTIPAZ_IDENTITY_READER_CERT_PUBLIC_KEY
         ) {
             val readerCert = requester.certChain!!.certificates.first()
-            readerCert.getExtensionValue(OID.X509_EXTENSION_MULTIPAZ_EXTENSION.oid)?.let {
-                MultipazExtension.fromCbor(it).googleAccount?.let {
-                    return TrustMetadata(
-                        displayName = it.emailAddress,
-                        displayIconUrl = it.profilePictureUri,
-                        disclaimer = "The email and picture shown are from the requester's Google Account. " +
-                                "This information has been verified but may not be their real identity"
-                    )
+            readerCert.getExtensionValue(OID.X509_EXTENSION_MULTIPAZ_EXTENSION.oid)?.let { extData ->
+                MultipazExtension.fromCbor(extData).googleAccount?.let { googleAccount ->
+                    if (googleAccount.emailAddress != null && googleAccount.profilePictureUri != null) {
+                        return TrustMetadata(
+                            displayName = googleAccount.emailAddress,
+                            displayIconUrl = googleAccount.profilePictureUri,
+                            disclaimer = "The email and picture shown are from the requester's Google Account. " +
+                                    "This information has been verified but may not be their real identity"
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Test: Manually tested.
