### PR TITLE
Split off mutable builder from CredentialLoader.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/credential/CredentialLoader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/credential/CredentialLoader.kt
@@ -25,61 +25,11 @@ import kotlin.reflect.KClass
 /**
  * A class that aids in creation of credentials from serialized data.
  *
- * The [CredentialLoader] is initially empty, but in the
- * [org.multipaz.credential] package, there are well known [Credential] implementations
- * which can be added using the [addCredentialImplementation] method. In addition,
- * applications may add their own [Credential] implementations.
+ * Use [CredentialLoaderBuilder] class to build one
  */
-internal class CredentialLoader {
-    private val createCredentialFunctions:
-            MutableMap<String, suspend (Document) -> Credential> = mutableMapOf()
-
-    /**
-     * Add a new [Credential] implementation to the loader.
-     *
-     * @param credentialType the credential type
-     * @param createCredentialFunction a function to create a [Credential] of the given type.
-     */
-    fun addCredentialImplementation(
-        credentialType: String,
-        createCredentialFunction: suspend (Document) -> Credential
-    ) {
-        if (createCredentialFunctions.contains(credentialType)) {
-            throw IllegalArgumentException("'$credentialType' is already registered")
-        }
-        createCredentialFunctions[credentialType] = createCredentialFunction
-    }
-
-    /**
-     * Adds [MdocCredential] implementation to the loader.
-     */
-    fun addMdocCredential() {
-        addCredentialImplementation(
-            credentialType = MdocCredential.CREDENTIAL_TYPE,
-            createCredentialFunction = { document -> MdocCredential(document) }
-        )
-    }
-
-    /**
-     * Adds [KeyBoundSdJwtVcCredential] implementation to the loader.
-     */
-    fun addKeyBoundSdJwtVcCredential() {
-        addCredentialImplementation(
-            credentialType = KeyBoundSdJwtVcCredential.CREDENTIAL_TYPE,
-            createCredentialFunction = { document -> KeyBoundSdJwtVcCredential(document) }
-        )
-    }
-
-    /**
-     * Adds [KeylessSdJwtVcCredential] implementation to the loader.
-     */
-    fun addKeylessSdJwtVcCredential() {
-        addCredentialImplementation(
-            credentialType = KeylessSdJwtVcCredential.CREDENTIAL_TYPE,
-            createCredentialFunction = { document -> KeylessSdJwtVcCredential(document) }
-        )
-    }
-
+internal class CredentialLoader(
+    private val createCredentialFunctions: Map<String, suspend (Document) -> Credential>
+) {
     /**
      * Loads a [Credential] from storage
      *

--- a/multipaz/src/commonMain/kotlin/org/multipaz/credential/CredentialLoaderBuilder.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/credential/CredentialLoaderBuilder.kt
@@ -1,0 +1,69 @@
+package org.multipaz.credential
+
+import org.multipaz.document.Document
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
+import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
+
+/**
+ * Builder for [CredentialLoader].
+ *
+ * The [CredentialLoaderBuilder] is initially empty. In most cases, well-known [Credential]
+ * implementations should be added using [addMdocCredential], [addKeyBoundSdJwtVcCredential] and
+ * [addKeylessSdJwtVcCredential] methods. Additionally, applications may add their own
+ * [Credential] implementations.
+ */
+internal class CredentialLoaderBuilder {
+    private val createCredentialFunctions:
+            MutableMap<String, suspend (Document) -> Credential> = mutableMapOf()
+
+    /**
+     * Adds a new [Credential] implementation to the loader.
+     *
+     * @param credentialType the credential type
+     * @param createCredentialFunction a function to create a [Credential] of the given type.
+     */
+    fun addCredentialImplementation(
+        credentialType: String,
+        createCredentialFunction: suspend (Document) -> Credential
+    ) {
+        if (createCredentialFunctions.contains(credentialType)) {
+            throw IllegalArgumentException("'$credentialType' is already registered")
+        }
+        createCredentialFunctions[credentialType] = createCredentialFunction
+    }
+
+    /**
+     * Adds [MdocCredential] implementation to the loader.
+     */
+    fun addMdocCredential() {
+        addCredentialImplementation(
+            credentialType = MdocCredential.CREDENTIAL_TYPE,
+            createCredentialFunction = { document -> MdocCredential(document) }
+        )
+    }
+
+    /**
+     * Adds [KeyBoundSdJwtVcCredential] implementation to the loader.
+     */
+    fun addKeyBoundSdJwtVcCredential() {
+        addCredentialImplementation(
+            credentialType = KeyBoundSdJwtVcCredential.CREDENTIAL_TYPE,
+            createCredentialFunction = { document -> KeyBoundSdJwtVcCredential(document) }
+        )
+    }
+
+    /**
+     * Adds [KeylessSdJwtVcCredential] implementation to the loader.
+     */
+    fun addKeylessSdJwtVcCredential() {
+        addCredentialImplementation(
+            credentialType = KeylessSdJwtVcCredential.CREDENTIAL_TYPE,
+            createCredentialFunction = { document -> KeylessSdJwtVcCredential(document) }
+        )
+    }
+
+    fun build(): CredentialLoader {
+        return CredentialLoader(createCredentialFunctions.toMap())
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.credential.Credential
+import org.multipaz.credential.CredentialLoaderBuilder
 
 /**
  * Class for storing real-world identity documents.
@@ -220,7 +221,7 @@ class DocumentStore private constructor(
         private val storage: Storage,
         private val secureAreaRepository: SecureAreaRepository,
     ) {
-        private val credentialLoader = CredentialLoader().apply {
+        private val credentialLoaderBuilder = CredentialLoaderBuilder().apply {
             addMdocCredential()
             addKeylessSdJwtVcCredential()
             addKeyBoundSdJwtVcCredential()
@@ -266,7 +267,7 @@ class DocumentStore private constructor(
             credentialType: String,
             createCredentialFunction: suspend (Document) -> Credential
         ): Builder {
-            credentialLoader.addCredentialImplementation(
+            credentialLoaderBuilder.addCredentialImplementation(
                 credentialType = credentialType,
                 createCredentialFunction = createCredentialFunction
             )
@@ -297,7 +298,7 @@ class DocumentStore private constructor(
             return DocumentStore(
                 storage = storage,
                 secureAreaRepository = secureAreaRepository,
-                credentialLoader = credentialLoader,
+                credentialLoader = credentialLoaderBuilder.build(),
                 documentMetadataFactory = documentMetadataFactory,
                 documentTableSpec = documentTableSpec
             )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -131,7 +131,7 @@ open class CloudSecureArea protected constructor(
     private val supportedAlgorithms_: List<Algorithm> by lazy {
         // TODO: get from server to support configurations where only a subset of algorithms are supported.
         Algorithm.entries.filter {
-            it.fullySpecified
+            it.fullySpecified && it.curve != null
         }
     }
 


### PR DESCRIPTION
This is an attempt to fix a flaky test. I still do not have a good explanation for the flake other than optimizer running amok, but this code restructuring will make it easier to reason about the code, as mutable and immutable objects are now split apart. It may also make it easier for the optimizer to reason about the code making the flake go away.