### PR TITLE
DeviceResponse: Calculate digest from the IssuerSignedItemBytes encoded version.

### DIFF
--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
@@ -358,6 +358,10 @@ class DeviceResponseTest {
             )
         }
         assertEquals("1.0", deviceResponse.version)
+
+        // Check we can call verify() on an instance we created ourselves
+        deviceResponse.verify(sessionTranscript)
+
         val encodedDeviceResponse = Cbor.encode(deviceResponse.toDataItem())
 
         val drParsed = DeviceResponse.fromDataItem(Cbor.decode(encodedDeviceResponse))
@@ -504,6 +508,13 @@ class DeviceResponseTest {
             )
         }
         assertEquals("1.0", deviceResponse.version)
+
+        // Check we can call verify() on an instance we created ourselves
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = AsymmetricKey.AnonymousExplicit(eReaderKey, Algorithm.ECDH_P256)
+        )
+
         val encodedDeviceResponse = Cbor.encode(deviceResponse.toDataItem())
 
         val drParsed = DeviceResponse.fromDataItem(Cbor.decode(encodedDeviceResponse))


### PR DESCRIPTION
This fixes a bug in DeviceResponse where we calculated the digest from a reencoded version of IssuerSignedItem which doesn't work in cases where the issuer used another map order than ours.

Test: Manally tested with ISO mdoc from issuer using different byte order.
