### PR TITLE
Export library version.

### DIFF
--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -10,11 +10,18 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.buildconfig)
     id("maven-publish")
 }
 
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
+
+buildConfig {
+    packageName("org.multipaz.util")
+    buildConfigField("VERSION", projectVersionName)
+    useKotlinOutput { internalVisibility = true }
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz/src/androidMain/kotlin/org/multipaz/util/Platform.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/util/Platform.android.kt
@@ -16,6 +16,8 @@ import java.io.File
 actual object Platform {
     actual val name = "Android ${Build.VERSION.SDK_INT}"
 
+    actual val version = BuildConfig.VERSION
+
     actual val promptModel: PromptModel by lazy {
         AndroidPromptModel.Builder().apply { addCommonDialogs() }.build()
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
@@ -19,6 +19,13 @@ expect object Platform {
     val name: String
 
     /**
+     * The version of the Multipaz library, for example `0.96.0` or `0.97.0-pre.1.aaf8d71e`.
+     *
+     * This string adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+     */
+    val version: String
+
+    /**
      * A [PromptModel] implementation suitable for the platform.
      */
     val promptModel: PromptModel

--- a/multipaz/src/iosMain/kotlin/org/multipaz/util/Platform.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/util/Platform.ios.kt
@@ -51,6 +51,8 @@ actual object Platform {
         IosPromptModel.Builder().apply { addCommonDialogs() }.build()
     }
 
+    actual val version = BuildConfig.VERSION
+
     actual val storage by lazy {
         SqliteStorage(
             connection = openDatabase(

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/util/Platform.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/util/Platform.jvm.kt
@@ -8,6 +8,8 @@ import org.multipaz.storage.ephemeral.EphemeralStorage
 actual object Platform {
     actual val name = "JVM ${System.getProperty("java.vm.version")} / Java ${System.getProperty("java.version")}"
 
+    actual val version = BuildConfig.VERSION
+
     actual val promptModel: PromptModel
         get() = throw NotImplementedError()
 

--- a/multipazctl/build.gradle.kts
+++ b/multipazctl/build.gradle.kts
@@ -1,16 +1,7 @@
 plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
-    alias(libs.plugins.buildconfig)
     alias(libs.plugins.ktor)
-}
-
-val projectVersionCode: Int by rootProject.extra
-val projectVersionName: String by rootProject.extra
-
-buildConfig {
-    packageName("org.multipaz.multipazctl")
-    buildConfigField("VERSION", projectVersionName)
 }
 
 kotlin {

--- a/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
+++ b/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
@@ -19,6 +19,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.crypto.buildCrl
+import org.multipaz.util.Platform
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.security.Security
@@ -426,7 +427,7 @@ Prints out version:
     }
 
     fun version(args: Array<String>) {
-        println(BuildConfig.VERSION)
+        println(Platform.version)
     }
 
     @JvmStatic

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -17,7 +17,6 @@ val projectVersionName: String by rootProject.extra
 
 buildConfig {
     packageName("org.multipaz.testapp")
-    buildConfigField("VERSION", projectVersionName)
     buildConfigField("TEST_APP_UPDATE_URL", System.getenv("TEST_APP_UPDATE_URL") ?: "")
     buildConfigField("TEST_APP_UPDATE_WEBSITE_URL", System.getenv("TEST_APP_UPDATE_WEBSITE_URL") ?: "")
     useKotlinOutput { internalVisibility = false }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AboutScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AboutScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.multipaz.testapp.BuildConfig
+import org.multipaz.util.Platform
 
 @Composable
 fun AboutScreen() {
@@ -22,7 +23,7 @@ fun AboutScreen() {
                     "tests for.")
         }
         item {
-            Text("Version ${BuildConfig.VERSION}")
+            Text("Version ${Platform.version}")
         }
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
@@ -24,6 +24,7 @@ import org.multipaz.compose.cards.InfoCard
 import org.multipaz.testapp.BuildConfig
 import org.multipaz.testapp.platformHttpClientEngineFactory
 import org.multipaz.util.Logger
+import org.multipaz.util.Platform
 
 private const val TAG = "AppUpdateCard"
 
@@ -36,7 +37,7 @@ fun AppUpdateCard() {
     //val currentVersion = "0.91.0-pre.48.574b479c"
     val updateUrl = BuildConfig.TEST_APP_UPDATE_URL
     val updateWebsiteUrl = BuildConfig.TEST_APP_UPDATE_WEBSITE_URL
-    val currentVersion = BuildConfig.VERSION
+    val currentVersion = Platform.version
 
     if (updateUrl.isEmpty()) {
         return


### PR DESCRIPTION
It's useful to know the Multipaz version being used, for example for display in mobile apps or website. Export it in the existing `Platform` object and change everything to use this.

Test: Manually tested.
