### PR TITLE
Handle small clock skew in JWT/CWT validation.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
@@ -94,7 +94,15 @@ suspend fun validateCwt(
         } else {
             val iat = body[WebTokenClaim.Iat]
                 ?: throw InvalidRequestException("$cwtName: either 'exp' or 'iat' is required")
-            iat + maxValidity - 5.seconds
+            if (iat > now) {
+                // Allow no more than 5 seconds clock mismatch
+                if (iat > now + 5.seconds) {
+                    throw InvalidRequestException("$cwtName: 'iat' is in future")
+                }
+                now + maxValidity
+            } else {
+                iat + maxValidity
+            }
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
@@ -99,7 +99,15 @@ suspend fun validateJwt(
         } else {
             val iat = body[WebTokenClaim.Iat]
                 ?: throw InvalidRequestException("$jwtName: either 'exp' or 'iat' is required")
-            iat + maxValidity
+            if (iat > now) {
+                // Allow no more than 5 seconds clock mismatch
+                if (iat > now + 5.seconds) {
+                    throw InvalidRequestException("$jwtName: 'iat' is in future")
+                }
+                now + maxValidity
+            } else {
+                iat + maxValidity
+            }
         }
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/CwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/CwtTest.kt
@@ -36,6 +36,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class CwtTest {
@@ -118,6 +119,26 @@ class CwtTest {
         } catch (err: InvalidRequestException) {
             assertTrue(err.message!!.lowercase().contains("expired"))
         }
+    }
+
+    @Test
+    fun testClockSkewLarge() = runBackendTest {
+        val cwt = makeCwt(privateTrustedKey, exp = null, iat = clock.now() + 30.seconds)
+        try {
+            validateCwt(
+                cwt, "test", privateTrustedKey.publicKey,
+                clock = clock, maxValidity = 1.minutes
+            )
+            fail()
+        } catch (err: InvalidRequestException) {
+            assertTrue(err.message!!.lowercase().contains("future"))
+        }
+    }
+
+    @Test
+    fun testClockSkewSmall() = runBackendTest {
+        val cwt = makeCwt(privateTrustedKey, exp = null, iat = clock.now() + 1.seconds)
+        validateCwt(cwt, "test", privateTrustedKey.publicKey, clock = clock)
     }
 
     @Test


### PR DESCRIPTION
When the clock is a bit off between the client and the server and the network is fast, `iat` can be a bit in the future. Tolerate small clock skews.

Test: manual testing with the server and additional unit tests.

Fixes #1421
