### PR TITLE
Fix potential unhandled NPE crash in upstream implementations.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
@@ -485,8 +485,8 @@ internal class GattClient(
             try {
                 gatt!!.disconnect()
                 gatt!!.close()
-            } catch (e: SecurityException) {
-                Logger.e(TAG, "Caught SecurityException while shutting down", e)
+            } catch (e: Throwable) {
+                Logger.e(TAG, "Caught Exception while shutting down", e)
             }
             gatt = null
             return

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
@@ -438,8 +438,8 @@ internal class GattServer(
                     gattServer!!.cancelConnection(currentConnection)
                 }
                 gattServer!!.close()
-            } catch (e: SecurityException) {
-                Logger.e(TAG, "Caught SecurityException while shutting down", e)
+            } catch (e: Throwable) {
+                Logger.e(TAG, "Caught Exception while shutting down", e)
             }
             gattServer = null
             return


### PR DESCRIPTION
- Fix the NPE handling to avoid upstream crash during BLE communications.

Tested with Wallet app not crashing but with a message.

Fixes #1456

- [x] Tests pass