### PR TITLE
ZKP: Use correct CBOR structures from ISO 18013-5 Second Edition draft.

### DIFF
--- a/multipaz-longfellow/src/commonMain/kotlin/org/multipaz/mdoc/zkp/longfellow/LongfellowZkSystem.kt
+++ b/multipaz-longfellow/src/commonMain/kotlin/org/multipaz/mdoc/zkp/longfellow/LongfellowZkSystem.kt
@@ -18,7 +18,6 @@ import org.multipaz.mdoc.zkp.ZkDocument
 import org.multipaz.mdoc.zkp.ZkDocumentData
 import org.multipaz.mdoc.zkp.ZkSystem
 import org.multipaz.mdoc.zkp.ZkSystemSpec
-import org.multipaz.request.MdocRequest
 import kotlin.time.Instant
 import org.multipaz.cbor.putCborArray
 import org.multipaz.request.RequestedClaim
@@ -205,7 +204,7 @@ class LongfellowZkSystem(): ZkSystem {
 
         val zkDocument = ZkDocument(
             proof=ByteString(proof),
-            zkDocumentData = ZkDocumentData (
+            documentData = ZkDocumentData (
                 zkSystemSpecId = zkSystemSpec.id,
                 docType = docType,
                 timestamp = timestamp,
@@ -219,11 +218,11 @@ class LongfellowZkSystem(): ZkSystem {
     }
 
     override fun verifyProof(zkDocument: ZkDocument, zkSystemSpec: ZkSystemSpec, encodedSessionTranscript: ByteString) {
-        if (zkDocument.zkDocumentData.msoX5chain == null || zkDocument.zkDocumentData.msoX5chain!!.certificates.isEmpty()) {
+        if (zkDocument.documentData.msoX5chain == null || zkDocument.documentData.msoX5chain!!.certificates.isEmpty()) {
             throw IllegalArgumentException("zkDocument must contain at least 1 certificate in msoX5chain.")
         }
 
-        val cert = zkDocument.zkDocumentData.msoX5chain!!.certificates[0]
+        val cert = zkDocument.documentData.msoX5chain!!.certificates[0]
         val ecPubKeyCoordinates = cert.ecPublicKey as EcPublicKeyDoubleCoordinate
         val x = getFormattedCoordinate(ecPubKeyCoordinates.x)
         val y = getFormattedCoordinate(ecPubKeyCoordinates.y)
@@ -234,7 +233,7 @@ class LongfellowZkSystem(): ZkSystem {
             ?: throw IllegalArgumentException("Circuit not found for system spec: $zkSystemSpec")
 
         val attributes = mutableListOf<NativeAttribute>()
-        for ((nameSpaceName, dataElements) in zkDocument.zkDocumentData.issuerSigned) {
+        for ((nameSpaceName, dataElements) in zkDocument.documentData.issuerSigned) {
             for ((dataElementName, dataElementValue) in dataElements) {
                 attributes.add(NativeAttribute(
                     key = dataElementName,
@@ -251,10 +250,10 @@ class LongfellowZkSystem(): ZkSystem {
             y,
             encodedSessionTranscript,
             encodedSessionTranscript.size,
-            formatDate(zkDocument.zkDocumentData.timestamp),
+            formatDate(zkDocument.documentData.timestamp),
             zkDocument.proof,
             zkDocument.proof.size,
-            zkDocument.zkDocumentData.docType,
+            zkDocument.documentData.docType,
             longfellowZkSystemSpec,
             attributes.toTypedArray()
         )

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -1233,13 +1233,13 @@ private suspend fun handleGetDataMdoc(
 
             try {
                 val zkSystemSpec = zkSystemRepository.getAllZkSystemSpecs().find {
-                    it.id == zkDocument.zkDocumentData.zkSystemSpecId
+                    it.id == zkDocument.documentData.zkSystemSpecId
                 }
                 if (zkSystemSpec == null) {
                     lines.add(
                         ResultLine(
                             "ZK proof",
-                            "ZK System Spec ID ${zkDocument.zkDocumentData.zkSystemSpecId} was not found."
+                            "ZK System Spec ID ${zkDocument.documentData.zkSystemSpecId} was not found."
                         )
                     )
                 } else {
@@ -1259,23 +1259,23 @@ private suspend fun handleGetDataMdoc(
                     )
                 }
 
-                if (zkDocument.zkDocumentData.msoX5chain == null) {
+                if (zkDocument.documentData.msoX5chain == null) {
                     lines.add(ResultLine("Issuer", "No msoX5chain in ZkDocumentData"))
                 } else {
                     val trustResult =
-                        trustManager.verify(zkDocument.zkDocumentData.msoX5chain!!.certificates)
+                        trustManager.verify(zkDocument.documentData.msoX5chain!!.certificates)
                     if (trustResult.isTrusted) {
                         val tp = trustResult.trustPoints[0]
                         val name = tp.metadata.displayName ?: tp.certificate.subject.name
                         lines.add(ResultLine("Issuer", "In trust list ($name)"))
                     } else {
                         val name =
-                            zkDocument.zkDocumentData.msoX5chain!!.certificates.first().subject.name
+                            zkDocument.documentData.msoX5chain!!.certificates.first().subject.name
                         lines.add(ResultLine("Issuer", "Not in trust list ($name)"))
                     }
                 }
 
-                for ((nameSpaceName, dataElements) in zkDocument.zkDocumentData.issuerSigned) {
+                for ((nameSpaceName, dataElements) in zkDocument.documentData.issuerSigned) {
                     lines.add(ResultLine("Namespace", nameSpaceName))
                     for ((dataElementName, dataElementValue) in dataElements) {
                         val valueStr = Cbor.toDiagnostics(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/ZkRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/ZkRequest.kt
@@ -15,7 +15,7 @@ data class ZkRequest(
         putCborArray("systemSpecs") {
             systemSpecs.forEach { systemSpec ->
                 addCborMap {
-                    put("id", systemSpec.id)
+                    put("zkSystemId", systemSpec.id)
                     put("system", systemSpec.system)
                     putCborMap("params") {
                         systemSpec.params.forEach { param ->
@@ -31,7 +31,7 @@ data class ZkRequest(
     companion object {
         internal fun fromDataItem(dataItem: DataItem): ZkRequest {
             val systemSpecs = dataItem["systemSpecs"].asArray.map { spec ->
-                val id = spec["id"].asTstr
+                val id = spec["zkSystemId"].asTstr
                 val system = spec["system"].asTstr
                 val systemSpec = ZkSystemSpec(
                     id = id,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/zkp/ZkDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/zkp/ZkDocument.kt
@@ -1,21 +1,18 @@
 package org.multipaz.mdoc.zkp
 
-import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.buildCborMap
-import org.multipaz.cbor.putCborArray
 import org.multipaz.cbor.toDataItem
-import org.multipaz.crypto.X509CertChain
 
 /**
  * Represents a document that contains a zero-knowledge (ZK) proof.
  *
- * @property zkDocumentData The structured data of the document.
+ * @property documentData The structured data of the document.
  * @property proof The ZK proof that attests to the integrity and validity of the document data.
  */
 data class ZkDocument(
-    val zkDocumentData: ZkDocumentData,
+    val documentData: ZkDocumentData,
     val proof: ByteString
 ) {
     /**
@@ -23,14 +20,14 @@ data class ZkDocument(
      *
      * The resulting DataItem will be a CBOR map containing two entries:
      * - "proof": The proof as a CBOR byte string
-     * - "zkDocumentData": The document data serialized to its CBOR representation
+     * - "documentData": The document data serialized to its CBOR representation
      *
      * @return A DataItem representing this ZkDocument in CBOR format
      */
     fun toDataItem(): DataItem {
         return buildCborMap {
             put("proof", proof.toByteArray().toDataItem())
-            put("zkDocumentData", zkDocumentData.toDataItem())
+            put("documentData", documentData.toDataItem())
         }
     }
 
@@ -41,7 +38,7 @@ data class ZkDocument(
          * This deserializes a CBOR representation back into a ZkDocument object.
          * It expects the DataItem to be a CBOR map with the following required fields:
          * - "proof": A CBOR byte string containing the ZK proof
-         * - "zkDocumentData": A CBOR structure that can be deserialized into ZkDocumentData
+         * - "documentData": A CBOR structure that can be deserialized into ZkDocumentData
          *
          * @param dataItem The CBOR DataItem to deserialize
          * @return A new ZkDocument instance
@@ -50,10 +47,10 @@ data class ZkDocument(
         fun fromDataItem(dataItem: DataItem): ZkDocument {
             val proof = dataItem.getOrNull("proof")?.asBstr
                 ?: throw IllegalArgumentException("Missing or invalid 'proof' field parsing ZkDocument.")
-            val zkDocumentDataDataItem = dataItem.getOrNull("zkDocumentData")
-                ?: throw IllegalArgumentException("Missing or invalid 'zkDocumentData' field parsing ZkDocument.")
+            val zkDocumentDataDataItem = dataItem.getOrNull("documentData")
+                ?: throw IllegalArgumentException("Missing or invalid 'documentData' field parsing ZkDocument.")
             return ZkDocument(
-                zkDocumentData = ZkDocumentData.fromDataItem(zkDocumentDataDataItem),
+                documentData = ZkDocumentData.fromDataItem(zkDocumentDataDataItem),
                 proof = ByteString(proof)
             )
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/zkp/ZkDocumentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/zkp/ZkDocumentData.kt
@@ -32,7 +32,7 @@ data class ZkDocumentData (
      * Converts this ZkDocumentData instance to a CBOR DataItem representation.
      *
      * The resulting DataItem will be a CBOR map containing:
-     * - "id": The ZK system specification identifier as a text string
+     * - "zkSystemId": The ZK system specification identifier as a text string
      * - "docType": The document type as a text string
      * - "timestamp": The timestamp as an ISO-8601 formatted string
      * - "issuerSignedItems": An array of issuer-signed data items
@@ -43,7 +43,7 @@ data class ZkDocumentData (
      */
     fun toDataItem(): DataItem {
         return buildCborMap {
-            put("id", zkSystemSpecId)
+            put("zkSystemId", zkSystemSpecId)
             put("docType", docType)
             put("timestamp", timestamp.toString())
             putCborMap("issuerSigned") {
@@ -86,7 +86,7 @@ data class ZkDocumentData (
          * It validates and extracts all required fields from the CBOR map structure.
          *
          * Expected CBOR structure:
-         * - "id": Required text string for the ZK system specification ID
+         * - "zkSystemId": Required text string for the ZK system specification ID
          * - "docType": Required text string for the document type
          * - "timestamp": Required text string in ISO-8601 format
          * - "issuerSignedItems": Optional array of DataItems (defaults to empty list)
@@ -98,8 +98,8 @@ data class ZkDocumentData (
          * @throws IllegalArgumentException if required fields are missing or have invalid types
          */
         fun fromDataItem(dataItem: DataItem): ZkDocumentData {
-            val zkSystemSpecId = dataItem.getOrNull("id")?.asTstr
-                ?: throw IllegalArgumentException("Missing or invalid 'id' field parsing ZkDocumentData.")
+            val zkSystemSpecId = dataItem.getOrNull("zkSystemId")?.asTstr
+                ?: throw IllegalArgumentException("Missing or invalid 'zkSystemId' field parsing ZkDocumentData.")
             val docType = dataItem.getOrNull("docType")?.asTstr
                 ?: throw IllegalArgumentException("Missing or invalid 'docType' field parsing ZkDocumentData.")
             val timestamp = dataItem.getOrNull("timestamp")?.asTstr

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -728,8 +728,8 @@ object VerificationUtil {
         }
         for (zkDocument in dr.zkDocuments) {
             val zkSystemSpec = zkSystemRepository?.getAllZkSystemSpecs()?.find {
-                it.id == zkDocument.zkDocumentData.zkSystemSpecId
-            } ?: throw IllegalStateException("Zk System '${zkDocument.zkDocumentData.zkSystemSpecId}' was not found.")
+                it.id == zkDocument.documentData.zkSystemSpecId
+            } ?: throw IllegalStateException("Zk System '${zkDocument.documentData.zkSystemSpecId}' was not found.")
             zkSystemRepository.lookup(zkSystemSpec.system)
                 ?.verifyProof(
                     zkDocument = zkDocument,
@@ -738,13 +738,13 @@ object VerificationUtil {
                 )
                 ?: throw IllegalStateException("Zk System '${zkSystemSpec.system}' was not found.")
 
-            val dt = documentTypeRepository?.getDocumentTypeForMdoc(zkDocument.zkDocumentData.docType)
+            val dt = documentTypeRepository?.getDocumentTypeForMdoc(zkDocument.documentData.docType)
 
-            if (zkDocument.zkDocumentData.msoX5chain == null) {
+            if (zkDocument.documentData.msoX5chain == null) {
                 throw IllegalStateException("Expected x5chain for the issuer")
             }
             val issuerSignedClaims = mutableListOf<MdocClaim>()
-            for ((namespaceName, dataElements) in zkDocument.zkDocumentData.issuerSigned) {
+            for ((namespaceName, dataElements) in zkDocument.documentData.issuerSigned) {
                 for ((dataElementName, value) in dataElements) {
                     val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
                     issuerSignedClaims.add(
@@ -760,7 +760,7 @@ object VerificationUtil {
             }
 
             val deviceSignedClaims = mutableListOf<MdocClaim>()
-            for ((namespaceName, dataElements) in zkDocument.zkDocumentData.deviceSigned) {
+            for ((namespaceName, dataElements) in zkDocument.documentData.deviceSigned) {
                 for ((dataElementName, value) in dataElements) {
                     val mdocAttr = dt?.mdocDocumentType?.namespaces?.get(namespaceName)?.dataElements?.get(dataElementName)
                     issuerSignedClaims.add(
@@ -777,7 +777,7 @@ object VerificationUtil {
 
             verifiedPresentations.add(
                 MdocVerifiedPresentation(
-                    documentSignerCertChain = zkDocument.zkDocumentData.msoX5chain!!,
+                    documentSignerCertChain = zkDocument.documentData.msoX5chain!!,
                     issuerSignedClaims = issuerSignedClaims,
                     deviceSignedClaims = deviceSignedClaims,
                     zkpUsed = true,
@@ -785,7 +785,7 @@ object VerificationUtil {
                     validUntil = null,
                     expectedUpdate = null,
                     signedAt = null,
-                    docType = zkDocument.zkDocumentData.docType
+                    docType = zkDocument.documentData.docType
                 )
             )
         }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
@@ -718,7 +718,7 @@ class DeviceRequestTest {
                       "zkRequest": {
                         "systemSpecs": [
                           {
-                            "id": "0",
+                            "zkSystemId": "0",
                             "system": "longfellow-zk",
                             "params": {
                               "circuit": "1234",
@@ -727,7 +727,7 @@ class DeviceRequestTest {
                             }
                           },
                           {
-                            "id": "1",
+                            "zkSystemId": "1",
                             "system": "other-system-zk",
                             "params": {
                               "foo": "bar",


### PR DESCRIPTION
Specifically, use

- "zkSystemId" instead of "id" in ZkDocumentData and ZkRequest
- "documentData" instead of "zkDocumentData" in ZkDocument

Test: Manually tested with 18013-5 proximity and OpenID4VP URI schemes.
