### PR TITLE
Use correct COSE algorithms in 18013-5 DeviceRequest.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestGenerator.kt
@@ -113,9 +113,10 @@ class DeviceRequestGenerator(
         val readerAuthenticationBytes =
             Cbor.encode(Tagged(24, Bstr(encodedReaderAuthentication)))
         val protectedHeaders = mapOf<CoseLabel, DataItem>(
+            // Make sure we use non-fully-specified algorithm since 18013-5 requires that.
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_ALG),
-                keyInfo.algorithm.coseAlgorithmIdentifier!!.toDataItem()
+                keyInfo.algorithm.curve!!.defaultSigningAlgorithm.coseAlgorithmIdentifier!!.toDataItem()
             )
         )
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
@@ -12,6 +12,7 @@ import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cose.Cose
 import org.multipaz.cose.toCoseLabel
+import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.SignatureVerificationException
@@ -73,6 +74,10 @@ class DeviceRequestTest {
             TestVectors.ISO_18013_5_ANNEX_D_READER_CERT.fromHexByteString(),
             readerCertChain.certificates[0].encoded
         )
+        assertEquals(
+            Algorithm.ES256.coseAlgorithmIdentifier!!,
+            readerAuth.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber.toInt()
+        )
 
         val docRequest = deviceRequest.docRequests.first()
         assertEquals(DrivingLicense.MDL_DOCTYPE, docRequest.docType)
@@ -90,7 +95,6 @@ class DeviceRequestTest {
         )
     }
 
-    // Test against the test vector in Annex D of 18013-5:2021
     @Test
     fun testAgainstMalformedReaderSignature() {
         val encodedSessionTranscriptBytes =
@@ -237,7 +241,10 @@ class DeviceRequestTest {
 
         // Now we can access readerAuthAll and readerAuth
         assertEquals(0, parsedDeviceRequest.readerAuthAll.size)
-        val unused = parsedDeviceRequest.docRequests[0].readerAuth
+        assertEquals(
+            Algorithm.ES384.coseAlgorithmIdentifier!!,
+            parsedDeviceRequest.docRequests[0].readerAuth!!.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber.toInt()
+        )
 
         assertEquals(parsedDeviceRequest, deviceRequest)
     }
@@ -284,7 +291,10 @@ class DeviceRequestTest {
 
         // Now we can access readerAuthAll and readerAuth
         assertEquals(0, parsedDeviceRequest.readerAuthAll.size)
-        val unused = parsedDeviceRequest.docRequests[0].readerAuth
+        assertEquals(
+            Algorithm.ES256.coseAlgorithmIdentifier!!,
+            parsedDeviceRequest.docRequests[0].readerAuth!!.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber.toInt()
+        )
 
         assertEquals(parsedDeviceRequest, deviceRequest)
     }
@@ -333,6 +343,10 @@ class DeviceRequestTest {
         // Now we can access readerAuthAll and readerAuth
         assertEquals(1, parsedDeviceRequest.readerAuthAll.size)
         assertNull(parsedDeviceRequest.docRequests[0].readerAuth)
+        assertEquals(
+            Algorithm.ES384.coseAlgorithmIdentifier!!,
+            parsedDeviceRequest.readerAuthAll[0].protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber.toInt()
+        )
 
         assertEquals(parsedDeviceRequest, deviceRequest)
     }
@@ -380,6 +394,10 @@ class DeviceRequestTest {
         // Now we can access readerAuthAll and readerAuth
         assertEquals(1, parsedDeviceRequest.readerAuthAll.size)
         assertNull(parsedDeviceRequest.docRequests[0].readerAuth)
+        assertEquals(
+            Algorithm.ES256.coseAlgorithmIdentifier!!,
+            parsedDeviceRequest.readerAuthAll[0].protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber.toInt()
+        )
 
         assertEquals(parsedDeviceRequest, deviceRequest)
     }


### PR DESCRIPTION
When we switched to AsymmetricKey we introduced a bug whereby the wrong COSE Algorithm would be used in the COSE_Sign1 for reader authentication, for example ESP256 (-9) instead of ES256 (-7). Add tests for this and fix it. Do this for both `DeviceRequest` and deprecated `DeviceRequestGenerator`.

Also simplify DeviceRequest.kt codeflows to not call a helper - this was introduced back before the AsymmetricKey change since we had multiple user-visible methods calling the same helper. It should probably have been simplified as part of moving to AsymmetricKey.

Test: Unit tests.
