### PR TITLE
add `multipaz-dcapi` to dokka `dependsOn`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,5 +77,6 @@ tasks.named("dokkaHtmlMultiModule") {
     dependsOn(
         ":samples:dokkaHtmlMultiModule",
         ":multipaz:dokkaHtmlMultiModule",
+        ":multipaz-dcapi:dokkaHtmlMultiModule",
     )
 }


### PR DESCRIPTION
this PR updates the dokka CI with the changes introduced in https://github.com/openwallet-foundation/multipaz/pull/1379. this started failing here (https://github.com/openwallet-foundation/multipaz-developer-website/actions/runs/19186583624/job/54854093449) btw

- [x] Tests pass
     - [x] manually tested on my fork - https://github.com/VishnuSanal/multipaz-developer-website/actions/runs/19188752300