### PR TITLE
Move to use SigningKey where possible.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -76,10 +76,9 @@ import kotlin.time.Instant.Companion.fromEpochMilliseconds
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.multipaz.crypto.SigningKey
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.mdoc.role.MdocRole
-import org.multipaz.securearea.SecureAreaProvider
-import java.security.Security
 import java.util.Calendar
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -176,8 +175,7 @@ class DeviceRetrievalHelperTest {
         documentSignerKey = createEcPrivateKey(EcCurve.P256)
         documentSignerCert = X509Cert.Builder(
             publicKey = documentSignerKey.publicKey,
-            signingKey = documentSignerKey,
-            signatureAlgorithm = documentSignerKey.curve.defaultSigningAlgorithm,
+            signingKey = SigningKey.anonymous(documentSignerKey, documentSignerKey.curve.defaultSigningAlgorithm),
             serialNumber = ASN1Integer(1L),
             subject = X500Name.fromName("CN=State of Utopia"),
             issuer = X500Name.fromName("CN=State of Utopia"),
@@ -401,9 +399,9 @@ class DeviceRetrievalHelperTest {
                             .setIssuerNamespaces(mergedIssuerNamespaces)
                             .setDeviceNamespacesSignature(
                                 deviceSignedData,
-                                mdocCredential.secureArea,
-                                mdocCredential.alias,
-                                null
+                                secureArea = mdocCredential.secureArea,
+                                keyAlias = mdocCredential.alias,
+                                keyUnlockData = null
                             )
                             .generate()
                     )

--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
@@ -100,14 +100,14 @@ private suspend fun handleGet(
     """.trimIndent()
     )
 
-    for (certificate in keyMaterial.attestationKeyCertificates.certificates) {
+    for (certificate in keyMaterial.attestationKey.certChain.certificates) {
         sb.append("<h3>Certificate</h3>")
         sb.append("<pre>")
         sb.append(ASN1.print(ASN1.decode(certificate.tbsCertificate)!!))
         sb.append("</pre>")
     }
     sb.append("<h2>Cloud Binding Key Attestation Root</h2>")
-    for (certificate in keyMaterial.cloudBindingKeyCertificates.certificates) {
+    for (certificate in keyMaterial.cloudBindingKey.certChain.certificates) {
         sb.append("<h3>Certificate</h3>")
         sb.append("<pre>")
         sb.append(ASN1.print(ASN1.decode(certificate.tbsCertificate)!!))
@@ -146,15 +146,9 @@ private fun createCloudSecureArea(
     val keyMaterial = keyMaterialDeferred.await()
     val settings = CloudSecureAreaSettings(backendEnvironment.getInterface(Configuration::class)!!)
     CloudSecureAreaServer(
-        serverSecureAreaBoundKey = keyMaterial.serverSecureAreaBoundKey,
+        serverSecureAreaBoundKey = keyMaterial.serverSecureAreaBoundKey.toByteArray(),
         attestationKey = keyMaterial.attestationKey,
-        attestationKeySignatureAlgorithm = keyMaterial.attestationKeySignatureAlgorithm,
-        attestationKeyIssuer = keyMaterial.attestationKeyIssuer,
-        attestationKeyCertification = keyMaterial.attestationKeyCertificates,
         cloudRootAttestationKey = keyMaterial.cloudBindingKey,
-        cloudRootAttestationKeySignatureAlgorithm = keyMaterial.cloudBindingKeySignatureAlgorithm,
-        cloudRootAttestationKeyIssuer = keyMaterial.cloudBindingKeyIssuer,
-        cloudRootAttestationKeyCertification = keyMaterial.cloudBindingKeyCertificates,
         e2eeKeyLimitSeconds = settings.cloudSecureAreaRekeyingIntervalSeconds,
         iosReleaseBuild = settings.iosReleaseBuild,
         iosAppIdentifiers = settings.iosAppIdentifiers,

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
@@ -26,7 +26,6 @@ import org.multipaz.mdoc.mso.MobileSecurityObjectParser
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.response.DeviceResponseGenerator
 import org.multipaz.mdoc.response.DocumentGenerator
-import org.multipaz.mdoc.util.toMdocRequest
 import org.multipaz.mdoc.zkp.ZkSystem
 import org.multipaz.mdoc.zkp.ZkSystemSpec
 import org.multipaz.models.openid.OpenID4VP

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
@@ -118,7 +118,6 @@ internal class CredentialFactoryAgeVerification : CredentialFactoryBase() {
                 signingKey,
                 taggedEncodedMso,
                 true,
-                signingKey.publicKey.curve.defaultSigningAlgorithm,
                 protectedHeaders,
                 unprotectedHeaders
             ).toDataItem()

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryBase.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryBase.kt
@@ -1,6 +1,7 @@
 package org.multipaz.openid4vci.credential
 
 import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.SigningKey
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.rpc.backend.BackendEnvironment
@@ -10,18 +11,21 @@ import org.multipaz.rpc.backend.Resources
  * Common parts of [CredentialFactory] implementation.
  */
 internal abstract class CredentialFactoryBase: CredentialFactory {
-    final override lateinit var signingCertificateChain: X509CertChain
-        private set
 
-    protected lateinit var signingKey: EcPrivateKey
+    protected lateinit var signingKey: SigningKey.X509Certified
+
+    override val signingCertificateChain: X509CertChain get() = signingKey.certChain
 
     final override suspend fun initialize() {
         val resources = BackendEnvironment.getInterface(Resources::class)!!
         val cert = X509Cert.fromPem(resources.getStringResource("ds_certificate.pem")!!)
-        signingCertificateChain = X509CertChain(listOf(cert))
-        signingKey = EcPrivateKey.fromPem(
-            resources.getStringResource("ds_private_key.pem")!!,
-            cert.ecPublicKey
+        // TODO: move to configuration
+        signingKey = SigningKey.X509CertifiedExplicit(
+            privateKey = EcPrivateKey.fromPem(
+                pemEncoding = resources.getStringResource("ds_private_key.pem")!!,
+                publicKey = cert.ecPublicKey
+            ),
+            certChain = X509CertChain(listOf(cert))
         )
     }
 }

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
@@ -4,7 +4,6 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Tagged
-import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.toDataItem
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
@@ -27,8 +26,6 @@ import kotlinx.datetime.yearsUntil
 import org.multipaz.cbor.RawCbor
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.Uint
-import org.multipaz.cbor.addCborMap
-import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.toDataItemFullDate
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
@@ -204,7 +201,6 @@ internal class CredentialFactoryMdl : CredentialFactoryBase() {
                 signingKey,
                 taggedEncodedMso,
                 true,
-                signingKey.publicKey.curve.defaultSigningAlgorithm,
                 protectedHeaders,
                 unprotectedHeaders
             ).toDataItem()

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -184,7 +184,6 @@ internal class CredentialFactoryMdocPid : CredentialFactoryBase() {
                 signingKey,
                 taggedEncodedMso,
                 true,
-                signingKey.publicKey.curve.defaultSigningAlgorithm,
                 protectedHeaders,
                 unprotectedHeaders
             ).toDataItem()

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
@@ -131,14 +131,6 @@ internal class CredentialFactoryUtopiaLoyalty : CredentialFactoryBase() {
 
         msoGenerator.addValueDigests(issuerNamespaces)
 
-        val documentSigningKeyCert = X509Cert.fromPem(
-            resources.getStringResource("ds_certificate.pem")!!
-        )
-        val documentSigningKey = EcPrivateKey.fromPem(
-            resources.getStringResource("ds_private_key.pem")!!,
-            documentSigningKeyCert.ecPublicKey
-        )
-
         val mso = msoGenerator.generate()
         val taggedEncodedMso = Cbor.encode(Tagged(24, Bstr(mso)))
 
@@ -152,15 +144,14 @@ internal class CredentialFactoryUtopiaLoyalty : CredentialFactoryBase() {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                X509CertChain(listOf(documentSigningKeyCert)).toDataItem()
+                signingCertificateChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(
             Cose.coseSign1Sign(
-                documentSigningKey,
+                signingKey,
                 taggedEncodedMso,
                 true,
-                documentSigningKey.publicKey.curve.defaultSigningAlgorithm,
                 protectedHeaders,
                 unprotectedHeaders
             ).toDataItem()

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaMovieTicket.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaMovieTicket.kt
@@ -60,8 +60,6 @@ internal class CredentialFactoryUtopiaMovieTicket : CredentialFactoryBase() {
 
         val sdJwt = SdJwt.create(
             issuerKey = signingKey,
-            issuerAlgorithm = signingKey.curve.defaultSigningAlgorithmFullySpecified,
-            issuerCertChain = signingCertificateChain,
             kbKey = null,
             claims = ticket.toJson() as JsonObject,
             nonSdClaims = buildJsonObject {

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
@@ -1,19 +1,14 @@
 package org.multipaz.openid4vci.credential
 
-import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.crypto.X509Cert
-import org.multipaz.documenttype.knowntypes.EUPersonalID
 import org.multipaz.documenttype.knowntypes.UtopiaNaturalization
 import org.multipaz.rpc.backend.BackendEnvironment
-import org.multipaz.rpc.backend.Resources
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.buildCborMap
-import org.multipaz.crypto.X509CertChain
 import org.multipaz.sdjwt.SdJwt
 import org.multipaz.server.getBaseUrl
 
@@ -72,8 +67,6 @@ internal class CredentialFactoryUtopiaNaturatization : CredentialFactoryBase() {
 
         val sdJwt = SdJwt.create(
             issuerKey = signingKey,
-            issuerAlgorithm = signingKey.curve.defaultSigningAlgorithmFullySpecified,
-            issuerCertChain = signingCertificateChain,
             kbKey = authenticationKey,
             claims = identityAttributes,
             nonSdClaims = buildJsonObject {

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/reader.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/reader.kt
@@ -7,6 +7,7 @@ import kotlinx.io.bytestring.ByteString
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.SigningKey
 import org.multipaz.crypto.X500Name
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.mdoc.util.MdocUtil
@@ -46,7 +47,7 @@ private suspend fun loadReaderIdentity(baseUrl: String): Openid4VpVerifierModel.
     val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P384)
     val readerRootKeySubject = "CN=$baseUrl"
     val readerRootKeyCertificate = MdocUtil.generateReaderRootCertificate(
-        readerRootKey = readerRootKey,
+        readerRootKey = SigningKey.anonymous(readerRootKey),
         subject = X500Name.fromName(readerRootKeySubject),
         serial = ASN1Integer(1L),
         validFrom = validFrom,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
@@ -18,6 +18,8 @@ object JsonWebSignature {
     /**
      * Sign a claims set.
      *
+     * Use [org.multipaz.jwt.buildJwt] instead.
+     *
      * @param key the key to sign with.
      * @param signatureAlgorithm a fully-specified signature algorithm to use.
      * @param claimsSet the claims set.
@@ -25,6 +27,7 @@ object JsonWebSignature {
      * @param x5c: the certificate chain to put in the "x5c" header parameter or `null`.
      * @return the compact serialization with the JWS.
      */
+    @Deprecated("Use org.multipaz.jwt.buildJwt instead")
     fun sign(
         key: EcPrivateKey,
         signatureAlgorithm: Algorithm,
@@ -55,6 +58,8 @@ object JsonWebSignature {
     /**
      * Sign a claims set using a [SecureArea].
      *
+     * Use [org.multipaz.jwt.buildJwt] instead.
+     *
      * @param secureArea the [SecureArea] for the key to sign with.
      * @param alias the alias for key to sign with.
      * @param keyUnlockData the [KeyUnlockData] to use or `null`.
@@ -63,6 +68,7 @@ object JsonWebSignature {
      * @param x5c: the certificate chain to put in the "x5c" header parameter or `null`.
      * @return the compact serialization of the JWS.
      */
+    @Deprecated("Use org.multipaz.jwt.buildJwt instead")
     suspend fun sign(
         secureArea: SecureArea,
         alias: String,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -29,8 +29,7 @@ import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.EcPrivateKey
-import org.multipaz.crypto.X509CertChain
+import org.multipaz.crypto.SigningKey
 import org.multipaz.document.Document
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
@@ -349,8 +348,7 @@ class DocumentType private constructor(
         document: Document,
         secureArea: SecureArea,
         createKeySettings: CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCertChain: X509CertChain,
+        dsKey: SigningKey.X509Certified,
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
@@ -406,7 +404,7 @@ class DocumentType private constructor(
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                dsCertChain.toDataItem()
+                dsKey.certChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(
@@ -414,7 +412,6 @@ class DocumentType private constructor(
                 dsKey,
                 taggedEncodedMso,
                 true,
-                dsKey.publicKey.curve.defaultSigningAlgorithm,
                 protectedHeaders,
                 unprotectedHeaders
             ).toDataItem()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestGenerator.kt
@@ -18,7 +18,6 @@ package org.multipaz.mdoc.request
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
-import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.RawCbor
 import org.multipaz.cbor.Tagged

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DocumentGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DocumentGenerator.kt
@@ -17,8 +17,6 @@ package org.multipaz.mdoc.response
 
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.CborArray
-import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.RawCbor
 import org.multipaz.cbor.Tagged

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIUtil.kt
@@ -9,22 +9,23 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.SigningKey
+import org.multipaz.jwt.buildJwt
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.securearea.CreateKeySettings
-import org.multipaz.securearea.KeyInfo
+import org.multipaz.securearea.SecureArea
 import org.multipaz.securearea.SecureAreaProvider
 import org.multipaz.util.toBase64Url
 import kotlin.random.Random
-import kotlin.time.Clock
 
 internal object OpenID4VCIUtil {
     const val TAG = "OpenidUtil"
 
     private val keyCreationMutex = Mutex()
 
-    private suspend fun getKey(alias: String): KeyInfo {
+    private suspend fun ensureKey(secureArea: SecureArea, alias: String) {
         val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
-        return try {
+        try {
             secureArea.getKeyInfo(alias)
         } catch (_: Exception) {
             keyCreationMutex.withLock {
@@ -32,20 +33,10 @@ internal object OpenID4VCIUtil {
                     secureArea.getKeyInfo(alias)
                 } catch (_: Exception) {
                     secureArea.createKey(alias, CreateKeySettings())
-                    secureArea.getKeyInfo(alias)
                 }
             }
         }
     }
-
-    private suspend fun sign(alias: String, message: ByteArray): ByteArray {
-        val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
-        val sig = secureArea.sign(alias, message, null)
-        return sig.toCoseEncoded()
-    }
-
-    suspend fun dpopKey(clientId: String) = getKey("dpop:$clientId")
-    suspend fun dpopSign(clientId: String, message: ByteArray) = sign("dpop:$clientId", message)
 
     suspend fun generateDPoP(
         clientId: String,
@@ -53,17 +44,27 @@ internal object OpenID4VCIUtil {
         dpopNonce: String?,
         accessToken: String? = null
     ): String {
-        val publicKey = dpopKey(clientId).publicKey
-        val alg = publicKey.curve.defaultSigningAlgorithmFullySpecified.joseAlgorithmIdentifier
-        val header = buildJsonObject {
-            put("typ", "dpop+jwt")
-            put("alg", alg)
-            put("jwk", publicKey.toJwk(additionalClaims = buildJsonObject { put("kid", JsonPrimitive(clientId)) }))
-        }.toString().encodeToByteArray().toBase64Url()
-        val body = buildJsonObject {
+        val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
+        val dpopAlias = "dpop:$clientId"
+        ensureKey(secureArea, dpopAlias)
+        val dpopKey = SigningKey.anonymous(secureArea, dpopAlias)
+        return buildJwt(
+            type = "dpop+jwt",
+            key = dpopKey,
+            header = {
+                put(
+                    "jwk",
+                    dpopKey.publicKey.toJwk(additionalClaims = buildJsonObject {
+                        put(
+                            "kid",
+                            JsonPrimitive(clientId)
+                        )
+                    })
+                )
+            }
+        ) {
             put("htm", "POST")
             put("htu", requestUrl)
-            put("iat", Clock.System.now().epochSeconds)
             if (dpopNonce != null) {
                 put("nonce", dpopNonce)
             }
@@ -72,10 +73,7 @@ internal object OpenID4VCIUtil {
                 val hash = Crypto.digest(Algorithm.SHA256, accessToken.encodeToByteArray())
                 put("ath", hash.toBase64Url())
             }
-        }.toString().encodeToByteArray().toBase64Url()
-        val message = "$header.$body"
-        val signature = dpopSign(clientId, message.encodeToByteArray()).toBase64Url()
-        return "$message.$signature"
+        }
     }
 
     suspend fun createClientAssertion(endpoint: String): String {
@@ -85,27 +83,18 @@ internal object OpenID4VCIUtil {
 
     suspend fun createWalletAttestationPoP(
         clientId: String,
-        keyInfo: KeyInfo,
+        key: SigningKey,
         endpointUrl: Url,
         nonce: String? = null
-    ): String {
-        val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
-        val alg = keyInfo.publicKey.curve.defaultSigningAlgorithmFullySpecified
-        val header = buildJsonObject {
-            put("typ", "oauth-client-attestation-pop+jwt")
-            put("alg", alg.joseAlgorithmIdentifier)
-        }.toString().encodeToByteArray().toBase64Url()
-        val body = buildJsonObject {
+    ): String = buildJwt(
+            type = "oauth-client-attestation-pop+jwt",
+            key = key
+        ) {
             put("iss", clientId)
             put("aud", endpointUrl.protocolWithAuthority)
-            put("iat", Clock.System.now().epochSeconds)
             put("jti", Random.Default.nextBytes(15).toBase64Url())
             if (nonce != null) {
                 put("nonce", nonce)
             }
-        }.toString().encodeToByteArray().toBase64Url()
-        val message = "$header.$body"
-        val sig = secureArea.sign(keyInfo.alias, message.encodeToByteArray(), null)
-        return "$message.${sig.toCoseEncoded().toBase64Url()}"
-    }
+        }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
@@ -1,5 +1,6 @@
 package org.multipaz.crypto
 
+import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Integer
@@ -122,10 +123,10 @@ class X509CertTests {
     }
 
     // Checks that X509Cert.verify() works with certificates created by X509Cert.Builder
-    private fun testCertSignedWithCurve(curve: EcCurve) {
+    private fun testCertSignedWithCurve(curve: EcCurve) = runTest {
         if (!Crypto.supportedCurves.contains(curve)) {
             println("Skipping testCertSignedWithCurve($curve) since platform does not support the curve.")
-            return
+            return@runTest
         }
 
         val key = Crypto.createEcPrivateKey(curve)
@@ -135,8 +136,7 @@ class X509CertTests {
         val issuer = X500Name.fromName("CN=Foobar2")
         val cert = X509Cert.Builder(
             publicKey = key.publicKey,
-            signingKey = key,
-            signatureAlgorithm = key.curve.defaultSigningAlgorithm,
+            signingKey = SigningKey.anonymous(key, key.curve.defaultSigningAlgorithm),
             serialNumber = serialNumber,
             subject = subject,
             issuer = issuer,
@@ -236,7 +236,7 @@ class X509CertTests {
     }
 
     @Test
-    fun testExtensions() {
+    fun testExtensions() = runTest {
         val key = Crypto.createEcPrivateKey(EcCurve.P256)
         val now = Clock.System.now()
 
@@ -244,8 +244,7 @@ class X509CertTests {
 
         val cert = buildX509Cert(
             publicKey = key.publicKey,
-            signingKey = key,
-            signatureAlgorithm = key.curve.defaultSigningAlgorithmFullySpecified,
+            signingKey = SigningKey.anonymous(key, key.curve.defaultSigningAlgorithmFullySpecified),
             serialNumber = ASN1Integer(1L),
             subject = X500Name.fromName("CN=Foo"),
             issuer = X500Name.fromName("CN=Foo"),

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestParserTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestParserTest.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.mdoc.request
 
+import kotlinx.coroutines.test.runTest
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
@@ -23,6 +24,7 @@ import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.SigningKey
 import org.multipaz.crypto.X500Name
 import org.multipaz.crypto.X509Cert
 import org.multipaz.mdoc.TestVectors
@@ -132,11 +134,11 @@ class DeviceRequestParserTest {
         assertFalse(dr.readerAuthenticated)
     }
 
-    fun testDeviceRequestParserReaderAuthHelper(curve: EcCurve) {
+    fun testDeviceRequestParserReaderAuthHelper(curve: EcCurve) = runTest {
         // TODO: use assumeTrue() when available in kotlin-test
         if (!Crypto.supportedCurves.contains(curve)) {
             println("Curve $curve not supported on platform")
-            return
+            return@runTest
         }
 
         val encodedSessionTranscript = Cbor.encode(Bstr(byteArrayOf(0x01, 0x02)))
@@ -153,8 +155,7 @@ class DeviceRequestParserTest {
         )
         val readerCert = X509Cert.Builder(
             publicKey = readerKey.publicKey,
-            signingKey = readerKey,
-            signatureAlgorithm = curve.defaultSigningAlgorithm,
+            signingKey = SigningKey.anonymous(readerKey, curve.defaultSigningAlgorithm),
             serialNumber = ASN1Integer(1),
             subject = X500Name.fromName("CN=Test Key"),
             issuer = X500Name.fromName("CN=Test Key"),

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -50,6 +50,7 @@ import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import kotlinx.coroutines.test.runTest
+import org.multipaz.crypto.SigningKey
 import kotlin.time.Clock
 import kotlin.time.Instant
 import org.multipaz.document.DocumentStoreTest
@@ -149,8 +150,7 @@ class DeviceResponseGeneratorTest {
         dsKey = Crypto.createEcPrivateKey(EcCurve.P256)
         dsCert = X509Cert.Builder(
             publicKey = dsKey.publicKey,
-            signingKey = dsKey,
-            signatureAlgorithm = Algorithm.ES256,
+            signingKey = SigningKey.anonymous(dsKey, Algorithm.ES256),
             serialNumber = ASN1Integer(1),
             subject = X500Name.fromName("CN=State of Utopia DS Key"),
             issuer = X500Name.fromName("CN=State of Utopia DS Key"),

--- a/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
@@ -1,5 +1,6 @@
 package org.multipaz.sdjwt
 
+import kotlinx.coroutines.test.runTest
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -18,6 +19,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
 import org.multipaz.crypto.SignatureVerificationException
+import org.multipaz.crypto.SigningKey
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.toHex
@@ -1514,12 +1516,10 @@ class SdJwtTest {
     }
 
     @Test
-    fun testCreate() {
+    fun testCreate() = runTest {
         val issuerKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val sdJwt = SdJwt.create(
-            issuerKey = issuerKey,
-            issuerAlgorithm = Algorithm.ESP256,
-            issuerCertChain = null,
+            issuerKey = SigningKey.anonymous(issuerKey, Algorithm.ESP256),
             kbKey = null,
             random = Random(0),
             claims = Json.parseToJsonElement(
@@ -2361,13 +2361,11 @@ class SdJwtTest {
     }
 
     @Test
-    fun testPresent() {
+    fun testPresent() = runTest {
         val issuerKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val kbKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val sdJwt = SdJwt.create(
-            issuerKey = issuerKey,
-            issuerAlgorithm = Algorithm.ESP256,
-            issuerCertChain = null,
+            issuerKey = SigningKey.anonymous(issuerKey, Algorithm.ESP256),
             kbKey = kbKey.publicKey,
             random = Random(0),
             claims = Json.parseToJsonElement(
@@ -2414,8 +2412,7 @@ class SdJwtTest {
                 )
             )
             .present(
-                kbKey = kbKey,
-                kbAlgorithm = Algorithm.ESP256,
+                signingKey = SigningKey.anonymous(kbKey, Algorithm.ESP256),
                 nonce = nonce,
                 audience = "https://verifier.example.org",
                 creationTime = creationTime

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/server/BackendEnvironmentExt.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/server/BackendEnvironmentExt.kt
@@ -11,11 +11,13 @@ import kotlinx.serialization.json.jsonObject
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.SigningKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Configuration
 import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.cache
+import org.multipaz.securearea.SecureAreaRepository
 import org.multipaz.storage.StorageTableSpec
 
 suspend fun BackendEnvironment.Companion.getBaseUrl(): String =
@@ -24,33 +26,37 @@ suspend fun BackendEnvironment.Companion.getBaseUrl(): String =
 suspend fun BackendEnvironment.Companion.getDomain(): String =
     Url(getBaseUrl()).protocolWithAuthority
 
-data class ServerIdentity(
-    val privateKey: EcPrivateKey,
-    val certificateChain: X509CertChain
-)
-
 /**
  * Server identity is a pair of private key and certificate chain for the corresponding
  * public key.
  */
 suspend fun BackendEnvironment.Companion.getServerIdentity(
     name: String,
-    fallback: () -> ServerIdentity? = { null }
-): ServerIdentity =
-    cache(ServerIdentity::class, name) { _, _ -> readServerIdentity(name, fallback) }
+    fallback: suspend () -> SigningKey.X509CertifiedExplicit? = { null }
+): SigningKey =
+    cache(SigningKey::class, name) { _, _ -> readServerIdentity(name, fallback) }
 
 suspend fun BackendEnvironment.Companion.readServerIdentity(
     name: String,
-    fallback: () -> ServerIdentity? = { null }
-): ServerIdentity {
+    fallback: suspend () -> SigningKey.X509CertifiedExplicit? = { null }
+): SigningKey {
     // Read configuration
     val identityString = getInterface(Configuration::class)!!.getValue(name)
     if (identityString != null) {
         try {
             val identity = Json.parseToJsonElement(identityString).jsonObject
-            val jwk = identity["jwk"]!!.jsonObject
-            val x5c = identity["x5c"]!!.jsonArray
-            return ServerIdentity(EcPrivateKey.fromJwk(jwk), X509CertChain.fromX5c(x5c))
+            return if (identity.containsKey("jwk")) {
+                // Old way - for compatibility
+                val jwk = identity["jwk"]!!.jsonObject
+                val x5c = identity["x5c"]!!.jsonArray
+                SigningKey.X509CertifiedExplicit(
+                    privateKey = EcPrivateKey.fromJwk(jwk),
+                    certChain = X509CertChain.fromX5c(x5c)
+                )
+            } else {
+                val secureAreaRepository = getInterface(SecureAreaRepository::class)
+                SigningKey.parse(identity, secureAreaRepository)
+            }
         } catch (err: Exception) {
             throw IllegalStateException("Invalid '$name' configuration", err)
         }
@@ -62,9 +68,9 @@ suspend fun BackendEnvironment.Companion.readServerIdentity(
         val blob = table.get(name)
         if (blob != null) {
             val cbor = Cbor.decode(blob.toByteArray())
-            return ServerIdentity(
-                EcPrivateKey.fromDataItem(cbor["privateKey"]),
-                X509CertChain.fromDataItem(cbor["certificateChain"])
+            return SigningKey.X509CertifiedExplicit(
+                privateKey = EcPrivateKey.fromDataItem(cbor["privateKey"]),
+                certChain = X509CertChain.fromDataItem(cbor["certificateChain"])
             )
         }
         val fallbackIdentity = fallback.invoke()
@@ -72,7 +78,7 @@ suspend fun BackendEnvironment.Companion.readServerIdentity(
 
         val cbor = buildCborMap {
             put("privateKey", fallbackIdentity.privateKey.toDataItem())
-            put("certificateChain", fallbackIdentity.certificateChain.toDataItem())
+            put("certificateChain", fallbackIdentity.certChain.toDataItem())
         }
         table.insert(key = name, data = ByteString(Cbor.encode(cbor)))
         return fallbackIdentity

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
@@ -13,6 +13,7 @@ import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import kotlinx.coroutines.test.runTest
 import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -39,13 +40,12 @@ class JsonWebSignatureTestsNimbus {
     // TODO: Check for other curves than just P-256.
 
     @Test
-    fun testSigning() {
+    fun testSigning() = runTest {
         val signingKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val now = Clock.System.now()
         val signingKeyCert = X509Cert.Builder(
             publicKey = signingKey.publicKey,
-            signingKey = signingKey,
-            signatureAlgorithm = signingKey.curve.defaultSigningAlgorithm,
+            signingKey = SigningKey.anonymous(signingKey, signingKey.curve.defaultSigningAlgorithm),
             serialNumber = ASN1Integer(1L),
             subject = X500Name.fromName("CN=Test Key"),
             issuer = X500Name.fromName("CN=Test Key"),
@@ -94,13 +94,12 @@ class JsonWebSignatureTestsNimbus {
     }
 
     @Test
-    fun testVerification() {
+    fun testVerification() = runTest {
         val signingKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val now = Clock.System.now()
         val signingKeyCert = X509Cert.Builder(
             publicKey = signingKey.publicKey,
-            signingKey = signingKey,
-            signatureAlgorithm = signingKey.curve.defaultSigningAlgorithm,
+            signingKey = SigningKey.anonymous(signingKey, signingKey.curve.defaultSigningAlgorithm),
             serialNumber = ASN1Integer(1L),
             subject = X500Name.fromName("CN=Test Key"),
             issuer = X500Name.fromName("CN=Test Key"),

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -32,10 +32,8 @@ import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.crypto.X509Cert
-import org.multipaz.crypto.X509CertChain
+import org.multipaz.crypto.SigningKey
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentCannedRequest
@@ -93,9 +91,7 @@ object TestAppUtils {
     suspend fun generateEncodedDeviceRequest(
         request: DocumentCannedRequest,
         encodedSessionTranscript: ByteArray,
-        readerKey: EcPrivateKey,
-        readerCert: X509Cert,
-        readerRootCert: X509Cert,
+        readerKey: SigningKey.X509Compatible,
         zkSystemRepository: ZkSystemRepository? = null,
     ): ByteArray {
         val mdocRequest = request.mdocRequest!!
@@ -129,8 +125,6 @@ object TestAppUtils {
                     zkRequest = zkRequest
                 ),
                 readerKey = readerKey,
-                signatureAlgorithm = readerKey.curve.defaultSigningAlgorithm,
-                readerKeyCertificateChain = X509CertChain(listOf(readerCert, readerRootCert)),
             )
         }.toDataItem())
     }
@@ -171,8 +165,7 @@ object TestAppUtils {
             validFrom: Instant,
             validUntil: Instant
         ) -> CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey.X509Certified,
         deviceKeyAlgorithm: Algorithm,
         deviceKeyMacAlgorithm: Algorithm,
         numCredentialsPerDomain: Int,
@@ -188,7 +181,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     EUPersonalID.getDocumentType(),
@@ -213,8 +205,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 dcqlTestProvisionSdJwtVc(
                     displayName = "Max's PID",
@@ -231,8 +222,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 dcqlTestProvisionSdJwtVc(
                     displayName = "Erika's PID",
@@ -249,8 +239,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 dcqlTestProvisionSdJwtVc(
                     displayName = "Erika's ID Card",
@@ -264,8 +253,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 dcqlTestProvisionSdJwtVc(
                     displayName = "Erika's Residence Card",
@@ -280,8 +268,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 dcqlTestProvisionSdJwtVc(
                     displayName = "Erika's Reward Card",
@@ -294,8 +281,7 @@ object TestAppUtils {
                     documentStore = documentStore,
                     secureArea = secureArea,
                     secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
-                    dsKey = dsKey,
-                    dsCert = dsCert
+                    dsKey = dsKey
                 )
                 return null
             }
@@ -305,7 +291,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -319,7 +304,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -333,7 +317,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -347,7 +330,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -361,7 +343,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -375,7 +356,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -389,7 +369,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -403,7 +382,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -417,7 +395,6 @@ object TestAppUtils {
                     secureArea,
                     secureAreaCreateKeySettingsFunc,
                     dsKey,
-                    dsCert,
                     deviceKeyAlgorithm,
                     deviceKeyMacAlgorithm,
                     numCredentialsPerDomain,
@@ -446,8 +423,7 @@ object TestAppUtils {
             validFrom: Instant,
             validUntil: Instant
         ) -> CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert
+        dsKey: SigningKey
     ): Document {
         val cardArt = getDrawableResourceBytes(
             getSystemResourceEnvironment(),
@@ -478,7 +454,6 @@ object TestAppUtils {
             secureArea = secureArea,
             secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
             dsKey = dsKey,
-            dsCert = dsCert
         )
         return document
     }
@@ -498,8 +473,7 @@ object TestAppUtils {
             validFrom: Instant,
             validUntil: Instant
         ) -> CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey,
     ) {
         for (domain in listOf(CREDENTIAL_DOMAIN_SDJWT_NO_USER_AUTH, CREDENTIAL_DOMAIN_SDJWT_USER_AUTH)) {
             val credential = KeyBoundSdJwtVcCredential.create(
@@ -519,8 +493,6 @@ object TestAppUtils {
 
             val sdJwt = SdJwt.create(
                 issuerKey = dsKey,
-                issuerAlgorithm = dsKey.curve.defaultSigningAlgorithmFullySpecified,
-                issuerCertChain = X509CertChain(listOf(dsCert)),
                 kbKey = (credential as? SecureAreaBoundCredential)?.let {
                     it.secureArea.getKeyInfo(
                         it.alias
@@ -555,8 +527,7 @@ object TestAppUtils {
             validFrom: Instant,
             validUntil: Instant
         ) -> CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey.X509Certified,
         deviceKeyAlgorithm: Algorithm,
         deviceKeyMacAlgorithm: Algorithm,
         documentType: DocumentType,
@@ -592,7 +563,6 @@ object TestAppUtils {
             validFrom = validFrom,
             validUntil = validUntil,
             dsKey = dsKey,
-            dsCert = dsCert,
             numCredentialsPerDomain = 10,
             givenNameOverride = givenNameOverride
         )
@@ -609,8 +579,7 @@ object TestAppUtils {
             validFrom: Instant,
             validUntil: Instant
         ) -> CreateKeySettings,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey.X509Certified,
         deviceKeyAlgorithm: Algorithm,
         deviceKeyMacAlgorithm: Algorithm,
         numCredentialsPerDomain: Int,
@@ -647,7 +616,6 @@ object TestAppUtils {
                 validFrom = validFrom,
                 validUntil = validUntil,
                 dsKey = dsKey,
-                dsCert = dsCert,
                 numCredentialsPerDomain = numCredentialsPerDomain,
                 givenNameOverride = givenNameOverride
             )
@@ -664,7 +632,6 @@ object TestAppUtils {
                 validFrom = validFrom,
                 validUntil = validUntil,
                 dsKey = dsKey,
-                dsCert = dsCert,
                 numCredentialsPerDomain = numCredentialsPerDomain,
                 givenNameOverride = givenNameOverride
             )
@@ -687,8 +654,7 @@ object TestAppUtils {
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey.X509Certified,
         numCredentialsPerDomain: Int,
         givenNameOverride: String
     ) {
@@ -775,7 +741,7 @@ object TestAppUtils {
                 val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
                     Pair(
                         CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                        X509CertChain(listOf(dsCert)).toDataItem()
+                        dsKey.certChain.toDataItem()
                     )
                 )
                 val encodedIssuerAuth = Cbor.encode(
@@ -783,7 +749,6 @@ object TestAppUtils {
                         dsKey,
                         taggedEncodedMso,
                         true,
-                        dsKey.publicKey.curve.defaultSigningAlgorithm,
                         protectedHeaders,
                         unprotectedHeaders
                     ).toDataItem()
@@ -823,8 +788,7 @@ object TestAppUtils {
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey.X509Certified,
         numCredentialsPerDomain: Int,
         givenNameOverride: String
     ): String? {
@@ -912,7 +876,7 @@ object TestAppUtils {
             val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
                 Pair(
                     CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                    X509CertChain(listOf(dsCert)).toDataItem()
+                    dsKey.certChain.toDataItem()
                 )
             )
             val encodedIssuerAuth = Cbor.encode(
@@ -920,7 +884,6 @@ object TestAppUtils {
                     dsKey,
                     taggedEncodedMso,
                     true,
-                    dsKey.publicKey.curve.defaultSigningAlgorithm,
                     protectedHeaders,
                     unprotectedHeaders
                 ).toDataItem()
@@ -961,8 +924,7 @@ object TestAppUtils {
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
-        dsKey: EcPrivateKey,
-        dsCert: X509Cert,
+        dsKey: SigningKey,
         numCredentialsPerDomain: Int,
         givenNameOverride: String
     ) {
@@ -1024,8 +986,6 @@ object TestAppUtils {
                 val kbKey = (credential as? SecureAreaBoundCredential)?.getAttestation()?.publicKey
                 val sdJwt = SdJwt.create(
                     issuerKey = dsKey,
-                    issuerAlgorithm = dsKey.publicKey.curve.defaultSigningAlgorithmFullySpecified,
-                    issuerCertChain = X509CertChain(listOf(dsCert)),
                     kbKey = kbKey,
                     claims = identityAttributes,
                     nonSdClaims = buildJsonObject {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -357,8 +357,6 @@ fun IsoMdocProximityReadingScreen(
                                             request = requestSelected.value.sampleRequest,
                                             encodedSessionTranscript = readerSessionTranscript.value!!,
                                             readerKey = app.readerKey,
-                                            readerCert = app.readerCert,
-                                            readerRootCert = app.readerRootCert,
                                         )
                                     readerMostRecentDeviceResponse.value = byteArrayOf()
                                     readerTransport.value!!.sendMessage(
@@ -753,8 +751,6 @@ private suspend fun doReaderFlowWithTransport(
         request = selectedRequest.value.sampleRequest,
         encodedSessionTranscript = readerSessionTranscript.value!!,
         readerKey = app.readerKey,
-        readerCert = app.readerCert,
-        readerRootCert = app.readerRootCert,
         zkSystemRepository = app.zkSystemRepository,
     )
     Logger.iCbor(TAG, "deviceRequest", encodedDeviceRequest)


### PR DESCRIPTION
SigningKey encapsulates private key (software or SecureArea-resident), algorithm, and (optionally)
certificate chain or JWT-style key id ('kid'). Move to use SecureKey in almost all cases instead of
using EcPrivateKey as this (1) removes the need to pass private key, algorithm, and key identity
as three independent values (2) makes code much more generic, as SecureArea-based keys can now be
used in almost all places instead of software keys.

Also, restructured SecureArea class hierarchy, in parcifular SecureKey.X509Certified can now be
explicitly used with APIs where only keys with corresponding X509 certificates are accepted.

Test: unit tests, manual testing of testapp with verifier, openid4vci server, CSA server, and
  proximity sharing.

Fixes #1317