### PR TITLE
Fix for a flaky unit test.

### DIFF
--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
@@ -196,6 +197,11 @@ tasks["compileKotlinIosArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosSimulatorArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinJvm"].dependsOn("kspCommonMainKotlinMetadata")
 
+tasks.withType<Test> {
+    testLogging {
+        exceptionFormat = TestExceptionFormat.FULL
+    }
+}
 android {
     namespace = "org.multipaz"
     compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
@@ -97,6 +97,11 @@ class Document internal constructor(
     internal var deleted = false
         private set
 
+    /** Clear cached credentials; only used for testing */
+    internal suspend fun deleteCache() = lock.withLock {
+        credentialCache.clear()
+    }
+
     /**
      * Returns the list of identifiers for all credentials for this document.
      */

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.time.Instant;
 import kotlinx.io.bytestring.ByteString
+import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -75,6 +76,9 @@ class DocumentStoreTest {
             ) {
                 addCredentialImplementation(TestSecureAreaBoundCredential.CREDENTIAL_TYPE) { document ->
                     TestSecureAreaBoundCredential(document)
+                }
+                addCredentialImplementation(TestCredential.CREDENTIAL_TYPE) { document ->
+                    TestCredential(document)
                 }
             }
             testBody(documentStore)
@@ -668,6 +672,9 @@ class DocumentStoreTest {
                 for (documentId in documentStore.listDocuments()) {
                     // May be deleted before we load it
                     val document = documentStore.lookupDocument(documentId) ?: continue
+                    if (Random.Default.nextBoolean()) {
+                        document.deleteCache()
+                    }
                     document.getCredentials()
                 }
                 yield()  // so that this coroutine does not spin without a chance to be cancelled
@@ -684,7 +691,9 @@ class DocumentStoreTest {
                 ).addToDocument()
                 yield()
             }
-            documentStore.deleteDocument(document.identifier)
+            if (Random.Default.nextBoolean()) {
+                documentStore.deleteDocument(document.identifier)
+            }
         }
         frontEndJob.cancelAndJoin()
     }


### PR DESCRIPTION
Our caching was so efficient that it almost always prevented read from
storage, masking the error in the test. Added test-only internal API to clear the
credential cache. Fixed the unit test itself (credential type was not registered)

Also enable full exception logging in unit tests.

Fixes #1312

Signed-off-by: Peter Sorotokin <sorotokin@gmail.com>