### PR TITLE
Utilities to launch coroutines that are bound to the current composab…

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiContext.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiContext.kt
@@ -1,0 +1,22 @@
+package org.multipaz.compose
+
+import android.content.Context
+import java.lang.Exception
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+class UiContext(val context: Context): CoroutineContext.Element {
+    object Key: CoroutineContext.Key<UiContext>
+
+    override val key: CoroutineContext.Key<*>
+        get() = Key
+
+    class NotUiBoundCoroutineError:
+        Exception("Current coroutine was is not Android-Context-bound")
+
+    companion object Companion {
+        suspend fun current(): Context {
+            return coroutineContext[Key]?.context ?: throw NotUiBoundCoroutineError()
+        }
+    }
+}

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
@@ -5,16 +5,22 @@ import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.camera.CameraFrame
 import org.multipaz.context.applicationContext
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
+import kotlin.coroutines.CoroutineContext
 
 private const val TAG = "Util"
 
@@ -103,4 +109,12 @@ actual fun ImageBitmap.cropRotateScaleImage(
         outputHeightPx = outputHeightPx,
         targetWidthPx = targetWidthPx
     ).asImageBitmap()
+}
+
+@Composable
+actual fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext
+): CoroutineScope {
+    val context = LocalContext.current
+    return rememberCoroutineScope { getContext() + UiContext(context) }
 }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
@@ -1,8 +1,13 @@
 package org.multipaz.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.camera.CameraFrame
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 data class ApplicationInfo(
     val name: String,
@@ -135,3 +140,10 @@ expect fun ImageBitmap.cropRotateScaleImage(
     outputHeightPx: Int,
     targetWidthPx: Int
 ): ImageBitmap
+
+@Composable
+expect fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext = {
+        EmptyCoroutineContext
+    }
+): CoroutineScope

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
@@ -1,13 +1,15 @@
 package org.multipaz.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.useContents
-import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
@@ -16,17 +18,16 @@ import org.multipaz.compose.camera.CameraImage
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGBitmapContextCreateImage
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
-import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextRotateCTM
 import platform.CoreGraphics.CGContextScaleCTM
 import platform.CoreGraphics.CGContextTranslateCTM
 import platform.CoreGraphics.CGImageAlphaInfo
-import platform.CoreGraphics.CGImageRef
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIGraphicsImageRenderer
 import platform.UIKit.UIGraphicsImageRendererFormat
 import platform.UIKit.UIImage
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.PI
 
 actual fun getApplicationInfo(appId: String): ApplicationInfo {
@@ -153,3 +154,8 @@ actual fun ImageBitmap.cropRotateScaleImage(
         targetWidthPx = targetWidthPx
     )
 }
+
+@Composable
+actual fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext
+): CoroutineScope = rememberCoroutineScope(getContext)


### PR DESCRIPTION
Utilities to launch coroutines that are bound to the current composable UI

Such coroutine
 - is cancelled when UI to which it is bound goes away
 - has access to the Android Context which owns the UI
