### PR TITLE
Collection of fixes for OpenID4VCI.

### DIFF
--- a/multipaz-backend-server/src/main/java/org/multipaz/backend/openid4vci/OpenID4VCIBackendImpl.kt
+++ b/multipaz-backend-server/src/main/java/org/multipaz/backend/openid4vci/OpenID4VCIBackendImpl.kt
@@ -29,11 +29,11 @@ class OpenID4VCIBackendImpl: OpenID4VCIBackend, RpcAuthInspector by RpcAuthBacke
         return clientId
     }
 
-    override suspend fun createJwtClientAssertion(tokenUrl: String): String =
+    override suspend fun createJwtClientAssertion(authorizationServerIdentifier: String): String =
         OpenID4VCIBackendUtil.createJwtClientAssertion(
             signingKey = clientAssertionKey,
             clientId = clientId,
-            tokenUrl = tokenUrl,
+            authorizationServerIdentifier = authorizationServerIdentifier,
         )
 
     override suspend fun createJwtWalletAttestation(keyAttestation: KeyAttestation): String {

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
@@ -8,6 +8,7 @@ import org.multipaz.rpc.handler.InvalidRequestException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.cbor.DataItem
+import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.documenttype.knowntypes.AgeVerification
 import org.multipaz.documenttype.knowntypes.EUPersonalID
@@ -32,7 +33,7 @@ internal interface CredentialFactory {
     val cryptographicBindingMethods: List<String>  // must be empty for keyless credentials
     val name: String  // human-readable name
     val logo: String?  // relative URL for the image
-    val signingCertificateChain: X509CertChain  // for the key that is used to sign the credential
+    val signingKey: AsymmetricKey.X509Certified  // the key that is used to sign the credential
 
     /**
      * Ensures that resources are loaded

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
@@ -110,7 +110,7 @@ internal class CredentialFactoryAgeVerification : CredentialFactoryBase() {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingCertificateChain.toDataItem()
+                signingKey.certChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryBase.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryBase.kt
@@ -19,9 +19,7 @@ import kotlin.time.Clock
  */
 internal abstract class CredentialFactoryBase: CredentialFactory {
 
-    protected lateinit var signingKey: AsymmetricKey.X509Certified
-
-    override val signingCertificateChain: X509CertChain get() = signingKey.certChain
+    override lateinit var signingKey: AsymmetricKey.X509Certified
 
     final override suspend fun initialize() {
         signingKey = BackendEnvironment.getServerIdentity("ds_jwk") {

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
@@ -193,7 +193,7 @@ internal class CredentialFactoryMdl : CredentialFactoryBase() {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingCertificateChain.toDataItem()
+                signingKey.certChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -176,7 +176,7 @@ internal class CredentialFactoryMdocPid : CredentialFactoryBase() {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingCertificateChain.toDataItem()
+                signingKey.certChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
@@ -144,7 +144,7 @@ internal class CredentialFactoryUtopiaLoyalty : CredentialFactoryBase() {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingCertificateChain.toDataItem()
+                signingKey.certChain.toDataItem()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
@@ -56,7 +56,9 @@ internal class CredentialFactoryUtopiaNaturatization : CredentialFactoryBase() {
             put("given_name", coreData["given_name"].asTstr)
             put("family_name", coreData["family_name"].asTstr)
             put("birth_date", coreData["birth_date"].asDateString.toString())
-            put("naturalization_date", nzData["naturalization_date"].asDateString.toString())
+            if (nzData.hasKey("naturalization_date")) {
+                put("naturalization_date", nzData["naturalization_date"].asDateString.toString())
+            }
         }
 
         val now = Clock.System.now()

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/authorizeChallenge.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/authorizeChallenge.kt
@@ -41,7 +41,6 @@ suspend fun authorizeChallenge(call: ApplicationCall) {
             call.request,
             state.dpopKey ?: throw IllegalArgumentException("DPoP is required"),
             state.clientId!!,
-            state.dpopNonce,
             null
         )
     }

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/challenge.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/challenge.kt
@@ -1,0 +1,33 @@
+package org.multipaz.openid4vci.request
+
+import io.ktor.http.ContentType
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.multipaz.jwt.Challenge
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
+import org.multipaz.rpc.handler.InvalidRequestException
+
+/**
+ * Issues a fresh wallet attestation challenge
+ */
+suspend fun challenge(call: ApplicationCall) {
+    val configuration = BackendEnvironment.getInterface(Configuration::class)!!
+    val useClientAttestationChallenge =
+        configuration.getValue("use_client_attestation_challenge") != "false"
+    if (!useClientAttestationChallenge) {
+        throw InvalidRequestException("client attestation challenge is not supported")
+    }
+    call.response.header("Cache-Control", "no-store")
+    call.response.header("DPoP-Nonce", Challenge.create())
+    call.respondText(
+        text = buildJsonObject {
+            put("attestation_challenge", Challenge.create())
+        }.toString(),
+        contentType = ContentType.Application.Json
+    )
+}
+

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/nonce.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/nonce.kt
@@ -8,6 +8,8 @@ import kotlin.time.Clock
 import kotlinx.io.bytestring.buildByteString
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.multipaz.jwt.Challenge
+import org.multipaz.openid4vci.util.addFreshNonceHeaders
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.handler.InvalidRequestException
@@ -26,6 +28,7 @@ suspend fun nonce(call: ApplicationCall) {
         expiration = Clock.System.now() + 10.minutes
     )
     call.response.header("Cache-Control", "no-store")
+    addFreshNonceHeaders(call)
     call.respondText(
         text = buildJsonObject {
             put("c_nonce", cNonce)

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/signingCertificate.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/signingCertificate.kt
@@ -14,7 +14,7 @@ suspend fun signingCertificate(call: ApplicationCall) {
         ?: throw InvalidRequestException("'credential_id' parameter required")
     val credentialFactory = CredentialFactory.getRegisteredFactories().byOfferId[credentialId]
         ?: throw InvalidRequestException("invalid 'credential_id' parameter value")
-    val certificate = credentialFactory.signingCertificateChain.certificates.last()
+    val certificate = credentialFactory.signingKey.certChain.certificates.last()
     call.respondText(ContentType.Text.Plain) {
         certificate.toPem()
     }

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/wellKnownOauthAuthorization.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/wellKnownOauthAuthorization.kt
@@ -9,24 +9,36 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Configuration
+import org.multipaz.server.baseUrl
 import org.multipaz.server.getBaseUrl
 
 /**
  * Generates `.well-known/oauth-authorization-server` metadata file.
  */
 suspend fun wellKnownOauthAuthorization(call: ApplicationCall) {
-    val baseUrl = BackendEnvironment.getBaseUrl()
+    val configuration = BackendEnvironment.getInterface(Configuration::class)!!
+    val baseUrl = configuration.baseUrl
+    val useClientAssertion = configuration.getValue("use_client_assertion") == "true"
+    val useClientAttestationChallenge =
+        configuration.getValue("use_client_attestation_challenge") != "false"
     call.respondText(
         text = buildJsonObject {
             put("issuer", baseUrl)
+            if (useClientAttestationChallenge) {
+                put("challenge_endpoint", "$baseUrl/challenge")
+            }
             put("authorization_endpoint", "$baseUrl/authorize")
-            // OAuth for First-Party Apps (FiPA)
-            put("authorization_challenge_endpoint", "$baseUrl/authorize_challenge")
+            // OAuth for First-Party Apps (FiPA), this got reworked substantially, disable for now
+            //put("authorization_challenge_endpoint", "$baseUrl/authorize_challenge")
             put("token_endpoint", "$baseUrl/token")
             put("pushed_authorization_request_endpoint", "$baseUrl/par")
             put("require_pushed_authorization_requests", true)
             putJsonArray("token_endpoint_auth_methods_supported") {
-                add("none")
+                if (useClientAssertion) {
+                    add("private_key_jwt")
+                } else {
+                    add("attest_jwt_client_auth")
+                }
             }
             putJsonArray("response_types_supported") {
                 add("code")
@@ -35,6 +47,12 @@ suspend fun wellKnownOauthAuthorization(call: ApplicationCall) {
                 add("S256")
             }
             putJsonArray("dpop_signing_alg_values_supported") {
+                add("ES256")
+            }
+            putJsonArray("client_attestation_signing_alg_values_supported") {
+                add("ES256")
+            }
+            putJsonArray("client_attestation_pop_signing_alg_values_supported") {
                 add("ES256")
             }
         }.toString(),

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
@@ -91,11 +91,12 @@ suspend fun wellKnownOpenidCredentialIssuer(call: ApplicationCall) {
                             }
                         }
                         putJsonArray("credential_signing_alg_values_supported") {
-                            val cert = credentialFactory.signingCertificateChain.certificates.first()
-                            add(cert.ecPublicKey.curve.defaultSigningAlgorithmFullySpecified.joseAlgorithmIdentifier)
-                        }
-                        putJsonArray("token_endpoint_auth_methods_supported") {
-                            add("attest_jwt_client_auth")
+                            val signingKey = credentialFactory.signingKey
+                            if (credentialFactory.format is Openid4VciFormatMdoc) {
+                                add(signingKey.algorithm.coseAlgorithmIdentifier)
+                            } else {
+                                add(signingKey.algorithm.joseAlgorithmIdentifier)
+                            }
                         }
                         putJsonObject("credential_metadata") {
                             putJsonArray("display") {

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/ApplicationExt.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/ApplicationExt.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.put
 import org.multipaz.openid4vci.request.authorizeChallenge
 import org.multipaz.openid4vci.request.authorizeGet
 import org.multipaz.openid4vci.request.authorizePost
+import org.multipaz.openid4vci.request.challenge
 import org.multipaz.openid4vci.request.credential
 import org.multipaz.openid4vci.request.credentialRequest
 import org.multipaz.openid4vci.request.fetchResource
@@ -117,6 +118,7 @@ fun Application.configureRouting(configuration: ServerConfiguration) {
         get("/authorize") { runRequest { authorizeGet(call) } }
         post("/authorize") { runRequest { authorizePost(call) } }
         post("/authorize_challenge") { runRequest { authorizeChallenge(call) } }
+        post("/challenge") { runRequest { challenge(call) } }
         post("/credential_request") { runRequest { credentialRequest(call) } }
         post("/credential") { runRequest { credential(call) } }
         get("/finish_authorization") { runRequest { finishAuthorization(call) } }

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/DPoPNonceException.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/DPoPNonceException.kt
@@ -1,3 +1,0 @@
-package org.multipaz.openid4vci.util
-
-class DPoPNonceException: Exception("DPoP nonce incorrect or missing")

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/IssuanceState.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/util/IssuanceState.kt
@@ -23,7 +23,6 @@ data class IssuanceState(
     var codeChallenge: ByteString?,
     val configurationId: String?,
     var clientState: String? = null,
-    var dpopNonce: ByteString? = null,
     var authorized: Boolean? = null,
     var openid4VpVerifierModel: Openid4VpVerifierModel? = null,
     var systemOfRecordAuthCode: String? = null,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/AsymmetricKey.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/AsymmetricKey.kt
@@ -152,7 +152,7 @@ sealed class AsymmetricKey {
     data class X509CertifiedExplicit(
         override val certChain: X509CertChain,
         override val privateKey: EcPrivateKey,
-        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithm
+        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithmFullySpecified
     ): X509Certified(), Explicit {
         override val publicKey: EcPublicKey get() = privateKey.publicKey
         override suspend fun sign(message: ByteArray) = sign(this, message)
@@ -163,7 +163,7 @@ sealed class AsymmetricKey {
     data class NamedExplicit(
         override val keyId: String,
         override val privateKey: EcPrivateKey,
-        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithm
+        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithmFullySpecified
     ): Named(), Explicit {
         override val publicKey: EcPublicKey get() = privateKey.publicKey
         override suspend fun sign(message: ByteArray) = sign(this, message)
@@ -173,7 +173,7 @@ sealed class AsymmetricKey {
     /** [AsymmetricKey] which is both [AsymmetricKey.Anonymous] and [AsymmetricKey.Explicit]. */
     data class AnonymousExplicit(
         override val privateKey: EcPrivateKey,
-        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithm
+        override val algorithm: Algorithm = privateKey.curve.defaultSigningAlgorithmFullySpecified
     ): Anonymous(), Explicit {
         override val publicKey: EcPublicKey get() = privateKey.publicKey
         override suspend fun sign(message: ByteArray) = sign(this, message)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/jwt/Challenge.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/jwt/Challenge.kt
@@ -1,0 +1,54 @@
+package org.multipaz.jwt
+
+import kotlinx.io.bytestring.buildByteString
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.rpc.handler.InvalidRequestException
+import org.multipaz.storage.StorageTableSpec
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * Helper object to generate and validate short single-use unique values with expiration that are
+ * suitable for use as JWT nonce/challenge.
+ *
+ * This implementation is not a very scalable, but it is the simplest one that is persistent and
+ * would reliably detect nonce/challenge replay.
+ */
+object Challenge {
+    /**
+     * Generates a nonce/challenge string.
+     *
+     * @param expiration time when this nonce becomes invalid (10 minutes from now by default)
+     * @return new unique nonce
+     */
+    suspend fun create(
+        expiration: Instant = Clock.System.now() + 10.minutes
+    ): String =
+        BackendEnvironment.getTable(challengeTableSpec).insert(
+            key = null,
+            data = buildByteString {},
+            expiration = expiration
+        )
+
+    /**
+     * Validates a nonce/challenge and atomically marks it as used, so another attempt to validate
+     * it will fail.
+     *
+     * @param challenge challenge to validate
+     * @throws ChallengeInvalidException when the given challenge is expired or invalid
+     */
+    suspend fun validateAndConsume(challenge: String) {
+        val table = BackendEnvironment.getTable(challengeTableSpec)
+        if (!table.delete(challenge)) {
+            throw ChallengeInvalidException()
+        }
+    }
+
+    private val challengeTableSpec = StorageTableSpec(
+        name = "ActiveChallenges",
+        supportExpiration = true,
+        supportPartitions = false
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/jwt/ChallengeInvalidException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/jwt/ChallengeInvalidException.kt
@@ -1,0 +1,3 @@
+package org.multipaz.jwt
+
+class ChallengeInvalidException(): Exception("Challenge is missing or not valid")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackend.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackend.kt
@@ -32,7 +32,7 @@ interface OpenID4VCIBackend {
      * Creates fresh OAuth JWT client assertion based on the server-side key.
      */
     @RpcMethod
-    suspend fun createJwtClientAssertion(tokenUrl: String): String
+    suspend fun createJwtClientAssertion(authorizationServerIdentifier: String): String
 
     /**
      * Creates OAuth JWT wallet attestation based on the mobile-platform-specific [KeyAttestation].

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
@@ -25,25 +25,16 @@ object OpenID4VCIBackendUtil {
     suspend fun createJwtClientAssertion(
         signingKey: AsymmetricKey,
         clientId: String,
-        tokenUrl: String,
+        authorizationServerIdentifier: String,
     ): String = buildJwt(
         type = "JWT",
         key = signingKey,
         expiresIn = 5.minutes
     ) {
-        // TODO: figure out what should be passed as `aud`.
-        //  per 'https://datatracker.ietf.org/doc/html/rfc7523#page-5' tokenUrl is appropriate,
-        //  but Openid validation suite does not seem to take that.
-        val aud = if (tokenUrl.endsWith("/token")) {
-            // A hack to get authorization url from token url; would not work in general case.
-            tokenUrl.substring(0, tokenUrl.length - 5)
-        } else {
-            tokenUrl
-        }
         put("jti", Random.Default.nextBytes(18).toBase64Url())
         put("iss", clientId)
         put("sub", clientId) // RFC 7523 Section 3, item 2.B
-        put("aud", aud)
+        put("aud", authorizationServerIdentifier)
     }
 
     /**
@@ -88,7 +79,7 @@ object OpenID4VCIBackendUtil {
         userAuthentication: List<String>? = null,
         keyStorage: List<String>? = null
     ): String  = buildJwt(
-        type = "keyattestation+jwt",  // TODO: it is now key-attestation+jwt in the spec
+        type = "key-attestation+jwt",
         key = signingKey,
         expiresIn = 5.minutes
     ) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIUtil.kt
@@ -76,25 +76,25 @@ internal object OpenID4VCIUtil {
         }
     }
 
-    suspend fun createClientAssertion(endpoint: String): String {
+    suspend fun createClientAssertion(authorizationServerIdentifier: String): String {
         val backend = BackendEnvironment.getInterface(OpenID4VCIBackend::class)!!
-        return backend.createJwtClientAssertion(endpoint)
+        return backend.createJwtClientAssertion(authorizationServerIdentifier)
     }
 
     suspend fun createWalletAttestationPoP(
         clientId: String,
         key: AsymmetricKey,
-        endpointUrl: Url,
-        nonce: String? = null
+        authenticationServerIdentifier: String,
+        challenge: String?
     ): String = buildJwt(
             type = "oauth-client-attestation-pop+jwt",
             key = key
         ) {
             put("iss", clientId)
-            put("aud", endpointUrl.protocolWithAuthority)
+            put("aud", authenticationServerIdentifier)
             put("jti", Random.Default.nextBytes(15).toBase64Url())
-            if (nonce != null) {
-                put("nonce", nonce)
+            if (challenge != null) {
+                put("challenge", challenge)
             }
         }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -327,8 +327,6 @@ class SdJwt(
          * This implementation uses recursive disclosures for all claims in the [claims] parameter.
          *
          * @param issuerKey the key to sign the issuerSigned JWT with.
-         * @param issuerAlgorithm the algorithm to use for signing, e.g. [Algorithm.ESP256].
-         * @param issuerCertChain if set, this will be included as a `x5c` header element in the Issuer-signed JWT.
          * @param kbKey if set, a `cnf` claim with this public key will be included in the Issuer-signed JWT.
          * @param claims the object with claims that can be selectively disclosed.
          * @param nonSdClaims claims to include in the Issuer-signed JWT which are always disclosed. This must at least

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
@@ -31,7 +31,7 @@ class OpenIDBackendUtilTest {
             val assertionJwt = OpenID4VCIBackendUtil.createJwtClientAssertion(
                 signingKey = AsymmetricKey.NamedExplicit("client", signingKey),
                 clientId = CLIENT_ID,
-                tokenUrl = "http://example.com",
+                authorizationServerIdentifier = "http://example.com",
             )
             validateJwt(
                 jwt = assertionJwt,
@@ -100,7 +100,7 @@ class OpenIDBackendUtilTest {
                 jwtName = "Key attestation",
                 publicKey = null,
                 checks = mapOf(
-                    JwtCheck.TYP to "keyattestation+jwt",  // TODO: it is now key-attestation+jwt
+                    JwtCheck.TYP to "key-attestation+jwt",
                     JwtCheck.TRUST to "fake_trust"
                 )
             )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/OpenID4VCILocalBackend.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/OpenID4VCILocalBackend.kt
@@ -8,11 +8,11 @@ import org.multipaz.securearea.KeyAttestation
 class OpenID4VCILocalBackend: OpenID4VCIBackend {
     override suspend fun getClientId(): String = CLIENT_ID
     
-    override suspend fun createJwtClientAssertion(tokenUrl: String): String =
+    override suspend fun createJwtClientAssertion(authorizationServerIdentifier: String): String =
         OpenID4VCIBackendUtil.createJwtClientAssertion(
             signingKey = clientAssertionKey,
             clientId = CLIENT_ID,
-            tokenUrl = tokenUrl,
+            authorizationServerIdentifier = authorizationServerIdentifier,
         )
 
     override suspend fun createJwtWalletAttestation(keyAttestation: KeyAttestation): String =


### PR DESCRIPTION
 - Updates for 'typ' and 'aud' fields in some JWTs
 - Added support for 'challenge' field and end-point for client attestation
 - Moved to non-session-bound DPoP nonce, issue DPoP nonce more aggressively (e.g. on issuance 'nonce' endpoint) and be prepared in the client to make use of them
 - Use COSE identifiers for mDoc signing algorithm in issuer metadata

Fixes #1372, #1345

Testing: manual, added more scenarios to openid4vci integration test