### PR TITLE
AndroidKeystore: Improve support for Attest Keys.

### DIFF
--- a/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
+++ b/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
@@ -824,7 +824,7 @@ class CborSymbolProcessor(
             }
             if (typeInfo.specifiedHash != null && computedHash != typeInfo.specifiedHash) {
                 val encoded = computedHash.toBase64Url()
-                logger.error("Schema change detected, new schemaHash = \"${encoded}\"", declaration)
+                logger.error("Schema change detected for $className, new schemaHash = \"${encoded}\"", declaration)
             }
             schemaIds[declaration] = typeInfo.specifiedId ?: computedHash
         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreCreateKeySettings.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreCreateKeySettings.kt
@@ -150,6 +150,10 @@ class AndroidKeystoreCreateKeySettings private constructor(
          * [setAttestKeyAlias() method](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setAttestKeyAlias(java.lang.String))
          * for more information about attest keys.
          *
+         * When an attest key is used, the certificate chain for the created key will include the certificate
+         * for the key as its leaf certificate (signed by the attest key) followed by the attestation for the
+         * attest key.
+         *
          * @param attestKeyAlias the Android Keystore alias of the attest key or `null` to not use an attest key.
          * @return the builder.
          */

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Algorithm.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Algorithm.kt
@@ -217,6 +217,11 @@ enum class Algorithm(
         description = "ECDH using X448 curve without KDF", curve = EcCurve.X448,
         isKeyAgreement = true),
 
+    ANDROID_KEYSTORE_ATTEST_KEY(
+        description = "Android Keystore Attest Key",
+        fullySpecified = true
+    )
+
     ;
 
     companion object {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
@@ -7,7 +7,7 @@ import org.multipaz.crypto.X509CertChain
 // TODO: move this class to Android source tree once annotation processors can work across
 // multiple source trees
 @CborSerializable(
-    schemaHash = "gP0r1c9hn728ckbAetDcK-Os1Jkq349doM2KnOdr710"
+    schemaHash = "GPjoYX7w6oLhI969qgnHFLhrW0HAXtbhu9gacgBibAw"
 )
 internal data class AndroidSecureAreaKeyMetadata(
     val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
@@ -8,7 +8,7 @@ import org.multipaz.crypto.EcPublicKey
 // TODO: move this class to iOS source tree once annotation processors can work across
 // multiple source trees
 @CborSerializable(
-    schemaHash = "okPebBsfGHrGeeSEzxKcVkUcpqlYMSZKPnciGJNDpTY"
+    schemaHash = "gkdLkv688A8DbRvIxxLKnjofvCHrtsJWuTvRh0ZhGTo"
 )
 internal data class SecureEnclaveAreaKeyMetadata(
     val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -968,7 +968,7 @@ open class CloudSecureArea protected constructor(
     }
 
     @CborSerializable(
-        schemaHash = "05D8znv6joCoUVuDwC6vx-QB2kxFSChce08UfGvdQSg"
+        schemaHash = "1nfI37qZNUhsEDoWxGOOmH3_1Akqb8axdvs_i2PawpU"
     )
     internal data class KeyMetadata(
         val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -309,7 +309,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         return false
     }
 
-    @CborSerializable(schemaHash = "s3fitojNQkNiyyWqszh98yfetQJdp-anpxmfq1wnyCY")
+    @CborSerializable(schemaHash = "uDNIH6LIvDH5IXbAKIX7aVmFeEJwBUZAd7s7prLKBBw")
     internal data class KeyMetadata(
         val algorithm: Algorithm,
         val passphraseRequired: Boolean,


### PR DESCRIPTION
Introduce Algorithm.ANDROID_KEYSTORE_ATTEST_KEY which can be used to create an Android Keystore Attest Key which can be used together with existing AndroidKeystoreCreateKeySettings.setAttestKeyAlias(). This is an improvement as up to now the application would need to use the native Android APIs to create an Attest Key.

Also change KeyInfo.attestation for a key using an attest key. The previous behavior was that the attestation only contained a single certificate and the new behavior is that the attest key's attestation chain is appended at the end. This way the attestation won't have to be special cased and it goes all the way up to the attestation root, like normal keys.

Also add new items in Android Keystore Secure Area screen in testapp for this.

Finally, also change error message in CborSymbolProcessor to reference the class name for schema changes.

Test: Manually tested + unit tests.
