### PR TITLE
Fix incorrect `apv` and `apu` JWE headers

### DIFF
--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/openid/OpenID4VP.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/openid/OpenID4VP.kt
@@ -496,8 +496,9 @@ object OpenID4VP {
                         claimsSet = vpToken.jsonObject,
                         recipientPublicKey = reReaderPublicKey,
                         encAlg = reEncAlg,
-                        apu = nonce.encodeToByteString(),
-                        apv = walletGeneratedNonce.encodeToByteString(),
+                        // TODO: set correct apu value SessionTranscript.mdocGeneratedNonce https://github.com/openwallet-foundation/multipaz/issues/1288
+                        apu = walletGeneratedNonce.encodeToByteString(), 
+                        apv = nonce.encodeToByteString(),
                         kid = reKid,
                         compressionLevel = compressionLevel
                     )


### PR DESCRIPTION
Reordered `apu` and `apv` parameters in JsonWebEncryption.encrypt call and added a TODO comment for correct `apu` header value  implementation.

Related to #1288, does not completely fix it

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR