### PR TITLE
Adding new getAuthKeyChainsNeedingCertification method to multipaz legacy. This will be used to generate auth key chains with the full keystore chain attached to them.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/HardwareIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/HardwareIdentityCredential.java
@@ -38,6 +38,8 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Collection;
 
+import java.util.List;
+import java.util.Optional;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -275,6 +277,13 @@ class HardwareIdentityCredential extends IdentityCredential {
 
     @Override
     public @NonNull
+    List<List<X509Certificate>> getAuthKeyChainsNeedingCertification(byte[] challenge) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+
+    @Override
+    public @NonNull
     Collection<X509Certificate> getAuthKeysNeedingCertification() {
         return mCredential.getAuthKeysNeedingCertification();
     }
@@ -282,12 +291,27 @@ class HardwareIdentityCredential extends IdentityCredential {
     @SuppressWarnings("deprecation")
     @Override
     public void storeStaticAuthenticationData(@NonNull X509Certificate authenticationKey,
-            @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
+        @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
         try {
             mCredential.storeStaticAuthenticationData(authenticationKey, staticAuthData);
         } catch (android.security.identity.UnknownAuthenticationKeyException e) {
             throw new UnknownAuthenticationKeyException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void storeStaticAuthenticationData(@NonNull PublicKey authenticationKey,
+        @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void storeStaticAuthenticationData(
+        @NonNull PublicKey authenticationKey,
+        @NonNull Calendar expirationDate,
+        @NonNull byte[] staticAuthData)
+        throws UnknownAuthenticationKeyException {
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
@@ -735,14 +735,25 @@ public class KeystoreIdentityCredential extends IdentityCredential {
 
     @Override
     public @NonNull
+    List<List<X509Certificate>> getAuthKeyChainsNeedingCertification(byte[] challenge) {
+        return mData.getAuthKeyChainsNeedingCertification(challenge);
+    }
+
+    @Override
+    public @NonNull
     Collection<X509Certificate> getAuthKeysNeedingCertification() {
         return mData.getAuthKeysNeedingCertification();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void storeStaticAuthenticationData(@NonNull X509Certificate authenticationKey,
-            @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
+        @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
+        mData.storeStaticAuthenticationData(authenticationKey, null, staticAuthData);
+    }
+
+    @Override
+    public void storeStaticAuthenticationData(@NonNull PublicKey authenticationKey,
+        @NonNull byte[] staticAuthData) throws UnknownAuthenticationKeyException {
         mData.storeStaticAuthenticationData(authenticationKey, null, staticAuthData);
     }
 
@@ -755,6 +766,14 @@ public class KeystoreIdentityCredential extends IdentityCredential {
         mData.storeStaticAuthenticationData(authenticationKey, expirationDate, staticAuthData);
     }
 
+    @Override
+    public void storeStaticAuthenticationData(
+        @NonNull PublicKey authenticationKey,
+        @NonNull Calendar expirationDate,
+        @NonNull byte[] staticAuthData)
+        throws UnknownAuthenticationKeyException {
+        mData.storeStaticAuthenticationData(authenticationKey, expirationDate, staticAuthData);
+    }
 
     @Override
     public @NonNull


### PR DESCRIPTION


- [x] Tests pass
- [x] Appropriate changes to README are included in PR