### PR TITLE
Cbor: Add missing opt-in for ExperimentalEncodingApi.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
@@ -18,6 +18,7 @@ import org.multipaz.util.toBase64
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.toHex
 import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 /**
  * Abstract base class for CBOR data items.
@@ -379,6 +380,7 @@ sealed class DataItem(
      *
      * @return a [JsonElement].
      */
+    @OptIn(ExperimentalEncodingApi::class)
     fun toJson(): JsonElement {
         // See RFC 8949 section 6.1
         return when (this) {


### PR DESCRIPTION
This was noticed by a downstream when integrating the 0.94.0 release.

Test: Unit tests.
