### PR TITLE
fix dokka ci

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,5 @@ tasks.named("dokkaHtmlMultiModule") {
     dependsOn(
         ":samples:dokkaHtmlMultiModule",
         ":multipaz:dokkaHtmlMultiModule",
-        ":multipaz-models:dokkaHtmlMultiModule"
     )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ kotlin.native.cacheKind.iosSimulatorArm64=none
 kotlin.native.cacheKind.iosArm64=none
 
 kotlin.apple.xcodeCompatibility.nowarn=true
+
+# to ignore the native "Kotlin/Native targets cannot be built on this machine and are disabled" warning
+kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
remove reference to multipaz-models in dokka deps & suppress dokka warning ("Kotlin/Native targets cannot be built on this machine and are disabled")

Fixes https://github.com/openwallet-foundation/multipaz/issues/1348

- [x] Tests pass (https://github.com/VishnuSanal/multipaz-developer-website/actions/runs/18966729244) (built website: https://vishnusanal.github.io/multipaz-developer-website/)