### PR TITLE
multipaz-android-legacy: Make some legacy API public.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
@@ -37,23 +37,23 @@ public class AccessControlProfile {
     }
 
     @NonNull
-    AccessControlProfileId getAccessControlProfileId() {
+    public AccessControlProfileId getAccessControlProfileId() {
         return mAccessControlProfileId;
     }
 
     /**
      * Returns the authentication timeout, in milliseconds.
      */
-    long getUserAuthenticationTimeout() {
+    public long getUserAuthenticationTimeout() {
         return mUserAuthenticationTimeoutMillis;
     }
 
-    boolean isUserAuthenticationRequired() {
+    public boolean isUserAuthenticationRequired() {
         return mUserAuthenticationRequired;
     }
 
     @Nullable
-    X509Certificate getReaderCertificate() {
+    public X509Certificate getReaderCertificate() {
         return mReaderCertificate;
     }
 

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
@@ -49,23 +49,23 @@ public class PersonalizationData {
 
     @NonNull LinkedHashMap<String, NamespaceData> mNamespaces = new LinkedHashMap<>();
 
-    Collection<AccessControlProfile> getAccessControlProfiles() {
+    public Collection<AccessControlProfile> getAccessControlProfiles() {
         return Collections.unmodifiableCollection(mProfiles);
     }
 
-    Collection<String> getNamespaces() {
+    public Collection<String> getNamespaces() {
         return Collections.unmodifiableCollection(mNamespaces.keySet());
     }
 
-    Collection<NamespaceData> getNamespaceDatas() {
+    public Collection<NamespaceData> getNamespaceDatas() {
         return Collections.unmodifiableCollection(mNamespaces.values());
     }
 
-    NamespaceData getNamespaceData(String namespace) {
+    public NamespaceData getNamespaceData(String namespace) {
         return mNamespaces.get(namespace);
     }
 
-    static class NamespaceData {
+    public static class NamespaceData {
 
         @NonNull protected String mNamespace;
         @NonNull protected LinkedHashMap<String, EntryData> mEntries = new LinkedHashMap<>();
@@ -74,15 +74,15 @@ public class PersonalizationData {
             this.mNamespace = namespace;
         }
 
-        String getNamespaceName() {
+        public String getNamespaceName() {
             return mNamespace;
         }
 
-        Collection<String> getEntryNames() {
+        public Collection<String> getEntryNames() {
             return Collections.unmodifiableCollection(mEntries.keySet());
         }
 
-        Collection<AccessControlProfileId> getAccessControlProfileIds(String name) {
+        public Collection<AccessControlProfileId> getAccessControlProfileIds(String name) {
             EntryData value = mEntries.get(name);
             if (value != null) {
                 return value.mAccessControlProfileIds;
@@ -90,7 +90,7 @@ public class PersonalizationData {
             return null;
         }
 
-        byte[] getEntryValue(String name) {
+        public byte[] getEntryValue(String name) {
             EntryData value = mEntries.get(name);
             if (value != null) {
                 return value.mValue;

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentUtilTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentUtilTest.kt
@@ -17,7 +17,6 @@ package org.multipaz.document
 
 import kotlinx.coroutines.runBlocking
 import org.multipaz.claim.Claim
-import org.multipaz.credential.CredentialLoader
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.securearea.CreateKeySettings
@@ -28,11 +27,11 @@ import org.multipaz.storage.Storage
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import kotlinx.coroutines.test.runTest
 import kotlin.time.Instant;
-import org.multipaz.document.DocumentStoreTest.TestSecureAreaBoundCredential
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
 
 class DocumentUtilTest {
     private lateinit var storage: Storage
@@ -64,7 +63,7 @@ class DocumentUtilTest {
         val authKeySettings = CreateKeySettings()
         val numCreds = 10
         val maxUsesPerCred = 5
-        val minValidTimeMillis = 10L
+        val minValidTime = 10.milliseconds
         var numCredsCreated: Int
         val managedCredDomain = "managedCredentials"
 
@@ -85,7 +84,7 @@ class DocumentUtilTest {
             Instant.fromEpochMilliseconds(100),
             numCreds,
             maxUsesPerCred,
-            minValidTimeMillis,
+            minValidTime,
             false
         )
         assertEquals(numCreds.toLong(), numCredsCreated.toLong())
@@ -121,7 +120,7 @@ class DocumentUtilTest {
             Instant.fromEpochMilliseconds(100),
             numCreds,
             maxUsesPerCred,
-            minValidTimeMillis,
+            minValidTime,
             false
         )
         assertEquals(0, numCredsCreated.toLong())
@@ -148,7 +147,7 @@ class DocumentUtilTest {
             Instant.fromEpochMilliseconds(100),
             numCreds,
             maxUsesPerCred,
-            minValidTimeMillis,
+            minValidTime,
             false
         )
         assertEquals(0, numCredsCreated.toLong())
@@ -178,7 +177,7 @@ class DocumentUtilTest {
             Instant.fromEpochMilliseconds(100),
             numCreds,
             maxUsesPerCred,
-            minValidTimeMillis,
+            minValidTime,
             false
         )
         assertEquals(5, numCredsCreated.toLong())
@@ -233,7 +232,7 @@ class DocumentUtilTest {
             Instant.fromEpochMilliseconds(195),
             numCreds,
             maxUsesPerCred,
-            minValidTimeMillis,
+            minValidTime,
             false
         )
         assertEquals(5, numCredsCreated.toLong())


### PR DESCRIPTION
This is required to migrate from IdentityCredentialStore to DocumentStore and preserving data in the process.

Also ensure we never return a negative number from `DocumentUtil.managedCredentialHelper()`.

Test: Manually tested.
