### PR TITLE
NFC: Fix issues with errors when dialog is hidden.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ScanNfcTagPromptDialog.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ScanNfcTagPromptDialog.kt
@@ -201,7 +201,9 @@ class NfcReaderCallback<T>(
                 } catch (e: NfcTagLostException) {
                     // This is to to properly handle emulated tags - such as on Android - which may be showing
                     // disambiguation UI if multiple applications have registered for the same AID.
-                    dialogMessage.value = initialMessage
+                    if (initialMessage != null) {
+                        dialogMessage.value = initialMessage
+                    }
                     Logger.w(TAG, "Tag lost", e)
                 } catch (e: Throwable) {
                     Logger.e(TAG, "Error in interaction func", e)

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReader.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReader.android.kt
@@ -6,6 +6,7 @@ import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.NfcDialogParameters
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration.Companion.seconds
 
 private object NfcTagReaderAndroid: NfcTagReader {
     override val external: Boolean
@@ -22,7 +23,8 @@ private object NfcTagReaderAndroid: NfcTagReader {
     ): T {
         val promptModel = AndroidPromptModel.get(coroutineContext)
         val result = promptModel.scanNfcPromptModel.displayPrompt(
-            NfcDialogParameters(message, tagInteractionFunc, options, context)
+            parameters = NfcDialogParameters(message, tagInteractionFunc, options, context),
+            lingerDuration = if (message != null) 2.seconds else 0.seconds
         )
         @Suppress("UNCHECKED_CAST")
         return result as T

--- a/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModel.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModel.kt
@@ -31,9 +31,7 @@ class AndroidPromptModel(
 
     override val passphrasePromptModel = SinglePromptModel<PassphraseRequest, String?>()
     val biometricPromptModel = SinglePromptModel<BiometricPromptState, Boolean>()
-    val scanNfcPromptModel = SinglePromptModel<NfcDialogParameters<Any>, Any?>(
-        lingerDuration = 2.seconds
-    )
+    val scanNfcPromptModel = SinglePromptModel<NfcDialogParameters<Any>, Any?>()
 
     @Volatile
     private var scope: CoroutineScope? = null


### PR DESCRIPTION
For the case where we're scanning a holder's Android device with two wallets and there's no wallet role owner (or the wallet role owner isn't registering the NDEF AID), Android shows a disambiguation dialog which results in transceive() failing when the two devices are no longer in the field.

The application - e.g. Multipaz Identity Reader - should be able to catch the exception and then restart NFC scanning as a NFC tag reader. However in this situation the following things happen

- Despite the prompt being invisible, it shows the error
- The app must wait for linger duration until it can start reading again.

This PR fixes these two problems.

Test: Manually tested with Multipaz Identity Reader.
