### PR TITLE
testapp: Use non-backed-up storage.

### DIFF
--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -308,7 +308,7 @@ class App private constructor (val promptModel: PromptModel) {
     }
 
     private suspend fun settingsInit() {
-        settingsModel = TestAppSettingsModel.create(Platform.storage)
+        settingsModel = TestAppSettingsModel.create(Platform.nonBackedUpStorage)
     }
 
     private suspend fun documentTypeRepositoryInit() {
@@ -323,7 +323,7 @@ class App private constructor (val promptModel: PromptModel) {
     }
 
     private suspend fun documentStoreInit() {
-        softwareSecureArea = SoftwareSecureArea.create(Platform.storage)
+        softwareSecureArea = SoftwareSecureArea.create(Platform.nonBackedUpStorage)
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(softwareSecureArea)
             .add(Platform.getSecureArea())
@@ -344,7 +344,7 @@ class App private constructor (val promptModel: PromptModel) {
             }
             .build()
         documentStore = buildDocumentStore(
-            storage = Platform.storage,
+            storage = Platform.nonBackedUpStorage,
             secureAreaRepository = secureAreaRepository
         ) {
             //setTableSpec(testDocumentTableSpec)
@@ -374,7 +374,7 @@ class App private constructor (val promptModel: PromptModel) {
             documentMetadataInitializer = App::initializeDocumentMetadata
         )
         provisioningSupport = ProvisioningSupport(
-            storage = Platform.storage,
+            storage = Platform.nonBackedUpStorage,
             secureArea = Platform.getSecureArea(),
         )
         provisioningSupport.init()
@@ -483,7 +483,7 @@ class App private constructor (val promptModel: PromptModel) {
     private lateinit var keyStorage: StorageTable
 
     private suspend fun keyStorageInit() {
-        keyStorage = Platform.storage.getTable(
+        keyStorage = Platform.nonBackedUpStorage.getTable(
             StorageTableSpec(
                 name = "TestAppKeys",
                 supportPartitions = false,


### PR DESCRIPTION
It looks like recent Android versions are backing up and restoring the app's data directory. This leads to crashes when the app is starting up and looking for Android Keystore keys that don't exist. This can easily be reproduced by uninstalling and then reinstalling the app. For example, if you squash multiple commits into one then - because we use the number of commits as the version number - you need to uninstall the old version and reinstall so this is easy to run into.

Move testapp entirely to storing its data in non-backed-up data to work around this.

Test: Manually tested.
