### PR TITLE
MdocTransportOptions: Split "use L2CAP" into engagement and GATT.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
@@ -94,7 +94,7 @@ fun MdocProximityQrPresentment(
                         val advertisedTransports = qrSettings.availableConnectionMethods.advertise(
                             role = MdocRole.MDOC,
                             transportFactory = transportFactory,
-                            options = MdocTransportOptions(bleUseL2CAP = true),
+                            options = qrSettings.createTransportOptions,
                         )
                         val encodedDeviceEngagement = ByteString(Cbor.encode(
                             buildDeviceEngagement(eDeviceKey = eDeviceKey.publicKey) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManager.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManager.kt
@@ -12,7 +12,8 @@ internal interface BlePeripheralManager {
         client2ServerCharacteristicUuid: UUID,
         server2ClientCharacteristicUuid: UUID,
         identCharacteristicUuid: UUID?,
-        l2capCharacteristicUuid: UUID?
+        l2capCharacteristicUuid: UUID?,
+        startL2capServer: Boolean
     )
 
     fun setCallbacks(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -40,7 +40,12 @@ internal class BleTransportCentralMdoc(
     override val state: StateFlow<State> = _state.asStateFlow()
 
     override val connectionMethod: MdocConnectionMethod
-        get() = MdocConnectionMethodBle(false, true, null, uuid)
+        get() = MdocConnectionMethodBle(
+            supportsPeripheralServerMode = false,
+            supportsCentralClientMode = true,
+            peripheralServerModeUuid = null,
+            centralClientModeUuid = uuid
+        )
 
     init {
         centralManager.setUuids(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -43,7 +43,7 @@ internal class BleTransportCentralMdocReader(
                 supportsCentralClientMode = true,
                 peripheralServerModeUuid = null,
                 centralClientModeUuid = uuid,
-                peripheralServerModePsm = peripheralManager.l2capPsm,
+                peripheralServerModePsm = if (options.bleUseL2CAPInEngagement) peripheralManager.l2capPsm else null,
                 peripheralServerModeMacAddress = null
             )
         }
@@ -58,7 +58,8 @@ internal class BleTransportCentralMdocReader(
                 UUID.fromString("0000000b-a123-48ce-896b-4c76973373e6")
             } else {
                 null
-            }
+            },
+            startL2capServer = options.bleUseL2CAPInEngagement
         )
         peripheralManager.setCallbacks(
             onError = { error ->

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -43,7 +43,7 @@ internal class BleTransportPeripheralMdoc(
                 supportsCentralClientMode = false,
                 peripheralServerModeUuid = uuid,
                 centralClientModeUuid = null,
-                peripheralServerModePsm = peripheralManager.l2capPsm,
+                peripheralServerModePsm = if (options.bleUseL2CAPInEngagement) peripheralManager.l2capPsm else null,
                 peripheralServerModeMacAddress = null
             )
         }
@@ -58,7 +58,8 @@ internal class BleTransportPeripheralMdoc(
                 UUID.fromString("0000000a-a123-48ce-896b-4c76973373e6")
             } else {
                 null
-            }
+            },
+            startL2capServer = options.bleUseL2CAPInEngagement
         )
         peripheralManager.setCallbacks(
             onError = { error ->

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -39,7 +39,12 @@ internal class BleTransportPeripheralMdocReader(
     override val state: StateFlow<State> = _state.asStateFlow()
 
     override val connectionMethod: MdocConnectionMethod
-        get() = MdocConnectionMethodBle(true, false, uuid, null)
+        get() = MdocConnectionMethodBle(
+            supportsPeripheralServerMode = true,
+            supportsCentralClientMode = false,
+            peripheralServerModeUuid = uuid,
+            centralClientModeUuid = null
+        )
 
     init {
         centralManager.setUuids(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransportOptions.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransportOptions.kt
@@ -3,8 +3,10 @@ package org.multipaz.mdoc.transport
 /**
  * Options for using a [MdocTransport].
  *
- * @property bleUseL2CAP set to `true` to use L2CAP if available, `false` otherwise
+ * @property bleUseL2CAP set to `true` to use BLE L2CAP if available, `false` otherwise
+ * @property bleUseL2CAPInEngagement set to `true` to use BLE L2CAP from the engagement, `false` otherwise.
  */
 data class MdocTransportOptions(
-    val bleUseL2CAP: Boolean = false
+    val bleUseL2CAP: Boolean = false,
+    val bleUseL2CAPInEngagement: Boolean = false
 )

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
@@ -22,7 +22,10 @@ class TestAppMdocNdefService: MdocNdefService() {
             staticHandoverBleCentralClientModeEnabled = settingsModel.presentmentBleCentralClientModeEnabled.value,
             staticHandoverBlePeripheralServerModeEnabled = settingsModel.presentmentBlePeripheralServerModeEnabled.value,
             staticHandoverNfcDataTransferEnabled = settingsModel.presentmentNfcDataTransferEnabled.value,
-            transportOptions = MdocTransportOptions(bleUseL2CAP = settingsModel.presentmentBleL2CapEnabled.value),
+            transportOptions = MdocTransportOptions(
+                bleUseL2CAP = settingsModel.presentmentBleL2CapEnabled.value,
+                bleUseL2CAPInEngagement = settingsModel.presentmentBleL2CapInEngagementEnabled.value
+            ),
             promptModel = platformPromptModel,
             presentmentActivityClass = TestAppMdocNfcPresentmentActivity::class.java
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -132,11 +132,12 @@ class TestAppSettingsModel private constructor(
     //
 
     private suspend fun init() {
-        bind(presentmentBleCentralClientModeEnabled, "presentmentBleCentralClientModeEnabled", true)
-        bind(presentmentBlePeripheralServerModeEnabled, "presentmentBlePeripheralServerModeEnabled", false)
+        bind(presentmentBleCentralClientModeEnabled, "presentmentBleCentralClientModeEnabled", false)
+        bind(presentmentBlePeripheralServerModeEnabled, "presentmentBlePeripheralServerModeEnabled", true)
         bind(presentmentNfcDataTransferEnabled, "presentmentNfcDataTransferEnabled", false)
         bind(presentmentSessionEncryptionCurve, "presentmentSessionEncryptionCurve", EcCurve.P256)
-        bind(presentmentBleL2CapEnabled, "presentmentBleL2CapEnabled", true)
+        bind(presentmentBleL2CapEnabled, "presentmentBleL2CapEnabled", false)
+        bind(presentmentBleL2CapInEngagementEnabled, "presentmentBleL2CapInEngagementEnabled", true)
         bind(presentmentUseNegotiatedHandover, "presentmentUseNegotiatedHandover", true)
         bind(presentmentAllowMultipleRequests, "presentmentAllowMultipleRequests", false)
         bind(presentmentNegotiatedHandoverPreferredOrder, "presentmentNegotiatedHandoverPreferredOrder",
@@ -153,7 +154,8 @@ class TestAppSettingsModel private constructor(
         bind(readerBleCentralClientModeEnabled, "readerBleCentralClientModeEnabled", true)
         bind(readerBlePeripheralServerModeEnabled, "readerBlePeripheralServerModeEnabled", true)
         bind(readerNfcDataTransferEnabled, "readerNfcDataTransferEnabled", true)
-        bind(readerBleL2CapEnabled, "readerBleL2CapEnabled", true)
+        bind(readerBleL2CapEnabled, "readerBleL2CapEnabled", false)
+        bind(readerBleL2CapInEngagementEnabled, "readerBleL2CapInEngagementEnabled", true)
         bind(readerAutomaticallySelectTransport, "readerAutomaticallySelectTransport", false)
         bind(readerAllowMultipleRequests, "readerAllowMultipleRequests", false)
 
@@ -168,6 +170,7 @@ class TestAppSettingsModel private constructor(
     val presentmentNfcDataTransferEnabled = MutableStateFlow<Boolean>(false)
     val presentmentSessionEncryptionCurve = MutableStateFlow<EcCurve>(EcCurve.P256)
     val presentmentBleL2CapEnabled = MutableStateFlow<Boolean>(false)
+    val presentmentBleL2CapInEngagementEnabled = MutableStateFlow<Boolean>(false)
     val presentmentUseNegotiatedHandover = MutableStateFlow<Boolean>(false)
     val presentmentAllowMultipleRequests = MutableStateFlow<Boolean>(false)
     val presentmentNegotiatedHandoverPreferredOrder = MutableStateFlow<List<String>>(listOf())
@@ -179,6 +182,7 @@ class TestAppSettingsModel private constructor(
     val readerBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(false)
     val readerNfcDataTransferEnabled = MutableStateFlow<Boolean>(false)
     val readerBleL2CapEnabled = MutableStateFlow<Boolean>(false)
+    val readerBleL2CapInEngagementEnabled = MutableStateFlow<Boolean>(false)
     val readerAutomaticallySelectTransport = MutableStateFlow<Boolean>(false)
     val readerAllowMultipleRequests = MutableStateFlow<Boolean>(false)
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
@@ -54,7 +54,10 @@ class MultiDeviceTestsClient(
                 val getPsmFromReader = if (parts[6] == "true") true else false
                 val encodedDeviceEngagement = parts[7].fromBase64Url()
                 val test = Test.valueOf(testName)
-                val options = MdocTransportOptions(bleUseL2CAP = bleUseL2CAP)
+                val options = MdocTransportOptions(
+                    bleUseL2CAP = bleUseL2CAP,
+                    bleUseL2CAPInEngagement = bleUseL2CAP,
+                )
 
                 Logger.i(TAG, "====== STARTING ITERATION ${iterationNumber} OF ${numIterationsTotal} ======")
                 Logger.i(TAG, "Test: $test")

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -129,7 +129,10 @@ class MultiDeviceTestsServer(
                 true
             }
         }
-        val options = MdocTransportOptions(bleUseL2CAP = bleUseL2CAP)
+        val options = MdocTransportOptions(
+            bleUseL2CAP = bleUseL2CAP,
+            bleUseL2CAPInEngagement = bleUseL2CAP
+        )
 
         var holderSuccess = false
         var readerSuccess = false

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -128,7 +128,8 @@ fun IsoMdocProximitySharingScreen(
                             MdocProximityQrSettings(
                                 availableConnectionMethods = connectionMethods,
                                 createTransportOptions = MdocTransportOptions(
-                                    bleUseL2CAP = settingsModel.presentmentBleL2CapEnabled.value
+                                    bleUseL2CAP = settingsModel.presentmentBleL2CapEnabled.value,
+                                    bleUseL2CAPInEngagement = settingsModel.presentmentBleL2CapInEngagementEnabled.value
                                 )
                             )
                         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
@@ -171,6 +171,13 @@ fun SettingsScreen(
         }
         item {
             SettingToggle(
+                title = "Use L2CAP in engagement if available",
+                isChecked = app.settingsModel.presentmentBleL2CapInEngagementEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentBleL2CapInEngagementEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
                 title = "Keep connection open after first request",
                 isChecked = app.settingsModel.presentmentAllowMultipleRequests.collectAsState().value,
                 onCheckedChange = { app.settingsModel.presentmentAllowMultipleRequests.value = it },
@@ -222,6 +229,13 @@ fun SettingsScreen(
                 title = "Use L2CAP if available",
                 isChecked = app.settingsModel.readerBleL2CapEnabled.collectAsState().value,
                 onCheckedChange = { app.settingsModel.readerBleL2CapEnabled.value = it },
+            )
+        }
+        item {
+            SettingToggle(
+                title = "Use L2CAP in engagement if available",
+                isChecked = app.settingsModel.readerBleL2CapInEngagementEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.readerBleL2CapInEngagementEnabled.value = it },
             )
         }
         item {


### PR DESCRIPTION
Unfortunately Apple Wallet's L2CAP implementation is broken so production Identity Readers cannot default to leaving L2CAP on if they want to make sure they work with Apple Wallet. This is quite annoying as L2CAP is helpful for both performance and robustness (by virtue of being simpler).

However what we can do is to split the "use L2CAP" option into "use L2CAP in engagement" (which is the new thing being standardized in ISO/IEC 18013-5 Second Edition) and "use L2CAP from GATT layer" (the thing in ISO/IEC 18013-5:2021) and leave the former on and the latter off.

Also change the default for QR engagement (and NFC Static Handover, which isn't used by default) to be BLE Peripheral Server mode since that allows us to convey the PSM in the QR code thus leading to fast connections over L2CAP by default.

Test: Manually tested.