### PR TITLE
Mdoc: Use MdocBleServiceData to convey the BLE L2CAP PSM.

### DIFF
--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -196,7 +196,7 @@ class TestAppSettingsModel private constructor(
     val cryptoPreferBouncyCastle = MutableStateFlow<Boolean>(false)
 
     val observeModeEnabled = MutableStateFlow<Boolean>(false)
-    val observeModeEmitPollingFramesAsReader = MutableStateFlow<Boolean>(true)
+    val observeModeEmitPollingFramesAsReader = MutableStateFlow<Boolean>(false)
 }
 
 // Default to our open CSA, where "open" means it'll work with even unlocked bootloaders


### PR DESCRIPTION
Previously we were using another mechanism using a not-yet-allocated number. After conferring with the Bluetooth SIG we converged on another solution whereby ISO JTC1 SC17 would be assigned a 16-bit UUID.

The UUID actually hasn't been given to SC17 yet so we're using a temporary UUID of 0xFF01 for the test event.

Test: Manually tested.
