### PR TITLE
Multiple OpenID4VCI fixes for interop issues

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/claim/RenderClaimValue.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/claim/RenderClaimValue.kt
@@ -43,17 +43,28 @@ fun RenderClaimValue(
         modifier.fillMaxWidth()
     ) {
         if (claim.attribute?.type == DocumentAttributeType.Picture) {
-            val bytes = when (claim) {
-                is MdocClaim -> claim.value.asBstr
-                is JsonClaim -> claim.value.jsonPrimitive.content.fromBase64Url()
+            val img = try {
+                val bytes = when (claim) {
+                    is MdocClaim -> claim.value.asBstr
+                    is JsonClaim -> claim.value.jsonPrimitive.content.fromBase64Url()
+                }
+                decodeImage(bytes)
+            } catch (err: Exception) {
+                Text(
+                    text = "Image decoding: $err",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                null
             }
-            val img = decodeImage(bytes)
-            Image(
-                bitmap = img,
-                contentDescription = null,
-                alignment = Alignment.TopStart,
-                modifier = Modifier.fillMaxWidth().size(imageSize),
-            )
+            if (img != null) {
+                Image(
+                    bitmap = img,
+                    contentDescription = null,
+                    alignment = Alignment.TopStart,
+                    modifier = Modifier.fillMaxWidth().size(imageSize),
+                )
+            }
         } else {
             val str = claim.render(timeZone)
             Text(

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.AsymmetricKey
-import org.multipaz.crypto.X509CertChain
 import org.multipaz.documenttype.knowntypes.AgeVerification
 import org.multipaz.documenttype.knowntypes.EUPersonalID
 import org.multipaz.documenttype.knowntypes.Loyalty
@@ -27,7 +26,6 @@ internal interface CredentialFactory {
     val offerId: String
     val scope: String
     val format: Openid4VciFormat
-    val requireClientAttestation: Boolean get() = true
     val requireKeyAttestation: Boolean get() = true
     val proofSigningAlgorithms: List<String>  // must be empty for keyless credentials
     val cryptographicBindingMethods: List<String>  // must be empty for keyless credentials
@@ -60,6 +58,7 @@ internal interface CredentialFactory {
                 val factories = mutableListOf(
                     CredentialFactoryMdl(),
                     CredentialFactoryMdocPid(),
+                    CredentialFactorySdjwtPid(),
                     CredentialFactoryUtopiaNaturatization(),
                     CredentialFactoryUtopiaMovieTicket(),
                     CredentialFactoryAgeVerification(),

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
@@ -52,7 +52,7 @@ internal class CredentialFactoryMdl : CredentialFactoryBase() {
         get() = listOf("cose_key")
 
     override val name: String
-        get() = "Example Driver License (mDL)"
+        get() = "Driver License (mDL)"
 
     override val logo: String
         get() = "card-mdl.png"

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -40,7 +40,7 @@ import kotlin.time.Duration.Companion.days
  */
 internal class CredentialFactoryMdocPid : CredentialFactoryBase() {
     override val offerId: String
-        get() = "mDoc-Pid"
+        get() = "pid_mdoc"
 
     override val scope: String
         get() = "core"

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactorySdjwtPid.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactorySdjwtPid.kt
@@ -1,0 +1,172 @@
+package org.multipaz.openid4vci.credential
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.yearsUntil
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.CborDouble
+import org.multipaz.cbor.CborFloat
+import org.multipaz.cbor.CborInt
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.IndefLengthBstr
+import org.multipaz.cbor.IndefLengthTstr
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.Tstr
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.documenttype.DocumentAttributeType
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Resources
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.server.getBaseUrl
+import org.multipaz.util.Logger
+import org.multipaz.util.toBase64Url
+import kotlin.collections.List
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+
+/** EU PID credential */
+internal class CredentialFactorySdjwtPid : CredentialFactoryBase() {
+    override val offerId: String
+        get() = "pid_sd_jwt"
+
+    override val scope: String
+        get() = "core"
+
+    override val format: Openid4VciFormat
+        get() = FORMAT
+
+    override val requireKeyAttestation: Boolean get() = true
+
+    override val proofSigningAlgorithms: List<String>
+        get() = CredentialFactory.DEFAULT_PROOF_SIGNING_ALGORITHMS
+
+    override val cryptographicBindingMethods: List<String>
+        get() = listOf("jwk")
+
+    override val name: String
+        get() = "Personal ID (SD-JWT)"
+
+    override val logo: String
+        get() = "card-pid.png"
+
+    override suspend fun makeCredential(
+        data: DataItem,
+        authenticationKey: EcPublicKey?
+    ): String {
+        check(authenticationKey != null)
+
+        val coreData = data["core"]
+        val dateOfBirth = coreData["birth_date"].asDateString
+
+        val documentType = EUPersonalID.getDocumentType().jsonDocumentType!!
+
+        val resources = BackendEnvironment.getInterface(Resources::class)!!
+        val now = Clock.System.now()
+
+        val timeZone = TimeZone.currentSystemDefault()
+        val dateOfBirthInstant = dateOfBirth.atStartOfDayIn(timeZone)
+
+        val identityAttributes = buildJsonObject {
+            put("given_name", coreData["given_name"].asTstr)
+            put("family_name", coreData["family_name"].asTstr)
+
+            val added = mutableSetOf("birthdate", "given_name", "family_name", "picture")
+            put("birthdate", dateOfBirth.toString())
+
+            if (coreData.hasKey("portrait")) {
+                put("picture", coreData["portrait"].asBstr.toBase64Url())
+            } else {
+                val bytes = resources.getRawResource("female.jpg")!!
+                put("picture", bytes.toByteArray().toBase64Url())
+            }
+
+            if (coreData.hasKey("utopia_id_number")) {
+                put("personal_administrative_number",
+                    coreData["utopia_id_number"].asTstr)
+                added.add("personal_administrative_number")
+            }
+
+            // Transfer core fields that have counterparts in the PID credential
+            for ((nameItem, value) in coreData.asMap) {
+                val name = nameItem.asTstr
+                val attribute = documentType.claims[name]
+                if (!added.contains(name) && attribute != null) {
+                    val typeMatches = when (attribute.type) {
+                        DocumentAttributeType.Blob, DocumentAttributeType.Picture ->
+                            value is Bstr || value is IndefLengthBstr
+                        DocumentAttributeType.Boolean ->
+                            value == Simple.TRUE || value == Simple.FALSE
+                        DocumentAttributeType.String, is DocumentAttributeType.StringOptions ->
+                            value is Tstr || value is IndefLengthTstr
+                        DocumentAttributeType.Number, is DocumentAttributeType.IntegerOptions ->
+                            value is CborInt || value is CborFloat || value is CborDouble
+                        DocumentAttributeType.Date ->
+                            value is Tagged && value.tagNumber == Tagged.FULL_DATE_STRING
+                        DocumentAttributeType.DateTime ->
+                            value is Tagged && value.tagNumber == Tagged.DATE_TIME_STRING
+                        is DocumentAttributeType.ComplexType -> true
+                    }
+                    if (typeMatches) {
+                        put(name, value.toJson())
+                    } else {
+                        Logger.e(TAG, "Skipped '$name': type mismatch")
+                    }
+                }
+            }
+
+            // Values derived from the birth_date
+            put("age_in_years", dateOfBirth.yearsUntil(now.toLocalDateTime(timeZone).date))
+            put("age_birth_year", dateOfBirth.year)
+            putJsonObject("age_equal_or_over") {
+                for (age in listOf(14, 18, 21)) {
+                    val isOver = now > dateOfBirthInstant.plus(age, DateTimeUnit.YEAR, timeZone)
+                    put(age.toString(), isOver)
+                }
+            }
+            added.addAll(listOf("age_in_years", "age_birth_year", "age_equal_or_over"))
+
+            // Add all mandatory elements for completeness.
+            for ((elementName, data) in documentType.claims) {
+                if (!added.contains(elementName)) {
+                    data.sampleValueJson?.let { put(elementName, it) }
+                }
+            }
+
+        }
+
+        val timeSigned = now
+        val validFrom = Clock.System.now()
+        val validUntil = validFrom + 30.days
+        val issuer = BackendEnvironment.getBaseUrl()
+
+        val sdJwt = SdJwt.create(
+            issuerKey = signingKey,
+            kbKey = authenticationKey,
+            claims = identityAttributes,
+            nonSdClaims = buildJsonObject {
+                put("iss", issuer)
+                put("vct", documentType.vct)
+                put("iat", timeSigned.epochSeconds)
+                put("nbf", validFrom.epochSeconds)
+                put("exp", validUntil.epochSeconds)
+            }
+        )
+        return sdJwt.compactSerialization
+    }
+
+    companion object {
+        private val FORMAT = Openid4VciFormatSdJwt(EUPersonalID.EUPID_VCT)
+        private const val TAG = "CredentialFactorySdjwtPid"
+    }
+}

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
@@ -14,10 +14,7 @@ import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.crypto.X509Cert
-import org.multipaz.crypto.X509CertChain
 import org.multipaz.documenttype.knowntypes.Loyalty
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
 import org.multipaz.mdoc.mso.MobileSecurityObjectGenerator
@@ -41,8 +38,6 @@ internal class CredentialFactoryUtopiaLoyalty : CredentialFactoryBase() {
 
     override val format: Openid4VciFormat
         get() = openId4VciFormatLoyalty
-
-    override val requireClientAttestation: Boolean get() = false
 
     override val requireKeyAttestation: Boolean get() = false
 

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaMovieTicket.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaMovieTicket.kt
@@ -23,8 +23,6 @@ internal class CredentialFactoryUtopiaMovieTicket : CredentialFactoryBase() {
     override val format: Openid4VciFormat
         get() = FORMAT
 
-    override val requireClientAttestation: Boolean get() = false
-
     override val requireKeyAttestation: Boolean get() = false
 
     override val proofSigningAlgorithms: List<String>

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaNaturatization.kt
@@ -22,8 +22,6 @@ internal class CredentialFactoryUtopiaNaturatization : CredentialFactoryBase() {
     override val format: Openid4VciFormat
         get() = FORMAT
 
-    override val requireClientAttestation: Boolean get() = false
-
     override val requireKeyAttestation: Boolean get() = false
 
     override val proofSigningAlgorithms: List<String>

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -9,14 +9,11 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headers
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveText
-import io.ktor.server.response.header
 import io.ktor.server.response.respondText
 import kotlinx.datetime.LocalDate
-import kotlinx.io.bytestring.ByteString
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.util.fromBase64Url
-import org.multipaz.util.toBase64Url
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -34,7 +31,6 @@ import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItemFullDate
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.jwt.Challenge
 import org.multipaz.jwt.ChallengeInvalidException
 import org.multipaz.openid4vci.credential.CredentialFactory
 import org.multipaz.openid4vci.credential.Openid4VciFormat
@@ -49,7 +45,6 @@ import org.multipaz.jwt.JwtCheck
 import org.multipaz.util.Logger
 import org.multipaz.jwt.validateJwt
 import org.multipaz.openid4vci.util.respondWithNewDPoPNonce
-import kotlin.random.Random
 
 /**
  * Issues a credential based on DPoP authentication with access token.
@@ -80,9 +75,6 @@ suspend fun credential(call: ApplicationCall) {
     if (factory == null) {
         throw IllegalStateException(
             "No credential can be created for scope '${state.scope}' and the given format")
-    }
-    if (state.clientAttestationKey == null && factory.requireClientAttestation) {
-        throw InvalidRequestException("this credential type requires client attestation")
     }
 
     val credentialData = readSystemOfRecord(state)
@@ -121,7 +113,7 @@ suspend fun credential(call: ApplicationCall) {
             throw InvalidRequestException("Unsupported proof type")
         }
         proofs = proofsObj[proofType]!!.jsonArray
-        if (proofs.size == 0) {
+        if (proofs.isEmpty()) {
             throw InvalidRequestException("'proofs' is empty")
         }
     }

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/ApplicationExt.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/ApplicationExt.kt
@@ -64,6 +64,7 @@ private typealias RequestWrapper =
  * Defines server endpoints for HTTP GET and POST.
  */
 fun Application.configureRouting(configuration: ServerConfiguration) {
+    checkConfiguration(configuration)
     // TODO: when https://youtrack.jetbrains.com/issue/KTOR-8088 is resolved, there
     //  may be a better way to inject our custom wrapper for all request handlers
     //  (instead of doing it for every request like we do today).
@@ -223,5 +224,13 @@ fun Application.traceCalls(configuration: ServerConfiguration) {
         trace.flush()
         traceStream.write(buffer.toString())
         traceStream.flush()
+    }
+}
+
+private fun checkConfiguration(configuration: ServerConfiguration) {
+    val supportClientAssertion = configuration.getValue("support_client_assertion") != "false"
+    val supportClientAttestation = configuration.getValue("support_client_attestation") != "false"
+    if (!supportClientAssertion && !supportClientAttestation) {
+        throw IllegalArgumentException("No client authentication methods supported")
     }
 }

--- a/multipaz-openid4vci-server/src/main/resources/resources/www/display_metadata.js
+++ b/multipaz-openid4vci-server/src/main/resources/resources/www/display_metadata.js
@@ -25,6 +25,40 @@ async function displayCredentialConfig(configId) {
     img.className = "credential_logo";
     img.setAttribute("src", display.logo?.uri);
     item.appendChild(img);
+    let credType = document.createElement("p");
+    credType.className = "credential_type";
+    let credTypeText = "Format: "
+    if (config.format == "mso_mdoc") {
+        credTypeText += " mDoc [" + config.doctype + "]"
+    } else if (config.format == "dc+sd-jwt") {
+        credTypeText += " SD-JWT [" + config.vct + "]"
+    } else {
+        credTypeText += config.format
+    }
+    credType.textContent = credTypeText;
+    item.appendChild(credType);
+    let proofsHeading = document.createElement("h4");
+    proofsHeading.textContent = "OpenID4VCI Proof Types Accepted";
+    item.appendChild(proofsHeading);
+    let proofsList = document.createElement("ul");
+    item.appendChild(proofsList);
+    let proofs = config.proof_types_supported;
+    if (proofs == null || proofs.length == 0) {
+        let li = document.createElement("li");
+        li.textContent = "Not key bound, no proof needed";
+        proofsList.appendChild(li);
+    } else {
+        for (proof in proofs) {
+            let li = document.createElement("li");
+            let text = proof
+            let algs = proofs[proof].proof_signing_alg_values_supported
+            if (algs) {
+                text = text + " [" + algs.join(", ") + "]";
+            }
+            li.textContent = text;
+            proofsList.appendChild(li);
+        }
+    }
 
     let title = document.createElement("h3");
     title.textContent = "Authorization Code Flow";

--- a/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -107,7 +107,8 @@ class ProvisioningClientTest {
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
                 "-param", "use_scopes=true",
-                "-param", "use_client_assertion=true"
+                "-param", "support_client_assertion=true",
+                "-param", "support_client_attestation=false"
             )
         )
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
@@ -41,7 +41,7 @@ object JsonWebSignature {
         val headerStr = buildJsonObject {
             put("alg", JsonPrimitive(signatureAlgorithm.joseAlgorithmIdentifier!!))
             type?.let { put("typ", JsonPrimitive(it)) }
-            x5c?.let { put("x5c", x5c.toX5c()) }
+            x5c?.let { put("x5c", x5c.toX5c(excludeRoot = true)) }
         }.toString().encodeToByteArray().toBase64Url()
         val bodyStr = claimsSet.toString().encodeToByteArray().toBase64Url()
         val toBeSigned = "$headerStr.$bodyStr".encodeToByteArray()
@@ -80,7 +80,7 @@ object JsonWebSignature {
         val headerStr = buildJsonObject {
             put("alg", JsonPrimitive(secureArea.getKeyInfo(alias).algorithm.joseAlgorithmIdentifier!!))
             type?.let { put("typ", JsonPrimitive(it)) }
-            x5c?.let { put("x5c", x5c.toX5c()) }
+            x5c?.let { put("x5c", x5c.toX5c(excludeRoot = true)) }
         }.toString().encodeToByteArray().toBase64Url()
         val bodyStr = claimsSet.toString().encodeToByteArray().toBase64Url()
         val toBeSigned = "$headerStr.$bodyStr".encodeToByteArray()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/jwt/buildJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/jwt/buildJwt.kt
@@ -63,7 +63,7 @@ private fun AsymmetricKey.addToJwtHeader(header: JsonObjectBuilder) {
     )
     when (this) {
         is AsymmetricKey.X509CertifiedSecureAreaBased,
-        is AsymmetricKey.X509CertifiedExplicit -> header.put("x5c", certChain.toX5c())
+        is AsymmetricKey.X509CertifiedExplicit -> header.put("x5c", certChain.toX5c(excludeRoot = true))
         is AsymmetricKey.NamedExplicit,
         is AsymmetricKey.NamedSecureAreaBased -> header.put("kid", keyId)
         is AsymmetricKey.AnonymousExplicit,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/ClientAuthenticationType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/ClientAuthenticationType.kt
@@ -1,0 +1,15 @@
+package org.multipaz.provisioning.openid4vci
+
+/**
+ * OpenID client authentication required by the server.
+ *
+ * Client authentication (unless it is `NONE`) tells the issuance server that our wallet/client can
+ * be trusted to keep the credentials. Issuance server communicates acceptable forms of
+ * client authentication in `.well-known/oauth-authorization-server` metadata file,
+ * using `token_endpoint_auth_methods_supported` array.
+ */
+internal enum class ClientAuthenticationType {
+    NONE,  // No client authentication is required by the issuer
+    CLIENT_ASSERTION,  // JWT bearer client assertion, see RFC 7523
+    CLIENT_ATTESTATION  // Wallet attestation as defined in OpenID4VCI 1.0 Appendix E.
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
@@ -11,6 +11,7 @@ import org.multipaz.jwt.buildJwt
 import org.multipaz.securearea.KeyAttestation
 import org.multipaz.util.toBase64Url
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -72,7 +73,8 @@ object OpenID4VCIBackendUtil {
         walletLink: String?
     ): String = buildJwt(
         type = "oauth-client-attestation+jwt",
-        key = signingKey
+        key = signingKey,
+        expiresIn = 2000.days  // long-lived
     ) {
         put("iss", attestationIssuer)
         put("sub", clientId)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/util/JwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/util/JwtTest.kt
@@ -143,12 +143,12 @@ class JwtTest {
         val root = X509Cert.Builder(
             publicKey = trustedKey,
             signingKey = AsymmetricKey.anonymous(
-                privateKey = Crypto.createEcPrivateKey(EcCurve.P384),
-                algorithm = EcCurve.P384.defaultSigningAlgorithm
+                privateKey = privateTrustedKey,
+                algorithm = privateTrustedKey.curve.defaultSigningAlgorithm
             ),
             serialNumber = ASN1Integer(57),
             subject = X500Name.fromName("CN=test-x5c"),
-            issuer = X500Name.fromName("CN=test-ca"),
+            issuer = X500Name.fromName("CN=test-x5c"),
             validFrom = clock.now() - 10.days,
             validUntil = clock.now() + 100.days
         ).build()
@@ -181,7 +181,7 @@ class JwtTest {
                 put("kid", kid)
             }
             if (x5c != null) {
-                put("x5c", x5c.toX5c())
+                put("x5c", x5c.toX5c(excludeRoot = true))
             }
         }.toString().encodeToByteArray().toBase64Url()
         val body = buildJsonObject {

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
@@ -21,6 +21,7 @@ import org.multipaz.storage.Storage
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
 import kotlin.test.Test
+import kotlin.time.Duration
 
 class OpenIDBackendUtilTest {
     @Test
@@ -67,6 +68,7 @@ class OpenIDBackendUtilTest {
                 jwt = attestationJwt,
                 jwtName = "Client Attestation",
                 publicKey = null,
+                maxValidity = Duration.INFINITE,
                 checks = mapOf(
                     JwtCheck.TRUST to "fake_trust",
                     JwtCheck.TYP to "oauth-client-attestation+jwt",

--- a/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
+++ b/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
@@ -359,7 +359,7 @@ object MultipazCtl {
 
         val json = buildJsonObject {
             put("jwk", privateKey.toJwk())
-            put("x5c", X509CertChain(listOf(certificate)).toX5c())
+            put("x5c", X509CertChain(listOf(certificate)).toX5c(excludeRoot = false))
         }
         println(jsonPrettyPrint.encodeToString(json))
         println("")


### PR DESCRIPTION
 - x5c in most cases must not contain root certificate
 - x5c validation in JWT
 - do not send client authentication if it is not required
 - add `exp` claim to wallet attestation
 - accept both client attestation and client assertion
 - list credential type and required proof types on the web page
 - EU PID in SD-JWT format
 - Don't crash when credential image is SVG (but no SVG rendering yet)
 - Use scopes when possible for openid user authorization
 - Don't crash when images in claims are incorrectly encoded

Fixes #1402