### PR TITLE
Highlight open source developer website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Bug fixes and new features are welcome! We use GitHub and request that changes a
 submitted as pull requests. When uploading a PR, it will be reviewed by maintainers,
 here are some pointers about what we're looking for:
 
+## Contributing to Code
+
 - A PR should not contain unrelated changes
   - In particular do not include unrelated changes even despite how tempting it is to e.g. change
     `check(!something.isEmpty())` to `check(something.isNotEmpty())` in a unrelated file,
@@ -24,3 +26,9 @@ here are some pointers about what we're looking for:
 
 Before uploading a PR, it's generally a good idea to manually review the commit (using
 e.g. `git show`) and check that it meets all the requirements above.
+
+## Contributing to Documentation
+
+The Multipaz developer website at [developer.multipaz.org](https://developer.multipaz.org) is also open source! 
+For documentation contributions, see the [website repository](https://github.com/openwallet-foundation/multipaz-developer-website).
+

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ which is a simple Android mDL reader application.
 
 ## Developer Resources
 
-[developer.multipaz.org](developer.multipaz.org) is a comprehensive resource for developers.
+[developer.multipaz.org](developer.multipaz.org) is a comprehensive resource for developers. **The entire developer website is open source** and contributions are welcome!
 
 ### Documentation
 
@@ -139,6 +139,7 @@ which is a simple Android mDL reader application.
 ### Community & Contribution
 
 - [Contributing Guide](https://developer.multipaz.org/contributing/contributing)
+- [Website Contribution Guide](https://github.com/openwallet-foundation/multipaz-developer-website)
 - [Blog](https://developer.multipaz.org/blog)
 - [Discord](https://discord.com/invite/openwalletfoundation)
 


### PR DESCRIPTION
Makes it more visible that [developer.multipaz.org](https://developer.multipaz.org) is open source and encourages contributions.

**Changes:**
- Added badges and prominent open source messaging in README
- Updated CONTRIBUTING.md to mention documentation contributions
- Points contributors to [website repository](https://github.com/openwallet-foundation/multipaz-developer-website)

**Why:** Many developers don't realize the documentation is open source. This increases transparency and encourages community contributions.

---

### Checklist
- [ ] Tests pass
- [x] Appropriate changes to README are included in PR