### PR TITLE
fix crash when the requested document is not present in the holder

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="presentment_error">Something went wrong</string>
     <string name="presentment_canceled">Presentment was canceled</string>
     <string name="presentment_timeout">Timed out waiting for reader</string>
+    <string name="presentment_empty">No documents present to satisfy the request</string>
     <string name="presentment_waiting_for_request">Waiting for request</string>
     <string name="presentment_document_picker_title">Select Document</string>
     <string name="presentment_document_picker_text">Multiple documents can fulfill the request. Please select one</string>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/CredentialPresentmentModalBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/CredentialPresentmentModalBottomSheet.kt
@@ -102,9 +102,11 @@ import org.multipaz.multipaz_compose.generated.resources.credential_presentment_
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list_anonymous
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list_app
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list_website
+import org.multipaz.presentment.Combination
 import org.multipaz.presentment.CredentialPresentmentSetOptionMemberMatch
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
+import org.multipaz.presentment.model.PresentmentModel
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
@@ -117,70 +119,6 @@ private val PAGER_INDICATOR_HEIGHT = 30.dp
 private val PAGER_INDICATOR_PADDING = 8.dp
 
 private const val TAG = "CredentialPresentmentModalBottomSheet"
-
-private data class CombinationElement(
-    val matches: List<CredentialPresentmentSetOptionMemberMatch>
-)
-
-private data class Combination(
-    val elements: List<CombinationElement>
-)
-
-private fun CredentialPresentmentData.generateCombinations(preselectedDocuments: List<Document>): List<Combination> {
-    val combinations = mutableListOf<Combination>()
-
-    // First consolidate all single-member options into one...
-    val consolidated = consolidate()
-
-    // ...then explode all combinations
-    val credentialSetsMaxPath = mutableListOf<Int>()
-    consolidated.credentialSets.forEachIndexed { n, credentialSet ->
-        // If a credentialSet is optional, it's an extra combination we tag at the end
-        credentialSetsMaxPath.add(credentialSet.options.size + (if (credentialSet.optional) 1 else 0))
-    }
-
-    for (path in credentialSetsMaxPath.generateAllPaths()) {
-        val elements = mutableListOf<CombinationElement>()
-        consolidated.credentialSets.forEachIndexed { credentialSetNum, credentialSet ->
-            val omitCredentialSet = (path[credentialSetNum] == credentialSet.options.size)
-            if (omitCredentialSet) {
-                check(credentialSet.optional)
-            } else {
-                val option = credentialSet.options[path[credentialSetNum]]
-                for (member in option.members) {
-                    elements.add(CombinationElement(
-                        matches = member.matches
-                    ))
-                }
-            }
-        }
-        combinations.add(Combination(
-            elements = elements
-        ))
-    }
-
-    if (preselectedDocuments.size == 0) {
-        return combinations
-    }
-
-    val setOfPreselectedDocuments = preselectedDocuments.toSet()
-    combinations.forEach { combination ->
-        if (combination.elements.size == preselectedDocuments.size) {
-            val chosenElements = mutableListOf<CombinationElement>()
-            combination.elements.forEachIndexed { n, element ->
-                val match = element.matches.find { setOfPreselectedDocuments.contains(it.credential.document) }
-                if (match == null) {
-                    return@forEach
-                }
-                chosenElements.add(CombinationElement(matches = listOf(match)))
-            }
-            // Winner, winner, chicken dinner!
-            return listOf(Combination(elements = chosenElements))
-        }
-    }
-    Logger.w(TAG, "Error picking combination for pre-selected documents")
-    return combinations
-}
 
 private fun setMatch(
     oldValue: List<List<Int>>,
@@ -231,6 +169,7 @@ fun CredentialPresentmentModalBottomSheet(
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
     imageLoader: ImageLoader,
+    combinations: List<Combination>,
     dynamicMetadataResolver: (requester: Requester) -> TrustMetadata? = { chain -> null },
     appName: String? = null,
     appIconPainter: Painter? = null,
@@ -249,7 +188,7 @@ fun CredentialPresentmentModalBottomSheet(
             }
         }
     }
-    val combinations = remember { credentialPresentmentData.generateCombinations(preselectedDocuments) }
+    val combinations = remember { combinations }
     val selectMatchCombinationAndElement = remember { mutableStateOf<Pair<Int, Int>?>(null) }
     val matchSelectionLists = remember {
         val initialSelections = combinations.map { List(it.elements.size) { 0 } }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Presentment.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Presentment.kt
@@ -52,6 +52,8 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.multipaz.multipaz_compose.generated.resources.presentment_empty
+import org.multipaz.presentment.model.PresentmentEmpty
 import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "Presentment"
@@ -182,6 +184,11 @@ fun Presentment(
                                     "", painterResource(Res.drawable.presentment_icon_error),
                                     stringResource(Res.string.presentment_timeout)
                                 )
+                            }  else if (presentmentModel.error is PresentmentEmpty) {
+                                Triple(
+                                    "", painterResource(Res.drawable.presentment_icon_error),
+                                    stringResource(Res.string.presentment_empty)
+                                )
                             } else {
                                 Triple(
                                     "", painterResource(Res.drawable.presentment_icon_error),
@@ -267,6 +274,7 @@ private fun ConsentPrompt(
         requester = presentmentModel.consentData.requester,
         trustPoint = presentmentModel.consentData.trustPoint,
         credentialPresentmentData = presentmentModel.consentData.credentialPresentmentData,
+        combinations = presentmentModel.consentData.combinations,
         preselectedDocuments = presentmentModel.consentData.preselectedDocuments,
         imageLoader = imageLoader,
         dynamicMetadataResolver = presentmentModel.consentData.dynamicMetadataResolver,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentData.kt
@@ -1,6 +1,8 @@
 package org.multipaz.presentment
 
 import org.multipaz.document.Document
+import org.multipaz.util.Logger
+import org.multipaz.util.generateAllPaths
 
 /**
  * An object containing data related to a credential presentment event.
@@ -76,4 +78,77 @@ interface CredentialPresentmentData {
      * @return a [CredentialPresentmentSelection].
      */
     fun select(preselectedDocuments: List<Document>): CredentialPresentmentSelection
+
+    fun generateCombinations(preselectedDocuments: List<Document>): List<Combination> {
+
+        val combinations = mutableListOf<Combination>()
+
+        // First consolidate all single-member options into one...
+        val consolidated = consolidate()
+
+        // ...then explode all combinations
+        val credentialSetsMaxPath = mutableListOf<Int>()
+        consolidated.credentialSets.forEachIndexed { n, credentialSet ->
+            // If a credentialSet is optional, it's an extra combination we tag at the end
+            credentialSetsMaxPath.add(credentialSet.options.size + (if (credentialSet.optional) 1 else 0))
+        }
+
+        for (path in credentialSetsMaxPath.generateAllPaths()) {
+            val elements = mutableListOf<CombinationElement>()
+            consolidated.credentialSets.forEachIndexed { credentialSetNum, credentialSet ->
+                val omitCredentialSet = (path[credentialSetNum] == credentialSet.options.size)
+                if (omitCredentialSet) {
+                    check(credentialSet.optional)
+                } else {
+                    val option = credentialSet.options[path[credentialSetNum]]
+                    for (member in option.members) {
+                        elements.add(
+                            CombinationElement(
+                                matches = member.matches
+                            )
+                        )
+                    }
+                }
+            }
+            combinations.add(
+                Combination(
+                    elements = elements
+                )
+            )
+        }
+
+        if (preselectedDocuments.size == 0) {
+            return combinations
+        }
+
+        val setOfPreselectedDocuments = preselectedDocuments.toSet()
+        combinations.forEach { combination ->
+            if (combination.elements.size == preselectedDocuments.size) {
+                val chosenElements = mutableListOf<CombinationElement>()
+                combination.elements.forEachIndexed { n, element ->
+                    val match =
+                        element.matches.find { setOfPreselectedDocuments.contains(it.credential.document) }
+                    if (match == null) {
+                        return@forEach
+                    }
+                    chosenElements.add(CombinationElement(matches = listOf(match)))
+                }
+                // Winner, winner, chicken dinner!
+                return listOf(Combination(elements = chosenElements))
+            }
+        }
+        Logger.w(
+            "CredentialPresentmentData",
+            "Error picking combination for pre-selected documents"
+        )
+        return combinations
+    }
 }
+
+public data class CombinationElement(
+    val matches: List<CredentialPresentmentSetOptionMemberMatch>
+)
+
+public data class Combination(
+    val elements: List<CombinationElement>
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/PresentmentEmpty.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/PresentmentEmpty.kt
@@ -1,0 +1,8 @@
+package org.multipaz.presentment.model
+
+/**
+ * Thrown when no documents exists to satisfy the request
+ *
+ * @property message message to display.
+ */
+class PresentmentEmpty(message: String): Exception(message)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/PresentmentModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/PresentmentModel.kt
@@ -16,10 +16,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.multipaz.document.Document
+import org.multipaz.presentment.Combination
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
+import org.multipaz.presentment.CredentialPresentmentSetOptionMemberMatch
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
+import org.multipaz.util.generateAllPaths
 import kotlin.coroutines.resume
 import kotlin.time.Duration.Companion.seconds
 
@@ -341,8 +344,20 @@ class PresentmentModel {
         trustPoint: TrustPoint?
     ): CredentialPresentmentSelection? {
         check(_state.value == State.PROCESSING)
+
+        val combinations = credentialPresentmentData.generateCombinations(preselectedDocuments)
+
+        if (combinations.firstOrNull()
+                ?.elements?.firstOrNull()
+                ?.matches.isNullOrEmpty()
+        ) {
+            setCompleted(PresentmentEmpty("No matching documents"))
+            return null
+        }
+
         _consentData = ConsentData(
             credentialPresentmentData = credentialPresentmentData,
+            combinations = combinations,
             preselectedDocuments = preselectedDocuments,
             requester = requester,
             trustPoint = trustPoint,
@@ -367,6 +382,7 @@ class PresentmentModel {
      */
     data class ConsentData(
         val credentialPresentmentData: CredentialPresentmentData,
+        val combinations: List<Combination>,
         val preselectedDocuments: List<Document>,
         val requester: Requester,
         val trustPoint: TrustPoint?,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -56,6 +56,8 @@ import org.multipaz.documenttype.knowntypes.PhotoID
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.openid.dcql.DcqlQuery
 import org.multipaz.openid.dcql.DcqlResponse
+import org.multipaz.presentment.Combination
+import org.multipaz.presentment.model.PresentmentModel
 import org.multipaz.presentment.model.SimplePresentmentSource
 import org.multipaz.request.Requester
 import org.multipaz.sdjwt.SdJwt
@@ -325,6 +327,7 @@ fun ConsentPromptScreen(
                 requester = it.requester,
                 trustPoint = it.trustPoint,
                 credentialPresentmentData = it.dcqlResponse,
+                combinations = it.combinations,
                 preselectedDocuments = emptyList(),
                 imageLoader = imageLoader,
                 dynamicMetadataResolver = { requester ->
@@ -363,7 +366,8 @@ fun ConsentPromptScreen(
 private data class QueryResult(
     val requester: Requester,
     val trustPoint: TrustPoint?,
-    val dcqlResponse: DcqlResponse
+    val dcqlResponse: DcqlResponse,
+    val combinations: List<Combination>
 )
 
 private suspend fun getQueryResult(
@@ -491,7 +495,8 @@ private suspend fun getQueryResult(
     )
     val dcqlQuery = DcqlQuery.fromJson(dcql = dcql)
     val dcqlResponse = dcqlQuery.execute(presentmentSource = presentmentSource)
-    return QueryResult(requester, trustPoint, dcqlResponse)
+    val combinations = dcqlResponse.generateCombinations(emptyList())
+    return QueryResult(requester, trustPoint, dcqlResponse, combinations)
 }
 
 private suspend fun calculateRequester(


### PR DESCRIPTION
Fixes https://github.com/openwallet-foundation/multipaz/issues/1408 + addresses https://github.com/openwallet-foundation/multipaz/issues/1464

- [x] Tests pass (manually tested with and without empty `documentStore`)
- [ ] Appropriate changes to README are included in PR

### steps to test

- build testapp
- try to request for a document type that is not present in the documentstore (or delete all docs from the document store and request for any doc type)
- you should see a "no matching document present" bottom sheet - the app used to crash previously