### PR TITLE
Added missing claims for US-based mDLs

### DIFF
--- a/multipaz-records-server/src/main/java/org/multipaz/records/data/recordTypes.kt
+++ b/multipaz-records-server/src/main/java/org/multipaz/records/data/recordTypes.kt
@@ -108,6 +108,12 @@ val recordTypes = RecordType.buildMap {
                 description = "Apartment/Unit Number",
                 icon = Icon.APARTMENT,
             )
+            addString(
+                identifier = "us_county_code",
+                displayName = "If in US, County Code",
+                description = "Three-digit code",
+                icon = Icon.NUMBERS,
+            )
         }
         addString(
             identifier = "family_name_national_character",


### PR DESCRIPTION
Some of the pre-cut queries that we have (like US Transportation) require US-specific claims which are not mandatory in mDLs and thus fail for all mDLs provisioned from the server. Add them for mDLs that have issuance country set to "US".

Fixes #1298

Test: manual testing using private server and testapp