### PR TITLE
Use base64, not base64url for Android origins.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentials.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentials.android.kt
@@ -46,6 +46,7 @@ import org.multipaz.context.AndroidUiContext
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.documenttype.DocumentAttribute
+import org.multipaz.util.toBase64
 import org.multipaz.util.toBase64Url
 import kotlin.time.Duration.Companion.seconds
 import java.io.ByteArrayOutputStream
@@ -470,5 +471,5 @@ internal actual suspend fun defaultRequest(request: JsonObject): JsonObject {
  * @return the origin string of the form "android:apk-key-hash:<sha256_hash-of-apk-signing-cert>"
  */
 fun getAppOrigin(appSigningInfo: ByteArray): String {
-    return "android:apk-key-hash:${Crypto.digest(Algorithm.SHA256, appSigningInfo).toBase64Url()}"
+    return "android:apk-key-hash:${Crypto.digest(Algorithm.SHA256, appSigningInfo).toBase64()}"
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -101,7 +101,7 @@ object VerificationUtil {
         zkSystemSpecs: List<ZkSystemSpec>
     ): JsonObject {
         val requests = exchangeProtocols.map { exchangeProtocol ->
-            generateSigleRequest(
+            generateSingleRequest(
                 exchangeProtocol = exchangeProtocol,
                 docType = docType,
                 claims = claims,
@@ -118,7 +118,7 @@ object VerificationUtil {
         }
     }
 
-    private suspend fun generateSigleRequest(
+    private suspend fun generateSingleRequest(
         exchangeProtocol: String,
         docType: String,
         claims: List<MdocRequestedClaim>,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -322,6 +322,7 @@ private suspend fun doDcRequestFlow(
     }
 
     Logger.i(TAG, "clientId: $clientId")
+    Logger.i(TAG, "origin: $origin")
     Logger.iJson(TAG, "Request", dcRequestObject)
     val t0 = Clock.System.now()
     val dcResponseObject = DigitalCredentials.Default.request(dcRequestObject)
@@ -344,6 +345,8 @@ private suspend fun doDcRequestFlow(
     )
     when (dcResponse) {
         is MdocApiDcResponse -> {
+            Logger.iCbor(TAG, "deviceResponse", dcResponse.deviceResponse)
+            Logger.iCbor(TAG, "sessionTranscript", dcResponse.sessionTranscript)
             showResponse(
                 /* vpToken = */ null,
                 /* deviceResponse = */ dcResponse.deviceResponse,
@@ -354,6 +357,8 @@ private suspend fun doDcRequestFlow(
             )
         }
         is OpenID4VPDcResponse -> {
+            Logger.iJson(TAG, "vpToken", dcResponse.vpToken)
+            Logger.iCbor(TAG, "sessionTranscript", dcResponse.sessionTranscript)
             showResponse(
                 /* vpToken = */ dcResponse.vpToken,
                 /* deviceResponse = */ null,


### PR DESCRIPTION
This fixes a problem with app-to-app presentment. Tested against Google Wallet using OpenID4VP 1.0 unsigned requests. Also add logging to testapp for these kinds of requests to easier diagnose.

Also fix a spelling error with a private function in VeritificationUtil.kt.

Test: Manually tested.
