### PR TITLE
Implement HKDF and HPKE in Kotlin Multiplatform.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportWifiAware.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportWifiAware.kt
@@ -44,7 +44,7 @@ import androidx.annotation.DoNotInline
 import androidx.annotation.RequiresApi
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.Hkdf
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.util.HexUtil
@@ -97,17 +97,17 @@ class DataTransportWifiAware(
         // Service name is always derived from EReaderKey as per 18013-5.
         var ikm = mEncodedEDeviceKeyBytes
         var info = "NANService".toByteArray()
-        var salt = byteArrayOf()
-        serviceName = HexUtil.toHex(Crypto.hkdf(Algorithm.HMAC_SHA256, ikm!!, salt, info, 16), true)
+        var salt = null
+        serviceName = HexUtil.toHex(Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm!!, salt, info, 16), true)
         Logger.d(TAG, String.format("Using calculated service name '$serviceName'"))
 
         // If the passphrase isn't given, derive as per 18013-5.
         if (mPassphrase == null) {
             ikm = mEncodedEDeviceKeyBytes
             info = "NANPassphrase".toByteArray()
-            salt = byteArrayOf()
+            salt = null
             mPassphrase = Base64.encodeToString(
-                Crypto.hkdf(Algorithm.HMAC_SHA256, ikm!!, salt, info, 32),
+                Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm!!, salt, info, 32),
                 Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
             )
             Logger.d(TAG, String.format("Using calculated passphrase '$mPassphrase'"))

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
@@ -25,7 +25,7 @@ import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.os.Build
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.Hkdf
 import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 import java.io.ByteArrayOutputStream
@@ -72,8 +72,8 @@ internal class GattClient(
         if (encodedEDeviceKeyBytes != null) {
             val ikm: ByteArray = encodedEDeviceKeyBytes
             val info = "BLEIdent".toByteArray()
-            val salt = byteArrayOf()
-            identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+            val salt = null
+            identValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
         }
         try {
             gatt = device.connectGatt(context, false, this, BluetoothDevice.TRANSPORT_LE)

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
@@ -28,7 +28,7 @@ import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.os.Build
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.Hkdf
 import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 import java.io.ByteArrayOutputStream
@@ -74,8 +74,8 @@ internal class GattServer(
     fun setEDeviceKeyBytes(encodedEDeviceKeyBytes: ByteArray) {
         val ikm: ByteArray = encodedEDeviceKeyBytes
         val info = "BLEIdent".toByteArray()
-        val salt = byteArrayOf()
-        identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+        val salt = null
+        identValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
     }
 
     @SuppressLint("NewApi")

--- a/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
+++ b/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
@@ -50,6 +50,7 @@ import org.multipaz.util.toBase64Url
 import org.multipaz.certext.CloudKeyAttestation
 import org.multipaz.certext.MultipazExtension
 import org.multipaz.certext.toCbor
+import org.multipaz.crypto.Hkdf
 import org.multipaz.crypto.SigningKey
 import org.multipaz.device.AndroidKeystoreSecurityLevel
 import org.multipaz.jwt.buildJwt
@@ -333,14 +334,14 @@ class CloudSecureAreaServer(
                 }
             )
         )
-        state.skDevice = Crypto.hkdf(
+        state.skDevice = Hkdf.deriveKey(
             Algorithm.HMAC_SHA256,
             zab,
             salt,
             "SKDevice".toByteArray(),
             32
         )
-        state.skCloud = Crypto.hkdf(
+        state.skCloud = Hkdf.deriveKey(
             Algorithm.HMAC_SHA256,
             zab,
             salt,

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -109,14 +109,12 @@ kotlin {
         val javaSharedMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation(libs.tink)
             }
         }
 
         val jvmMain by getting {
             dependsOn(javaSharedMain)
             dependencies {
-                implementation(libs.tink)
                 implementation(libs.ktor.client.java)
             }
         }
@@ -148,6 +146,7 @@ kotlin {
                 implementation(libs.postgresql)
                 implementation(libs.nimbus.oauth2.oidc.sdk)
                 implementation(libs.kotlinx.serialization.json)
+                implementation(libs.tink)
             }
         }
 

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -22,7 +22,6 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
 import org.multipaz.context.applicationContext
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
@@ -41,6 +40,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.buildByteString
+import org.multipaz.crypto.Hkdf
 import org.multipaz.util.appendByteArray
 import org.multipaz.util.appendUInt32
 import org.multipaz.util.getUInt32
@@ -589,8 +589,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
 
         val ikm = Cbor.encode(Tagged(24, Bstr(Cbor.encode(eSenderKey.toCoseKey().toDataItem()))))
         val info = "BLEIdent".encodeToByteArray()
-        val salt = byteArrayOf()
-        expectedIdentValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+        val salt = null
+        expectedIdentValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
 
         suspendCancellableCoroutine<Boolean> { continuation ->
             setWaitCondition(WaitState.GET_READER_IDENT, continuation)

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -22,7 +22,6 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
 import org.multipaz.context.applicationContext
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
@@ -39,6 +38,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteStringBuilder
+import org.multipaz.crypto.Hkdf
 import org.multipaz.util.getUInt32
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -491,8 +491,8 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
     override suspend fun setESenderKey(eSenderKey: EcPublicKey) {
         val ikm = Cbor.encode(Tagged(24, Bstr(Cbor.encode(eSenderKey.toCoseKey().toDataItem()))))
         val info = "BLEIdent".encodeToByteArray()
-        val salt = byteArrayOf()
-        identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+        val salt = null
+        identValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
     }
 
     override suspend fun waitForStateCharacteristicWriteOrL2CAPClient() {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Algorithm.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Algorithm.kt
@@ -75,6 +75,10 @@ enum class Algorithm(
     SHA512(coseAlgorithmIdentifier = -44, hashAlgorithmName = "sha-512",
         description = "SHA-2 (512 bit)"),
 
+    /** HMAC w/ SHA-1 (insecure, shouldn't be used) */
+    HMAC_INSECURE_SHA1(joseAlgorithmIdentifier = "HS1",  // Note: doesn't exist in COSE registry
+        description = "HMAC with SHA-1"),
+
     /** HMAC w/ SHA-256 */
     HMAC_SHA256(coseAlgorithmIdentifier = 5, joseAlgorithmIdentifier = "HS256",
         description = "HMAC with SHA-256"),
@@ -98,18 +102,6 @@ enum class Algorithm(
     /** AES-GCM mode w/ 256-bit key, 128-bit tag */
     A256GCM(coseAlgorithmIdentifier = 3, joseAlgorithmIdentifier = "A256GCM",
         description = "AES-GCM mode w/ 256-bit key, 128-bit tag"),
-
-    /**
-     * Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM,
-     * the HKDF-SHA256 KDF and the AES-128-GCM AEAD.
-     *
-     * Note that this value is still TBD and the proposed value is from
-     * [Use of Hybrid Public-Key Encryption (HPKE) with CBOR Object Signing and Encryption (COSE)](https://www.ietf.org/archive/id/draft-ietf-cose-hpke-07.html#IANA)
-     *
-     */
-    HPKE_BASE_P256_SHA256_AES128GCM(coseAlgorithmIdentifier = 35,
-        description = "Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM, " +
-                "the HKDF-SHA256 KDF and the AES-128-GCM AEAD"),
 
     /** RSASSA-PKCS1-v1_5 using SHA-256 */
     RS256(coseAlgorithmIdentifier = -257, joseAlgorithmIdentifier = "RS256",

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
@@ -91,26 +91,6 @@ expect object Crypto {
     ): ByteArray
 
     /**
-     * Computes an HKDF.
-     *
-     * @param algorithm must be one of [Algorithm.HMAC_SHA256], [Algorithm.HMAC_SHA384], [Algorithm.HMAC_SHA512].
-     * @param ikm the input keying material.
-     * @param salt optional salt. A possibly non-secret random value. If no salt is provided (ie. if
-     * salt has length 0) then an array of 0s of the same size as the hash digest is used as salt.
-     * @param info optional context and application specific information.
-     * @param size the length of the generated pseudorandom string in bytes. The maximal
-     * size is DigestSize, where DigestSize is the size of the underlying HMAC.
-     * @return size pseudorandom bytes.
-     */
-    fun hkdf(
-        algorithm: Algorithm,
-        ikm: ByteArray,
-        salt: ByteArray?,
-        info: ByteArray?,
-        size: Int
-    ): ByteArray
-
-    /**
      * Checks signature validity.
      *
      * @param publicKey the public key the signature was made with.
@@ -161,48 +141,6 @@ expect object Crypto {
     fun keyAgreement(
         key: EcPrivateKey,
         otherKey: EcPublicKey
-    ): ByteArray
-
-    /**
-     * Encrypts data using HPKE according to [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/).
-     *
-     * The resulting ciphertext and encapsulated key should be sent to the receiver and both
-     * parties must also agree on the AAD used.
-     *
-     * @param cipherSuite the cipher suite for selecting the KEM, KDF, and encryption algorithm.
-     *   Presently only [Algorithm.HPKE_BASE_P256_SHA256_AES128GCM] is supported.
-     * @param receiverPublicKey the public key of the receiver, curve must match the cipher suite.
-     * @param plainText the data to encrypt.
-     * @param aad additional authenticated data.
-     * @return the ciphertext and the encapsulated key.
-     */
-    fun hpkeEncrypt(
-        cipherSuite: Algorithm,
-        receiverPublicKey: EcPublicKey,
-        plainText: ByteArray,
-        aad: ByteArray
-    ): Pair<ByteArray, EcPublicKey>
-
-    /**
-     * Decrypts data using HPKE according to [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/).
-     *
-     * The ciphertext and encapsulated key should be received from the sender and both parties
-     * must also agree on the AAD to use.
-     *
-     * @param cipherSuite the cipher suite for selecting the KEM, KDF, and encryption algorithm.
-     *   Presently only [Algorithm.HPKE_BASE_P256_SHA256_AES128GCM] is supported.
-     * @param receiverPrivateKey the private key of the receiver, curve must match the cipher suite.
-     * @param cipherText the data to decrypt.
-     * @param aad additional authenticated data.
-     * @param encapsulatedPublicKey the encapsulated key.
-     * @return the plaintext.
-     */
-    fun hpkeDecrypt(
-        cipherSuite: Algorithm,
-        receiverPrivateKey: EcPrivateKey,
-        cipherText: ByteArray,
-        aad: ByteArray,
-        encapsulatedPublicKey: EcPublicKey,
     ): ByteArray
 
     internal fun ecPublicKeyToPem(publicKey: EcPublicKey): String

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Hkdf.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Hkdf.kt
@@ -1,0 +1,109 @@
+package org.multipaz.crypto
+
+import kotlinx.io.bytestring.buildByteString
+import kotlin.math.ceil
+
+/**
+ * HMAC-based Extract-and-Expand Key Derivation Function (HKDF) according
+ * to [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
+ */
+object Hkdf {
+
+    private fun getHashLen(kdfAlgorithm: Algorithm): Int {
+        return when (kdfAlgorithm) {
+            Algorithm.HMAC_INSECURE_SHA1 -> 20
+            Algorithm.HMAC_SHA256 -> 32
+            Algorithm.HMAC_SHA384 -> 48
+            Algorithm.HMAC_SHA512 -> 64
+            else -> throw IllegalArgumentException("$kdfAlgorithm is not a KDF algorithm")
+        }
+    }
+
+    /**
+     * The "extract" part of HKDF.
+     *
+     * If `null` is passed for the [salt] parameter, an array the same length
+     * as the hash function for [algorithm] is used, with all entries set to zero.
+     *
+     * @param algorithm the KDF algorithm to use e.g. [Algorithm.HMAC_SHA256].
+     * @param ikm input key material.
+     * @param salt optional salt value (a non-secret random value).
+     * @return a pseudorandom key, the same length as the hash function for [algorithm].
+     */
+    fun extract(
+        algorithm: Algorithm,
+        ikm: ByteArray,
+        salt: ByteArray?
+    ): ByteArray {
+        return Crypto.mac(
+            algorithm = algorithm,
+            key = salt ?: ByteArray(getHashLen(algorithm)),
+            message = ikm
+        )
+    }
+
+    /**
+     * The "expand" part of HKDF.
+     *
+     * @param algorithm the KDF algorithm to use e.g. [Algorithm.HMAC_SHA256].
+     * @param prk a pseudorandom key of at least the length for the hash function for [algorithm].
+     * @param info context and application specific information (can be zero-length).
+     * @param length length of output keying material in octets.
+     * @return output keying material of [length] octets.
+     */
+    fun expand(
+        algorithm: Algorithm,
+        prk: ByteArray,
+        info: ByteArray,
+        length: Int
+    ): ByteArray {
+        val hashLen = getHashLen(algorithm)
+        if (length > 255 * hashLen) {
+            throw IllegalArgumentException("HKDF length $length is too large")
+        }
+        val n = (length + hashLen - 1) / hashLen
+        val combinedT = buildByteString {
+            var prevT = byteArrayOf()
+            for (i in 1..n) {
+                val counter = byteArrayOf(i.toByte())
+                val message = prevT + info + counter
+                val newT = Crypto.mac(algorithm, prk, message)
+                append(newT)
+                prevT = newT
+            }
+        }
+        val okm = ByteArray(length)
+        combinedT.copyInto(okm, 0, 0, length)
+        return okm
+    }
+
+    /**
+     * Derives a symmetric encryption key according to HKDF as defined by
+     * [RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869).
+     *
+     * @param algorithm the KDF algorithm to use e.g. [Algorithm.HMAC_SHA256].
+     * @param ikm input key material.
+     * @param salt optional salt value (a non-secret random value).
+     * @param info context and application specific information (can be zero-length).
+     * @param length length of output keying material in octets.
+     * @return output keying material of [length] octets.
+     */
+    fun deriveKey(
+        algorithm: Algorithm,
+        ikm: ByteArray,
+        salt: ByteArray?,
+        info: ByteArray,
+        length: Int
+    ): ByteArray {
+        return expand(
+            algorithm = algorithm,
+            prk = extract(
+                algorithm = algorithm,
+                ikm = ikm,
+                salt = salt
+            ),
+            info = info,
+            length = length
+        )
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Hpke.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Hpke.kt
@@ -1,0 +1,648 @@
+package org.multipaz.crypto
+
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.buildByteString
+import org.multipaz.util.appendInt16
+import org.multipaz.util.appendInt32
+import org.multipaz.util.appendInt64
+import org.multipaz.util.appendString
+import org.multipaz.util.toHex
+import kotlin.experimental.xor
+
+/**
+ * Hybrid Public Key Encryption according to [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/).
+ */
+object Hpke {
+
+    /**
+     * Key encapsulation mechanisms to use for HPKE.
+     *
+     * Reference: RFC 9180 Table 2.
+     */
+    enum class Kem(
+        internal val curve: EcCurve,
+        internal val algId: Int     // According to RFC 9180 Table 2
+    ) {
+        /** Key encapsulation mechanism using P-256 EC key agreement and SHA-2 hashing with a 256-bit digest. */
+        DHKEM_P256_HKDF_SHA256(curve = EcCurve.P256, algId = 0x0010),
+
+        /** Key encapsulation mechanism using P-384 EC key agreement and SHA-2 hashing with a 384-bit digest. */
+        DHKEM_P384_HKDF_SHA384(curve = EcCurve.P384, algId = 0x0011),
+
+        /** Key encapsulation mechanism using P-521 EC key agreement and SHA-2 hashing with a 512-bit digest. */
+        DHKEM_P521_HKDF_SHA512(curve = EcCurve.P521, algId = 0x0012),
+
+        /** Key encapsulation mechanism using X25519 EC key agreement and SHA-2 hashing with a 256-bit digest. */
+        DHKEM_X25519_HKDF_SHA256(curve = EcCurve.X25519, algId = 0x0020),
+
+        /** Key encapsulation mechanism using X448 EC key agreement and SHA-2 hashing with a 512-bit digest. */
+        DHKEM_X448_HKDF_SHA512(curve = EcCurve.X448, algId = 0x0021)
+    }
+
+    /**
+     * Key-derivation functions to use for HPKE.
+     *
+     * Reference: RFC 9180 Table 3.
+     */
+    enum class Kdf(
+        internal val alg: Algorithm,
+        internal val algId: Int,       // According to RFC 9180 Table 3
+        internal val nh: Int,          // KDF hash output size in bytes
+    ) {
+        /** HMAC-based key derivation function that uses SHA-2 hashing with a 256-bit digest. */
+        HKDF_SHA256(alg = Algorithm.HMAC_SHA256, algId = 0x0001, nh = 32),
+
+        /** HMAC-based key derivation function that uses SHA-2 hashing with a 256-bit digest. */
+        HKDF_SHA384(alg = Algorithm.HMAC_SHA384, algId = 0x0002, nh = 48),
+
+        /** HMAC-based key derivation function that uses SHA-2 hashing with a 256-bit digest. */
+        HKDF_SHA512(alg = Algorithm.HMAC_SHA512, algId = 0x0003, nh = 64)
+    }
+
+    /**
+     * AEAD (Authenticated encryption with authenticated data) algorithms to use for HPKE.
+     *
+     * Reference: RFC 9180 Table 5.
+     */
+    enum class Aead(
+        internal val alg: Algorithm,
+        internal val algId: Int,      // According to RFC 9180 Table 5
+        internal val nk: Int,         // key size in bytes
+        internal val nn: Int,         // nonce size in bytes
+    ) {
+        /**
+         * A mode where HPKE is used only for generating secrets which the sender and received can
+         * obtain via [Encrypter.exportSecret] and [Decrypter.exportSecret].
+         */
+        EXPORT_ONLY(alg = Algorithm.UNSET, algId = 0xffff, nk = 0, nn = 0),
+
+        /** AES in Galois Counter Mode with 128-bit keys */
+        AES_128_GCM(alg = Algorithm.A128GCM, algId = 0x0001, nk = 16, nn = 12),
+
+        /** AES in Galois Counter Mode with 256-bit keys */
+        AES_256_GCM(alg = Algorithm.A256GCM, algId = 0x0002, nk = 32, nn = 12),
+    }
+
+    /**
+     * Cipher suite to use for HPKE.
+     *
+     * Also see common combinations in [Hpke.CipherSuite.Companion] such as
+     * [DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM].
+     *
+     * @property kem the key encapsulation mechanisms to use.
+     * @property kdf the key-derivation functions to use.
+     * @property aead the AEAD algorithm to use.
+     */
+    data class CipherSuite(
+        val kem: Kem,
+        val kdf: Kdf,
+        val aead: Aead
+    ) {
+        companion object {
+            /**
+             * A cipher suite for HPKE using [Kem.DHKEM_X25519_HKDF_SHA256] as the KEM,
+             * [Kdf.HKDF_SHA256] as the KDF, and [Aead.AES_128_GCM] as the AEAD.
+             */
+            val DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_128_GCM = CipherSuite(
+                kem = Kem.DHKEM_X25519_HKDF_SHA256,
+                kdf = Kdf.HKDF_SHA256,
+                aead = Aead.AES_128_GCM
+            )
+
+            /**
+             * A cipher suite for HPKE using [Kem.DHKEM_P256_HKDF_SHA256] as the KEM,
+             * [Kdf.HKDF_SHA256] as the KDF, and [Aead.AES_128_GCM] as the AEAD.
+             */
+            val DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM = CipherSuite(
+                kem = Kem.DHKEM_P256_HKDF_SHA256,
+                kdf = Kdf.HKDF_SHA256,
+                aead = Aead.AES_128_GCM,
+            )
+
+            /**
+             * A cipher suite for HPKE using [Kem.DHKEM_P521_HKDF_SHA512] as the KEM,
+             * [Kdf.HKDF_SHA512] as the KDF, and [Aead.AES_256_GCM] as the AEAD.
+             */
+            val DHKEM_P521_HKDF_SHA512_HKDF_SHA512_AES_256_GCM = CipherSuite(
+                kem = Kem.DHKEM_P521_HKDF_SHA512,
+                kdf = Kdf.HKDF_SHA512,
+                aead = Aead.AES_256_GCM,
+            )
+        }
+    }
+
+    private fun getKemSuiteId(cipherSuite: CipherSuite): ByteArray {
+        return buildByteString {
+            appendString("KEM")
+            appendInt16(cipherSuite.kem.algId)
+        }.toByteArray()
+    }
+
+    private fun getHpkeSuiteId(cipherSuite: CipherSuite): ByteArray {
+        return buildByteString {
+            appendString("HPKE")
+            appendInt16(cipherSuite.kem.algId)
+            appendInt16(cipherSuite.kdf.algId)
+            appendInt16(cipherSuite.aead.algId)
+        }.toByteArray()
+    }
+
+    private fun labeledExtract(
+        suiteId: ByteArray,
+        kdf: Kdf,
+        salt: ByteArray?, // Can be null for empty string salt
+        label: String,
+        ikm: ByteArray
+    ): ByteArray {
+        val labelBytes = label.encodeToByteArray()
+        val labeledIkm = "HPKE-v1".encodeToByteArray() + suiteId + labelBytes + ikm
+        return Hkdf.extract(kdf.alg, labeledIkm, salt)
+    }
+
+    private fun labeledExpand(
+        suiteId: ByteArray,
+        kdf: Kdf,
+        prk: ByteArray,
+        label: String,
+        info: ByteArray,
+        length: Int
+    ): ByteArray {
+        val labelBytes = label.encodeToByteArray()
+        val lengthBytes = buildByteString { appendInt16(length) }.toByteArray()
+        val labeledInfo = lengthBytes + "HPKE-v1".encodeToByteArray() + suiteId + labelBytes + info
+        return Hkdf.expand(kdf.alg, prk, labeledInfo, length)
+    }
+
+    private fun extractAndExpand(
+        suiteId: ByteArray,
+        kdf: Kdf,
+        dh: ByteArray,
+        kemContext: ByteArray,
+        length: Int
+    ): ByteArray {
+        val eaePrk = labeledExtract(
+            suiteId = suiteId,
+            kdf = kdf,
+            salt = null,
+            label = "eae_prk",
+            ikm = dh
+        )
+        val sharedSecret = labeledExpand(
+            suiteId = suiteId,
+            kdf = kdf,
+            prk = eaePrk,
+            label = "shared_secret",
+            info = kemContext,
+            length = length
+        )
+        return sharedSecret
+    }
+
+    internal data class HpkeContext(
+        val cipherSuite: CipherSuite,
+        val key: ByteArray,
+        val baseNonce: ByteArray,
+        val exporterSecret: ByteArray
+    )
+
+    private suspend fun calcContext(
+        mode: Mode,
+        cipherSuite: CipherSuite,
+        dh: ByteArray,
+        info: ByteArray,
+        kemContext: ByteArray,
+        receiverKey: SigningKey?,
+        receiverKeyPub: EcPublicKey?,
+        psk: ByteArray?,
+        pskId: ByteArray?,
+        authKey: SigningKey?,
+        authKeyPub: EcPublicKey?
+    ): HpkeContext {
+        if (psk != null) {
+            require(pskId != null) {
+                "psk is non-null but pskId is null"
+            }
+        }
+        if (pskId != null) {
+            require(psk != null) {
+                "pskId is non-null but psk is null"
+            }
+        }
+
+        val sharedSecret = if (authKey != null) {
+            val dhSum = dh + authKey.keyAgreement(receiverKeyPub!!)
+            extractAndExpand(
+                suiteId = getKemSuiteId(cipherSuite),
+                kdf = cipherSuite.kdf,
+                dh = dhSum,
+                kemContext = kemContext + authKey.publicKey.serialize(),
+                length = cipherSuite.kdf.nh
+            )
+        } else if (authKeyPub != null) {
+            val dhSum = dh + receiverKey!!.keyAgreement(authKeyPub)
+            extractAndExpand(
+                suiteId = getKemSuiteId(cipherSuite),
+                kdf = cipherSuite.kdf,
+                dh = dhSum,
+                kemContext = kemContext + authKeyPub.serialize(),
+                length = cipherSuite.kdf.nh
+            )
+        } else {
+            extractAndExpand(
+                suiteId = getKemSuiteId(cipherSuite),
+                kdf = cipherSuite.kdf,
+                dh = dh,
+                kemContext = kemContext,
+                length = cipherSuite.kdf.nh
+            )
+        }
+        //println("sharedSecret = ${sharedSecret.toHex()}")
+
+        val pskIdHash = labeledExtract(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            salt = null,
+            label = "psk_id_hash",
+            ikm = pskId ?: byteArrayOf()
+        )
+
+        val infoHash = labeledExtract(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            salt = null,
+            label = "info_hash",
+            ikm = info
+        )
+
+        val keyScheduleContext = byteArrayOf(mode.value.toByte()) + pskIdHash + infoHash
+        //println("keyScheduleContext: ${keyScheduleContext.toHex()}")
+
+        val secret = labeledExtract(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            salt = sharedSecret,
+            label = "secret",
+            ikm = psk ?: byteArrayOf()
+        )
+        //println("secret: ${secret.toHex()}")
+
+        val key = labeledExpand(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            prk = secret,
+            label = "key",
+            info = keyScheduleContext,
+            length = cipherSuite.aead.nk
+        )
+        //println("key: ${key.toHex()}")
+
+        val baseNonce = labeledExpand(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            prk = secret,
+            label = "base_nonce",
+            info = keyScheduleContext,
+            length = cipherSuite.aead.nn
+        )
+        //println("baseNonce: ${baseNonce.toHex()}")
+
+        val exporterSecret = labeledExpand(
+            suiteId = getHpkeSuiteId(cipherSuite),
+            kdf = cipherSuite.kdf,
+            prk = secret,
+            label = "exp",
+            info = keyScheduleContext,
+            length = cipherSuite.kdf.nh
+        )
+        //println("exporterSecret: ${exporterSecret.toHex()}")
+
+        return HpkeContext(
+            cipherSuite = cipherSuite,
+            key = key,
+            baseNonce = baseNonce,
+            exporterSecret = exporterSecret,
+        )
+    }
+
+    /**
+     * An object which can be used for HPKE encryption.
+     *
+     * Use [getEncrypter] to create an instance.
+     *
+     * This can be used for either single-shot operation or for encrypting multiple messages.
+     * When used to encrypt multiple messages the sequence counter is automatically managed
+     * by this object.
+     *
+     * @property encapsulatedKey the encapsulated key which should be sent to the receiver.
+     */
+    @ConsistentCopyVisibility
+    data class Encrypter internal constructor(
+        val encapsulatedKey: ByteString,
+        private val hpkeContext: HpkeContext
+    ) {
+        internal var seq: Long = 0
+
+        /**
+         * Encrypts a message to the receiver.
+         *
+         * @param plaintext the message to encrypt.
+         * @param aad additional authenticated data.
+         * @return the encrypted message, including the authentication tag at the end.
+         */
+        fun encrypt(
+            plaintext: ByteArray,
+            aad: ByteArray
+        ): ByteArray {
+            require(hpkeContext.cipherSuite.aead != Aead.EXPORT_ONLY) {
+                "Cipher suite is configured for Aead.EXPORT_ONLY"
+            }
+
+            val encodedSeq = buildByteString {
+                appendInt32(0)
+                appendInt64(seq)
+            }.toByteArray()
+            require(hpkeContext.baseNonce.size == 12)
+            val effectiveNonce = encodedSeq.mapIndexed { n, value -> value xor hpkeContext.baseNonce[n] }.toByteArray()
+
+            val ciphertext = Crypto.encrypt(
+                algorithm = hpkeContext.cipherSuite.aead.alg,
+                key = hpkeContext.key,
+                nonce = effectiveNonce,
+                messagePlaintext = plaintext,
+                aad = aad
+            )
+
+            seq += 1
+            return ciphertext
+        }
+
+        /**
+         * Exports a secret.
+         *
+         * This generates a secret according to Section 5.3 of RFC 9180.
+         *
+         * @param context domain-specific context.
+         * @param length length of the secret to generate.
+         */
+        fun exportSecret(
+            context: ByteArray,
+            length: Int,
+        ): ByteArray {
+            return labeledExpand(
+                suiteId = getHpkeSuiteId(hpkeContext.cipherSuite),
+                kdf = hpkeContext.cipherSuite.kdf,
+                prk = hpkeContext.exporterSecret,
+                label = "sec",
+                info = context,
+                length = length
+            )
+        }
+    }
+
+    internal enum class Mode(
+        val value: Int,  // According to RFC 9180 Table 1
+    ) {
+        Base(0x00),
+        Psk(0x01),
+        Auth(0x02),
+        AuthPsk(0x03),
+    }
+
+    /**
+     * Creates a [Encrypter] object for HPKE in for the given [cipherSuite].
+     *
+     * @param cipherSuite the cipher suite to use, for example [Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM].
+     * @param receiverPublicKey the public key to encrypt the data against, must be compatible with [cipherSuite].
+     * @param info data which can be used to influence the generation of keys (e.g., to fold in identity information).
+     * @param psk pre-shared key to use or `null`.
+     * @param pskId the identifier for the optional pre-shared key, must be non-`null` exactly when [psk] is non-`null`.
+     * @param authKey optional authentication key or `null`.
+     * @return a [Encrypter] object which can be used to encrypt messages to the receiver.
+     */
+    suspend fun getEncrypter(
+        cipherSuite: CipherSuite,
+        receiverPublicKey: EcPublicKey,
+        info: ByteArray,
+        psk: ByteArray? = null,
+        pskId: ByteArray? = null,
+        authKey: SigningKey? = null
+    ): Encrypter {
+        val encapsulatedPublicKey = Crypto.createEcPrivateKey(cipherSuite.kem.curve)
+        return getEncrypterInternal(
+            cipherSuite = cipherSuite,
+            receiverPublicKey = receiverPublicKey,
+            info = info,
+            encapsulatedKey = encapsulatedPublicKey,
+            psk = psk,
+            pskId = pskId,
+            authKey = authKey
+        )
+    }
+
+    internal fun EcPublicKey.serialize(): ByteArray {
+        return when (curve) {
+            EcCurve.X448,
+            EcCurve.X25519 -> {
+                this as EcPublicKeyOkp
+                x
+            }
+            else -> {
+                this as EcPublicKeyDoubleCoordinate
+                asUncompressedPointEncoding
+            }
+        }
+    }
+
+    internal fun EcPublicKey.Companion.fromSerialized(
+        curve: EcCurve,
+        encoded: ByteArray
+    ): EcPublicKey {
+        return when (curve) {
+            EcCurve.X448,
+            EcCurve.X25519 -> {
+                EcPublicKeyOkp(curve = curve, x = encoded)
+            }
+            else -> {
+                EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(curve, encoded)
+            }
+        }
+    }
+
+    internal suspend fun getEncrypterInternal(
+        cipherSuite: CipherSuite,
+        receiverPublicKey: EcPublicKey,
+        info: ByteArray,
+        encapsulatedKey: EcPrivateKey,
+        psk: ByteArray?,
+        pskId: ByteArray?,
+        authKey: SigningKey?
+    ): Encrypter {
+        val dh = Crypto.keyAgreement(encapsulatedKey, receiverPublicKey)
+        val enc = encapsulatedKey.publicKey.serialize()
+        val kemContext = enc + receiverPublicKey.serialize()
+
+        val mode = if (authKey != null) {
+            if (psk != null) {
+                Mode.AuthPsk
+            } else {
+                Mode.Auth
+            }
+        } else {
+            if (psk != null) {
+                Mode.Psk
+            } else {
+                Mode.Base
+            }
+        }
+
+        val context = calcContext(
+            mode = mode,
+            cipherSuite = cipherSuite,
+            dh = dh,
+            info = info,
+            kemContext = kemContext,
+            receiverKey = null,
+            receiverKeyPub = receiverPublicKey,
+            psk = psk,
+            pskId = pskId,
+            authKey = authKey,
+            authKeyPub = null,
+        )
+
+        return Encrypter(
+            encapsulatedKey = ByteString(enc),
+            hpkeContext = context
+        )
+    }
+
+    /**
+     * An object which can be used for HPKE decryption.
+     *
+     * Use [getDecrypter] to create an instance.
+     *
+     * This can be used for either single-shot operation or for decrypting multiple messages.
+     * When used to decrypt multiple messages the sequence counter is automatically managed
+     * by this object.
+     */
+    @ConsistentCopyVisibility
+    data class Decrypter internal constructor(
+        private val hpkeContext: HpkeContext
+    ) {
+        internal var seq: Long = 0
+
+        /**
+         * Decrypts an encrypted message from the sender.
+         *
+         * @param ciphertext the encrypted message to decrypt, including the authentication tag at the end.
+         * @param aad additional authenticated data.
+         * @return the decrypted message.
+         */
+        fun decrypt(ciphertext: ByteArray, aad: ByteArray): ByteArray {
+            require(hpkeContext.cipherSuite.aead != Aead.EXPORT_ONLY) {
+                "Cipher suite is configured for Aead.EXPORT_ONLY"
+            }
+
+            val encodedSeq = buildByteString {
+                appendInt32(0)
+                appendInt64(seq)
+            }.toByteArray()
+            require(hpkeContext.baseNonce.size == 12)
+            val effectiveNonce = encodedSeq.mapIndexed { n, value -> value xor hpkeContext.baseNonce[n] }.toByteArray()
+
+            val plaintext = Crypto.decrypt(
+                algorithm = hpkeContext.cipherSuite.aead.alg,
+                key = hpkeContext.key,
+                nonce = effectiveNonce,
+                messageCiphertext = ciphertext,
+                aad = aad
+            )
+
+            seq += 1
+            return plaintext
+        }
+
+        /**
+         * Exports a secret.
+         *
+         * This generates a secret according to Section 5.3 of RFC 9180.
+         *
+         * @param context domain-specific context.
+         * @param length length of the secret to generate.
+         */
+        fun exportSecret(
+            context: ByteArray,
+            length: Int,
+        ): ByteArray {
+            return labeledExpand(
+                suiteId = getHpkeSuiteId(hpkeContext.cipherSuite),
+                kdf = hpkeContext.cipherSuite.kdf,
+                prk = hpkeContext.exporterSecret,
+                label = "sec",
+                info = context,
+                length = length
+            )
+        }
+    }
+
+    /**
+     * Creates a [Decrypter] object for HPKE for the given [cipherSuite].
+     *
+     * @param cipherSuite the cipher suite to use, for example [Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM].
+     * @param receiverPrivateKey a [SigningKey] for the key the data is encrypted against, must be compatible
+     *   with the curve in [cipherSuite] and must support key agreement.
+     * @param encapsulatedKey the encapsulated key, received from the sender.
+     * @param info data which can be used to influence the generation of keys (e.g., to fold in identity information).
+     * @param psk pre-shared key to use or `null`.
+     * @param pskId the identifier for the optional pre-shared key, must be non-`null` exactly when [psk] is non-`null`.
+     * @param authKey optional authentication key or `null`.
+     * @return a [Decrypter] object which can be used to decrypt messages from the sender.
+     */
+    suspend fun getDecrypter(
+        cipherSuite: CipherSuite,
+        receiverPrivateKey: SigningKey,
+        encapsulatedKey: ByteArray,
+        info: ByteArray,
+        psk: ByteArray? = null,
+        pskId: ByteArray? = null,
+        authKey: EcPublicKey? = null
+    ): Decrypter {
+        val encapsulatedPublicKey = EcPublicKey.fromSerialized(
+            curve = cipherSuite.kem.curve,
+            encoded = encapsulatedKey
+        )
+
+        val mode = if (authKey != null) {
+            if (psk != null) {
+                Mode.AuthPsk
+            } else {
+                Mode.Auth
+            }
+        } else {
+            if (psk != null) {
+                Mode.Psk
+            } else {
+                Mode.Base
+            }
+        }
+
+        val dh = receiverPrivateKey.keyAgreement(encapsulatedPublicKey)
+        val kemContext = encapsulatedKey + receiverPrivateKey.publicKey.serialize()
+        val context = calcContext(
+            mode = mode,
+            cipherSuite = cipherSuite,
+            dh = dh,
+            info = info,
+            kemContext = kemContext,
+            receiverKey = receiverPrivateKey,
+            receiverKeyPub = null,
+            psk = psk,
+            pskId = pskId,
+            authKey = null,
+            authKeyPub = authKey,
+        )
+
+        return Decrypter(
+            hpkeContext = context
+        )
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
@@ -35,6 +35,7 @@ import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 import kotlin.time.Instant
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.crypto.Hkdf
 import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.mdoc.zkp.ZkDocument
 
@@ -287,7 +288,7 @@ class DeviceResponseParser(
                 val sessionTranscriptBytes = Cbor.encode(Tagged(24, Bstr(encodedSessionTranscript)))
                 val salt = Crypto.digest(Algorithm.SHA256, sessionTranscriptBytes)
                 val info = "EMacKey".encodeToByteArray()
-                val eMacKey = Crypto.hkdf(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
+                val eMacKey = Hkdf.deriveKey(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
                 val expectedTag = Cose.coseMac0(
                     Algorithm.HMAC_SHA256,
                     eMacKey,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DocumentGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DocumentGenerator.kt
@@ -31,6 +31,7 @@ import org.multipaz.document.NameSpacedData
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.Hkdf
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
 import org.multipaz.securearea.KeyLockedException
 import org.multipaz.securearea.KeyUnlockData
@@ -138,7 +139,7 @@ class DocumentGenerator
             val sessionTranscriptBytes = Cbor.encode(Tagged(24, Bstr(encodedSessionTranscript)))
             val salt = Crypto.digest(Algorithm.SHA256, sessionTranscriptBytes)
             val info = "EMacKey".encodeToByteArray()
-            val eMacKey = Crypto.hkdf(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
+            val eMacKey = Hkdf.deriveKey(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
             encodedDeviceMac = Cbor.encode(
                 Cose.coseMac0(
                     Algorithm.HMAC_SHA256,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
@@ -24,6 +24,7 @@ import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
 import kotlinx.io.bytestring.ByteStringBuilder
 import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.Hkdf
 import org.multipaz.mdoc.role.MdocRole
 
 /**
@@ -62,9 +63,9 @@ class SessionEncryption(
         val sessionTranscriptBytes = Cbor.encode(Tagged(24, Bstr(encodedSessionTranscript)))
         val salt = Crypto.digest(Algorithm.SHA256, sessionTranscriptBytes)
         var info = "SKDevice".encodeToByteArray()
-        val deviceSK = Crypto.hkdf(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
+        val deviceSK = Hkdf.deriveKey(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
         info = "SKReader".encodeToByteArray()
-        val readerSK = Crypto.hkdf(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
+        val readerSK = Hkdf.deriveKey(Algorithm.HMAC_SHA256, sharedSecret, salt, info, 32)
         if (role == MdocRole.MDOC) {
             skSelf = deviceSK
             skRemote = readerSK

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
@@ -7,7 +7,7 @@ import org.multipaz.crypto.X509CertChain
 // TODO: move this class to Android source tree once annotation processors can work across
 // multiple source trees
 @CborSerializable(
-    schemaHash = "GPjoYX7w6oLhI969qgnHFLhrW0HAXtbhu9gacgBibAw"
+    schemaHash = "EDN-FU9m5AKWZp1x1Qes6QGsRntZqG9DnKvizC8DpZs"
 )
 internal data class AndroidSecureAreaKeyMetadata(
     val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
@@ -8,7 +8,7 @@ import org.multipaz.crypto.EcPublicKey
 // TODO: move this class to iOS source tree once annotation processors can work across
 // multiple source trees
 @CborSerializable(
-    schemaHash = "gkdLkv688A8DbRvIxxLKnjofvCHrtsJWuTvRh0ZhGTo"
+    schemaHash = "-v4WwMHCPeluKbrc0KuRdwXCxRhcXvHKlF1QB8Zh6dc"
 )
 internal data class SecureEnclaveAreaKeyMetadata(
     val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -78,6 +78,7 @@ import org.multipaz.util.Logger
 import org.multipaz.util.appendUInt32
 import org.multipaz.certext.MultipazExtension
 import org.multipaz.certext.fromCbor
+import org.multipaz.crypto.Hkdf
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -419,14 +420,14 @@ open class CloudSecureArea protected constructor(
                     }
                 )
             )
-            skDevice = Crypto.hkdf(
+            skDevice = Hkdf.deriveKey(
                 Algorithm.HMAC_SHA256,
                 zab,
                 salt,
                 "SKDevice".encodeToByteArray(),
                 32
             )
-            skCloud = Crypto.hkdf(
+            skCloud = Hkdf.deriveKey(
                 Algorithm.HMAC_SHA256,
                 zab,
                 salt,
@@ -968,7 +969,7 @@ open class CloudSecureArea protected constructor(
     }
 
     @CborSerializable(
-        schemaHash = "1nfI37qZNUhsEDoWxGOOmH3_1Akqb8axdvs_i2PawpU"
+        schemaHash = "w-5iNr7XcEFY2B2L8dT64GO06QiTsDV87YdGHeocruI"
     )
     internal data class KeyMetadata(
         val algorithm: Algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -33,6 +33,7 @@ import org.multipaz.storage.StorageTableSpec
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.Hkdf
 import kotlin.random.Random
 
 /**
@@ -135,7 +136,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         passphrase: String
     ): ByteArray {
         val info = "ICPrivateKeyEncryption1".encodeToByteArray()
-        return Crypto.hkdf(
+        return Hkdf.deriveKey(
             Algorithm.HMAC_SHA256,
             passphrase.encodeToByteArray(),
             encodedPublicKey,
@@ -309,7 +310,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         return false
     }
 
-    @CborSerializable(schemaHash = "uDNIH6LIvDH5IXbAKIX7aVmFeEJwBUZAd7s7prLKBBw")
+    @CborSerializable(schemaHash = "6ifPnbV5Efd5Yf9NLMh4wXHWIVySzLaTeJqnGxrPuzI")
     internal data class KeyMetadata(
         val algorithm: Algorithm,
         val passphraseRequired: Boolean,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
@@ -250,21 +250,6 @@ class CryptoTests {
         }
     }
 
-    @Test
-    fun hkdf() {
-        // From https://datatracker.ietf.org/doc/html/rfc5869#appendix-A
-        assertEquals(
-            "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
-            Crypto.hkdf(
-                Algorithm.HMAC_SHA256,
-                "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".fromHex(),
-                "000102030405060708090a0b0c".fromHex(),
-                "f0f1f2f3f4f5f6f7f8f9".fromHex(),
-                42
-            ).toHex()
-        )
-    }
-
     fun testJwkEncodeDecode(curve: EcCurve) {
         // TODO: use assumeTrue() when available in kotlin-test
         if (!Crypto.supportedCurves.contains(curve)) {
@@ -398,27 +383,4 @@ class CryptoTests {
     fun testUncompressedFromTo_BRAINPOOLP384R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP384R1)
     @Test
     fun testUncompressedFromTo_BRAINPOOLP512R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP512R1)
-
-
-    @Test
-    fun testHpkeRoundtrip() {
-        val receiver = Crypto.createEcPrivateKey(EcCurve.P256)
-        val plainText = "Hello World".encodeToByteArray()
-        val aad = "123".encodeToByteArray()
-
-        val (cipherText, encKey) = Crypto.hpkeEncrypt(
-            Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
-            receiver.publicKey,
-            plainText,
-            aad)
-
-        val decryptedText = Crypto.hpkeDecrypt(
-            Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
-            receiver,
-            cipherText,
-            aad,
-            encKey)
-
-        assertContentEquals(decryptedText, plainText)
-    }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/HkdfTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/HkdfTests.kt
@@ -1,0 +1,186 @@
+package org.multipaz.crypto
+
+import org.multipaz.testUtilSetupCryptoProvider
+import org.multipaz.util.fromHex
+import kotlin.test.BeforeTest
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class HkdfTests {
+
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
+    private data class TestVector(
+        val alg: Algorithm,
+        val ikmHex: String,
+        val saltHex: String?,
+        val infoHex: String,
+        val length: Int,
+        val prkHex: String,
+        val okmHex: String,
+    )
+
+    private fun testAgainstTestVector(t: TestVector) {
+        assertContentEquals(
+            t.prkHex.fromHex(),
+            Hkdf.extract(
+                algorithm = t.alg,
+                ikm = t.ikmHex.fromHex(),
+                salt = t.saltHex?.fromHex()
+            )
+        )
+
+        assertContentEquals(
+            t.okmHex.fromHex(),
+            Hkdf.deriveKey(
+                algorithm = t.alg,
+                ikm = t.ikmHex.fromHex(),
+                salt = t.saltHex?.fromHex(),
+                info = t.infoHex.fromHex(),
+                length = t.length
+            )
+        )
+    }
+
+    @Test
+    fun testAppendix_A_1() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_SHA256,
+            ikmHex = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+            saltHex = "000102030405060708090a0b0c",
+            infoHex = "f0f1f2f3f4f5f6f7f8f9",
+            length = 42,
+            prkHex = "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5",
+            okmHex = "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        )
+    )
+
+    @Test
+    fun testAppendix_A_2() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_SHA256,
+            ikmHex = "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f",
+            saltHex = "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+            infoHex = "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            length = 82,
+            prkHex = "06a6b88c5853361a06104c9ceb35b45c" +
+                    "ef760014904671014a193f40c15fc244",
+            okmHex = "b11e398dc80327a1c8e7f78c596a4934" +
+                    "4f012eda2d4efad8a050cc4c19afa97c" +
+                    "59045a99cac7827271cb41c65e590e09" +
+                    "da3275600c2f09b8367793a9aca3db71" +
+                    "cc30c58179ec3e87c14c01d5c1f3434f" +
+                    "1d87"
+        )
+    )
+
+    @Test
+    fun testAppendix_A_3() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_SHA256,
+            ikmHex = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+            saltHex = null,
+            infoHex = "",
+            length = 42,
+            prkHex = "19ef24a32c717b167f33a91d6f648bdf" +
+                    "96596776afdb6377ac434c1c293ccb04",
+            okmHex = "8da4e775a563c18f715f802a063c5a31" +
+                    "b8a11f5c5ee1879ec3454e5f3c738d2d" +
+                    "9d201395faa4b61a96c8"
+        )
+    )
+
+    @Test
+    fun testAppendix_A_4() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_INSECURE_SHA1,
+            ikmHex = "0b0b0b0b0b0b0b0b0b0b0b",
+            saltHex = "000102030405060708090a0b0c",
+            infoHex = "f0f1f2f3f4f5f6f7f8f9",
+            length = 42,
+            prkHex = "9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243",
+            okmHex = "085a01ea1b10f36933068b56efa5ad81" +
+                    "a4f14b822f5b091568a9cdd4f155fda2" +
+                    "c22e422478d305f3f896"
+        )
+    )
+
+    @Test
+    fun testAppendix_A_5() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_INSECURE_SHA1,
+            ikmHex = "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f",
+            saltHex = "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+            infoHex = "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            length = 82,
+            prkHex = "8adae09a2a307059478d309b26c4115a224cfaf6",
+            okmHex = "0bd770a74d1160f7c9f12cd5912a06eb" +
+                    "ff6adcae899d92191fe4305673ba2ffe" +
+                    "8fa3f1a4e5ad79f3f334b3b202b2173c" +
+                    "486ea37ce3d397ed034c7f9dfeb15c5e" +
+                    "927336d0441f4c4300e2cff0d0900b52" +
+                    "d3b4"
+        )
+    )
+
+    /* Marked as @Ignore out because an empty salt (different from `null` salt) will use an empty
+     * key for the HMAC operation and this is not supported on JVM because it's trivially not
+     * secure. Note: It does work on iOS and the test does pass there,
+     */
+    @Ignore
+    @Test
+    fun testAppendix_A_6() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_INSECURE_SHA1,
+            ikmHex = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+            saltHex = "",
+            infoHex = "",
+            length = 42,
+            prkHex = "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01",
+            okmHex = "0ac1af7002b3d761d1e55298da9d0506" +
+                    "b9ae52057220a306e07b6b87e8df21d0" +
+                    "ea00033de03984d34918"
+        )
+    )
+
+    @Test
+    fun testAppendix_A_7() = testAgainstTestVector(
+        TestVector(
+            alg = Algorithm.HMAC_INSECURE_SHA1,
+            ikmHex = "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+            saltHex = null,
+            infoHex = "",
+            length = 42,
+            prkHex = "2adccada18779e7c2077ad2eb19d3f3e731385dd",
+            okmHex = "2c91117204d745f3500d636a62f64f0a" +
+                    "b3bae548aa53d423b0d1f27ebba6f5e5" +
+                    "673a081d70cce7acfc48"
+        )
+    )
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/HpkeTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/HpkeTests.kt
@@ -1,0 +1,641 @@
+package org.multipaz.crypto
+
+import kotlinx.coroutines.test.runTest
+import org.multipaz.crypto.Hpke.serialize
+import org.multipaz.testUtilSetupCryptoProvider
+import org.multipaz.util.fromHex
+import org.multipaz.util.toHex
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class HpkeTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
+    private fun parseKey(
+        curve: EcCurve,
+        encodedPriv: ByteArray,
+        encodedPub: ByteArray
+    ): EcPrivateKey {
+        when (curve) {
+            EcCurve.X25519,
+            EcCurve.X448 -> {
+                return EcPrivateKeyOkp(
+                    curve = curve,
+                    d = encodedPriv,
+                    x = encodedPub,
+                )
+            }
+            else -> {
+                val pub = EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(
+                    curve = curve,
+                    encoded = encodedPub
+                )
+                return EcPrivateKeyDoubleCoordinate(
+                    curve = curve,
+                    d = encodedPriv,
+                    x = pub.x,
+                    y = pub.y
+                )
+            }
+        }
+    }
+
+    @Test
+    fun roundTrip() = runTest {
+        val receiver = Crypto.createEcPrivateKey(EcCurve.P256)
+        val plainText = "Hello World".encodeToByteArray()
+        val aad = "123".encodeToByteArray()
+        val info = "abc".encodeToByteArray()
+
+        val encrypter = Hpke.getEncrypter(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPublicKey = receiver.publicKey,
+            info = info
+        )
+        val cipherText = encrypter.encrypt(
+            plaintext = plainText,
+            aad = aad
+        )
+
+        val decrypter = Hpke.getDecrypter(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPrivateKey = SigningKey.AnonymousExplicit(receiver),
+            encapsulatedKey = encrypter.encapsulatedKey.toByteArray(),
+            info = info
+        )
+        val decryptedText = decrypter.decrypt(
+            ciphertext = cipherText,
+            aad = aad
+        )
+
+        assertContentEquals(decryptedText, plainText)
+    }
+
+    data class TestDataSeqValues(
+        val aadHex: String,
+        val ptHex: String,
+        val ctHex: String
+    )
+
+    data class ExportedValues(
+        val exporterContext: String,
+        val length: Int,
+        val exportedValue: String,
+    )
+
+    data class TestData(
+        val cipherSuite: Hpke.CipherSuite,
+        val infoHex: String,
+        val encPrivHex: String,
+        val encPubHex: String,
+        val receiverPrivHex: String,
+        val receiverPubHex: String,
+        val psk: String?,
+        val pskId: String?,
+        val authPrivHex: String?,
+        val authPubHex: String?,
+        val sequencesToCheck: Map<Int, TestDataSeqValues>,
+        val exportedValuesToCheck: List<ExportedValues>,
+    )
+
+    // Test vector for mode_base for DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+    @Test
+    fun testVectorsAppendix_A_1_1() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "52c4a758a802cd8b936eceea314432798d5baf2d7e9235dc084ab1b9cfa2f736",
+                encPubHex = "37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431",
+                receiverPrivHex = "4612c550263fc8ad58375df3f557aac531d26850903e55a9f23f21d8534e8ac8",
+                receiverPubHex = "3948cfe0ad1ddb695d780e59077195da6c56506b027329794ab02bca80815c4d",
+                psk = null,
+                pskId = null,
+                authPrivHex = null,
+                authPubHex = null,
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "f938558b5d72f1a23810b4be2ab4f84331acc02fc97babc53a52ae8218a355a9" +
+                                "6d8770ac83d07bea87e13c512a"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "af2d7e9ac9ae7e270f46ba1f975be53c09f8d875bdc8535458c2494e8a6eab25" +
+                                "1c03d0c22a56b8ca42c2063b84"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "498dfcabd92e8acedc281e85af1cb4e3e31c7dc394a1ca20e173cb7251649158" +
+                                "8d96a19ad4a683518973dcc180"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "583bd32bc67a5994bb8ceaca813d369bca7b2a42408cddef5e22f880b631215a" +
+                                "09fc0012bc69fccaa251c0246d"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "7175db9717964058640a3a11fb9007941a5d1757fda1a6935c805c21af32505b" +
+                                "f106deefec4a49ac38d71c9e0a"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "957f9800542b0b8891badb026d79cc54597cb2d225b54c00c5238c25d05c30e3" +
+                                "fbeda97d2e0e1aba483a2df9f2"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "3853fe2b4035195a573ffc53856e77058e15d9ea064de3e59f4961d0095250ee"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "2e8f0b54673c7029649d4eb9d5e33bf1872cf76d623ff164ac185da9e88c21a5"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "e9e43065102c3836401bed8c3c3c75ae46be1639869391d62c61f1ec7af54931"
+                    ),
+                ),
+            )
+        )
+    }
+
+    // Test vector for mode_base for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+    @Test
+    fun testVectorsAppendix_A_3_1() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "4995788ef4b9d6132b249ce59a77281493eb39af373d236a1fe415cb0c2d7beb",
+                encPubHex = "04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b32" +
+                        "5ac98536d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4",
+                receiverPrivHex = "f3ce7fdae57e1a310d87f1ebbde6f328be0a99cdbcadf4d6589cf29de4b8ffd2",
+                receiverPubHex = "04fe8c19ce0905191ebc298a9245792531f26f0cece2460639e8bc39cb7f70" +
+                        "6a826a779b4cf969b8a0e539c7f62fb3d30ad6aa8f80e30f1d128aafd68a2ce72ea0",
+                psk = null,
+                pskId = null,
+                authPrivHex = null,
+                authPubHex = null,
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "5ad590bb8baa577f8619db35a36311226a896e7342a6d836d8b7bcd2f20b6c7f" +
+                                "9076ac232e3ab2523f39513434"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "fa6f037b47fc21826b610172ca9637e82d6e5801eb31cbd3748271affd4ecb06" +
+                                "646e0329cbdf3c3cd655b28e82"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "895cabfac50ce6c6eb02ffe6c048bf53b7f7be9a91fc559402cbc5b8dcaeb52b" +
+                                "2ccc93e466c28fb55fed7a7fec"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "8787491ee8df99bc99a246c4b3216d3d57ab5076e18fa27133f520703bc70ec9" +
+                                "99dd36ce042e44f0c3169a6a8f"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "2ad71c85bf3f45c6eca301426289854b31448bcf8a8ccb1deef3ebd87f60848a" +
+                                "a53c538c30a4dac71d619ee2cd"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "10f179686aa2caec1758c8e554513f16472bd0a11e2a907dde0b212cbe87d74f" +
+                                "367f8ffe5e41cd3e9962a6afb2"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "5e9bc3d236e1911d95e65b576a8a86d478fb827e8bdfe77b741b289890490d4d"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "6cff87658931bda83dc857e6353efe4987a201b849658d9b047aab4cf216e796"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "d8f1ea7942adbba7412c6d431c62d01371ea476b823eb697e1f6e6cae1dab85a"
+                    ),
+                ),
+            )
+        )
+    }
+
+    // Test vector for mode_psk for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+    @Test
+    fun testVectorsAppendix_A_3_2() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "57427244f6cc016cddf1c19c8973b4060aa13579b4c067fd5d93a5d74e32a90f",
+                encPubHex = "04305d35563527bce037773d79a13deabed0e8e7cde61eecee403496959e89" +
+                        "e4d0ca701726696d1485137ccb5341b3c1c7aaee90a4a02449725e744b1193b53b5f",
+                receiverPrivHex = "438d8bcef33b89e0e9ae5eb0957c353c25a94584b0dd59c991372a75b43cb661",
+                receiverPubHex = "040d97419ae99f13007a93996648b2674e5260a8ebd2b822e84899cd52d874" +
+                        "46ea394ca76223b76639eccdf00e1967db10ade37db4e7db476261fcc8df97c5ffd1",
+                psk = "0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82",
+                pskId = "456e6e796e20447572696e206172616e204d6f726961",
+                authPrivHex = null,
+                authPubHex = null,
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "90c4deb5b75318530194e4bb62f890b019b1397bbf9d0d6eb918890e1fb2be1a" +
+                                "c2603193b60a49c2126b75d0eb"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "9e223384a3620f4a75b5a52f546b7262d8826dea18db5a365feb8b997180b22d" +
+                                "72dc1287f7089a1073a7102c27"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "adf9f6000773035023be7d415e13f84c1cb32a24339a32eb81df02be9ddc6abc" +
+                                "880dd81cceb7c1d0c7781465b2"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "1f4cc9b7013d65511b1f69c050b7bd8bbd5a5c16ece82b238fec4f30ba2400e7" +
+                                "ca8ee482ac5253cffb5c3dc577"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "cdc541253111ed7a424eea5134dc14fc5e8293ab3b537668b8656789628e4589" +
+                                "4e5bb873c968e3b7cdcbb654a4"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "faf985208858b1253b97b60aecd28bc18737b58d1242370e7703ec33b73a4c31" +
+                                "a1afee300e349adef9015bbbfd"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "a115a59bf4dd8dc49332d6a0093af8efca1bcbfd3627d850173f5c4a55d0c185"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "4517eaede0669b16aac7c92d5762dd459c301fa10e02237cd5aeb9be969430c4"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "164e02144d44b607a7722e58b0f4156e67c0c2874d74cf71da6ca48a4cbdc5e0"
+                    ),
+                ),
+            )
+        )
+    }
+
+    // Test vector for mode_auth for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+    @Test
+    fun testVectorsAppendix_A_3_3() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "6b8de0873aed0c1b2d09b8c7ed54cbf24fdf1dfc7a47fa501f918810642d7b91",
+                encPubHex = "042224f3ea800f7ec55c03f29fc9865f6ee27004f818fcbdc6dc68932c1e52" +
+                        "e15b79e264a98f2c535ef06745f3d308624414153b22c7332bc1e691cb4af4d53454",
+                receiverPrivHex = "d929ab4be2e59f6954d6bedd93e638f02d4046cef21115b00cdda2acb2a4440e",
+                receiverPubHex = "04423e363e1cd54ce7b7573110ac121399acbc9ed815fae03b72ffbd4c18b0" +
+                        "1836835c5a09513f28fc971b7266cfde2e96afe84bb0f266920e82c4f53b36e1a78d",
+                psk = null,
+                pskId = null,
+                authPrivHex = "1120ac99fb1fccc1e8230502d245719d1b217fe20505c7648795139d177f0de9",
+                authPubHex = "04a817a0902bf28e036d66add5d544cc3a0457eab150f104285df1e293b5c1" +
+                        "0eef8651213e43d9cd9086c80b309df22cf37609f58c1127f7607e85f210b2804f73",
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "82ffc8c44760db691a07c5627e5fc2c08e7a86979ee79b494a17cc3405446ac2" +
+                                "bdb8f265db4a099ed3289ffe19"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "b0a705a54532c7b4f5907de51c13dffe1e08d55ee9ba59686114b05945494d96" +
+                                "725b239468f1229e3966aa1250"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "8dc805680e3271a801790833ed74473710157645584f06d1b53ad439078d880b" +
+                                "23e25256663178271c80ee8b7c"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "04c8f7aae1584b61aa5816382cb0b834a5d744f420e6dffb5ddcec633a21b8b3" +
+                                "472820930c1ea9258b035937a2"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "4a319462eaedee37248b4d985f64f4f863d31913fe9e30b6e13136053b69fe5d" +
+                                "70853c84c60a84bb5495d5a678"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "28e874512f8940fafc7d06135e7589f6b4198bc0f3a1c64702e72c9e6abaf9f0" +
+                                "5cb0d2f11b03a517898815c934"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "837e49c3ff629250c8d80d3c3fb957725ed481e59e2feb57afd9fe9a8c7c4497"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "594213f9018d614b82007a7021c3135bda7b380da4acd9ab27165c508640dbda"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "14fe634f95ca0d86e15247cca7de7ba9b73c9b9deb6437e1c832daf7291b79d5"
+                    ),
+                ),
+            )
+        )
+    }
+
+    // Test vector for mode_auth_psk for DHKEM(P-256, HKDF-SHA256), HKDF-SHA256, AES-128-GCM
+    @Test
+    fun testVectorsAppendix_A_3_4() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "36f771e411cf9cf72f0701ef2b991ce9743645b472e835fe234fb4d6eb2ff5a0",
+                encPubHex = "046a1de3fc26a3d43f4e4ba97dbe24f7e99181136129c48fbe872d4743e2b1" +
+                        "31357ed4f29a7b317dc22509c7b00991ae990bf65f8b236700c82ab7c11a84511401",
+                receiverPrivHex = "bdf4e2e587afdf0930644a0c45053889ebcadeca662d7c755a353d5b4e2a8394",
+                receiverPubHex = "04d824d7e897897c172ac8a9e862e4bd820133b8d090a9b188b8233a64dfbc" +
+                        "5f725aa0aa52c8462ab7c9188f1c4872f0c99087a867e8a773a13df48a627058e1b3",
+                psk = "0247fd33b913760fa1fa51e1892d9f307fbe65eb171e8132c2af18555a738b82",
+                pskId = "456e6e796e20447572696e206172616e204d6f726961",
+                authPrivHex = "b0ed8721db6185435898650f7a677affce925aba7975a582653c4cb13c72d240",
+                authPubHex = "049f158c750e55d8d5ad13ede66cf6e79801634b7acadcad72044eac2ae1d0" +
+                        "480069133d6488bf73863fa988c4ba8bde1c2e948b761274802b4d8012af4f13af9e",
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "b9f36d58d9eb101629a3e5a7b63d2ee4af42b3644209ab37e0a272d44365407d" +
+                                "b8e655c72e4fa46f4ff81b9246"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "51788c4e5d56276771032749d015d3eea651af0c7bb8e3da669effffed299ea1" +
+                                "f641df621af65579c10fc09736"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "3b5a2be002e7b29927f06442947e1cf709b9f8508b03823127387223d7127034" +
+                                "71c266efc355f1bc2036f3027c"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "8ddbf1242fe5c7d61e1675496f3bfdb4d90205b3dfbc1b12aab41395d71a8211" +
+                                "8e095c484103107cf4face5123"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "6de25ceadeaec572fbaa25eda2558b73c383fe55106abaec24d518ef6724a7ce" +
+                                "698f83ecdc53e640fe214d2f42"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "f380e19d291e12c5e378b51feb5cd50f6d00df6cb2af8393794c4df342126c2e" +
+                                "29633fe7e8ce49587531affd4d"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "595ce0eff405d4b3bb1d08308d70a4e77226ce11766e0a94c4fdb5d90025c978"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "110472ee0ae328f57ef7332a9886a1992d2c45b9b8d5abc9424ff68630f7d38d"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "18ee4d001a9d83a4c67e76f88dd747766576cac438723bad0700a910a4d717e6"
+                    ),
+                ),
+            )
+        )
+    }
+
+    // Test vector for mode_base for DHKEM(P-521, HKDF-SHA512), HKDF-SHA512, AES-256-GCM
+    @Test
+    fun testVectorsAppendix_A_6_1() = runTest {
+        checkTestVector(
+            TestData(
+                cipherSuite = Hpke.CipherSuite.DHKEM_P521_HKDF_SHA512_HKDF_SHA512_AES_256_GCM,
+                infoHex = "4f6465206f6e2061204772656369616e2055726e",
+                encPrivHex = "014784c692da35df6ecde98ee43ac425dbdd0969c0c72b42f2e708ab9d5354" +
+                        "15a8569bdacfcc0a114c85b8e3f26acf4d68115f8c91a66178cdbd03b7bcc5291e37" +
+                        "4b",
+                encPubHex = "040138b385ca16bb0d5fa0c0665fbbd7e69e3ee29f63991d3e9b5fa740aab8" +
+                        "900aaeed46ed73a49055758425a0ce36507c54b29cc5b85a5cee6bae0cf1c21f2731" +
+                        "ece2013dc3fb7c8d21654bb161b463962ca19e8c654ff24c94dd2898de12051f1ed0" +
+                        "692237fb02b2f8d1dc1c73e9b366b529eb436e98a996ee522aef863dd5739d2f29b0",
+                receiverPrivHex = "01462680369ae375e4b3791070a7458ed527842f6a98a79ff5e0d4cbde83c2" +
+                        "7196a3916956655523a6a2556a7af62c5cadabe2ef9da3760bb21e005202f7b24628" +
+                        "47",
+                receiverPubHex = "0401b45498c1714e2dce167d3caf162e45e0642afc7ed435df7902ccae0e84" +
+                        "ba0f7d373f646b7738bbbdca11ed91bdeae3cdcba3301f2457be452f271fa6837580" +
+                        "e661012af49583a62e48d44bed350c7118c0d8dc861c238c72a2bda17f64704f464b" +
+                        "57338e7f40b60959480c0e58e6559b190d81663ed816e523b6b6a418f66d2451ec64",
+                psk = null,
+                pskId = null,
+                authPrivHex = null,
+                authPubHex = null,
+                sequencesToCheck = mapOf(
+                    0 to TestDataSeqValues(
+                        aadHex = "436f756e742d30",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "170f8beddfe949b75ef9c387e201baf4132fa7374593dfafa90768788b7b2b20" +
+                                "0aafcc6d80ea4c795a7c5b841a"
+                    ),
+                    1 to TestDataSeqValues(
+                        aadHex = "436f756e742d31",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "d9ee248e220ca24ac00bbbe7e221a832e4f7fa64c4fbab3945b6f3af0c5ecd5e" +
+                                "16815b328be4954a05fd352256"
+                    ),
+                    2 to TestDataSeqValues(
+                        aadHex = "436f756e742d32",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "142cf1e02d1f58d9285f2af7dcfa44f7c3f2d15c73d460c48c6e0e506a3144ba" +
+                                "e35284e7e221105b61d24e1c7a"
+                    ),
+                    4 to TestDataSeqValues(
+                        aadHex = "436f756e742d34",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "3bb3a5a07100e5a12805327bf3b152df728b1c1be75a9fd2cb2bf5eac0cca1fb" +
+                                "80addb37eb2a32938c7268e3e5"
+                    ),
+                    255 to TestDataSeqValues(
+                        aadHex = "436f756e742d323535",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "4f268d0930f8d50b8fd9d0f26657ba25b5cb08b308c92e33382f369c768b558e" +
+                                "113ac95a4c70dd60909ad1adc7"
+                    ),
+                    256 to TestDataSeqValues(
+                        aadHex = "436f756e742d323536",
+                        ptHex = "4265617574792069732074727574682c20747275746820626561757479",
+                        ctHex = "dbbfc44ae037864e75f136e8b4b4123351d480e6619ae0e0ae437f036f2f8f1e" +
+                                "f677686323977a1ccbb4b4f16a"
+                    ),
+                ),
+                exportedValuesToCheck = listOf(
+                    ExportedValues(
+                        exporterContext = "",
+                        length = 32,
+                        exportedValue = "05e2e5bd9f0c30832b80a279ff211cc65eceb0d97001524085d609ead60d0412"
+                    ),
+                    ExportedValues(
+                        exporterContext = "00",
+                        length = 32,
+                        exportedValue = "fca69744bb537f5b7a1596dbf34eaa8d84bf2e3ee7f1a155d41bd3624aa92b63"
+                    ),
+                    ExportedValues(
+                        exporterContext = "54657374436f6e74657874",
+                        length = 32,
+                        exportedValue = "f389beaac6fcf6c0d9376e20f97e364f0609a88f1bc76d7328e9104df8477013"
+                    ),
+                ),
+            )
+        )
+    }
+
+    suspend fun checkTestVector(td: TestData) {
+        val info = td.infoHex.fromHex()
+
+        val encapsulatedKey = parseKey(
+            curve = td.cipherSuite.kem.curve,
+            encodedPriv = td.encPrivHex.fromHex(),
+            encodedPub = td.encPubHex.fromHex()
+        )
+        val receiverKey = parseKey(
+            curve = td.cipherSuite.kem.curve,
+            encodedPriv = td.receiverPrivHex.fromHex(),
+            encodedPub = td.receiverPubHex.fromHex()
+        )
+
+        val authKey = td.authPrivHex?.let {
+            parseKey(
+                curve = td.cipherSuite.kem.curve,
+                encodedPriv = td.authPrivHex.fromHex(),
+                encodedPub = td.authPubHex!!.fromHex()
+            )
+        }
+
+        val encrypter = Hpke.getEncrypterInternal(
+            cipherSuite = td.cipherSuite,
+            receiverPublicKey = receiverKey.publicKey,
+            info = info,
+            encapsulatedKey = encapsulatedKey,
+            psk = td.psk?.fromHex(),
+            pskId = td.pskId?.fromHex(),
+            authKey = authKey?.let { SigningKey.AnonymousExplicit(it) }
+        )
+
+        val decrypter = Hpke.getDecrypter(
+            cipherSuite = td.cipherSuite,
+            receiverPrivateKey = SigningKey.AnonymousExplicit(receiverKey),
+            encapsulatedKey = encapsulatedKey.publicKey.serialize(),
+            info = info,
+            psk = td.psk?.fromHex(),
+            pskId = td.pskId?.fromHex(),
+            authKey = authKey?.publicKey
+        )
+
+        for ((seq, seqData) in td.sequencesToCheck.entries) {
+            encrypter.seq = seq.toLong()
+            val ciphertext = encrypter.encrypt(
+                plaintext = seqData.ptHex.fromHex(),
+                aad = seqData.aadHex.fromHex()
+            )
+            assertEquals(seqData.ctHex, ciphertext.toHex())
+
+            decrypter.seq = seq.toLong()
+            val decrypted = decrypter.decrypt(
+                ciphertext = seqData.ctHex.fromHex(),
+                aad = seqData.aadHex.fromHex()
+            )
+            assertEquals(seqData.ptHex, decrypted.toHex())
+        }
+
+        for (e in td.exportedValuesToCheck) {
+            val exportedValueEncrypter = encrypter.exportSecret(
+                context = e.exporterContext.fromHex(),
+                length = e.length
+            )
+            assertEquals(e.exportedValue, exportedValueEncrypter.toHex())
+
+            val exportedValueDecrypter = decrypter.exportSecret(
+                context = e.exporterContext.fromHex(),
+                length = e.length
+            )
+            assertEquals(e.exportedValue, exportedValueDecrypter.toHex())
+        }
+    }
+
+}

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
@@ -4,7 +4,6 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
@@ -29,6 +28,7 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.readByteArray
+import org.multipaz.crypto.Hkdf
 import org.multipaz.util.getUInt32
 import platform.CoreBluetooth.CBCentralManager
 import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
@@ -526,8 +526,8 @@ internal class BleCentralManagerIos : BleCentralManager {
 
         val ikm = Cbor.encode(Tagged(24, Bstr(Cbor.encode(eSenderKey.toCoseKey().toDataItem()))))
         val info = "BLEIdent".encodeToByteArray()
-        val salt = byteArrayOf()
-        val expectedIdentValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+        val salt = null
+        val expectedIdentValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
         val identValue = identCharacteristic!!.value!!.toByteArray()
         if (!(expectedIdentValue contentEquals identValue)) {
             close()

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
@@ -4,7 +4,6 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
@@ -28,6 +27,7 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.readByteArray
+import org.multipaz.crypto.Hkdf
 import platform.CoreBluetooth.CBATTErrorSuccess
 import platform.CoreBluetooth.CBATTRequest
 import platform.CoreBluetooth.CBPeripheralManager
@@ -402,8 +402,8 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
     override suspend fun setESenderKey(eSenderKey: EcPublicKey) {
         val ikm = Cbor.encode(Tagged(24, Bstr(Cbor.encode(eSenderKey.toCoseKey().toDataItem()))))
         val info = "BLEIdent".encodeToByteArray()
-        val salt = byteArrayOf()
-        identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+        val salt = null
+        identValue = Hkdf.deriveKey(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
     }
 
     override suspend fun waitForStateCharacteristicWriteOrL2CAPClient() {

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/HpkeTestsAgainstTink.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/HpkeTestsAgainstTink.kt
@@ -1,0 +1,245 @@
+package org.multipaz.crypto
+
+import com.google.crypto.tink.HybridDecrypt
+import com.google.crypto.tink.HybridEncrypt
+import com.google.crypto.tink.InsecureSecretKeyAccess
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.RegistryConfiguration
+import com.google.crypto.tink.TinkProtoKeysetFormat
+import com.google.crypto.tink.config.TinkConfig
+import com.google.crypto.tink.hybrid.HybridConfig
+import com.google.crypto.tink.proto.HpkeAead
+import com.google.crypto.tink.proto.HpkeKdf
+import com.google.crypto.tink.proto.HpkeKem
+import com.google.crypto.tink.proto.HpkeParams
+import com.google.crypto.tink.proto.HpkePrivateKey
+import com.google.crypto.tink.proto.HpkePublicKey
+import com.google.crypto.tink.proto.KeyData
+import com.google.crypto.tink.proto.KeyStatusType
+import com.google.crypto.tink.proto.Keyset
+import com.google.crypto.tink.proto.OutputPrefixType
+import com.google.crypto.tink.shaded.protobuf.ByteString as TinkByteString
+import com.google.crypto.tink.subtle.EllipticCurves
+import kotlinx.coroutines.test.runTest
+import org.multipaz.testUtilSetupCryptoProvider
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class HpkeTestsAgainstTink {
+    @BeforeTest
+    fun setup() {
+        testUtilSetupCryptoProvider()
+        TinkConfig.register()
+        HybridConfig.register()
+    }
+
+    @Test
+    fun testHpkeEncryptAgainstTink() = runTest {
+        val receiver = Crypto.createEcPrivateKey(EcCurve.P256)
+        val plaintext = "Hello World".encodeToByteArray()
+        val aad = "".encodeToByteArray()  // Tink doesn't seem to support AAD
+        val info = "abc".encodeToByteArray()
+
+        val encrypter = Hpke.getEncrypter(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPublicKey = receiver.publicKey,
+            info = info
+        )
+        val cipherText = encrypter.encrypt(
+            plaintext = plaintext,
+            aad = aad
+        )
+
+        val decryptedText = tinkHpkeDecrypt(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPrivateKey = receiver,
+            cipherText = cipherText,
+            enc = encrypter.encapsulatedKey.toByteArray(),
+            aad = aad,
+            info = info,
+        )
+
+        assertContentEquals(decryptedText, plaintext)
+    }
+
+    @Test
+    fun testHpkeDecryptAgainstTink() = runTest {
+        val receiver = Crypto.createEcPrivateKey(EcCurve.P256)
+        val plaintext = "Hello World".encodeToByteArray()
+        val aad = "".encodeToByteArray()  // Tink doesn't seem to support AAD
+        val info = "abc".encodeToByteArray()
+
+        val (ciphertext, enc) = tinkHpkeEncrypt(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPublicKey = receiver.publicKey,
+            plainText = plaintext,
+            aad = aad,
+            info = info
+        )
+
+        val decrypter = Hpke.getDecrypter(
+            cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+            receiverPrivateKey = SigningKey.AnonymousExplicit(receiver),
+            encapsulatedKey = enc,
+            info = info
+        )
+        val decryptedtext = decrypter.decrypt(
+            ciphertext = ciphertext,
+            aad = aad,
+        )
+
+        assertContentEquals(decryptedtext, plaintext)
+    }
+
+    companion object {
+        private fun hpkeGetKeysetHandles(
+            publicKey: EcPublicKey,
+            privateKey: EcPrivateKey?
+        ): Pair<KeysetHandle, KeysetHandle?> {
+            val primaryKeyId = 1
+
+            val params = HpkeParams.newBuilder()
+                .setAead(HpkeAead.AES_128_GCM)
+                .setKdf(HpkeKdf.HKDF_SHA256)
+                .setKem(HpkeKem.DHKEM_P256_HKDF_SHA256)
+                .build()
+
+            val javaPublicKey = publicKey.javaPublicKey as ECPublicKey
+            val encodedKey = EllipticCurves.pointEncode(
+                EllipticCurves.CurveType.NIST_P256,
+                EllipticCurves.PointFormatType.UNCOMPRESSED,
+                javaPublicKey.w
+            )
+
+            val hpkePublicKey = HpkePublicKey.newBuilder()
+                .setVersion(0)
+                .setPublicKey(TinkByteString.copyFrom(encodedKey))
+                .setParams(params)
+                .build()
+
+            val publicKeyData = KeyData.newBuilder()
+                .setKeyMaterialType(KeyData.KeyMaterialType.ASYMMETRIC_PUBLIC)
+                .setTypeUrl("type.googleapis.com/google.crypto.tink.HpkePublicKey")
+                .setValue(hpkePublicKey.toByteString())
+                .build()
+
+            val publicKeysetKey = Keyset.Key.newBuilder()
+                .setKeyId(primaryKeyId)
+                .setKeyData(publicKeyData)
+                .setOutputPrefixType(OutputPrefixType.RAW)
+                .setStatus(KeyStatusType.ENABLED)
+                .build()
+
+            val publicKeyset = Keyset.newBuilder()
+                .setPrimaryKeyId(primaryKeyId)
+                .addKey(publicKeysetKey)
+                .build()
+
+            val publicKeysetHandle = TinkProtoKeysetFormat.parseKeyset(
+                publicKeyset.toByteArray(),
+                InsecureSecretKeyAccess.get()
+            )
+            var privateKeysetHandle: KeysetHandle? = null
+
+            if (privateKey != null) {
+                val javaPrivateKey = privateKey.javaPrivateKey as ECPrivateKey
+                val hpkePrivateKey = HpkePrivateKey.newBuilder()
+                    .setPublicKey(hpkePublicKey)
+                    .setPrivateKey(TinkByteString.copyFrom(javaPrivateKey.s.toByteArray()))
+                    .build()
+
+                val privateKeyData = KeyData.newBuilder()
+                    .setKeyMaterialType(KeyData.KeyMaterialType.ASYMMETRIC_PRIVATE)
+                    .setTypeUrl("type.googleapis.com/google.crypto.tink.HpkePrivateKey")
+                    .setValue(hpkePrivateKey.toByteString())
+                    .build()
+
+                val privateKeysetKey = Keyset.Key.newBuilder()
+                    .setKeyId(primaryKeyId)
+                    .setKeyData(privateKeyData)
+                    .setOutputPrefixType(OutputPrefixType.RAW)
+                    .setStatus(KeyStatusType.ENABLED)
+                    .build()
+                val privateKeyset = Keyset.newBuilder()
+                    .setPrimaryKeyId(primaryKeyId)
+                    .addKey(privateKeysetKey)
+                    .build()
+                privateKeysetHandle = TinkProtoKeysetFormat.parseKeyset(
+                    privateKeyset.toByteArray(),
+                    InsecureSecretKeyAccess.get()
+                )
+            }
+
+            return Pair(publicKeysetHandle, privateKeysetHandle)
+        }
+
+        private fun tinkHpkeEncrypt(
+            cipherSuite: Hpke.CipherSuite,
+            receiverPublicKey: EcPublicKey,
+            plainText: ByteArray,
+            aad: ByteArray,
+            info: ByteArray
+        ): Pair<ByteArray, ByteArray> {
+            require(cipherSuite == Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM) {
+                "Only Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM is supported right now"
+            }
+            require(receiverPublicKey.curve == EcCurve.P256)
+            require(aad.isEmpty()) {
+                // TODO: Looks like there's no way to set the AAD with Tink...
+                "Only supporting empty AADs right now"
+            }
+
+            val (publicKeysetHandle, _) = hpkeGetKeysetHandles(receiverPublicKey, null)
+
+            val encryptor = publicKeysetHandle.getPrimitive(
+                /* configuration = */ RegistryConfiguration.get(),
+                /* targetClassObject = */ HybridEncrypt::class.java
+            )
+            val output = encryptor.encrypt(plainText, info)
+
+            // Output from Tink is (serialized encapsulated key || ciphertext) so we need to break it
+            // up ourselves
+
+            receiverPublicKey as EcPublicKeyDoubleCoordinate
+            val coordinateSize = (receiverPublicKey.curve.bitSize + 7)/8
+            val encapsulatedPublicKeySize = 1 + 2*coordinateSize
+
+            val enc = output.sliceArray(IntRange(0, encapsulatedPublicKeySize - 1))
+            val cipherText = output.sliceArray(IntRange(encapsulatedPublicKeySize, output.size - 1))
+
+            return Pair(cipherText, enc)
+        }
+
+        private fun tinkHpkeDecrypt(
+            cipherSuite: Hpke.CipherSuite,
+            receiverPrivateKey: EcPrivateKey,
+            cipherText: ByteArray,
+            enc: ByteArray,
+            aad: ByteArray,
+            info: ByteArray,
+        ): ByteArray {
+            require(cipherSuite == Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM) {
+                "Only Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM is supported right now"
+            }
+            require(receiverPrivateKey.curve == EcCurve.P256)
+            require(aad.isEmpty()) {
+                // TODO: Looks like there's no way to set the AAD with Tink...
+                "Only supporting empty AADs right now"
+            }
+
+            val (_, privateKeysetHandle) =
+                hpkeGetKeysetHandles(receiverPrivateKey.publicKey, receiverPrivateKey)
+
+            val decryptor = privateKeysetHandle!!.getPrimitive(
+                /* configuration = */ RegistryConfiguration.get(),
+                /* targetClassObject = */ HybridDecrypt::class.java
+            )
+
+            // Tink expects the input to be (serialized encapsulated key || ciphertext)
+            return decryptor.decrypt(enc + cipherText, info)
+        }
+    }
+}


### PR DESCRIPTION
Instead of relying on a platform implementation via `Crypto` object, implement both HKDF and HPKE in pure Kotlin Multiplatform.

For HKDF also expose the `extract` and `expand` sub-operations. For HPKE, instead of just implementing a single cipher-suite do implement all four modes (base, psk, auth, auth_psk) and add support for all KEMs and most of the AEADs (ChaCha20Poly1305 to be added later). IOW, this is a much more complete implementation than what you'd find in e.g. Tink.

Remove the HPKE entry from `Algorithm` since this was for [COSE-HPKE](https://datatracker.ietf.org/doc/draft-ietf-cose-hpke/) which we didn't even implement. Instead, callers can use `Hpke.CipherSuite` instead.

This also lets us drop the dependency on Tink except for unit tests, which is nice.

Additionally, this makes `Crypto` even smaller, basically just EC-support (including signing and key agreement), symmetric encryption, digests, and message authentication codes (MACs).

Fixes #1340.

Test: New unit tests using published test vectors.
Test: Test again Tink implementation for Java-only unit tests.
Test: Manually tested new implementations against old implementations.
