### PR TITLE
Add support for native version of navigator.credentials.get().

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,6 +123,7 @@ androidx-sqlite-bundled = { module="androidx.sqlite:sqlite-bundled", version.ref
 postgresql = { module="org.postgresql:postgresql", version.ref = "postgresql" }
 play-services-identity-credentials = {module = "com.google.android.gms:play-services-identity-credentials", version.ref = "play-services-identity-credentials"}
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref="androidx-credentials" }
+androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref="androidx-credentials" }
 androidx-credentials-registry-provider = { module = "androidx.credentials.registry:registry-provider", version.ref = "androidx-credentials-registry-provider" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref="errorprone"}
 mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref="mlkit-barcode-scanning"}

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
@@ -5,16 +5,23 @@ import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.camera.CameraFrame
+import org.multipaz.context.AndroidUiContext
 import org.multipaz.context.applicationContext
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
+import kotlin.coroutines.CoroutineContext
 
 private const val TAG = "Util"
 
@@ -29,8 +36,11 @@ actual fun getApplicationInfo(appId: String): ApplicationInfo {
 
 actual fun decodeImage(encodedData: ByteArray): ImageBitmap {
     val bitmap = BitmapFactory.decodeByteArray(encodedData, 0, encodedData.size)
-    Logger.e(TAG, "Failed to decode image (${encodedData.size} bytes)")
-    return bitmap?.asImageBitmap() ?: ImageBitmap(1, 1)
+    if (bitmap == null) {
+        Logger.e(TAG, "Failed to decode image (${encodedData.size} bytes)")
+        return ImageBitmap(1, 1)
+    }
+    return bitmap.asImageBitmap()
 }
 
 actual fun encodeImageToPng(image: ImageBitmap): ByteString {
@@ -103,4 +113,12 @@ actual fun ImageBitmap.cropRotateScaleImage(
         outputHeightPx = outputHeightPx,
         targetWidthPx = targetWidthPx
     ).asImageBitmap()
+}
+
+@Composable
+actual fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext
+): CoroutineScope {
+    val context = LocalContext.current
+    return rememberCoroutineScope { getContext() + AndroidUiContext(context) }
 }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
@@ -1,8 +1,13 @@
 package org.multipaz.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.camera.CameraFrame
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 data class ApplicationInfo(
     val name: String,
@@ -135,3 +140,23 @@ expect fun ImageBitmap.cropRotateScaleImage(
     outputHeightPx: Int,
     targetWidthPx: Int
 ): ImageBitmap
+
+/**
+ * Like [androidx.compose.runtime.rememberCoroutineScope] but also makes a platform-specific UI context available in
+ * the coroutine context.
+ *
+ * On Android this makes [org.multipaz.context.UiContext] available in the coroutine-context and
+ * callers can use [org.multipaz.context.UiContext.Companion.current] to get a [android.content.Context]
+ * object for which [android.content.Context.getActivity] will return the Activity the coroutine is bound to.
+ *
+ * On iOS this is equivalent to [androidx.compose.runtime.rememberCoroutineScope].
+ *
+ * @param getContext optional context.
+ * @return the [CoroutineScope].
+ */
+@Composable
+expect fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext = {
+        EmptyCoroutineContext
+    }
+): CoroutineScope

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/CredentialPresentmentModalBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/CredentialPresentmentModalBottomSheet.kt
@@ -434,9 +434,9 @@ private fun ConsentPage(
             iconUrl = metadata.displayIconUrl,
             disclaimer = metadata.disclaimer,
         )
-    } else if (requester.websiteOrigin != null) {
+    } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
         RequesterDisplayData(
-            name = requester.websiteOrigin,
+            name = requester.origin,
         )
     } else if (appInfo != null) {
         RequesterDisplayData(
@@ -578,10 +578,10 @@ private fun CredentialSetViewer(
                     Res.string.credential_presentment_share_with_known_requester,
                     requesterDisplayData.name
                 )
-            } else if (requester.websiteOrigin != null) {
+            } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
                 stringResource(
                     Res.string.credential_presentment_share_with_known_requester,
-                    requester.websiteOrigin!!
+                    requester.origin!!
                 )
             } else if (appInfo != null) {
                 stringResource(
@@ -597,10 +597,10 @@ private fun CredentialSetViewer(
                     Res.string.credential_presentment_share_and_stored_by_known_requester,
                     requesterDisplayData.name
                 )
-            } else if (requester.websiteOrigin != null) {
+            } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
                 stringResource(
                     Res.string.credential_presentment_share_and_stored_by_known_requester,
-                    requester.websiteOrigin!!
+                    requester.origin!!
                 )
             } else if (appInfo != null) {
                 stringResource(
@@ -727,7 +727,7 @@ private fun RelyingPartyTrailer(
     trustPoint: TrustPoint?,
 ) {
     if (trustPoint != null) {
-        var text = if (requester.websiteOrigin != null) {
+        var text = if (requester.origin != null && isWebOrigin(requester.origin!!)) {
             stringResource(Res.string.credential_presentment_info_verifier_in_trust_list_website)
         } else if (requester.appId != null) {
             stringResource(Res.string.credential_presentment_info_verifier_in_trust_list_app)
@@ -757,7 +757,7 @@ private fun RelyingPartyTrailer(
             )
         }
     } else {
-        val text = if (requester.websiteOrigin != null) {
+        val text = if (requester.origin != null && isWebOrigin(requester.origin!!)) {
             stringResource(Res.string.credential_presentment_warning_verifier_not_in_trust_list_website)
         } else if (requester.appId != null) {
             stringResource(Res.string.credential_presentment_warning_verifier_not_in_trust_list_app)
@@ -1054,3 +1054,5 @@ private fun RelyingPartySection(
         Spacer(modifier = Modifier.height(16.dp))
     }
 }
+
+private fun isWebOrigin(origin: String) = origin.startsWith("http://") || origin.startsWith("https://")

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
@@ -1,13 +1,15 @@
 package org.multipaz.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.useContents
-import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.io.bytestring.ByteString
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
@@ -16,17 +18,16 @@ import org.multipaz.compose.camera.CameraImage
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGBitmapContextCreateImage
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
-import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextRotateCTM
 import platform.CoreGraphics.CGContextScaleCTM
 import platform.CoreGraphics.CGContextTranslateCTM
 import platform.CoreGraphics.CGImageAlphaInfo
-import platform.CoreGraphics.CGImageRef
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIGraphicsImageRenderer
 import platform.UIKit.UIGraphicsImageRendererFormat
 import platform.UIKit.UIImage
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.PI
 
 actual fun getApplicationInfo(appId: String): ApplicationInfo {
@@ -153,3 +154,8 @@ actual fun ImageBitmap.cropRotateScaleImage(
         targetWidthPx = targetWidthPx
     )
 }
+
+@Composable
+actual fun rememberUiBoundCoroutineScope(
+    getContext: @DisallowComposableCalls () -> CoroutineContext
+): CoroutineScope = rememberCoroutineScope(getContext)

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
@@ -30,6 +30,8 @@ import kotlinx.datetime.LocalDate
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborMap
 
 /**
  * Object containing the metadata of the Driving License
@@ -150,13 +152,13 @@ object DrivingLicense {
                 buildCborArray {
                     addCborMap {
                         put("vehicle_category_code", "A")
-                        put("issue_date", Tagged(1004, Tstr("2018-08-09")))
-                        put("expiry_date", Tagged(1004, Tstr("2028-09-01")))
+                        put("issue_date", Tagged(Tagged.FULL_DATE_STRING, Tstr("2018-08-09")))
+                        put("expiry_date", Tagged(Tagged.FULL_DATE_STRING, Tstr("2028-09-01")))
                     }
                     addCborMap {
                         put("vehicle_category_code", "B")
-                        put("issue_date", Tagged(1004, Tstr("2017-02-23")))
-                        put("expiry_date", Tagged(1004, Tstr("2028-09-01")))
+                        put("issue_date", Tagged(Tagged.FULL_DATE_STRING, Tstr("2017-02-23")))
+                        put("expiry_date", Tagged(Tagged.FULL_DATE_STRING, Tstr("2028-09-01")))
                     }
                 }
             )
@@ -493,10 +495,10 @@ object DrivingLicense {
                 "domestic_driving_privileges",
                 "Domestic Driving Privileges",
                 "Vehicle types the license holder is authorized to operate",
-                false,
+                true,
                 AAMVA_NAMESPACE,
                 Icon.DIRECTIONS_CAR,
-                Simple.NULL
+                buildCborArray {}
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
@@ -506,7 +508,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.IntegerOptions(
@@ -536,7 +538,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.MILITARY_TECH,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(
@@ -553,7 +555,7 @@ object DrivingLicense {
                 true,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                "N".toDataItem()
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(
@@ -570,7 +572,7 @@ object DrivingLicense {
                 true,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                "N".toDataItem()
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -580,7 +582,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -590,7 +592,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
@@ -600,7 +602,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.PERSON,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.IntegerOptions(
@@ -676,7 +678,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.STARS,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.IntegerOptions(
@@ -712,7 +714,7 @@ object DrivingLicense {
                 true,
                 AAMVA_NAMESPACE,
                 Icon.CALENDAR_CLOCK,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
@@ -735,7 +737,7 @@ object DrivingLicense {
                 false,
                 MDL_NAMESPACE,
                 Icon.FACE,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.Picture,
@@ -745,7 +747,7 @@ object DrivingLicense {
                 false,
                 MDL_NAMESPACE,
                 Icon.FINGERPRINT,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.Picture,
@@ -755,7 +757,7 @@ object DrivingLicense {
                 false,
                 MDL_NAMESPACE,
                 Icon.SIGNATURE,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.Picture,
@@ -765,7 +767,7 @@ object DrivingLicense {
                 false,
                 MDL_NAMESPACE,
                 Icon.EYE_TRACKING,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -775,7 +777,7 @@ object DrivingLicense {
                 false,
                 AAMVA_NAMESPACE,
                 Icon.STARS,
-                Simple.NULL
+                null
             )
             .addMdocAttribute(
                 DocumentAttributeType.Number,
@@ -785,7 +787,7 @@ object DrivingLicense {
                 true,
                 AAMVA_NAMESPACE,
                 Icon.NUMBERS,
-                Simple.NULL
+                1.toDataItem()
             )
             .addSampleRequest(
                 id = "us-transportation",

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
@@ -171,7 +171,7 @@ object EUPersonalID {
                 sampleValue = SampleData.BIRTH_PLACE.toDataItem(),
             )
             .addJsonAttribute(
-                type = DocumentAttributeType.String,
+                type = DocumentAttributeType.ComplexType,
                 identifier = "place_of_birth",
                 displayName = "Place of Birth",
                 description = "Country and municipality or state/province where the PID holder was born",

--- a/multipaz-models/build.gradle.kts
+++ b/multipaz-models/build.gradle.kts
@@ -71,6 +71,8 @@ kotlin {
                 implementation(libs.accompanist.permissions)
                 implementation(libs.androidx.material)
                 implementation(libs.play.services.identity.credentials)
+                implementation(libs.androidx.credentials)
+                implementation(libs.androidx.credentials.play.services.auth)
             }
         }
 

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.kt
@@ -1,7 +1,10 @@
 package org.multipaz.models.digitalcredentials
 
+import kotlinx.serialization.json.JsonObject
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.models.verification.VerificationUtil
+import org.multipaz.models.verification.VerifiedPresentation
 
 /**
  * An interface for interacting with the W3C Digital Credentials API provider
@@ -62,6 +65,29 @@ interface DigitalCredentials {
     )
 
     /**
+     * Request credentials from wallet applications.
+     *
+     * This is a wrapper for a native implementation of the
+     * [W3C Digital Credentials API](https://www.w3.org/TR/digital-credentials/)
+     * available in web browsers via `navigator.credentials.get()`. This may not be available
+     * on all platforms.
+     *
+     * This will trigger external components for the user to interact with so make sure to launch
+     * this from a coroutine which is properly bound to the UI, see [org.multipaz.context.UiContext]
+     * for details.
+     *
+     * Use [VerificationUtil.generateDcRequestMdoc] or [VerificationUtil.generateDcRequestSdJwt]
+     * to generate requests and use [VerificationUtil.decryptDcResponse] to decrypt the response.
+     * Once decrypted [VerificationUtil.verifyMdocDeviceResponse],
+     * [VerificationUtil.verifyOpenID4VPResponse] can be used to generate [VerifiedPresentation]
+     * instances for further checks and analysis.
+     *
+     * @param request a W3C Digital Credentials request.
+     * @return the W3C Digital Credentials response.
+     */
+    suspend fun request(request: JsonObject): JsonObject
+
+    /**
      * The default implementation of the [DigitalCredentials] API on the platform.
      */
     object Default: DigitalCredentials {
@@ -86,6 +112,8 @@ interface DigitalCredentials {
         override suspend fun stopExportingCredentials(
             documentStore: DocumentStore
         ) = defaultStopExportingCredentials(documentStore)
+
+        override suspend fun request(request: JsonObject): JsonObject = defaultRequest(request)
     }
 }
 
@@ -107,3 +135,7 @@ internal expect suspend fun defaultStartExportingCredentials(
 internal expect suspend fun defaultStopExportingCredentials(
     documentStore: DocumentStore,
 )
+
+internal expect suspend fun defaultRequest(
+    request: JsonObject
+): JsonObject

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/DigitalCredentialsPresentmentMechanism.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/DigitalCredentialsPresentmentMechanism.kt
@@ -10,7 +10,7 @@ import org.multipaz.document.Document
  * [W3C Digital Credentials API](https://w3c-fedid.github.io/digital-credentials/).
  *
  * @property appId the id of the application making the request.
- * @property webOrigin the origin of the website if the application is a web browser, or `null` if it's not.
+ * @property origin the origin of the requester.
  * @property protocol the `protocol` field in the `DigitalCredentialGetRequest` dictionary in to the W3C DC API.
  * @property data the `data` field in the `DigitalCredentialGetRequest` dictionary in the W3C DC API.
  * @property preselectedDocuments the list of documents the user may have preselected earlier (for
@@ -19,7 +19,7 @@ import org.multipaz.document.Document
  */
 abstract class DigitalCredentialsPresentmentMechanism(
     val appId: String,
-    val webOrigin: String?,
+    val origin: String,
     val protocol: String,
     val data: JsonObject,
     val preselectedDocuments: List<Document>

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
@@ -109,15 +109,13 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
         preReq
     }
 
-    val origin = presentmentMechanism.webOrigin
-        ?: throw IllegalArgumentException("origin is not available")
-
     val response = OpenID4VP.generateResponse(
         version = version,
         preselectedDocuments = presentmentMechanism.preselectedDocuments,
         source = source,
         showConsentPrompt = showConsentPrompt,
-        origin = origin,
+        appId = presentmentMechanism.appId,
+        origin = presentmentMechanism.origin,
         request = req,
         requesterCertChain = requesterCertChain,
     )
@@ -152,7 +150,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
 
     val dcapiInfo = buildCborArray {
         add(encryptionInfoBase64)
-        add(presentmentMechanism.webOrigin!!)
+        add(presentmentMechanism.origin)
     }
 
     val encodedSessionTranscript = Cbor.encode(
@@ -178,7 +176,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         val request = docRequest.toMdocRequest(
             documentTypeRepository = documentTypeRepository,
             mdocCredential = null,
-            requesterWebsiteOrigin = presentmentMechanism.webOrigin,
+            requesterOrigin = presentmentMechanism.origin,
             requesterAppId = presentmentMechanism.appId
         )
         val trustPoint = source.findTrustPoint(request.requester)

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/uriSchemePresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/uriSchemePresentment.kt
@@ -80,6 +80,7 @@ internal suspend fun uriSchemePresentment(
         preselectedDocuments = listOf(),
         source = source,
         showConsentPrompt = showConsentPrompt,
+        appId = null, // TODO: maybe pass the browser's appId if we can
         origin = mechanism.origin,
         request = requestObject,
         requesterCertChain = requesterChain,

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/DcResponse.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/DcResponse.kt
@@ -1,0 +1,6 @@
+package org.multipaz.models.verification
+
+/**
+ * Abstract base class for W3C Digital Credentials API responses.
+ */
+sealed class DcResponse

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/JsonVerifiedPresentation.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/JsonVerifiedPresentation.kt
@@ -1,0 +1,29 @@
+package org.multipaz.models.verification
+
+import org.multipaz.claim.JsonClaim
+import org.multipaz.crypto.X509CertChain
+import kotlin.time.Instant
+
+/**
+ * A verified presentation of a JSON-based credential
+ *
+ * @property vct the Verifiable Credential Type.
+ */
+data class JsonVerifiedPresentation(
+    override val documentSignerCertChain: X509CertChain,
+    override val issuerSignedClaims: List<JsonClaim>,
+    override val deviceSignedClaims: List<JsonClaim>,
+    override val validFrom: Instant?,
+    override val validUntil: Instant?,
+    override val signedAt: Instant?,
+    override val expectedUpdate: Instant?,
+    val vct: String
+): VerifiedPresentation(
+    documentSignerCertChain = documentSignerCertChain,
+    issuerSignedClaims = issuerSignedClaims,
+    deviceSignedClaims = deviceSignedClaims,
+    validFrom = validFrom,
+    validUntil = validUntil,
+    signedAt = signedAt,
+    expectedUpdate = expectedUpdate
+)

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/MdocApiDcResponse.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/MdocApiDcResponse.kt
@@ -1,0 +1,14 @@
+package org.multipaz.models.verification
+
+import org.multipaz.cbor.DataItem
+
+/**
+ * A response using W3C Digital Credentials API response using the `org-iso-mdoc` exchange protocol.
+ *
+ * @property deviceResponse the `DeviceResponse` CBOR.
+ * @property sessionTranscript the `SessionTranscript` CBOR needed to verify the device response.
+ */
+data class MdocApiDcResponse(
+    val deviceResponse: DataItem,
+    val sessionTranscript: DataItem
+): DcResponse()

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/MdocVerifiedPresentation.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/MdocVerifiedPresentation.kt
@@ -1,0 +1,29 @@
+package org.multipaz.models.verification
+
+import org.multipaz.claim.MdocClaim
+import org.multipaz.crypto.X509CertChain
+import kotlin.time.Instant
+
+/**
+ * A verified presentation of an ISO mdoc credential
+ *
+ * @property docType the ISO mdoc document type, e.g. `org.iso.18013.5.1.mDL`.
+ */
+data class MdocVerifiedPresentation(
+    override val documentSignerCertChain: X509CertChain,
+    override val issuerSignedClaims: List<MdocClaim>,
+    override val deviceSignedClaims: List<MdocClaim>,
+    override val validFrom: Instant?,
+    override val validUntil: Instant?,
+    override val signedAt: Instant?,
+    override val expectedUpdate: Instant?,
+    val docType: String
+): VerifiedPresentation(
+    documentSignerCertChain = documentSignerCertChain,
+    issuerSignedClaims = issuerSignedClaims,
+    deviceSignedClaims = deviceSignedClaims,
+    validFrom = validFrom,
+    validUntil = validUntil,
+    signedAt = signedAt,
+    expectedUpdate = expectedUpdate
+)

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/OpenID4VPDcResponse.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/OpenID4VPDcResponse.kt
@@ -1,0 +1,16 @@
+package org.multipaz.models.verification
+
+import kotlinx.serialization.json.JsonObject
+import org.multipaz.cbor.DataItem
+
+/**
+ * A response using W3C Digital Credentials API response using the `openid4vp-v1-signed` or
+ * `openid4vp-v1-unsigned` exchange protocols.
+ *
+ * @property vpToken the `vp_token` according to OpenID4VP.
+ * @property sessionTranscript the `SessionTranscript` CBOR needed to verify embedded ISO mdoc responses.
+ */
+class OpenID4VPDcResponse(
+    val vpToken: JsonObject,
+    val sessionTranscript: DataItem
+): DcResponse()

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/VerificationUtil.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/VerificationUtil.kt
@@ -1,0 +1,758 @@
+package org.multipaz.models.verification
+
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.addCborArray
+import org.multipaz.cbor.addCborMap
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.claim.JsonClaim
+import org.multipaz.claim.MdocClaim
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
+import org.multipaz.crypto.JsonWebEncryption
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.request.DeviceRequestGenerator
+import org.multipaz.mdoc.response.DeviceResponseParser
+import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.mdoc.zkp.ZkSystemSpec
+import org.multipaz.models.openid.OpenID4VP
+import org.multipaz.models.verification.DcResponse
+import org.multipaz.models.verification.MdocApiDcResponse
+import org.multipaz.models.verification.OpenID4VPDcResponse
+import org.multipaz.request.JsonRequestedClaim
+import org.multipaz.request.MdocRequestedClaim
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.sdjwt.SdJwtKb
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.toBase64Url
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.time.Instant
+
+private const val TAG = "VerificationUtil"
+
+/**
+ * Utility functions for requesting and verifying credentials.
+ */
+object VerificationUtil {
+    /**
+     * Utility function to generate a W3C Digital Credentials API request for requesting a single ISO mdoc credential.
+     *
+     * The request can expressed for multiple exchange protocols simultaneously, for example OpenID4VP 1.0 and
+     * ISO/IEC 18013:2025 Annex C.
+     *
+     * The following exchange protocols are supported by this function
+     * - org-iso-mdoc
+     * - openid4vp
+     * - openid4vp-v1-signed
+     * - openid4v4-v1-unsigned
+     *
+     * This can be used on the server-side to generate the request. The resulting [JsonObject] can be serialized
+     * to a string using [Json.encodeToString] and sent to the browser or requesting app which can pass it to
+     * `navigator.credentials.get()` or its native Credential Manager implementation.
+     *
+     * @param exchangeProtocols a list of W3C Exchange Protocol strings to generate requests for. The order of
+     *   requests in the resulting JSON will match the order in this list.
+     * @param docType the ISO mdoc document type, e.g. "org.iso.18013.5.1.mDL".
+     * @param claims the namespaces and data elements to request.
+     * @param nonce the nonce to use. For OpenID4VP, this will be base64url-encoded without padding. For mdoc-api
+     *   this will be used as is.
+     * @param origin the origin to use.
+     * @param clientId the client id to use, must be non-null for signed requests.
+     * @param responseEncryptionKey the key to encrypt the response against or `null` to not encrypt the response.
+     *   Note that in some protocols encryption of the response is mandatory and this will throw [IllegalArgumentException]
+     *   if this is `null` for such protocols
+     * @param readerAuthenticationKey an optional key to use for reader authentication.
+     * @param readerAuthenticationCertChain the certification for [readerAuthenticationKey].
+     * @param zkSystemSpecs if non-empty, request a ZK proof using these systems.
+     * @return a [JsonObject] with the request.
+     */
+    fun generateDcRequestMdoc(
+        exchangeProtocols: List<String>,
+        docType: String,
+        claims: List<MdocRequestedClaim>,
+        nonce: ByteString,
+        origin: String,
+        clientId: String?,
+        responseEncryptionKey: EcPublicKey?,
+        readerAuthenticationKey: EcPrivateKey?,
+        readerAuthenticationCertChain: X509CertChain?,
+        zkSystemSpecs: List<ZkSystemSpec>
+    ): JsonObject {
+        return buildJsonObject {
+            putJsonArray("requests") {
+                for (exchangeProtocol in exchangeProtocols) {
+                    addJsonObject {
+                        put("protocol", exchangeProtocol)
+                        when (exchangeProtocol) {
+                            "openid4vp",
+                            "openid4vp-v1-unsigned",
+                            "openid4vp-v1-signed" -> {
+                                put(
+                                    "data",
+                                    OpenID4VP.generateRequest(
+                                        version = if (exchangeProtocol == "openid4vp") {
+                                            OpenID4VP.Version.DRAFT_24
+                                        } else {
+                                            OpenID4VP.Version.DRAFT_29
+                                        },
+                                        origin = origin,
+                                        clientId = clientId,
+                                        nonce = nonce.toByteArray().toBase64Url(),
+                                        responseEncryptionKey = responseEncryptionKey,
+                                        requestSigningKey = readerAuthenticationKey,
+                                        requestSigningKeyCertification = readerAuthenticationCertChain,
+                                        responseMode = OpenID4VP.ResponseMode.DC_API,
+                                        responseUri = null,
+                                        dclqQuery = calcDcqlMdoc(docType, claims, zkSystemSpecs)
+                                    )
+                                )
+                            }
+
+                            "org-iso-mdoc" -> {
+                                if (responseEncryptionKey == null) {
+                                    throw IllegalArgumentException("Response encryption is mandatory for org-iso-mdoc")
+                                }
+                                val encryptionInfo = buildCborArray {
+                                    add("dcapi")
+                                    addCborMap {
+                                        put("nonce", nonce.toByteArray())
+                                        put("recipientPublicKey", responseEncryptionKey.toCoseKey().toDataItem())
+                                    }
+                                }
+                                val base64EncryptionInfo = Cbor.encode(encryptionInfo).toBase64Url()
+                                val dcapiInfo = buildCborArray {
+                                    add(base64EncryptionInfo)
+                                    add(origin)
+                                }
+                                val sessionTranscript = Cbor.encode(
+                                    buildCborArray {
+                                        add(Simple.NULL) // DeviceEngagementBytes
+                                        add(Simple.NULL) // EReaderKeyBytes
+                                        addCborArray {
+                                            add("dcapi")
+                                            add(Crypto.digest(Algorithm.SHA256, Cbor.encode(dcapiInfo)))
+                                        }
+                                    }
+                                )
+                                val itemsToRequest = mutableMapOf<String, MutableMap<String, Boolean>>()
+                                for (claim in claims) {
+                                    itemsToRequest.getOrPut(claim.namespaceName) { mutableMapOf() }
+                                        .put(claim.dataElementName, claim.intentToRetain)
+                                }
+                                val generator = DeviceRequestGenerator(sessionTranscript)
+                                generator.addDocumentRequest(
+                                    docType = docType,
+                                    itemsToRequest = itemsToRequest,
+                                    requestInfo = null,
+                                    readerKey = readerAuthenticationKey,
+                                    signatureAlgorithm = readerAuthenticationKey?.publicKey?.curve?.defaultSigningAlgorithmFullySpecified
+                                        ?: Algorithm.UNSET,
+                                    readerKeyCertificateChain = readerAuthenticationCertChain,
+                                    zkSystemSpecs = zkSystemSpecs
+                                )
+                                val deviceRequest = generator.generate()
+                                val base64DeviceRequest = deviceRequest.toBase64Url()
+                                putJsonObject("data") {
+                                    put("deviceRequest", base64DeviceRequest)
+                                    put("encryptionInfo", base64EncryptionInfo)
+                                }
+                            }
+
+                            else -> throw IllegalArgumentException("Unsupported exchange protocol $exchangeProtocol")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Utility function to generate a W3C Digital Credentials API request for requesting a single SD-JWT credential.
+     *
+     * The request can expressed for multiple exchange protocols simultaneously, for example OpenID4VP 1.0 and
+     * ISO/IEC 18013:2025 Annex C.
+     *
+     * The following exchange protocols are supported by this function
+     * - org-iso-mdoc
+     * - openid4vp
+     * - openid4vp-v1-signed
+     * - openid4v4-v1-unsigned
+     *
+     * This can be used on the server-side to generate the request. The resulting [JsonObject] can be serialized
+     * to a string using [Json.encodeToString] and sent to the browser or requesting app which can pass it to
+     * `navigator.credentials.get()` or its native Credential Manager implementation.
+     *
+     * @param exchangeProtocols a list of W3C Exchange Protocol strings to generate requests for. The order of
+     *   requests in the resulting JSON will match the order in this list.
+     * @param vct the Verifiable Credential Types to request, e.g. "urn:eudi:pid:1".
+     * @param claims the claims to request.
+     * @param nonce the nonce to use. For OpenID4VP, this will be base64url-encoded without padding. For mdoc-api
+     *   this will be used as is.
+     * @param origin the origin to use.
+     * @param clientId the client id to use, must be non-null for signed requests.
+     * @param responseEncryptionKey the key to encrypt the response against or `null` to not encrypt the response.
+     *   Note that in some protocols encryption of the response is mandatory and this will throw [IllegalArgumentException]
+     *   if this is `null` for such protocols
+     * @param readerAuthenticationKey an optional key to use for reader authentication.
+     * @param readerAuthenticationCertChain the certification for [readerAuthenticationKey].
+     * @return a [JsonObject] with the request.
+     */
+    fun generateDcRequestSdJwt(
+        exchangeProtocols: List<String>,
+        vct: List<String>,
+        claims: List<JsonRequestedClaim>,
+        nonce: ByteString,
+        origin: String,
+        clientId: String?,
+        responseEncryptionKey: EcPublicKey?,
+        readerAuthenticationKey: EcPrivateKey?,
+        readerAuthenticationCertChain: X509CertChain?
+    ): JsonObject {
+        return buildJsonObject {
+            putJsonArray("requests") {
+                for (exchangeProtocol in exchangeProtocols) {
+                    addJsonObject {
+                        put("protocol", exchangeProtocol)
+                        when (exchangeProtocol) {
+                            "openid4vp",
+                            "openid4vp-v1-unsigned",
+                            "openid4vp-v1-signed" -> {
+                                put(
+                                    "data",
+                                    OpenID4VP.generateRequest(
+                                        version = if (exchangeProtocol == "openid4vp") {
+                                            OpenID4VP.Version.DRAFT_24
+                                        } else {
+                                            OpenID4VP.Version.DRAFT_29
+                                        },
+                                        origin = origin,
+                                        clientId = clientId,
+                                        nonce = nonce.toByteArray().toBase64Url(),
+                                        responseEncryptionKey = responseEncryptionKey,
+                                        requestSigningKey = readerAuthenticationKey,
+                                        requestSigningKeyCertification = readerAuthenticationCertChain,
+                                        responseMode = OpenID4VP.ResponseMode.DC_API,
+                                        responseUri = null,
+                                        dclqQuery = calcDcqlSdJwt(vct, claims)
+                                    )
+                                )
+                            }
+                            else -> throw IllegalArgumentException("Unsupported exchange protocol $exchangeProtocol")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun calcDcqlMdoc(
+        docType: String,
+        claims: List<MdocRequestedClaim>,
+        zkSystemSpecs: List<ZkSystemSpec>
+    ) = buildJsonObject {
+        putJsonArray("credentials") {
+            addJsonObject {
+                put("id", JsonPrimitive("cred1"))
+                if (zkSystemSpecs.isNotEmpty()) {
+                    put("format", JsonPrimitive("mso_mdoc_zk"))
+                } else {
+                    put("format", JsonPrimitive("mso_mdoc"))
+                }
+                putJsonObject("meta") {
+                    put("doctype_value", JsonPrimitive(docType))
+                    if (zkSystemSpecs.isNotEmpty()) {
+                        putJsonArray("zk_system_type") {
+                            for (spec in zkSystemSpecs) {
+                                addJsonObject {
+                                    put("system", spec.system)
+                                    put("id", spec.id)
+                                    spec.params.forEach { param ->
+                                        put(param.key, param.value.toJson())
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                putJsonArray("claims") {
+                    for (claim in claims) {
+                        addJsonObject {
+                            putJsonArray("path") {
+                                add(JsonPrimitive(claim.namespaceName))
+                                add(JsonPrimitive(claim.dataElementName))
+                            }
+                            put("intent_to_retain", JsonPrimitive(claim.intentToRetain))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun calcDcqlSdJwt(
+        vct: List<String>,
+        claims: List<JsonRequestedClaim>
+    ) = buildJsonObject {
+        putJsonArray("credentials") {
+            addJsonObject {
+                put("id", JsonPrimitive("cred1"))
+                put("format", JsonPrimitive("dc+sd-jwt"))
+                putJsonObject("meta") {
+                    put(
+                        "vct_values",
+                        buildJsonArray {
+                            vct.forEach {
+                                add(it)
+                            }
+                        }
+                    )
+                }
+                putJsonArray("claims") {
+                    for (claim in claims) {
+                        addJsonObject {
+                            putJsonArray("path") {
+                                claim.claimPath.forEach {
+                                    add(it)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Decrypts a W3C Digital Credentials response.
+     *
+     * @param response the W3C Digital Credentials API response.
+     * @param nonce the nonce.
+     * @param origin the origin.
+     * @param responseEncryptionKey the response encryption or `null` if the response isn't encrypted.
+     * @return a [OpenID4VPDcResponse] or [MdocApiDcResponse] with the cleartext response.
+     */
+    fun decryptDcResponse(
+        response: JsonObject,
+        nonce: ByteString,
+        origin: String,
+        responseEncryptionKey: EcPrivateKey?,
+    ): DcResponse {
+        val exchangeProtocol = response["protocol"]!!.jsonPrimitive.content
+        when (exchangeProtocol) {
+            "openid4vp",
+            "openid4vp-v1-signed",
+            "openid4vp-v1-unsigned" -> {
+                val response = response["data"]!!.jsonObject["response"]!!.jsonPrimitive.content
+                val splits = response.split(".")
+                val responseObj = if (splits.size == 3) {
+                    // Unsecured JWT
+                    Json.decodeFromString(JsonObject.serializer(), splits[1].fromBase64Url().decodeToString())
+                } else {
+                    if (responseEncryptionKey == null) {
+                        throw IllegalStateException("Response is encryption but no key was provided for decryption")
+                    }
+                    JsonWebEncryption.decrypt(response, responseEncryptionKey)
+                }
+                val vpToken = responseObj["vp_token"]!!.jsonObject
+
+                val handoverInfo = if (exchangeProtocol == "openid4vp") {
+                    // Draft 24
+                    buildCborArray {
+                        add(origin)
+                        add("web-origin:$origin")
+                        add(nonce.toByteArray().toBase64Url())
+                    }
+                } else {
+                    // OpenID4VP 1.0
+                    buildCborArray {
+                        val jwkThumbPrint = if (responseEncryptionKey == null) {
+                            Simple.NULL
+                        } else {
+                            Bstr(responseEncryptionKey.publicKey.toJwkThumbprint(Algorithm.SHA256).toByteArray())
+                        }
+                        // B.2.6.2. Invocation via the Digital Credentials API
+                        add(origin)
+                        add(nonce.toByteArray().toBase64Url())
+                        add(jwkThumbPrint)
+                    }
+                }
+                val encodedHandoverInfo = Cbor.encode(handoverInfo)
+                Logger.iCbor(TAG, "handoverInfo", encodedHandoverInfo)
+                val sessionTranscript = buildCborArray {
+                    add(Simple.NULL) // DeviceEngagementBytes
+                    add(Simple.NULL) // EReaderKeyBytes
+                    addCborArray {
+                        add("OpenID4VPDCAPIHandover")
+                        add(Crypto.digest(Algorithm.SHA256, encodedHandoverInfo))
+                    }
+                }
+                Logger.iCbor(TAG, "sessionTranscript", Cbor.encode(sessionTranscript))
+                return OpenID4VPDcResponse(
+                    vpToken = vpToken,
+                    sessionTranscript = sessionTranscript
+                )
+            }
+
+            "org-iso-mdoc" -> {
+                if (responseEncryptionKey == null) {
+                    throw IllegalStateException("Response is encryption but no key was provided for decryption")
+                }
+                val encryptionInfo = buildCborArray {
+                    add("dcapi")
+                    addCborMap {
+                        put("nonce", nonce.toByteArray())
+                        put("recipientPublicKey", responseEncryptionKey.publicKey.toCoseKey().toDataItem())
+                    }
+                }
+                val base64EncryptionInfo = Cbor.encode(encryptionInfo).toBase64Url()
+                val dcapiInfo = buildCborArray {
+                    add(base64EncryptionInfo)
+                    add(origin)
+                }
+                val sessionTranscript = buildCborArray {
+                    add(Simple.NULL) // DeviceEngagementBytes
+                    add(Simple.NULL) // EReaderKeyBytes
+                    addCborArray {
+                        add("dcapi")
+                        add(Crypto.digest(Algorithm.SHA256, Cbor.encode(dcapiInfo)))
+                    }
+                }
+                val encryptedResponseBase64 = response["data"]!!.jsonObject["response"]!!.jsonPrimitive.content
+                val array = Cbor.decode(encryptedResponseBase64.fromBase64Url()).asArray
+                if (array[0].asTstr != "dcapi") {
+                    throw IllegalArgumentException("Excepted dcapi as first array element")
+                }
+                val encryptionParameters = array[1].asMap
+                val enc = encryptionParameters[Tstr("enc")]!!.asBstr
+                val encapsulatedPublicKey = EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(
+                    EcCurve.P256,
+                    enc
+                )
+                val cipherText = encryptionParameters[Tstr("cipherText")]!!.asBstr
+                val encodedDeviceResponse = Crypto.hpkeDecrypt(
+                    cipherSuite = Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
+                    receiverPrivateKey = responseEncryptionKey,
+                    cipherText = cipherText,
+                    aad = Cbor.encode(sessionTranscript),
+                    encapsulatedPublicKey = encapsulatedPublicKey
+                )
+                return MdocApiDcResponse(
+                    deviceResponse = Cbor.decode(encodedDeviceResponse),
+                    sessionTranscript = sessionTranscript
+                )
+            }
+
+            else -> throw IllegalArgumentException("Unsupported exchange protocol $exchangeProtocol")
+        }
+    }
+
+    /**
+     * Generates [VerifiedPresentation] from an OpenID4VP response.
+     *
+     * @param now the current time.
+     * @param vpToken the `vp_token` according to OpenID4VP 1.0.
+     * @param sessionTranscript the ISO mdoc `SessionTranscript` CBOR.
+     * @param nonce the nonce used in the request.
+     * @param documentTypeRepository a [DocumentTypeRepository] or `null`.
+     * @param zkSystemRepository a [ZkSystemRepository] used for verifying ZKP proofs or `null`.
+     * @return a list of [VerifiedPresentation], one for each credential in the response.
+     */
+    fun verifyOpenID4VPResponse(
+        now: Instant,
+        vpToken: JsonObject,
+        sessionTranscript: DataItem,
+        nonce: ByteString,
+        documentTypeRepository: DocumentTypeRepository?,
+        zkSystemRepository: ZkSystemRepository?,
+    ): List<VerifiedPresentation> {
+        val verifiedPresentations = mutableListOf<VerifiedPresentation>()
+        for ((credId, credValue) in vpToken.entries) {
+            val creds = credValue as? JsonArray ?: JsonArray(listOf(credValue))
+            for (cred in creds) {
+                val credBase64 = cred.jsonPrimitive.content
+                // Simple heuristic to determine if this is JSON or CBOR
+                if (credBase64.startsWith("ey")) {
+                    val sdjwtVerifiedPresentations = verifySdJwtPresentation(
+                        now = now,
+                        compactSerialization = credBase64,
+                        nonce = nonce,
+                        documentTypeRepository = documentTypeRepository,
+                    )
+                    verifiedPresentations.add(sdjwtVerifiedPresentations)
+                } else {
+                    val mdocVerifiedPresentations = verifyMdocDeviceResponse(
+                        now = now,
+                        deviceResponse = Cbor.decode(credBase64.fromBase64Url()),
+                        sessionTranscript = sessionTranscript,
+                        eReaderKey = null,
+                        documentTypeRepository = documentTypeRepository,
+                        zkSystemRepository = zkSystemRepository
+                    )
+                    verifiedPresentations.addAll(mdocVerifiedPresentations)
+                }
+            }
+        }
+        return verifiedPresentations
+    }
+
+    /**
+     * Generates [VerifiedPresentation] from an SD-JWT / SD-JWT+KB presentation.
+     *
+     * @param now the current time.
+     * @param compactSerialization the compact serialization of the SD-JWT or SD-JWT+KB.
+     * @param nonce the nonce used in the request.
+     * @param documentTypeRepository a [DocumentTypeRepository] or `null`.
+     * @return a [VerifiedPresentation] instance.
+     */
+    fun verifySdJwtPresentation(
+        now: Instant,
+        compactSerialization: String,
+        nonce: ByteString,
+        documentTypeRepository: DocumentTypeRepository?,
+    ): VerifiedPresentation {
+        val (sdJwt, sdJwtKb) = if (compactSerialization.endsWith("~")) {
+            Pair(SdJwt(compactSerialization), null)
+        } else {
+            val sdJwtKb = SdJwtKb(compactSerialization)
+            Pair(sdJwtKb.sdJwt, sdJwtKb)
+        }
+
+        val issuerCertChain = sdJwt.x5c
+        if (issuerCertChain == null) {
+            throw IllegalStateException("Issuer-signed key not in `x5c` in header")
+        }
+        val processedPayload = if (sdJwtKb != null) {
+            sdJwtKb.verify(
+                issuerKey = issuerCertChain.certificates.first().ecPublicKey,
+                checkNonce = { nonceInCredential -> nonceInCredential == nonce.toByteArray().toBase64Url() },
+                checkAudience = { true }, // TODO
+                checkCreationTime = { true }
+            )
+        } else {
+            sdJwt.verify(
+                issuerKey = issuerCertChain.certificates.first().ecPublicKey
+            )
+        }
+
+        val vct = processedPayload["vct"]!!.jsonPrimitive.content
+        val validFrom = processedPayload["nbf"]?.jsonPrimitive?.intOrNull?.let { Instant.fromEpochSeconds(it.toLong()) }
+        val validUntil = processedPayload["exp"]?.jsonPrimitive?.intOrNull?.let { Instant.fromEpochSeconds(it.toLong()) }
+        val signedAt = processedPayload["iat"]?.jsonPrimitive?.intOrNull?.let { Instant.fromEpochSeconds(it.toLong()) }
+        val dt = documentTypeRepository?.getDocumentTypeForJson(vct)
+
+
+        val claims = mutableListOf<JsonClaim>()
+        for ((claimName, claimValue) in processedPayload) {
+            val jsonAttr = dt?.jsonDocumentType?.getDocumentAttribute(claimName)
+            claims.add(JsonClaim(
+                displayName = jsonAttr?.displayName ?: claimName,
+                attribute = jsonAttr,
+                claimPath = JsonArray(listOf(JsonPrimitive(claimName))),
+                value = claimValue
+            ))
+        }
+
+        val deviceSignedClaims = mutableListOf<JsonClaim>()
+        if (sdJwtKb != null) {
+            for ((claimName, claimValue) in sdJwtKb.jwtBody) {
+                val jsonAttr = dt?.jsonDocumentType?.getDocumentAttribute(claimName)
+                claims.add(JsonClaim(
+                    displayName = jsonAttr?.displayName ?: claimName + " (Device Signed)",
+                    attribute = jsonAttr,
+                    claimPath = JsonArray(listOf(JsonPrimitive(claimName))),
+                    value = claimValue
+                ))
+            }
+        }
+
+        return JsonVerifiedPresentation(
+            documentSignerCertChain = issuerCertChain,
+            issuerSignedClaims = claims,
+            deviceSignedClaims = deviceSignedClaims,
+            validFrom = validFrom,
+            validUntil = validUntil,
+            signedAt = signedAt,
+            expectedUpdate = null,  // Not defined for SD-JWT
+            vct = vct
+        )
+    }
+
+    /**
+     * Generates [VerifiedPresentation] from an ISO 18013-5 response.
+     *
+     * @param now the current time.
+     * @param deviceResponse the `DeviceResponse` CBOR.
+     * @param sessionTranscript the ISO mdoc `SessionTranscript` CBOR.
+     * @param eReaderKey the ephemeral reader key, if 18013-5 session encryption is used.
+     * @param documentTypeRepository a [DocumentTypeRepository] or `null`.
+     * @param zkSystemRepository a [ZkSystemRepository] used for verifying ZKP proofs or `null`.
+     * @return a list of [VerifiedPresentation], one for each document in the response.
+     */
+    fun verifyMdocDeviceResponse(
+        now: Instant,
+        deviceResponse: DataItem,
+        sessionTranscript: DataItem,
+        eReaderKey: EcPrivateKey?,
+        documentTypeRepository: DocumentTypeRepository?,
+        zkSystemRepository: ZkSystemRepository?,
+    ): List<VerifiedPresentation> {
+        val parser = DeviceResponseParser(
+            encodedDeviceResponse = Cbor.encode(deviceResponse),
+            encodedSessionTranscript = Cbor.encode(sessionTranscript)
+        )
+        eReaderKey?.let { parser.setEphemeralReaderKey(it) }
+        val dr = parser.parse()
+        val verifiedPresentations = mutableListOf<VerifiedPresentation>()
+        for (document in dr.documents) {
+            if (!document.issuerSignedAuthenticated) {
+                throw IllegalStateException("Issuer-signed data failed authentication")
+            }
+            if (document.numIssuerEntryDigestMatchFailures > 0) {
+                throw IllegalStateException(
+                    "${document.numIssuerEntryDigestMatchFailures} digest failures in issuer-signed data"
+                )
+            }
+            Logger.iCbor(TAG, "sessionTranscript", Cbor.encode(sessionTranscript))
+            if (!document.deviceSignedAuthenticated) {
+                throw IllegalStateException("Device-signed data failed authentication")
+            }
+            val dt = documentTypeRepository?.getDocumentTypeForMdoc(document.docType)
+
+            val issuerSignedClaims = mutableListOf<MdocClaim>()
+            for (namespaceName in document.issuerNamespaces) {
+                for (dataElementName in document.getIssuerEntryNames(namespaceName)) {
+                    val value = document.getIssuerEntryData(namespaceName, dataElementName)
+                    val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
+                    issuerSignedClaims.add(
+                        MdocClaim(
+                            displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
+                            attribute = mdocAttr?.attribute,
+                            namespaceName = namespaceName,
+                            dataElementName = dataElementName,
+                            value = Cbor.decode(value)
+                        )
+                    )
+                }
+            }
+
+            val deviceSignedClaims = mutableListOf<MdocClaim>()
+            for (namespaceName in document.deviceNamespaces) {
+                for (dataElementName in document.getDeviceEntryNames(namespaceName)) {
+                    val value = document.getDeviceEntryData(namespaceName, dataElementName)
+                    val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
+                    deviceSignedClaims.add(
+                        MdocClaim(
+                            displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
+                            attribute = mdocAttr?.attribute,
+                            namespaceName = namespaceName,
+                            dataElementName = dataElementName,
+                            value = Cbor.decode(value)
+                        )
+                    )
+                }
+            }
+            verifiedPresentations.add(
+                MdocVerifiedPresentation(
+                    documentSignerCertChain = document.issuerCertificateChain,
+                    issuerSignedClaims = issuerSignedClaims,
+                    deviceSignedClaims = deviceSignedClaims,
+                    validFrom = document.validityInfoValidFrom,
+                    validUntil = document.validityInfoValidUntil,
+                    expectedUpdate = document.validityInfoExpectedUpdate,
+                    signedAt = document.validityInfoSigned,
+                    docType = document.docType
+                )
+            )
+
+        }
+        for (zkDocument in dr.zkDocuments) {
+            val zkSystemSpec = zkSystemRepository?.getAllZkSystemSpecs()?.find {
+                it.id == zkDocument.zkDocumentData.zkSystemSpecId
+            } ?: throw IllegalStateException("Zk System '${zkDocument.zkDocumentData.zkSystemSpecId}' was not found.")
+            zkSystemRepository.lookup(zkSystemSpec.system)
+                ?.verifyProof(
+                    zkDocument = zkDocument,
+                    zkSystemSpec = zkSystemSpec,
+                    encodedSessionTranscript = ByteString(Cbor.encode(sessionTranscript))
+                )
+                ?: throw IllegalStateException("Zk System '${zkSystemSpec.system}' was not found.")
+
+            val dt = documentTypeRepository?.getDocumentTypeForMdoc(zkDocument.zkDocumentData.docType)
+
+            if (zkDocument.zkDocumentData.msoX5chain == null) {
+                throw IllegalStateException("Expected x5chain for the issuer")
+            }
+            val issuerSignedClaims = mutableListOf<MdocClaim>()
+            for ((namespaceName, dataElements) in zkDocument.zkDocumentData.issuerSigned) {
+                for ((dataElementName, value) in dataElements) {
+                    val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
+                    issuerSignedClaims.add(
+                        MdocClaim(
+                            displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
+                            attribute = mdocAttr?.attribute,
+                            namespaceName = namespaceName,
+                            dataElementName = dataElementName,
+                            value = value
+                        )
+                    )
+                }
+            }
+
+            val deviceSignedClaims = mutableListOf<MdocClaim>()
+            for ((namespaceName, dataElements) in zkDocument.zkDocumentData.deviceSigned) {
+                for ((dataElementName, value) in dataElements) {
+                    val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
+                    issuerSignedClaims.add(
+                        MdocClaim(
+                            displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
+                            attribute = mdocAttr?.attribute,
+                            namespaceName = namespaceName,
+                            dataElementName = dataElementName,
+                            value = value
+                        )
+                    )
+                }
+            }
+
+            verifiedPresentations.add(
+                MdocVerifiedPresentation(
+                    documentSignerCertChain = zkDocument.zkDocumentData.msoX5chain!!,
+                    issuerSignedClaims = issuerSignedClaims,
+                    deviceSignedClaims = deviceSignedClaims,
+                    validFrom = null,
+                    validUntil = null,
+                    expectedUpdate = null,
+                    signedAt = null,
+                    docType = zkDocument.zkDocumentData.docType
+                )
+            )
+        }
+
+        return verifiedPresentations
+    }
+}

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/VerifiedPresentation.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/verification/VerifiedPresentation.kt
@@ -1,0 +1,29 @@
+package org.multipaz.models.verification
+
+import org.multipaz.claim.Claim
+import org.multipaz.crypto.X509CertChain
+import kotlin.time.Instant
+
+/**
+ * A verified presentation of credential.
+ *
+ * This is an abstract base class, see [JsonVerifiedPresentation] and [MdocVerifiedPresentation] for
+ * concrete implementations.
+ *
+ * @property documentSignerCertChain the certificate chain of the document signer key or `null` if not know.
+ * @property issuerSignedClaims the claims signed by the issuer.
+ * @property deviceSignedClaims the claims signed by the device.
+ * @property validFrom the point in time this presentation is valid from.
+ * @property validUntil the point in time this presentation is valid until.
+ * @property signedAt the point in time this was signed.
+ * @property expectedUpdate the point in time an update is expected, if any.
+ */
+sealed class VerifiedPresentation(
+    open val documentSignerCertChain: X509CertChain?,
+    open val issuerSignedClaims: List<Claim>,
+    open val deviceSignedClaims: List<Claim>,
+    open val validFrom: Instant?,
+    open val validUntil: Instant?,
+    open val signedAt: Instant?,
+    open val expectedUpdate: Instant?,
+)

--- a/multipaz-models/src/commonTest/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentmentTest.kt
+++ b/multipaz-models/src/commonTest/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentmentTest.kt
@@ -59,7 +59,7 @@ class DigitalCredentialsPresentmentTest {
         var closed: Boolean = false
     ): DigitalCredentialsPresentmentMechanism(
         appId = APP_ID,
-        webOrigin = ORIGIN,
+        origin = ORIGIN,
         protocol = protocol,
         data = data,
         preselectedDocuments = documents,

--- a/multipaz-models/src/iosMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.ios.kt
+++ b/multipaz-models/src/iosMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.ios.kt
@@ -1,5 +1,6 @@
 package org.multipaz.models.digitalcredentials
 
+import kotlinx.serialization.json.JsonObject
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 
@@ -29,5 +30,9 @@ internal actual suspend fun defaultStartExportingCredentials(
 internal actual suspend fun defaultStopExportingCredentials(
     documentStore: DocumentStore,
 ) {
+    throw NotImplementedError("DigitalCredentials is not available on iOS")
+}
+
+internal actual suspend fun defaultRequest(request: JsonObject): JsonObject {
     throw NotImplementedError("DigitalCredentials is not available on iOS")
 }

--- a/multipaz-models/src/jvmMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.jvm.kt
+++ b/multipaz-models/src/jvmMain/kotlin/org/multipaz/models/digitalcredentials/DigitalCredentials.jvm.kt
@@ -1,5 +1,6 @@
 package org.multipaz.models.digitalcredentials
 
+import kotlinx.serialization.json.JsonObject
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import kotlin.IllegalStateException
@@ -30,5 +31,9 @@ internal actual suspend fun defaultStartExportingCredentials(
 internal actual suspend fun defaultStopExportingCredentials(
     documentStore: DocumentStore,
 ) {
+    throw NotImplementedError("DigitalCredentials is not available on JVM")
+}
+
+internal actual suspend fun defaultRequest(request: JsonObject): JsonObject {
     throw NotImplementedError("DigitalCredentials is not available on JVM")
 }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/context/AndroidUiContext.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/context/AndroidUiContext.kt
@@ -1,0 +1,33 @@
+package org.multipaz.context
+
+import android.content.Context
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+/**
+ * An object for binding an Android activity context to a coroutine.
+ *
+ * @param context the [Context] that is being held.
+ */
+class AndroidUiContext(private val context: Context): UiContext(), CoroutineContext.Element {
+    private object Key: CoroutineContext.Key<AndroidUiContext>
+
+    override val key: CoroutineContext.Key<*>
+        get() = Key
+
+    class NotUiBoundCoroutineError:
+        Error("Current coroutine is not UiContext-bound")
+
+    companion object Companion {
+        /**
+         * Gets the activity associated with the coroutine.
+         *
+         * @return the activity context, ie. a [Context] for which [Context.getActivity] will return the
+         *   associated [android.app.Activity].
+         * @throws NotUiBoundCoroutineError if no context is bound to the coroutine.
+         */
+        suspend fun current(): Context {
+            return coroutineContext[Key]?.context ?: throw NotUiBoundCoroutineError()
+        }
+    }
+}

--- a/multipaz/src/androidMain/kotlin/org/multipaz/context/ContextUtil.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/context/ContextUtil.kt
@@ -18,14 +18,19 @@ fun Context.getActivity(): Activity? = when (this) {
  *
  * Must be explicitly initialized as early as possible using [initializeApplication]
  */
-val applicationContext: Context get() = _applicationContext!!
+val applicationContext: Context
+    get() = _applicationContext!!
 
 private var _applicationContext: Context? = null
 
 /**
- * Initializes [applicationContext].
+ * Initializes the application.
+ *
+ * @param applicationContext the application [Context].
  */
-fun initializeApplication(applicationContext: Context) {
+fun initializeApplication(
+    applicationContext: Context,
+) {
     if (_applicationContext == null) {
         check(applicationContext.getActivity() == null) { "Not an application context" }
         _applicationContext = applicationContext

--- a/multipaz/src/commonMain/kotlin/org/multipaz/context/UiContext.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/context/UiContext.kt
@@ -1,0 +1,9 @@
+package org.multipaz.context
+
+/**
+ * Abstract base class for holding UI relevant data that may be accessed by a coroutine.
+ *
+ * If using multipaz-compose, the [rememberUiBoundCoroutineScope] can be used to bind an
+ * activity context to a coroutine.
+ */
+abstract class UiContext

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectGenerator.kt
@@ -236,7 +236,7 @@ class MobileSecurityObjectGenerator(
         if (validUntil.nanosecondsOfSecond != 0 ) {
             Logger.w(TAG, "Dropping non-zero fractional seconds for timestamp validUntil")
         }
-        if (expectedUpdate?.nanosecondsOfSecond != 0 ) {
+        if (expectedUpdate != null && expectedUpdate.nanosecondsOfSecond != 0 ) {
             Logger.w(TAG, "Dropping non-zero fractional seconds for timestamp expectedUpdate")
         }
         mSigned = Instant.fromEpochSeconds(signed.epochSeconds, 0)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/util/MdocUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/util/MdocUtil.kt
@@ -25,7 +25,6 @@ import org.multipaz.asn1.ASN1TaggedObject
 import org.multipaz.asn1.OID
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.RawCbor
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.Tagged
@@ -706,13 +705,13 @@ object MdocUtil {
  * @param mdocCredential if set, the returned list is filtered so it only references data
  *     elements available in the credential.
  * @param requesterAppId the appId if an app is making the request or `null`.
- * @param requesterWebsiteOrigin the website origin if a website is making the request or `null`.
+ * @param requesterOrigin the origin or `null`.
  */
 fun DeviceRequestParser.DocRequest.toMdocRequest(
     documentTypeRepository: DocumentTypeRepository,
     mdocCredential: MdocCredential?,
     requesterAppId: String? = null,
-    requesterWebsiteOrigin: String? = null,
+    requesterOrigin: String? = null,
 ): MdocRequest {
     val requestedData = mutableMapOf<String, MutableList<Pair<String, Boolean>>>()
     for (namespaceName in namespaces) {
@@ -730,7 +729,7 @@ fun DeviceRequestParser.DocRequest.toMdocRequest(
                 null
             },
             appId = requesterAppId,
-            websiteOrigin = requesterWebsiteOrigin
+            origin = requesterOrigin
         ),
         requestedClaims = MdocUtil.generateRequestedClaims(
             docType,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
@@ -6,11 +6,15 @@ import org.multipaz.crypto.X509CertChain
  * Details about the entity requesting data.
  *
  * @property certChain if the requester signed the request and provided a certificate chain.
- * @property appId if the requester is a local application, for example `com.example.app` or `<teamId>.<bundleId>`.
- * @property websiteOrigin set if the verifier is a website, for example https://gov.example.com
+ * @property appId if this is a request from a local application, this contains the app identifier
+ *   for example `com.example.app` on Android or `<teamId>.<bundleId>` on iOS.
+ * @property origin the origin of the requester, if known. If this calling application is a trusted web browser
+ *   this may be a website origin such as https://www.example.com. Otherwise this is set to the origin
+ *   for the native application, for example on Android this will be of the form
+ *   "android:apk-key-hash:<sha256_hash-of-apk-signing-cert>".
  */
 data class Requester(
     val certChain: X509CertChain? = null,
     val appId: String? = null,
-    val websiteOrigin: String? = null
+    val origin: String? = null,
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -295,6 +295,7 @@ class SdJwt(
      * @param nonce the nonce, obtained from the verifier.
      * @param audience the audience, obtained from the verifier.
      * @param creationTime the time the presentation was made.
+     * @return a [SdJwtKb].
      */
     fun present(
         kbKey: EcPrivateKey,

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp
 
+import android.content.pm.PackageManager
 import android.os.Build
 import com.jakewharton.processphoenix.ProcessPhoenix
 import io.ktor.client.engine.HttpClientEngineFactory
@@ -17,6 +18,7 @@ import multipazproject.samples.testapp.generated.resources.app_icon_red
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.multipaz.compose.notifications.NotificationManagerAndroid
 import org.multipaz.crypto.Algorithm
+import org.multipaz.models.digitalcredentials.getAppOrigin
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.PromptModel
 import org.multipaz.util.Logger
@@ -113,4 +115,11 @@ actual val platformIsEmulator: Boolean by lazy {
             || Build.PRODUCT == "google_sdk")
     // another Android SDK emulator check
     /* || SystemProperties.getProp("ro.kernel.qemu") == "1") */
+}
+
+@Suppress("DEPRECATION")
+actual fun getAppToAppOrigin(): String {
+    val packageInfo = applicationContext.packageManager
+        .getPackageInfo(applicationContext.packageName, PackageManager.GET_SIGNATURES)
+    return getAppOrigin(packageInfo.signatures!![0].toByteArray())
 }

--- a/samples/testapp/src/commonMain/composeResources/values/strings.xml
+++ b/samples/testapp/src/commonMain/composeResources/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="nfc_screen_title">NFC sharing and scanning</string>
     <string name="iso_mdoc_proximity_sharing_title">ISO mdoc Proximity Sharing</string>
     <string name="iso_mdoc_proximity_reading_title">ISO mdoc Proximity Reading</string>
+    <string name="dc_request_title">W3C Digital Credentials Requests</string>
+    <string name="show_response_title">Received Credentials</string>
     <string name="iso_mdoc_multi_device_testing_title">ISO mdoc Multi-Device Testing</string>
     <string name="certificate_viewer_examples_title">CertificateViewer Examples</string>
     <string name="certificate_viewer_title">Certificate Viewer</string>

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -5,6 +5,7 @@ import androidx.navigation.navArgument
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.about_screen_title
 import multipazproject.samples.testapp.generated.resources.android_keystore_secure_area_screen_title
+import multipazproject.samples.testapp.generated.resources.dc_request_title
 import multipazproject.samples.testapp.generated.resources.barcode_scanning_title
 import multipazproject.samples.testapp.generated.resources.camera_title
 import multipazproject.samples.testapp.generated.resources.certificate_viewer_examples_title
@@ -17,7 +18,6 @@ import multipazproject.samples.testapp.generated.resources.provisioning_test_tit
 import multipazproject.samples.testapp.generated.resources.passphrase_entry_field_screen_title
 import multipazproject.samples.testapp.generated.resources.qr_codes_screen_title
 import multipazproject.samples.testapp.generated.resources.nfc_screen_title
-import multipazproject.samples.testapp.generated.resources.presentment_title
 import multipazproject.samples.testapp.generated.resources.secure_enclave_secure_area_screen_title
 import multipazproject.samples.testapp.generated.resources.software_secure_area_screen_title
 import multipazproject.samples.testapp.generated.resources.certificate_viewer_title
@@ -33,6 +33,7 @@ import multipazproject.samples.testapp.generated.resources.rich_text_title
 import multipazproject.samples.testapp.generated.resources.screen_lock_title
 import multipazproject.samples.testapp.generated.resources.selfie_check_title
 import multipazproject.samples.testapp.generated.resources.settings_screen_title
+import multipazproject.samples.testapp.generated.resources.show_response_title
 import multipazproject.samples.testapp.generated.resources.trust_point_viewer_screen_title
 import multipazproject.samples.testapp.generated.resources.trusted_issuers_screen_title
 import multipazproject.samples.testapp.generated.resources.trusted_verifiers_screen_title
@@ -179,6 +180,27 @@ data object IsoMdocProximityReadingDestination : Destination {
     override val title = Res.string.iso_mdoc_proximity_reading_title
 }
 
+data object DcRequestDestination : Destination {
+    override val route = "dc_request"
+    override val title = Res.string.dc_request_title
+}
+
+data object ShowResponseDestination : Destination {
+    override val route = "show_response"
+    override val title = Res.string.show_response_title
+    const val VP_TOKEN = "vp_token_arg"
+    const val DEVICE_RESPONSE = "device_response_arg"
+    const val SESSION_TRANSCRIPT = "session_transcript_arg"
+    const val NONCE = "nonce_arg"
+    val routeWithArgs = "$route/{$VP_TOKEN}/{$DEVICE_RESPONSE}/{$SESSION_TRANSCRIPT}/{$NONCE}"
+    val arguments = listOf(
+        navArgument(VP_TOKEN) { type = NavType.StringType },
+        navArgument(DEVICE_RESPONSE) { type = NavType.StringType },
+        navArgument(SESSION_TRANSCRIPT) { type = NavType.StringType },
+        navArgument(NONCE) { type = NavType.StringType },
+    )
+}
+
 data object IsoMdocMultiDeviceTestingDestination : Destination {
     override val route = "iso_mdoc_multi_device_testing"
     override val title = Res.string.iso_mdoc_multi_device_testing_title
@@ -262,6 +284,8 @@ val appDestinations = listOf(
     NfcDestination,
     IsoMdocProximitySharingDestination,
     IsoMdocProximityReadingDestination,
+    DcRequestDestination,
+    ShowResponseDestination,
     IsoMdocMultiDeviceTestingDestination,
     CertificatesViewerExamplesDestination,
     CertificateViewerDestination,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
@@ -38,3 +38,5 @@ expect fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*>
 expect fun platformRestartApp()
 
 expect val platformSecureAreaHasKeyAgreement: Boolean
+
+expect fun getAppToAppOrigin(): String

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -57,6 +57,7 @@ import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.sdjwt.SdJwt
 import org.multipaz.securearea.software.SoftwareCreateKeySettings
 import org.multipaz.testapp.ui.DocumentCreationMode
+import org.multipaz.util.truncateToWholeSeconds
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.iterator
@@ -591,7 +592,7 @@ object TestAppUtils {
             cardArt = ByteString(cardArt),
         )
 
-        val now = Clock.System.now()
+        val now = Clock.System.now().truncateToWholeSeconds()
         val signedAt = now - 1.hours
         val validFrom =  now - 1.hours
         val validUntil = now + 365.days
@@ -801,8 +802,6 @@ object TestAppUtils {
                                 sampleValue
                             }
                             addDataElement(deName, value)
-                        } else {
-                            Logger.w(TAG, "No sample value for data element $deName")
                         }
                     }
                 }
@@ -947,8 +946,6 @@ object TestAppUtils {
                         sampleValue
                     }
                     put(claimName, value)
-                } else {
-                    Logger.w(TAG, "No sample value for claim $claimName")
                 }
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ComboBox.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ComboBox.kt
@@ -1,0 +1,79 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun<T: Any> ComboBox(
+    headline: String,
+    availableRequests: List<T>,
+    comboBoxSelected: MutableState<T>,
+    comboBoxExpanded: MutableState<Boolean>,
+    getDisplayName: (T) -> String,
+    onSelected: (index: Int, value: T) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+
+            Text(
+                modifier = Modifier.padding(end = 16.dp),
+                text = headline
+            )
+
+            ExposedDropdownMenuBox(
+                expanded = comboBoxExpanded.value,
+                onExpandedChange = {
+                    comboBoxExpanded.value = !comboBoxExpanded.value
+                }
+            ) {
+                TextField(
+                    value = getDisplayName(comboBoxSelected.value),
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = comboBoxExpanded.value) },
+                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                )
+
+                ExposedDropdownMenu(
+                    expanded = comboBoxExpanded.value,
+                    onDismissRequest = { comboBoxExpanded.value = false }
+                ) {
+                    availableRequests.forEachIndexed { n, item ->
+                        DropdownMenuItem(
+                            text = { Text(text = getDisplayName(item)) },
+                            onClick = {
+                                comboBoxSelected.value = item
+                                comboBoxExpanded.value = false
+                                onSelected(n, comboBoxSelected.value)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -564,7 +564,7 @@ private fun calculateRequester(
         Requester(
             certChain = readerCert?.let { X509CertChain(certificates = listOf(readerCert, readerRootCert)) },
             appId = appId.appId,
-            websiteOrigin = origin.origin
+            origin = origin.origin
         ),
         trustPoint
     )
@@ -600,7 +600,7 @@ private fun calculateRequest(
         documentTypeRepository = docTypeRepo,
         mdocCredential = null,
         requesterAppId = requester.appId,
-        requesterWebsiteOrigin = requester.websiteOrigin,
+        requesterOrigin = requester.origin,
     )
     return MdocRequest(
         requester = requester,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -1,0 +1,339 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.multipaz.cbor.DataItem
+import org.multipaz.compose.rememberUiBoundCoroutineScope
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.documenttype.DocumentCannedRequest
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.models.digitalcredentials.DigitalCredentials
+import org.multipaz.models.verification.MdocApiDcResponse
+import org.multipaz.models.verification.OpenID4VPDcResponse
+import org.multipaz.request.JsonRequestedClaim
+import org.multipaz.request.MdocRequestedClaim
+import org.multipaz.testapp.App
+import org.multipaz.testapp.TestAppUtils
+import org.multipaz.testapp.getAppToAppOrigin
+import org.multipaz.trustmanagement.TrustManager
+import org.multipaz.util.Logger
+import org.multipaz.models.verification.VerificationUtil
+import kotlin.random.Random
+
+private const val TAG = "AppToAppReadingScreen"
+
+private data class RequestEntry(
+    val displayName: String,
+    val documentType: DocumentType,
+    val sampleRequest: DocumentCannedRequest
+)
+
+private enum class RequestProtocol(
+    val displayName: String,
+    val exchangeProtocolNames: List<String>,
+    val signRequest: Boolean,
+) {
+    W3C_DC_OPENID4VP_29(
+        displayName = "OpenID4VP 1.0",
+        exchangeProtocolNames = listOf("openid4vp-v1-signed"),
+        signRequest = true,
+    ),
+    W3C_DC_OPENID4VP_29_UNSIGNED(
+        displayName = "OpenID4VP 1.0 (Unsigned)",
+        exchangeProtocolNames = listOf("openid4vp-v1-unsigned"),
+        signRequest = false,
+    ),
+    W3C_DC_OPENID4VP_24(
+        displayName = "OpenID4VP Draft 24",
+        exchangeProtocolNames = listOf("openid4vp"),
+        signRequest = true,
+    ),
+    W3C_DC_OPENID4VP_24_UNSIGNED(
+        displayName = "OpenID4VP Draft 24 (Unsigned)",
+        exchangeProtocolNames = listOf("openid4vp"),
+        signRequest = false,
+    ),
+    W3C_DC_MDOC_API(
+        displayName = "ISO 18013-7 Annex C",
+        exchangeProtocolNames = listOf("org-iso-mdoc"),
+        signRequest = true
+    ),
+    W3C_DC_MDOC_API_UNSIGNED(
+        displayName = "ISO 18013-7 Annex C (Unsigned)",
+        exchangeProtocolNames = listOf("org-iso-mdoc"),
+        signRequest = false
+    ),
+
+    W3C_DC_MDOC_API_AND_OPENID4VP_29(
+        displayName = "ISO 18013-7 Annex C + OpenID4VP 1.0",
+        exchangeProtocolNames = listOf("org-iso-mdoc", "openid4vp-v1-signed"),
+        signRequest = true
+    ),
+    W3C_DC_MDOC_API_AND_OPENID4VP_29_UNSIGNED(
+        displayName = "ISO 18013-7 Annex C + OpenID4VP 1.0 (Unsigned)",
+        exchangeProtocolNames = listOf("org-iso-mdoc", "openid4vp-v1-unsigned"),
+        signRequest = false
+    ),
+    W3C_DC_MDOC_API_AND_OPENID4VP_24(
+        displayName = "ISO 18013-7 Annex C + OpenID4VP Draft 24",
+        exchangeProtocolNames = listOf("org-iso-mdoc", "openid4vp"),
+        signRequest = true
+    ),
+    W3C_DC_MDOC_API_AND_OPENID4VP_24_UNSIGNED(
+        displayName = "ISO 18013-7 Annex C + OpenID4VP Draft 24 (Unsigned)",
+        exchangeProtocolNames = listOf("org-iso-mdoc", "openid4vp"),
+        signRequest = false
+    ),
+
+    OPENID4VP_29_AND_W3C_DC_MDOC_API(
+        displayName = "OpenID4VP 1.0 + ISO 18013-7 Annex C",
+        exchangeProtocolNames = listOf("openid4vp-v1-signed", "org-iso-mdoc"),
+        signRequest = true
+    ),
+    OPENID4VP_29_UNSIGNED_AND_W3C_DC_MDOC_API(
+        displayName = "OpenID4VP 1.0 + ISO 18013-7 Annex C (Unsigned)",
+        exchangeProtocolNames = listOf("openid4vp-v1-unsigned", "org-iso-mdoc"),
+        signRequest = false
+    ),
+    OPENID4VP_24_AND_W3C_DC_MDOC_API(
+        displayName = "OpenID4VP Draft 24 + ISO 18013-7 Annex C",
+        exchangeProtocolNames = listOf("openid4vp", "org-iso-mdoc"),
+        signRequest = true
+    ),
+    OPENID4VP_24_UNSIGNED_AND_W3C_DC_MDOC_API(
+        displayName = "OpenID4VP Draft 24 + ISO 18013-7 Annex C (Unsigned)",
+        exchangeProtocolNames = listOf("openid4vp", "org-iso-mdoc"),
+        signRequest = false
+    ),
+}
+
+private enum class CredentialFormat(
+    val displayName: String,
+) {
+    ISO_MDOC("ISO mdoc"),
+    IETF_SDJWT("IETF SD-JWT"),
+}
+
+private var lastRequest: Int = 0
+private var lastProtocol: Int = 0
+private var lastFormat: Int = 0
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalCoroutinesApi::class)
+@Composable
+fun DcRequestScreen(
+    app: App,
+    showToast: (message: String) -> Unit,
+    showResponse: (vpToken: JsonObject?, deviceResponse: DataItem?, sessionTranscript: DataItem, nonce: ByteString?) -> Unit
+) {
+    val requestOptions = mutableListOf<RequestEntry>()
+    for (documentType in TestAppUtils.provisionedDocumentTypes) {
+        for (sampleRequest in documentType.cannedRequests) {
+            requestOptions.add(RequestEntry(
+                displayName = "${documentType.displayName}: ${sampleRequest.displayName}",
+                documentType = documentType,
+                sampleRequest = sampleRequest
+            ))
+        }
+    }
+    val requestDropdownExpanded = remember { mutableStateOf(false) }
+    val requestSelected = remember { mutableStateOf(requestOptions[lastRequest]) }
+    val protocolOptions = RequestProtocol.entries
+    val protocolDropdownExpanded = remember { mutableStateOf(false) }
+    val protocolSelected = remember { mutableStateOf(protocolOptions[lastProtocol]) }
+    val formatOptions = CredentialFormat.entries
+    val formatDropdownExpanded = remember { mutableStateOf(false) }
+    val formatSelected = remember { mutableStateOf(formatOptions[lastFormat]) }
+    val coroutineScope = rememberUiBoundCoroutineScope { app.promptModel }
+
+    LazyColumn(
+        modifier = Modifier.padding(8.dp)
+    ) {
+        item {
+            ComboBox(
+                headline = "Claims to request",
+                availableRequests = requestOptions,
+                comboBoxSelected = requestSelected,
+                comboBoxExpanded = requestDropdownExpanded,
+                getDisplayName = { it.displayName },
+                onSelected = { index, value -> lastRequest = index }
+            )
+        }
+        item {
+            ComboBox(
+                headline = "W3C Digital Credentials Protocol(s)",
+                availableRequests = protocolOptions,
+                comboBoxSelected = protocolSelected,
+                comboBoxExpanded = protocolDropdownExpanded,
+                getDisplayName = { it.displayName },
+                onSelected = { index, value -> lastProtocol = index }
+            )
+        }
+        item {
+            ComboBox(
+                headline = "Credential Format",
+                availableRequests = formatOptions,
+                comboBoxSelected = formatSelected,
+                comboBoxExpanded = formatDropdownExpanded,
+                getDisplayName = { it.displayName },
+                onSelected = { index, value -> lastFormat = index }
+            )
+        }
+        item {
+            TextButton(
+                onClick = {
+                    coroutineScope.launch {
+                        try {
+                            doDcRequestFlow(
+                                appReaderKey = app.readerKey,
+                                appReaderCertChain = X509CertChain(certificates = listOf(app.readerCert, app.readerRootCert)),
+                                documentType = requestSelected.value.documentType,
+                                request = requestSelected.value.sampleRequest,
+                                protocol = protocolSelected.value,
+                                format = formatSelected.value,
+                                issuerTrustManager = app.issuerTrustManager,
+                                documentTypeRepository = app.documentTypeRepository,
+                                zkSystemRepository = app.zkSystemRepository,
+                                showResponse = showResponse
+                            )
+                        } catch (error: Throwable) {
+                            Logger.e(TAG, "Error requesting credentials", error)
+                            showToast("Error: ${error.message}")
+                        }
+                    }
+                },
+                content = { Text("Request Digital Credential via AppToApp API") }
+            )
+        }
+    }
+}
+
+private suspend fun doDcRequestFlow(
+    appReaderKey: EcPrivateKey,
+    appReaderCertChain: X509CertChain,
+    documentType: DocumentType,
+    request: DocumentCannedRequest,
+    protocol: RequestProtocol,
+    format: CredentialFormat,
+    issuerTrustManager: TrustManager,
+    documentTypeRepository: DocumentTypeRepository,
+    zkSystemRepository: ZkSystemRepository,
+    showResponse: (vpToken: JsonObject?, deviceResponse: DataItem?, sessionTranscript: DataItem, nonce: ByteString?) -> Unit
+) {
+    when (format) {
+        CredentialFormat.ISO_MDOC -> {
+            require(request.mdocRequest != null) { "No ISO mdoc format in request" }
+        }
+
+        CredentialFormat.IETF_SDJWT -> {
+            require(request.jsonRequest != null) { "No IETF SD-JWT format in request" }
+        }
+    }
+
+    val nonce = ByteString(Random.Default.nextBytes(16))
+    val responseEncryptionKey = Crypto.createEcPrivateKey(EcCurve.P256)
+    val origin = getAppToAppOrigin()
+    val (readerKey, readerCertChain) = if (protocol.signRequest) {
+        Pair(appReaderKey, appReaderCertChain)
+    } else {
+        Pair(null, null)
+    }
+    // According to OpenID4VP, Client ID must be set for signed requests and not for unsigned requests
+    val clientId = "web-origin:$origin"
+
+    val dcRequestObject = when (format) {
+        CredentialFormat.ISO_MDOC -> {
+            val claims = mutableListOf<MdocRequestedClaim>()
+            request.mdocRequest!!.namespacesToRequest.forEach { namespaceRequest ->
+                namespaceRequest.dataElementsToRequest.forEach { (mdocDataElement, intentToRetain) ->
+                    claims.add(
+                        MdocRequestedClaim(
+                            namespaceName = namespaceRequest.namespace,
+                            dataElementName = mdocDataElement.attribute.identifier,
+                            intentToRetain = intentToRetain
+                        )
+                    )
+                }
+            }
+            VerificationUtil.generateDcRequestMdoc(
+                exchangeProtocols = protocol.exchangeProtocolNames,
+                docType = request.mdocRequest!!.docType,
+                claims = claims,
+                nonce = nonce,
+                origin = origin,
+                clientId = clientId,
+                responseEncryptionKey = responseEncryptionKey.publicKey,
+                readerAuthenticationKey = readerKey,
+                readerAuthenticationCertChain = readerCertChain,
+                zkSystemSpecs = if (request.mdocRequest!!.useZkp) {
+                    zkSystemRepository.getAllZkSystemSpecs()
+                } else {
+                    emptyList()
+                }
+            )
+        }
+
+        CredentialFormat.IETF_SDJWT -> {
+            val claims = request.jsonRequest!!.claimsToRequest.map { documentAttribute ->
+                val path = mutableListOf<JsonElement>()
+                documentAttribute.parentAttribute?.let {
+                    path.add(JsonPrimitive(it.identifier))
+                }
+                path.add(JsonPrimitive(documentAttribute.identifier))
+                JsonRequestedClaim(
+                    claimPath = JsonArray(path),
+                )
+            }
+            VerificationUtil.generateDcRequestSdJwt(
+                exchangeProtocols = protocol.exchangeProtocolNames,
+                vct = listOf(request.jsonRequest!!.vct),
+                claims = claims,
+                nonce = nonce,
+                origin = origin,
+                clientId = clientId,
+                responseEncryptionKey = responseEncryptionKey.publicKey,
+                readerAuthenticationKey = readerKey,
+                readerAuthenticationCertChain = readerCertChain,
+            )
+        }
+    }
+
+    Logger.i(TAG, "clientId: $clientId")
+    Logger.iJson(TAG, "Request", dcRequestObject)
+    val dcResponseObject = DigitalCredentials.Default.request(dcRequestObject)
+    Logger.iJson(TAG, "Response", dcResponseObject)
+
+    val dcResponse = VerificationUtil.decryptDcResponse(
+        response = dcResponseObject,
+        nonce = nonce,
+        origin = origin,
+        responseEncryptionKey = responseEncryptionKey,
+    )
+    when (dcResponse) {
+        is MdocApiDcResponse -> {
+            showResponse(null, dcResponse.deviceResponse, dcResponse.sessionTranscript, nonce)
+        }
+        is OpenID4VPDcResponse -> {
+            showResponse(dcResponse.vpToken, null, dcResponse.sessionTranscript, nonce)
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
@@ -1,0 +1,374 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.claim.organizeByNamespace
+import org.multipaz.compose.datetime.formattedDateTime
+import org.multipaz.compose.decodeImage
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.documenttype.DocumentAttributeType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.trustmanagement.TrustManager
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
+import org.multipaz.models.verification.JsonVerifiedPresentation
+import org.multipaz.models.verification.MdocVerifiedPresentation
+import org.multipaz.models.verification.VerificationUtil.verifyMdocDeviceResponse
+import org.multipaz.models.verification.VerificationUtil.verifyOpenID4VPResponse
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+private const val TAG = "ShowResponse"
+
+private sealed class Value
+
+private data class ValueText(
+    val text: String
+): Value()
+
+private data class ValueImage(
+    val text: String?,
+    val image: ImageBitmap
+): Value()
+
+private data class ValueDateTime(
+    val dateTime: Instant?
+): Value()
+
+private data class ValueDuration(
+    val duration: Duration
+): Value()
+
+private data class ValueCertChain(
+    val certChain: X509CertChain
+): Value()
+
+private data class Line(
+    val header: String,
+    val value: Value,
+    val onClick: (() -> Unit)? = null
+)
+
+private data class Section(
+    val header: String,
+    val lines: List<Line>
+)
+
+private data class VerificationResult(
+    val sections: List<Section>
+)
+
+@Composable
+fun ShowResponse(
+    vpToken: JsonObject?,
+    deviceResponse: DataItem?,
+    sessionTranscript: DataItem,
+    nonce: ByteString?,
+    eReaderKey: EcPrivateKey?,
+    issuerTrustManager: TrustManager,
+    documentTypeRepository: DocumentTypeRepository?,
+    zkSystemRepository: ZkSystemRepository?,
+    onViewCertChain: ((certChain: X509CertChain) -> Unit)?
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val verificationError = remember { mutableStateOf<Throwable?>(null) }
+    val verficationResult = remember { mutableStateOf<VerificationResult?>(null) }
+
+    LaunchedEffect(Unit) {
+        coroutineScope.launch {
+            val now = Clock.System.now()
+            try {
+                verficationResult.value = parseResponse(
+                    now = now,
+                    vpToken = vpToken,
+                    deviceResponse = deviceResponse,
+                    sessionTranscript = sessionTranscript,
+                    nonce = nonce,
+                    eReaderKey = eReaderKey,
+                    documentTypeRepository = documentTypeRepository,
+                    zkSystemRepository = zkSystemRepository,
+                    issuerTrustManager = issuerTrustManager,
+                    onViewCertChain = onViewCertChain
+                )
+            } catch (e: Throwable) {
+                Logger.e(TAG, "Error parsing response", e)
+                verificationError.value = e
+            }
+        }
+    }
+
+    if (verificationError.value != null) {
+        Text(text = verificationError.value!!.message ?: "Failed")
+    } else if (verficationResult.value != null) {
+        for (section in verficationResult.value!!.sections) {
+            val entries = mutableListOf<@Composable () -> Unit>()
+            for (line in section.lines) {
+                entries.add {
+                    Column(
+                        Modifier.fillMaxWidth().padding(8.dp)
+                            .clickable(
+                                enabled = line.onClick != null
+                            ) {
+                                line.onClick!!.invoke()
+                            }
+                    ) {
+                        Text(
+                            text = line.header,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        when (line.value) {
+                            is ValueDateTime -> {
+                                line.value.dateTime?.let {
+                                    Text(text =  formattedDateTime(instant = it))
+                                } ?: Text(text = "-")
+                            }
+                            is ValueDuration -> {
+                                Text(
+                                    text = "${line.value.duration.inWholeMilliseconds} msec"
+                                )
+                            }
+                            is ValueImage -> {
+                                line.value.text?.let {
+                                    Text(text = line.value.text)
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                }
+                                Image(
+                                    bitmap = line.value.image,
+                                    modifier = Modifier.size(200.dp),
+                                    contentDescription = null
+                                )
+                            }
+                            is ValueCertChain -> {
+                                Text(text = "Click to view")
+                            }
+
+                            is ValueText -> {
+                                Text(text = line.value.text)
+                            }
+                        }
+                    }
+                }
+            }
+            EntryList(
+                title = section.header,
+                entries = entries
+            )
+        }
+    }
+}
+
+private suspend fun parseResponse(
+    now: Instant,
+    vpToken: JsonObject?,
+    deviceResponse: DataItem?,
+    sessionTranscript: DataItem,
+    nonce: ByteString?,
+    eReaderKey: EcPrivateKey?,
+    documentTypeRepository: DocumentTypeRepository?,
+    zkSystemRepository: ZkSystemRepository?,
+    issuerTrustManager: TrustManager,
+    onViewCertChain: ((certChain: X509CertChain) -> Unit)?
+): VerificationResult {
+    val sections = mutableListOf<Section>()
+    var lines: MutableList<Line>
+
+    val verifiedPresentations = if (deviceResponse != null) {
+        verifyMdocDeviceResponse(
+            now = now,
+            deviceResponse = deviceResponse,
+            sessionTranscript = sessionTranscript,
+            eReaderKey = eReaderKey,
+            documentTypeRepository = documentTypeRepository,
+            zkSystemRepository = zkSystemRepository
+        )
+    } else if (vpToken != null) {
+        verifyOpenID4VPResponse(
+            now = now,
+            vpToken = vpToken,
+            sessionTranscript = sessionTranscript,
+            nonce = nonce!!,
+            documentTypeRepository = documentTypeRepository,
+            zkSystemRepository = zkSystemRepository
+        )
+    } else {
+        throw IllegalStateException("Either deviceResponse or vpToken must be non-null")
+    }
+
+    verifiedPresentations.forEachIndexed { vpNum, vp ->
+        lines = mutableListOf()
+        when (vp) {
+            is MdocVerifiedPresentation -> {
+                lines.add(Line("Credential format", ValueText("ISO mdoc")))
+                lines.add(Line("DocType", ValueText(vp.docType)))
+                lines.add(Line("Issuer DS curve", ValueText(vp.documentSignerCertChain.certificates.first().ecPublicKey.curve.name)))
+                val trustResult =
+                    issuerTrustManager.verify(vp.documentSignerCertChain.certificates, now)
+                if (trustResult.isTrusted) {
+                    val tpName =
+                        trustResult.trustPoints.first().metadata?.displayName?.let { " ($it)" } ?: ""
+                    lines.add(Line("Issuer Trusted", ValueText("Yes$tpName")))
+                } else {
+                    lines.add(Line("Issuer Trusted", ValueText("No")))
+                }
+                lines.add(
+                    Line(
+                        "Issuer certificate chain",
+                        ValueCertChain(vp.documentSignerCertChain),
+                        { onViewCertChain?.let { it(vp.documentSignerCertChain) } }
+                    )
+                )
+                lines.add(Line("Valid from", ValueDateTime(vp.validFrom)))
+                lines.add(Line("Valid until", ValueDateTime(vp.validUntil)))
+                lines.add(Line("Signed at", ValueDateTime(vp.signedAt)))
+                lines.add(Line("Expected update", ValueDateTime(vp.expectedUpdate)))
+
+                for (n in listOf(0, 1)) {
+                    val claims = if (n == 0) { vp.issuerSignedClaims } else { vp.deviceSignedClaims }
+                    for ((namespace, claims) in claims.organizeByNamespace()) {
+                        val namespaceHeader = if (n == 0) { "Namespace" } else { "Namespace (device-signed)" }
+                        lines.add(Line(namespaceHeader, ValueText(namespace)))
+                        for (claim in claims) {
+                            val line = if (claim.attribute != null && claim.attribute!!.type == DocumentAttributeType.Picture) {
+                                val image = decodeImage(claim.value.asBstr)
+                                Line(claim.displayName, ValueImage(claim.render(), image))
+                            } else {
+                                Line(claim.displayName, ValueText(claim.render()))
+                            }
+                            lines.add(line)
+                        }
+                    }
+                }
+            }
+
+            is JsonVerifiedPresentation -> {
+                lines.add(Line("Credential format", ValueText("IETF SD-JWT VC")))
+                lines.add(Line("Verifiable Credential Type", ValueText(vp.vct)))
+                lines.add(Line("Issuer DS curve", ValueText(vp.documentSignerCertChain.certificates.first().ecPublicKey.curve.name)))
+                val trustResult =
+                    issuerTrustManager.verify(vp.documentSignerCertChain.certificates, now)
+                if (trustResult.isTrusted) {
+                    val tpName =
+                        trustResult.trustPoints.first().metadata?.displayName?.let { " ($it)" } ?: ""
+                    lines.add(Line("Issuer Trusted", ValueText("Yes$tpName")))
+                } else {
+                    lines.add(Line("Issuer Trusted", ValueText("No")))
+                }
+                lines.add(
+                    Line(
+                        "Issuer certificate chain",
+                        ValueCertChain(vp.documentSignerCertChain),
+                        { onViewCertChain?.let { it(vp.documentSignerCertChain) } }
+                    )
+                )
+                lines.add(Line("Valid from", ValueDateTime(vp.validFrom)))
+                lines.add(Line("Valid until", ValueDateTime(vp.validUntil)))
+                lines.add(Line("Signed at", ValueDateTime(vp.signedAt)))
+                lines.add(Line("Expected update", ValueDateTime(vp.expectedUpdate)))
+                for (n in listOf(0, 1)) {
+                    val (claims, trailer) = if (n == 0) {
+                        Pair(vp.issuerSignedClaims, "")
+                    } else {
+                        Pair(vp.deviceSignedClaims, " (Device Signed)")
+                    }
+                    for (claim in claims) {
+                        val line = if (claim.attribute != null && claim.attribute!!.type == DocumentAttributeType.Picture) {
+                            val image = decodeImage(claim.value.jsonPrimitive.content.fromBase64Url())
+                            Line(claim.displayName + trailer, ValueImage(claim.render(), image))
+                        } else {
+                            Line(claim.displayName + trailer, ValueText(claim.render()))
+                        }
+                        lines.add(line)
+                    }
+                }
+            }
+        }
+        sections.add(
+            Section(
+                header = "Document ${vpNum + 1} of ${verifiedPresentations.size}",
+                lines = lines
+            )
+        )
+    }
+    return VerificationResult(sections)
+}
+
+@Composable
+private fun EntryList(
+    modifier: Modifier = Modifier,
+    title: String?,
+    entries: List<@Composable () -> Unit>,
+) {
+    if (title != null) {
+        Text(
+            modifier = modifier.padding(top = 16.dp, bottom = 8.dp),
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.secondary,
+        )
+    }
+
+    for (n in entries.indices) {
+        val section = entries[n]
+        val isFirst = (n == 0)
+        val isLast = (n == entries.size - 1)
+        val rounded = 16.dp
+        val firstRounded = if (isFirst) rounded else 0.dp
+        val endRound = if (isLast) rounded else 0.dp
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(shape = RoundedCornerShape(firstRounded, firstRounded, endRound, endRound))
+                .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+                .padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            CompositionLocalProvider(
+                LocalContentColor provides MaterialTheme.colorScheme.onSurface
+            ) {
+                section()
+            }
+        }
+        if (!isLast) {
+            Spacer(modifier = Modifier.height(2.dp))
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponseScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponseScreen.kt
@@ -1,0 +1,50 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.JsonObject
+import org.multipaz.cbor.DataItem
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.trustmanagement.TrustManager
+
+private const val TAG = "ShowResponseScreen"
+
+@Composable
+fun ShowResponseScreen(
+    vpToken: JsonObject?,
+    deviceResponse: DataItem?,
+    sessionTranscript: DataItem,
+    nonce: ByteString?,
+    issuerTrustManager: TrustManager,
+    documentTypeRepository: DocumentTypeRepository?,
+    zkSystemRepository: ZkSystemRepository?,
+    onViewCertChain: (certChain: X509CertChain) -> Unit
+) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth().padding(8.dp)
+            .verticalScroll(scrollState)
+    ) {
+        ShowResponse(
+            vpToken = vpToken,
+            deviceResponse = deviceResponse,
+            sessionTranscript = sessionTranscript,
+            nonce = nonce,
+            eReaderKey = null,
+            issuerTrustManager = issuerTrustManager,
+            documentTypeRepository = documentTypeRepository,
+            zkSystemRepository = zkSystemRepository,
+            onViewCertChain = onViewCertChain
+        )
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -39,6 +39,7 @@ import multipazproject.samples.testapp.generated.resources.face_detection_title
 import multipazproject.samples.testapp.generated.resources.selfie_check_title
 import multipazproject.samples.testapp.generated.resources.face_match_title
 import kotlinx.coroutines.launch
+import multipazproject.samples.testapp.generated.resources.dc_request_title
 import multipazproject.samples.testapp.generated.resources.barcode_scanning_title
 import multipazproject.samples.testapp.generated.resources.camera_title
 import multipazproject.samples.testapp.generated.resources.trusted_issuers_screen_title
@@ -67,6 +68,7 @@ fun StartScreen(
     onClickNfc: () -> Unit = {},
     onClickIsoMdocProximitySharing: () -> Unit = {},
     onClickIsoMdocProximityReading: () -> Unit = {},
+    onClickDcRequest: () -> Unit = {},
     onClickMdocTransportMultiDeviceTesting: () -> Unit = {},
     onClickCertificatesViewerExamples: () -> Unit = {},
     onClickRichText: () -> Unit = {},
@@ -221,6 +223,12 @@ fun StartScreen(
                 item {
                     TextButton(onClick = onClickIsoMdocProximityReading) {
                         Text(stringResource(Res.string.iso_mdoc_proximity_reading_title))
+                    }
+                }
+
+                item {
+                    TextButton(onClick = onClickDcRequest) {
+                        Text(stringResource(Res.string.dc_request_title))
                     }
                 }
 

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
@@ -135,3 +135,7 @@ private fun openDatabase(): SQLiteConnection {
 actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Darwin
 
 actual val platformSecureAreaHasKeyAgreement = true
+
+actual fun getAppToAppOrigin(): String {
+    TODO("Add support for iOS")
+}


### PR DESCRIPTION
Concretely, this includes a new `request()` method on the existing `DigitalCredentials` type which can be used to request credentials from local applications on the same device. Also add support for this in samples/testapp in a new "W3C Digital Credentials Request" screen which works a lot like https://verifier.multipaz.org except that it's a native app requesting from local apps on the device.

Since user interaction is needed for this, introduce new `UiContext` multiplatform class with concrete `AndroidUiContext` implementation for Android. This is used by `DigitalCredentials.request()` to get a reference to the Activity to bounce back to when having obtained the response from the wallet.

Also factor out existing verification code to `VerificationUtil` object and change multipaz-verifier-server to use this.

Test: Manually tested.
