### PR TITLE
NFC: Simplify NFC reading and allow using the tag after the scanning prompt.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
@@ -123,7 +123,9 @@ fun MdocProximityQrPresentment(
             }
 
             PresentmentModel.State.CONNECTING -> {
-                showQrCode(qrCodeToShow.value!!)
+                qrCodeToShow.value?.let {
+                    showQrCode(it)
+                }
             }
 
             PresentmentModel.State.WAITING_FOR_SOURCE,

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcIsoTagAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcIsoTagAndroid.kt
@@ -7,7 +7,8 @@ import kotlin.coroutines.CoroutineContext
 
 class NfcIsoTagAndroid(
     private val tag: IsoDep,
-    private val tagContext: CoroutineContext,
+    private val context: CoroutineContext,
+    private val updateMessage: (message: String) -> Unit
 ): NfcIsoTag() {
     companion object {
         private const val TAG = "NfcIsoTagAndroid"
@@ -16,16 +17,23 @@ class NfcIsoTagAndroid(
     override val maxTransceiveLength: Int
         get() = tag.maxTransceiveLength
 
+    override suspend fun close() {
+        // This is a no-op on Android
+    }
+
+    override suspend fun updateDialogMessage(message: String) {
+        updateMessage(message)
+    }
+
     override suspend fun transceive(command: CommandApdu): ResponseApdu {
         val encodedCommand = command.encode()
         check(encodedCommand.size <= maxTransceiveLength) {
             "APDU is ${encodedCommand.size} bytes which exceeds maxTransceiveLength of $maxTransceiveLength bytes"
         }
         // Because transceive() blocks the calling thread, we want to ensure this runs in the
-        // dedicated thread that was created for interacting with the tag and which onTagDiscovered()
-        // was called in.
+        // context such as Dispatchers.IO where it's allowed to do so.
         //
-        val responseApduData = withContext(tagContext) {
+        val responseApduData = withContext(context) {
             try {
                 tag.transceive(encodedCommand)
             } catch (e: TagLostException) {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/scanNfcTag.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/scanNfcTag.android.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager
 import org.multipaz.context.applicationContext
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.NfcDialogParameters
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
 
@@ -15,14 +16,12 @@ actual val nfcTagScanningSupportedWithoutDialog: Boolean = nfcTagScanningSupport
 
 actual suspend fun<T: Any> scanNfcTag(
     message: String?,
-    tagInteractionFunc: suspend (
-        tag: NfcIsoTag,
-        updateMessage: (message: String) -> Unit
-    ) -> T?,
+    tagInteractionFunc: suspend (tag: NfcIsoTag) -> T?,
+    context: CoroutineContext
 ): T {
     val promptModel = AndroidPromptModel.get(coroutineContext)
     val result = promptModel.scanNfcPromptModel.displayPrompt(
-        NfcDialogParameters(message, tagInteractionFunc)
+        NfcDialogParameters(message, tagInteractionFunc, context)
     )
     @Suppress("UNCHECKED_CAST")
     return result as T

--- a/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModel.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModel.kt
@@ -91,13 +91,12 @@ suspend fun showBiometricPrompt(
  *
  * @param initialMessage the message to initially show in the dialog or `null` to not show a dialog at all.
  * @param interactionFunction the function which is called when the tag is in the field.
+ * @param context the [CoroutineContext] to use for calls which blocks the calling thread.
  */
 class NfcDialogParameters<out T>(
     val initialMessage: String?,
-    val interactionFunction: suspend (
-        tag: NfcIsoTag,
-        updateMessage: (message: String) -> Unit
-    ) -> T?
+    val interactionFunction: suspend (tag: NfcIsoTag) -> T?,
+    val context: CoroutineContext
 )
 
 class BiometricPromptState(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
@@ -1,5 +1,7 @@
 package org.multipaz.mdoc.nfc
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import org.multipaz.cbor.DataItem
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.transport.MdocTransport
@@ -11,13 +13,25 @@ import org.multipaz.prompt.PromptDismissedException
 import org.multipaz.util.Logger
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.mdoc.role.MdocRole
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Clock
+import kotlin.time.Duration
 
 const private val TAG = "scanNfcMdocReader"
 
-private data class ScanNfcMdocReaderResult(
+/**
+ * Result from NFC engagement.
+ *
+ * @property transport The [MdocTransport] which to hand over to.
+ * @property encodedDeviceEngagement the device engagement that was used.
+ * @property handover the handover that was used.
+ * @property processingDuration the amount of time spent exchanging APDUs to set up the handover.
+ */
+data class ScanNfcMdocReaderResult(
     val transport: MdocTransport,
     val encodedDeviceEngagement: ByteString,
     val handover: DataItem,
+    val processingDuration: Duration
 )
 
 /**
@@ -25,16 +39,9 @@ private data class ScanNfcMdocReaderResult(
  *
  * This uses [scanNfcTag] to show a dialog prompting the user to tap the mdoc.
  *
- * When a connection has been established, [onHandover] is called with the created transport as well as
- * the device engagement and handover structures used.
- *
- * If the given transport is for [org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc] the
- * [onHandover] callback is called in the same coroutine used for interacting with the tag to ensure
- * continued communications with the remote NFC tag reader and the `updateMessage` parameter to [onHandover]
- * will be non-`null` which the application can use to update the message in the NFC scanning dialog.
- * Otherwise [onHandover] is called in the calling coroutine right after the NFC interaction with
- * `updateMessage` set to `null`. In either case, any exception thrown in [onHandover] will be thrown
- * from this method.
+ * This blocks until a connection has been established and on successful handover a [ScanNfcMdocReaderResult]
+ * instance is returned with the transport, device engagement, handover, and the time spent exchanging APDUs
+ * with the remote mdoc.
  *
  * @param message the message to display in the NFC tag scanning dialog or `null` to not show a dialog. Not all
  *   platforms supports not showing a dialog, use [org.multipaz.nfc.nfcTagScanningSupportedWithoutDialog] to check at
@@ -44,8 +51,8 @@ private data class ScanNfcMdocReaderResult(
  * @param selectConnectionMethod used to choose a connection method if the remote mdoc is using NFC static handover.
  * @param negotiatedHandoverConnectionMethods the connection methods to offer if the remote mdoc is using NFC
  * Negotiated Handover.
- * @param onHandover: Will be called on successful handover.
- * @return `true` if [onHandover] was invoked, `false` if no handover happened.
+ * @param context the [CoroutineContext] to use for calls to the tag which blocks the calling thread.
+ * @return a [ScanNfcMdocReaderResult] if successful handover was established, `null` if the user dismissed the dialog.
  */
 suspend fun scanNfcMdocReader(
     message: String?,
@@ -53,13 +60,8 @@ suspend fun scanNfcMdocReader(
     transportFactory: MdocTransportFactory = MdocTransportFactory.Default,
     selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?,
     negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
-    onHandover: suspend (
-        transport: MdocTransport,
-        encodedDeviceEngagement: ByteString,
-        handover: DataItem,
-        updateMessage: ((message: String) -> Unit)?
-    ) -> Unit
-): Boolean {
+    context: CoroutineContext = Dispatchers.IO
+): ScanNfcMdocReaderResult? {
     // Start creating transports for Negotiated Handover and start advertising these
     // immediately. This helps with connection time because the holder's device will
     // get a chance to opportunistically read the UUIDs which helps reduce scanning
@@ -80,7 +82,8 @@ suspend fun scanNfcMdocReader(
     try {
         val result = scanNfcTag(
             message = message,
-            tagInteractionFunc = tagInteractionFunc@{ tag, updateMessage ->
+            tagInteractionFunc = tagInteractionFunc@{ tag ->
+                val t0 = Clock.System.now()
                 val handoverResult = mdocReaderNfcHandover(
                     tag = tag,
                     negotiatedHandoverConnectionMethods = negotiatedHandoverTransports.map { it.connectionMethod },
@@ -118,32 +121,24 @@ suspend fun scanNfcMdocReader(
                     )
                 }
 
-                val result = ScanNfcMdocReaderResult(
-                    transport = transport!!,
-                    encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
-                    handover = handoverResult.handover
-                )
-
-                // If using NFC transport, run onHandover synchronously to keep the NFC tag reading
-                // dialog visible and NfcIsoTag instance alive.
-                if (result.transport is NfcTransportMdocReader) {
-                    result.transport.setTag(tag)
-                    onHandover(
-                        result.transport,
-                        result.encodedDeviceEngagement,
-                        result.handover,
-                        updateMessage
-                    )
+                if (transport is NfcTransportMdocReader) {
+                    transport.setTag(tag)
+                } else {
+                    tag.close()
                 }
-                result
-            }
+
+                ScanNfcMdocReaderResult(
+                    transport = transport,
+                    encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
+                    handover = handoverResult.handover,
+                    processingDuration = Clock.System.now() - t0
+                )
+            },
+            context = context
         )
-        if (result.transport !is NfcTransportMdocReader) {
-            onHandover(result.transport, result.encodedDeviceEngagement, result.handover, null)
-        }
-        return true
+        return result
     } catch (_: PromptDismissedException) {
-        return false
+        return null
     } finally {
         // Close listening transports that went unused.
         transportsToClose.forEach {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
@@ -73,6 +73,15 @@ class NfcTransportMdocReader(
         )
     }
 
+    /**
+     * Updates the message on the NFC scanning dialog
+     *
+     * @param message the message to show.
+     */
+    suspend fun updateDialogMessage(message: String) {
+        tag.updateDialogMessage(message)
+    }
+
     private var ioJob: Job? = null
 
     override suspend fun open(eSenderKey: EcPublicKey) {
@@ -241,6 +250,9 @@ class NfcTransportMdocReader(
             ioJob?.cancel()
             ioJob = null
             incomingMessages.close()
+            if (::tag.isInitialized) {
+                tag.close()
+            }
             _state.value = State.CLOSED
         }
     }
@@ -254,6 +266,7 @@ class NfcTransportMdocReader(
             return
         }
         Logger.w(TAG, "Failing transport with error", error)
+        Error().printStackTrace()
         incomingMessages.close(error)
         ioJob?.cancel()
         ioJob = null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
@@ -12,6 +12,8 @@ import kotlin.time.Duration
  * Class representing a ISO/IEC 14443-4 tag.
  *
  * This is an abstract super class intended for OS-specific code to implement the [transceive] method.
+ *
+ * Once you're done with the tag, [close] must be called to release all resources.
  */
 abstract class NfcIsoTag {
 
@@ -30,6 +32,18 @@ abstract class NfcIsoTag {
      * @throws NfcTagLostException if the tag was lost.
      */
     abstract suspend fun transceive(command: CommandApdu): ResponseApdu
+
+    /**
+     * Closes the tag and releases all resources.
+     */
+    abstract suspend fun close()
+
+    /**
+     * Updates the message in the Scan NFC dialog
+     *
+     * @param message the new message to show.
+     */
+    abstract suspend fun updateDialogMessage(message: String)
 
     /**
      * Selects an application according to ISO 7816-4 clause 11.2.2.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/scanNfcTag.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/scanNfcTag.kt
@@ -1,6 +1,9 @@
 package org.multipaz.nfc
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import org.multipaz.prompt.PromptDismissedException
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Is set to true if the device supports NFC scanning.
@@ -18,14 +21,22 @@ expect val nfcTagScanningSupportedWithoutDialog: Boolean
  * This only works if [nfcTagScanningSupported] is `true`.
  *
  * When a tag is in the field, [tagInteractionFunc] is called and is passed a [NfcIsoTag] which can be
- * used to communicate with the remote tag and also a function to update the message shown in the dialog.
- * The latter is useful if the transaction is expected to take a long time, for example if reading data
- * from a passport this can be used to convey the progress.
+ * used to communicate with the remote tag (using [NfcIsoTag.transceive]) and update the message shown in
+ * the dialog (using [NfcIsoTag.updateDialogMessage]. The latter is useful if the transaction is expected
+ * to take a long time, for example if reading data from a passport this can be used to convey the progress.
  *
  * If the given [tagInteractionFunc] returns `null` then polling is restarted, the session is kept alive,
- * the dialog stays visible, and the function may be called again if another tag enters the field. Otherwise
- * the session ends, a brief success indication is displayed, the dialog is removed, and the return value of
- * [tagInteractionFunc] is returned.
+ * the dialog stays visible, and the function may be called again if another tag enters the field.
+ *
+ * Otherwise if [tagInteractionFunc] is done interrogating the tag it must call [NfcIsoTag.close] and
+ * return a value. If this happens the session ends, a brief success indication is displayed, the dialog is
+ * removed, and the return value of [tagInteractionFunc] is returned.
+ *
+ * If [tagInteractionFunc] is not done interrogating the tag but wishes to defer processing to later, it may
+ * return a value (which must include a reference to the tag) and the return value of [tagInteractionFunc]
+ * is returned. When eventually done with the tag, [NfcIsoTag.close] must be called to release resources.
+ * Depending on the platform the dialog may be kept visible, for example this is true on iOS where the
+ * dialog is drawn by the operating system.
  *
  * If [tagInteractionFunc] throws an exception which isn't [NfcTagLostException] the message in
  * the [Throwable] is briefly displayed in the dialog with an error indication, and the exception is
@@ -42,6 +53,7 @@ expect val nfcTagScanningSupportedWithoutDialog: Boolean
  *   platforms supports not showing a dialog, use [nfcTagScanningSupportedWithoutDialog] to check at runtime
  *   if the platform supports this.
  * @param tagInteractionFunc the function which is called when the tag is in the field, see above.
+ * @param context the [CoroutineContext] to use for calls to the tag which blocks the calling thread.
  * @return return value of [tagInteractionFunc]
  * @throws PromptDismissedException if the user canceled the dialog
  * @throws IllegalArgumentException if [message] is `null` and [nfcTagScanningSupportedWithoutDialog] is `false`.
@@ -49,8 +61,6 @@ expect val nfcTagScanningSupportedWithoutDialog: Boolean
  */
 expect suspend fun<T: Any> scanNfcTag(
     message: String?,
-    tagInteractionFunc: suspend (
-        tag: NfcIsoTag,
-        updateMessage: (message: String) -> Unit
-    ) -> T?,
+    tagInteractionFunc: suspend (tag: NfcIsoTag) -> T?,
+    context: CoroutineContext = Dispatchers.IO
 ): T

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
@@ -37,6 +37,12 @@ class MdocNfcEngagementHelperTest {
         override val maxTransceiveLength: Int
             get() = 65536
 
+        override suspend fun close() {
+            transcript.appendLine("close")
+        }
+
+        override suspend fun updateDialogMessage(message: String) {}
+
         override suspend fun transceive(command: CommandApdu): ResponseApdu {
             transcript.appendLine("${command}")
             val response = engagementHelper.processApdu(command)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
@@ -34,6 +34,12 @@ class NfcTransportTests {
 
         override var maxTransceiveLength = 0xfeff
 
+        override suspend fun close() {
+            transcript.appendLine("close")
+        }
+
+        override suspend fun updateDialogMessage(message: String) {}
+
         @OptIn(ExperimentalCoroutinesApi::class)
         override suspend fun transceive(command: CommandApdu): ResponseApdu {
             transcript.appendLine("${command.toString().truncateTo(100)} (${command.encode().size} bytes)")
@@ -108,6 +114,7 @@ CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=65272) (7
 ResponseApdu(status=24869, payload=ByteString(size=65272 hex=000000000000000000000000000000000000000... (65274 bytes)
 CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=37) (5 bytes)
 ResponseApdu(status=36864, payload=ByteString(size=8989 hex=0000000000000000000000000000000000000000... (8991 bytes)
+close
             """.trimIndent().trim(),
             tag.transcript.toString().trim()
         )
@@ -167,6 +174,7 @@ CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=39) (5 by
 ResponseApdu(status=24878, payload=ByteString(size=4089 hex=0000000000000000000000000000000000000000... (4091 bytes)
 CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=46) (5 bytes)
 ResponseApdu(status=36864, payload=ByteString(size=39 hex=000000000000000000000000000000000000000000... (41 bytes)
+close
             """.trimIndent().trim(),
             tag.transcript.toString().trim()
         )

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/nfc/scanNfcTag.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/nfc/scanNfcTag.jvm.kt
@@ -1,15 +1,15 @@
 package org.multipaz.nfc
 
+import kotlin.coroutines.CoroutineContext
+
 actual val nfcTagScanningSupported = false
 
 actual val nfcTagScanningSupportedWithoutDialog: Boolean = false
 
 actual suspend fun<T: Any> scanNfcTag(
     message: String?,
-    tagInteractionFunc: suspend (
-        tag: NfcIsoTag,
-        updateMessage: (message: String) -> Unit
-    ) -> T?,
+    tagInteractionFunc: suspend (tag: NfcIsoTag) -> T?,
+    context: CoroutineContext
 ): T {
     throw NotImplementedError("scanNfcTag is not available for JVM")
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -192,12 +192,16 @@ data object ShowResponseDestination : Destination {
     const val DEVICE_RESPONSE = "device_response_arg"
     const val SESSION_TRANSCRIPT = "session_transcript_arg"
     const val NONCE = "nonce_arg"
-    val routeWithArgs = "$route/{$VP_TOKEN}/{$DEVICE_RESPONSE}/{$SESSION_TRANSCRIPT}/{$NONCE}"
+    const val EREADERKEY = "ereaderkey_arg"
+    const val METADATA = "metadata_arg"
+    val routeWithArgs = "$route/{$VP_TOKEN}/{$DEVICE_RESPONSE}/{$SESSION_TRANSCRIPT}/{$NONCE}/{$EREADERKEY}/{$METADATA}"
     val arguments = listOf(
         navArgument(VP_TOKEN) { type = NavType.StringType },
         navArgument(DEVICE_RESPONSE) { type = NavType.StringType },
         navArgument(SESSION_TRANSCRIPT) { type = NavType.StringType },
         navArgument(NONCE) { type = NavType.StringType },
+        navArgument(EREADERKEY) { type = NavType.StringType },
+        navArgument(METADATA) { type = NavType.StringType },
     )
 }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ShowResponseMetadata.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ShowResponseMetadata.kt
@@ -1,0 +1,16 @@
+package org.multipaz.testapp
+
+import org.multipaz.cbor.annotation.CborSerializable
+
+@CborSerializable
+data class ShowResponseMetadata(
+    val engagementType: String,
+    val transferProtocol: String,
+    val requestSize: Long,
+    val responseSize: Long,
+    val durationMsecNfcTapToEngagement: Long?,
+    val durationMsecEngagementReceivedToRequestSent: Long?,
+    val durationMsecRequestSentToResponseReceived: Long
+) {
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
@@ -76,12 +76,13 @@ fun NfcScreen(
                         try {
                             val ccFile = scanNfcTag(
                                 message = "Hold your phone near a NDEF tag.",
-                                tagInteractionFunc = { tag, updateMessage ->
+                                tagInteractionFunc = { tag ->
                                     tag.selectApplication(Nfc.NDEF_APPLICATION_ID)
                                     tag.selectFile(Nfc.NDEF_CAPABILITY_CONTAINER_FILE_ID)
                                     val ccFile = tag.readBinary(0, 15)
                                     check(ccFile.size == 15) { "CC file is ${ccFile.size} bytes, expected 15" }
-                                    updateMessage("CC file: ${ccFile.toHex()}")
+                                    tag.updateDialogMessage("CC file: ${ccFile.toHex()}")
+                                    tag.close()
                                     ccFile
                                 }
                             )
@@ -106,12 +107,13 @@ fun NfcScreen(
                         try {
                             val ccFile = scanNfcTag(
                                 message = "Hold your phone near a NDEF tag.",
-                                tagInteractionFunc = { tag, updateMessage ->
+                                tagInteractionFunc = { tag ->
                                     tag.selectApplication(Nfc.NDEF_APPLICATION_ID)
                                     tag.selectFile(Nfc.NDEF_CAPABILITY_CONTAINER_FILE_ID)
                                     val ccFile = tag.readBinary(0, 15)
                                     check(ccFile.size == 15) { "CC file is ${ccFile.size} bytes, expected 15" }
-                                    updateMessage("CC file: ${ccFile.toHex()}")
+                                    tag.updateDialogMessage("CC file: ${ccFile.toHex()}")
+                                    tag.close()
                                     ccFile
                                 },
                             )
@@ -141,12 +143,13 @@ fun NfcScreen(
                         try {
                             val ccFile = scanNfcTag(
                                 message = null,
-                                tagInteractionFunc = { tag, updateMessage ->
+                                tagInteractionFunc = { tag ->
                                     tag.selectApplication(Nfc.NDEF_APPLICATION_ID)
                                     tag.selectFile(Nfc.NDEF_CAPABILITY_CONTAINER_FILE_ID)
                                     val ccFile = tag.readBinary(0, 15)
                                     check(ccFile.size == 15) { "CC file is ${ccFile.size} bytes, expected 15" }
-                                    updateMessage("CC file: ${ccFile.toHex()}")
+                                    tag.updateDialogMessage("CC file: ${ccFile.toHex()}")
+                                    tag.close()
                                     ccFile
                                 },
                             )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponseScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponseScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.ui.unit.dp
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.JsonObject
 import org.multipaz.cbor.DataItem
+import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.testapp.ShowResponseMetadata
 import org.multipaz.trustmanagement.TrustManager
 
 private const val TAG = "ShowResponseScreen"
@@ -24,6 +26,8 @@ fun ShowResponseScreen(
     deviceResponse: DataItem?,
     sessionTranscript: DataItem,
     nonce: ByteString?,
+    eReaderKey: EcPrivateKey?,
+    metadata: ShowResponseMetadata,
     issuerTrustManager: TrustManager,
     documentTypeRepository: DocumentTypeRepository?,
     zkSystemRepository: ZkSystemRepository?,
@@ -40,7 +44,8 @@ fun ShowResponseScreen(
             deviceResponse = deviceResponse,
             sessionTranscript = sessionTranscript,
             nonce = nonce,
-            eReaderKey = null,
+            eReaderKey = eReaderKey,
+            metadata = metadata,
             issuerTrustManager = issuerTrustManager,
             documentTypeRepository = documentTypeRepository,
             zkSystemRepository = zkSystemRepository,


### PR DESCRIPTION
Currently `scanNfcMdocReader()` returns the result in a lambda with the semantics that if the created transport was for NFC data transfer, that lambda is called in a separate coroutine and the caller is expected to perform all data transfer in this call.

This is a somewhat unintuitive and even undesirable API as an Identity Reader app will typically want to switch to another screen as soon as data transfer is initiated and the fact that the launched coroutine is canceled with switching to another screen this doesn't work in practice for 18013-5 NFC data transfer.

Thus, change the API of `scanNfcTag()` to return the result in the return value and make the caller responsible for closing the `NfcIsoTag`. This change allows for deferred processing even after `scanNfcTag()` returns. Use this in `scanNfcMdocReader()` and have `NfcTransportMdocReader()` close the tag when itself is closed. Also move the function to update text in the Scan NFC dialog to `NfcIsoTag` itself.

As a result NFC data transfer now works much better both in Multipaz Test App and also in Identity Reader. This also paves the way for creating a hybrid 18013-5 transport where we try to stay on NFC as long as possible and fall back to BLE only if the tag and reader is separated (see AP 109.04 in ISO JTC1 SC17 WG10).

Also improve "ISO mdoc Proximity Reader" screen in testapp so it jumps directly to the "Received Credentials" screen in the case of the connection being closed after a single request. Also show more detailed "transfer info" including engagement type, transfer protocol, request/response size, and durations in various stages of the protocol.

Test: Manually tested on both Android and iOS.
