### PR TITLE
Build multipaz and multipaz-doctypes libraries for JavaScript.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ uiToolingPreview = "1.9.5"
 volley = "1.2.1"
 cbor = "0.9"
 camera = "1.5.1"
-ktor = "2.3.13"
+ktor = "3.3.3"
 logback = "1.5.21"
 androidx-lifecycle = "2.2.0"
 androidx-lifecycle-ktx = "2.10.0"
@@ -118,7 +118,7 @@ process-phoenix = { module = "com.jakewharton:process-phoenix", version.ref="pro
 coil-core = { module = "io.coil-kt.coil3:coil-core", version.ref = "coil" }
 coil-compose-core = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
-coil-ktor2 = { module = "io.coil-kt.coil3:coil-network-ktor2", version.ref = "coil" }
+coil-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/multipaz-backend-server/build.gradle.kts
+++ b/multipaz-backend-server/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
-project.setProperty("mainClassName", "org.multipaz.backend.server.Main")
+application {
+    mainClass.set("org.multipaz.backend.server.Main")
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz-csa-server/build.gradle.kts
+++ b/multipaz-csa-server/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
-project.setProperty("mainClassName", "org.multipaz.csa.server.Main")
+application {
+    mainClass.set("org.multipaz.csa.server.Main")
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz-doctypes/build.gradle.kts
+++ b/multipaz-doctypes/build.gradle.kts
@@ -17,6 +17,14 @@ kotlin {
 
     jvm()
 
+    js {
+        browser {
+            // Disable tests until fully implemented
+            testTask { enabled = false }
+        }
+        binaries.executable()
+    }
+
     listOf(
         iosX64(),
         iosArm64(),

--- a/multipaz-openid4vci-server/build.gradle.kts
+++ b/multipaz-openid4vci-server/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
-project.setProperty("mainClassName", "org.multipaz.openid4vci.server.Main")
+application {
+    mainClass.set("org.multipaz.openid4vci.server.Main")
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/authorize.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/authorize.kt
@@ -4,7 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -148,7 +148,7 @@ private suspend fun authorizeUsingSystemOfRecord(
             name.encodeURLParameter() + "=" + value.encodeURLParameter()
         }.joinToString("&"))
     }
-    val responseText = response.readBytes().decodeToString()
+    val responseText = response.readRawBytes().decodeToString()
     if (response.status != HttpStatusCode.Created) {
         Logger.e(TAG, "PAR request error: ${response.status}: $responseText")
         throw IllegalStateException("System-of-Record: PAR request error")

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -3,7 +3,7 @@ package org.multipaz.openid4vci.request
 import io.ktor.client.HttpClient
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headers
@@ -294,11 +294,11 @@ private suspend fun readSystemOfRecord(state: IssuanceState): DataItem {
             }
         }
         if (request.status != HttpStatusCode.OK) {
-            val text = request.readBytes().decodeToString()
+            val text = request.readRawBytes().decodeToString()
             Logger.e(TAG, "Error accessing data from the System of Record: $text")
             throw IllegalStateException("Could not access data from System of Record")
         }
-        return Cbor.decode(request.readBytes())
+        return Cbor.decode(request.readRawBytes())
     }
 }
 

--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/token.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/token.kt
@@ -4,7 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -215,7 +215,7 @@ private suspend fun obtainSystemOfRecordToken(systemOfRecordUrl: String, state: 
             name.encodeURLParameter() + "=" + value.encodeURLParameter()
         }.joinToString("&"))
     }
-    val responseText = response.readBytes().decodeToString()
+    val responseText = response.readRawBytes().decodeToString()
     if (response.status != HttpStatusCode.OK) {
         Logger.e(TAG, "token request error: ${response.status}: $responseText")
     }

--- a/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -6,7 +6,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
@@ -158,7 +158,7 @@ class ProvisioningClientTest {
             // Extract the parameter
             val request = client.get(authorizationUrl) {}
             Assert.assertEquals(HttpStatusCode.OK, request.status)
-            val authText = request.readBytes().decodeToString()
+            val authText = request.readRawBytes().decodeToString()
             val pattern = "name=\"authorizationCode\" value=\""
             val index = authText.indexOf(pattern)
             Assert.assertNotEquals(-1, index)
@@ -242,7 +242,7 @@ class ProvisioningClientTest {
                 }.toString())
             }
             Assert.assertEquals(HttpStatusCode.OK, response.status)
-            val json = Json.parseToJsonElement(response.readBytes().decodeToString()).jsonArray
+            val json = Json.parseToJsonElement(response.readRawBytes().decodeToString()).jsonArray
             val offerObject = json.first().jsonObject
             val preauthorizedOffer = offerObject["offer"]!!.jsonPrimitive.content
             val txCode = offerObject["tx_code"]!!.jsonPrimitive.content

--- a/multipaz-records-server/build.gradle.kts
+++ b/multipaz-records-server/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
-project.setProperty("mainClassName", "org.multipaz.records.server.Main")
+application {
+    mainClass.set("org.multipaz.records.server.Main")
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz-records-server/src/main/java/org/multipaz/records/request/identityOffer.kt
+++ b/multipaz-records-server/src/main/java/org/multipaz/records/request/identityOffer.kt
@@ -4,7 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.server.application.ApplicationCall
@@ -88,6 +88,6 @@ suspend fun identityOffer(call: ApplicationCall) {
     call.respondText (
         status = offerResponse.status,
         contentType = offerResponse.contentType(),
-        text = offerResponse.readBytes().decodeToString()
+        text = offerResponse.readRawBytes().decodeToString()
     )
 }

--- a/multipaz-server/src/main/java/org/multipaz/server/common/ServerEnvironment.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/ServerEnvironment.kt
@@ -78,7 +78,7 @@ class ServerEnvironment(
             }
 
             val httpClient = HttpClient(Java) {
-                install(HttpTimeout.Plugin)
+                install(HttpTimeout)
                 followRedirects = false
             }
 

--- a/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
@@ -11,7 +11,7 @@ import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.doublereceive.DoubleReceive
 import io.ktor.server.request.contentType
 import io.ktor.server.request.httpMethod

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
@@ -3,7 +3,7 @@ package org.multipaz.server.enrollment
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parameters
 import kotlinx.coroutines.CompletableDeferred
@@ -337,7 +337,7 @@ class EnrollmentImpl: Enrollment, RpcAuthInspector by serverAuth {
                     rpcAuthError = RpcAuthError.FAILED
                 )
             }
-            return X509Cert.fromPem(response.readBytes().decodeToString()).ecPublicKey
+            return X509Cert.fromPem(response.readRawBytes().decodeToString()).ecPublicKey
         }
 
         private val LOCALHOST = Regex("http://localhost([:/].*)?")

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/validateServerIdentityCertificateChain.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/validateServerIdentityCertificateChain.kt
@@ -2,7 +2,7 @@ package org.multipaz.server.enrollment
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import kotlinx.io.bytestring.ByteString
@@ -84,7 +84,7 @@ private suspend fun getIdentityRootCertificate(
         if (response.status != HttpStatusCode.OK) {
             throw InvalidRequestException("Could not reach: $certUrl")
         }
-        X509Cert(ByteString(response.readBytes()))
+        X509Cert(ByteString(response.readRawBytes()))
     }
 }
 

--- a/multipaz-verifier-server/build.gradle.kts
+++ b/multipaz-verifier-server/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
-project.setProperty("mainClassName", "org.multipaz.verifier.server.Main")
+application {
+    mainClass.set("org.multipaz.verifier.server.Main")
+}
 
 kotlin {
     jvmToolchain(17)

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -42,6 +42,14 @@ kotlin {
         publishLibraryVariants("release")
     }
 
+    js {
+        browser {
+            // Disable tests until fully implemented
+            testTask { enabled = false }
+        }
+        binaries.executable()
+    }
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -199,7 +207,7 @@ tasks.all {
     if (name == "compileDebugKotlinAndroid" || name == "compileReleaseKotlinAndroid" ||
         name == "androidReleaseSourcesJar" || name == "iosArm64SourcesJar" ||
         name == "iosSimulatorArm64SourcesJar" || name == "iosX64SourcesJar" ||
-        name == "jvmSourcesJar" || name == "sourcesJar") {
+        name == "jsSourcesJar" || name == "jvmSourcesJar" || name == "sourcesJar") {
         dependsOn("kspCommonMainKotlinMetadata")
     }
 }
@@ -208,6 +216,7 @@ tasks["compileKotlinIosX64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosSimulatorArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinJvm"].dependsOn("kspCommonMainKotlinMetadata")
+tasks["compileKotlinJs"].dependsOn("kspCommonMainKotlinMetadata")
 
 tasks.withType<Test> {
     testLogging {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
@@ -5,7 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.Json
@@ -95,7 +95,7 @@ object AppLinksCheck {
                 Logger.e(TAG, "Error fetching '$assetLinksUrl': HTTP status ${response.status.value}")
                 "[]"
             } else {
-                response.readBytes().decodeToString()
+                response.readRawBytes().decodeToString()
             }
         } catch (err: Exception) {
             Logger.e(TAG, "Error connecting to $appLinkServer", err)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanMdocReader.kt
@@ -1,7 +1,6 @@
 package org.multipaz.mdoc.nfc
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import org.multipaz.cbor.DataItem
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.transport.MdocTransport
@@ -46,7 +45,7 @@ suspend fun NfcTagReader.scanMdocReader(
     selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?,
     negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
     nfcScanOptions: NfcScanOptions = NfcScanOptions(),
-    context: CoroutineContext = Dispatchers.IO,
+    context: CoroutineContext = Dispatchers.Default,
 ): ScanMdocReaderResult? {
     // Start creating transports for Negotiated Handover and start advertising these
     // immediately. This helps with connection time because the holder's device will

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -2,6 +2,8 @@ package org.multipaz.mdoc.transport
 
 import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
@@ -9,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
@@ -61,7 +62,7 @@ internal class BleTransportCentralMdoc(
         )
         centralManager.setCallbacks(
             onError = { error ->
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -69,7 +70,7 @@ internal class BleTransportCentralMdoc(
                 }
             },
             onClosed = {
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -2,6 +2,8 @@ package org.multipaz.mdoc.transport
 
 import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
@@ -9,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.multipaz.crypto.EcPublicKey
@@ -63,7 +64,7 @@ internal class BleTransportCentralMdocReader(
         )
         peripheralManager.setCallbacks(
             onError = { error ->
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -71,7 +72,7 @@ internal class BleTransportCentralMdocReader(
                 }
             },
             onClosed = {
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -2,6 +2,8 @@ package org.multipaz.mdoc.transport
 
 import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
@@ -9,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.multipaz.crypto.EcPublicKey
@@ -63,7 +64,7 @@ internal class BleTransportPeripheralMdoc(
         )
         peripheralManager.setCallbacks(
             onError = { error ->
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -72,7 +73,7 @@ internal class BleTransportPeripheralMdoc(
             },
             onClosed = {
                 Logger.w(TAG, "BlePeripheralManager close")
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -2,6 +2,8 @@ package org.multipaz.mdoc.transport
 
 import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
@@ -9,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
@@ -60,7 +61,7 @@ internal class BleTransportPeripheralMdocReader(
         )
         centralManager.setCallbacks(
             onError = { error ->
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -69,7 +70,7 @@ internal class BleTransportPeripheralMdocReader(
             },
             onClosed = {
                 Logger.w(TAG, "BleCentralManager close")
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
@@ -1,5 +1,7 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.nfc.CommandApdu
@@ -11,7 +13,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
@@ -42,7 +44,7 @@ class NfcTransportMdoc(
                 if (instances.size > 1) {
                     Logger.w(TAG, "${instances.size} NfcTransportMdoc instances, expected just one")
                 }
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     instances.forEach { instance ->
                         instance.processApdu(
                             command = command,
@@ -65,7 +67,7 @@ class NfcTransportMdoc(
                 if (instances.size > 1) {
                     Logger.w(TAG, "${instances.size} NfcTransportMdoc instances, expected just one")
                 }
-                runBlocking {
+                CoroutineScope(Dispatchers.Default).launch {
                     // Get a read-only copy since the caller may modify `instances` variable.
                     instances.toList().forEach { instance ->
                         instance.onDeactivated()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -62,7 +61,7 @@ suspend fun List<MdocConnectionMethod>.advertise(
 @OptIn(ExperimentalCoroutinesApi::class)
 suspend fun List<MdocTransport>.waitForConnection(
     eSenderKey: EcPublicKey,
-    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 ): MdocTransport {
     lateinit var continuation: CancellableContinuation<MdocTransport>
     forEach { transport ->

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcTagReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcTagReader.kt
@@ -1,7 +1,6 @@
 package org.multipaz.nfc
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import org.multipaz.prompt.PromptDismissedException
 import kotlin.coroutines.CoroutineContext
 
@@ -66,7 +65,7 @@ interface NfcTagReader {
         message: String?,
         tagInteractionFunc: suspend (tag: NfcIsoTag) -> T?,
         options: NfcScanOptions = NfcScanOptions(),
-        context: CoroutineContext = Dispatchers.IO
+        context: CoroutineContext = Dispatchers.Default
     ): T
 
     companion object {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/MdocPresentmentMechanism.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/MdocPresentmentMechanism.kt
@@ -5,7 +5,6 @@ import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.mdoc.transport.MdocTransport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import kotlin.time.Duration
@@ -30,6 +29,6 @@ class MdocPresentmentMechanism(
 ): PresentmentMechanism {
 
     override fun close() {
-        CoroutineScope(Dispatchers.IO).launch() { transport.close() }
+        CoroutineScope(Dispatchers.Default).launch() { transport.close() }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
@@ -2,7 +2,7 @@ package org.multipaz.provisioning.openid4vci
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -32,7 +32,7 @@ internal data class AuthorizationConfiguration(
             if (metadataRequest.status != HttpStatusCode.OK) {
                 throw IllegalStateException("Invalid issuer, no $metadataUrl")
             }
-            val metadataText = metadataRequest.readBytes().decodeToString()
+            val metadataText = metadataRequest.readRawBytes().decodeToString()
             val metadata = Json.parseToJsonElement(metadataText).jsonObject
             val identifier = metadata.stringOrNull("issuer") ?: url
             val challengeEndpoint = metadata.stringOrNull("challenge_endpoint")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -2,7 +2,7 @@ package org.multipaz.provisioning.openid4vci
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.CancellationException
@@ -77,7 +77,7 @@ internal sealed class CredentialOffer {
                     if (response.status != HttpStatusCode.OK) {
                         throw IllegalStateException("Error retrieving '$url'")
                     }
-                    credentialOfferString = response.readBytes().decodeToString()
+                    credentialOfferString = response.readRawBytes().decodeToString()
                 }
                 val json = Json.parseToJsonElement(credentialOfferString).jsonObject
                 return parseJson(json)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
@@ -2,7 +2,7 @@ package org.multipaz.provisioning.openid4vci
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.Json
@@ -38,7 +38,7 @@ internal data class IssuerConfiguration(
             if (issuerMetadataRequest.status != HttpStatusCode.OK) {
                 throw IllegalStateException("Invalid issuer, no $issuerMetadataUrl")
             }
-            val credentialMetadataText = issuerMetadataRequest.readBytes().decodeToString()
+            val credentialMetadataText = issuerMetadataRequest.readRawBytes().decodeToString()
             val credentialMetadata = Json.parseToJsonElement(credentialMetadataText).jsonObject
 
             val authorizationServers = credentialMetadata.arrayOrNull("authorization_servers")
@@ -141,7 +141,7 @@ internal data class IssuerConfiguration(
                     val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
                     val response = httpClient.get(uri)
                     if (response.status == HttpStatusCode.OK) {
-                        logo = ByteString(response.readBytes())
+                        logo = ByteString(response.readRawBytes())
                     }
                 }
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -6,7 +6,7 @@ import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
@@ -132,7 +132,7 @@ internal class OpenID4VCIProvisioningClient(
         Logger.i(TAG, "Got successful response for nonce request")
         // A fresh DPoP nonce might or might not be given
         nonceResponse.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
-        val responseText = nonceResponse.readBytes().decodeToString()
+        val responseText = nonceResponse.readRawBytes().decodeToString()
         val cNonce = Json.parseToJsonElement(responseText).jsonObject.string("c_nonce")
         keyChallenge = cNonce
         return cNonce
@@ -191,7 +191,7 @@ internal class OpenID4VCIProvisioningClient(
             break
         }
 
-        val responseText = credentialResponse.readBytes().decodeToString()
+        val responseText = credentialResponse.readRawBytes().decodeToString()
         if (credentialResponse.status != HttpStatusCode.OK) {
             Logger.e(TAG,"Credential request error: ${credentialResponse.status} $responseText")
             throw IllegalStateException(
@@ -338,7 +338,7 @@ internal class OpenID4VCIProvisioningClient(
             if (response.status == HttpStatusCode.Created) {
                 break
             }
-            val responseText = response.readBytes().decodeToString()
+            val responseText = response.readRawBytes().decodeToString()
             Logger.e(TAG, "PAR request error: ${response.status}: $responseText")
             if (retryCount == 0) {
                 retryCount++
@@ -348,7 +348,7 @@ internal class OpenID4VCIProvisioningClient(
             }
             throw IllegalStateException("Error establishing authenticated channel with issuer")
         }
-        val responseText = response.readBytes().decodeToString()
+        val responseText = response.readRawBytes().decodeToString()
         val parsedResponse = Json.parseToJsonElement(responseText).jsonObject
         return parsedResponse.string("request_uri")
     }
@@ -494,7 +494,7 @@ internal class OpenID4VCIProvisioningClient(
             response.headers["DPoP-Nonce"]?.let { authorizationDPoPNonce = it }
             response.headers["OAuth-Client-Attestation-Challenge"]?.let { clientAttestationChallenge = it }
             if (response.status != HttpStatusCode.OK) {
-                val errResponseText = response.readBytes().decodeToString()
+                val errResponseText = response.readRawBytes().decodeToString()
                 if (preauthorizedCode != null && txCode != null) {
                     // Transaction Code may be wrong
                     val errResponse = Json.parseToJsonElement(errResponseText) as JsonObject
@@ -521,7 +521,7 @@ internal class OpenID4VCIProvisioningClient(
                     }
                 )
             }
-            val tokenResponseString = response.readBytes().decodeToString()
+            val tokenResponseString = response.readRawBytes().decodeToString()
             val tokenResponse = Json.parseToJsonElement(tokenResponseString) as JsonObject
             token = tokenResponse.string("access_token")
             val duration = tokenResponse.integer("expires_in")
@@ -546,7 +546,7 @@ internal class OpenID4VCIProvisioningClient(
                 Logger.i(TAG, "Got successful response for challenge request")
                 // DPoP nonce might or might not be given
                 authorizationDPoPNonce = response.headers["DPoP-Nonce"]
-                val responseText = response.readBytes().decodeToString()
+                val responseText = response.readRawBytes().decodeToString()
                 clientAttestationChallenge = Json.parseToJsonElement(responseText)
                     .jsonObject.string("attestation_challenge")
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/client/RpcAuthorizedDeviceClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/client/RpcAuthorizedDeviceClient.kt
@@ -3,7 +3,6 @@ package org.multipaz.rpc.client
 import io.ktor.client.engine.HttpClientEngineFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -87,7 +86,7 @@ class RpcAuthorizedDeviceClient private constructor(
         ): RpcAuthorizedDeviceClient {
             val poll = RpcPollHttp(httpTransport)
             val notifier = RpcNotifierPoll(poll)
-            val notificationJob = CoroutineScope(Dispatchers.IO).launch {
+            val notificationJob = CoroutineScope(Dispatchers.Default).launch {
                 notifier.loop()
             }
             val dispatcher = RpcDispatcherHttp(httpTransport, exceptionMap)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherLocal.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherLocal.kt
@@ -92,7 +92,7 @@ class RpcDispatcherLocal private constructor(
 
     fun encodeStateResult(result: Any): DataItem {
         val target = stateMap[result::class]
-            ?: throw IllegalStateException("${result::class.qualifiedName} was not registered")
+            ?: throw IllegalStateException("${result::class.simpleName} was not registered")
         return CborArray(mutableListOf(
             Tstr(target),
             Bstr(cipher.encrypt(Cbor.encode(targetMap[target]!!.serialize(result))))
@@ -141,7 +141,7 @@ class RpcDispatcherLocal private constructor(
                 val authContext = try {
                     if (state !is RpcAuthInspector) {
                         throw RpcAuthException(
-                            message = "${state::class.qualifiedName} must implement RpcAuthChecker",
+                            message = "${state::class.simpleName} must implement RpcAuthChecker",
                             rpcAuthError = RpcAuthError.NOT_SUPPORTED
                         )
                     }
@@ -186,7 +186,7 @@ class RpcDispatcherLocal private constructor(
             } else {
                 if (state is RpcAuthInspector) {
                     throw RpcAuthException(
-                        message = "${state::class.qualifiedName} requires authorization",
+                        message = "${state::class.simpleName} requires authorization",
                         rpcAuthError = RpcAuthError.REQUIRED
                     )
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/transport/KtorHttpTransport.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/transport/KtorHttpTransport.kt
@@ -7,7 +7,7 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 
@@ -35,7 +35,7 @@ class KtorHttpTransport: HttpTransport {
         baseUrl: String
     ) {
         httpClient = HttpClient(engine) {
-            install(HttpTimeout.Plugin)
+            install(HttpTimeout)
         }
         this.baseUrl = baseUrl
     }
@@ -75,6 +75,6 @@ class KtorHttpTransport: HttpTransport {
             throw HttpTransport.ConnectionException("Error", e)
         }
         HttpTransport.processStatus(url, response.status.value, response.status.description)
-        return ByteString(response.readBytes())
+        return ByteString(response.readRawBytes())
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
@@ -60,7 +59,7 @@ class DocumentStoreTest {
     private val CREDENTIAL_DOMAIN = "domain"
 
     @BeforeTest
-    fun setup() = runBlocking {
+    fun setup() = runTest {
         storage = EphemeralStorage()
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(SoftwareSecureArea.create(storage))

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentUtilTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentUtilTest.kt
@@ -15,7 +15,6 @@
  */
 package org.multipaz.document
 
-import kotlinx.coroutines.runBlocking
 import org.multipaz.claim.Claim
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.documenttype.DocumentTypeRepository
@@ -38,7 +37,7 @@ class DocumentUtilTest {
     private lateinit var secureAreaRepository: SecureAreaRepository
 
     @BeforeTest
-    fun setup() = runBlocking {
+    fun setup() = runTest {
         storage = EphemeralStorage()
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(SoftwareSecureArea.create(storage))

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
@@ -14,7 +14,6 @@ import org.multipaz.nfc.NfcIsoTag
 import org.multipaz.nfc.ResponseApdu
 import org.multipaz.util.UUID
 import org.multipaz.util.fromHex
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.ByteString
 import kotlin.test.Test
@@ -385,7 +384,7 @@ class MdocNfcEngagementHelperTest {
         )
     }
 
-    private fun testNfcEngagementHelper(
+    private suspend fun testNfcEngagementHelper(
         testBlock: suspend (tag: NfcIsoTag) -> Unit
     ): Pair<Boolean, Throwable?> {
         var handoverSuccess = false
@@ -396,12 +395,12 @@ class MdocNfcEngagementHelperTest {
             onError = { error -> handoverError = error },
             staticHandoverMethods = getConnectionMethods(),
         )
-        runBlocking { testBlock(LoopbackIsoTag(helper)) }
+        testBlock(LoopbackIsoTag(helper))
         return Pair(handoverSuccess, handoverError)
     }
 
     @Test
-    fun testWrongApplicationIdSelected() {
+    fun testWrongApplicationIdSelected() = runTest {
         var (handoverSuccess, handoverError) = testNfcEngagementHelper { tag ->
             // Off by one from the NDEF AID
             assertFailsWith(NfcCommandFailedException::class) {
@@ -417,7 +416,7 @@ class MdocNfcEngagementHelperTest {
     }
 
     @Test
-    fun testFiledIdBeforeApplicationSelectSelected() {
+    fun testFiledIdBeforeApplicationSelectSelected() = runTest {
         var (handoverSuccess, handoverError) = testNfcEngagementHelper { tag ->
             // Fails because application is not yet selected
             assertFailsWith(NfcCommandFailedException::class) {
@@ -433,7 +432,7 @@ class MdocNfcEngagementHelperTest {
     }
 
     @Test
-    fun testUnexpectedFileIdSelected() {
+    fun testUnexpectedFileIdSelected() = runTest {
         var (handoverSuccess, handoverError) = testNfcEngagementHelper { tag ->
             tag.selectApplication(Nfc.NDEF_APPLICATION_ID)
             // Fails because the FileID is unknown

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -15,7 +15,6 @@
  */
 package org.multipaz.mdoc.response
 
-import kotlinx.coroutines.runBlocking
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
@@ -76,7 +75,7 @@ class DeviceResponseGeneratorTest {
     private lateinit var dsCert: X509Cert
 
     @BeforeTest
-    fun setup() = runBlocking {
+    fun setup() = runTest {
         storage = EphemeralStorage()
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(SoftwareSecureArea.create(storage))

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
@@ -1,6 +1,5 @@
 package org.multipaz.mdoc.response
 
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -78,7 +77,7 @@ class DeviceResponseTest {
     private lateinit var photoIdTimeExpectedUpdate: Instant
 
     @BeforeTest
-    fun setup() = runBlocking {
+    fun setup() = runTest {
         storage = EphemeralStorage()
         softwareSecureArea = SoftwareSecureArea.create(storage)
         secureAreaRepository = SecureAreaRepository.Builder()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
@@ -7,7 +7,6 @@ import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.NfcIsoTag
 import org.multipaz.nfc.ResponseApdu
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
 import org.multipaz.mdoc.role.MdocRole
@@ -44,7 +43,7 @@ class NfcTransportTests {
         override suspend fun transceive(command: CommandApdu): ResponseApdu {
             transcript.appendLine("${command.toString().truncateTo(100)} (${command.encode().size} bytes)")
             val response = suspendCancellableCoroutine<ResponseApdu> { continuation ->
-                runBlocking {
+                runTest {
                     transport.processApdu(
                         command = command,
                         sendResponse = { response ->

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentmentTest.kt
@@ -1,7 +1,6 @@
 package org.multipaz.presentment.model
 
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -54,7 +53,7 @@ class DigitalCredentialsPresentmentTest {
     val documentStoreTestHarness = DocumentStoreTestHarness()
 
     @BeforeTest
-    fun setup() = runBlocking {
+    fun setup() = runTest {
         documentStoreTestHarness.initialize()
         documentStoreTestHarness.provisionStandardDocuments()
     }

--- a/multipaz/src/jsMain/kotlin/org/multipaz/tools/Tools.kt
+++ b/multipaz/src/jsMain/kotlin/org/multipaz/tools/Tools.kt
@@ -1,0 +1,21 @@
+@file:OptIn(ExperimentalJsExport::class)
+
+package org.multipaz.tools
+
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.util.fromHex
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+
+@JsExport
+fun cborToDiagnostic(text: String): String {
+    try {
+        val bytes = text.fromHex()
+        val dataItem = Cbor.decode(bytes)
+        return Cbor.toDiagnostics(dataItem,
+        setOf(DiagnosticOption.EMBEDDED_CBOR, DiagnosticOption.PRETTY_PRINT))
+    } catch (e: Exception) {
+        return "Error decoding: ${e.message}"
+    }
+}

--- a/multipaz/src/jsMain/resources/index.html
+++ b/multipaz/src/jsMain/resources/index.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Example of calling Multipaz from JS</title>
+    <style>
+        :root {
+            --bg-color: #fcfcfc;
+            --text-color: #333;
+            --border-color: #ccc;
+            --header-bg: #eee;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+        }
+
+        header {
+            background-color: var(--header-bg);
+            padding: 10px 20px;
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        h1 {
+            font-size: 1.2rem;
+            margin: 0;
+        }
+
+        .container {
+            display: flex;
+            flex: 1;
+            overflow: hidden; /* Prevent body scroll, let panels scroll */
+        }
+
+        .pane {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            padding: 10px;
+            min-width: 0; /* Fixes flex child overflow issues */
+        }
+
+        .pane-header {
+            font-weight: bold;
+            margin-bottom: 8px;
+            color: #555;
+            display: flex;
+            justify-content: space-between;
+        }
+
+        /* The arrow divider in the middle */
+        .divider {
+            width: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: #f5f5f5;
+            border-left: 1px solid var(--border-color);
+            border-right: 1px solid var(--border-color);
+            color: #888;
+            font-size: 1.5rem;
+            user-select: none;
+        }
+
+        textarea {
+            flex: 1;
+            width: 100%;
+            resize: none; /* Layout handles resizing */
+            border: 1px solid var(--border-color);
+            padding: 10px;
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+            font-size: 14px;
+            box-sizing: border-box;
+            outline: none;
+        }
+
+        textarea:focus {
+            border-color: #007bff;
+        }
+
+        /* Specific styles to distinguish input vs output visually */
+        #diagnosticOutput {
+            background-color: #fafafa;
+        }
+    </style>
+</head>
+<body>
+
+<header>
+    <h1>Simple example of calling <a href="https://developer.multipaz.org/kdocs/multipaz/org.multipaz.cbor/-cbor/to-diagnostics.html">Cbor.toDiagnostics()</a> from JS</h1>
+</header>
+
+<div class="container">
+    <div class="pane">
+        <div class="pane-header">
+            <span>Diagnostic Notation</span>
+        </div>
+        <textarea id="diagnosticOutput" readonly placeholder="Output will appear here..."></textarea>
+    </div>
+
+    <div class="divider" title="Converting Right to Left">
+        &larr;
+    </div>
+
+    <div class="pane">
+        <div class="pane-header">
+            <span>Cbor (Hex)</span>
+            <button onclick="clearAll()" style="font-size: 0.8rem;">Clear</button>
+        </div>
+        <textarea id="hexInput" placeholder="Paste hex bytes here (e.g. A1 01 02)..." autofocus></textarea>
+    </div>
+</div>
+
+<script src="multipaz.js"></script>
+
+<script>
+    // DOM Elements
+    const hexInput = document.getElementById('hexInput');
+    const diagOutput = document.getElementById('diagnosticOutput');
+
+    // Event Listener: Trigger conversion on keyup/input in the Hex box
+    hexInput.addEventListener('input', () => {
+        const rawHex = hexInput.value;
+
+        // 1. Clean the input (remove spaces, newlines, '0x' prefixes)
+        const cleanHex = rawHex.replace(/\s+|0x/g, '');
+
+        // 2. Run the conversion function
+        try {
+            if (cleanHex.length === 0) {
+                diagOutput.value = '';
+                return;
+            }
+
+            // Check for valid hex characters before passing to logic
+            if (!/^[0-9a-fA-F]+$/.test(cleanHex)) {
+                throw new Error("Invalid Hex characters");
+            }
+
+            // Call the conversion logic
+            const result = convertHexToDiagnostic(cleanHex);
+            diagOutput.value = result;
+
+        } catch (e) {
+            diagOutput.value = "Error: " + e.message;
+        }
+    });
+
+    function clearAll() {
+        hexInput.value = '';
+        diagOutput.value = '';
+        hexInput.focus();
+    }
+
+    function convertHexToDiagnostic(cleanHex) {
+        return multipaz.org.multipaz.tools.cborToDiagnostic(cleanHex)
+    }
+
+</script>
+
+</body>
+</html>

--- a/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
@@ -1,0 +1,102 @@
+package org.multipaz.crypto
+
+import org.multipaz.util.UUID
+
+actual object Crypto {
+    actual val supportedCurves: Set<EcCurve>
+        get() = TODO("Not yet implemented")
+    actual val provider: String
+        get() = TODO("Not yet implemented")
+
+    actual fun digest(
+        algorithm: Algorithm,
+        message: ByteArray
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    actual fun mac(
+        algorithm: Algorithm,
+        key: ByteArray,
+        message: ByteArray
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    actual fun encrypt(
+        algorithm: Algorithm,
+        key: ByteArray,
+        nonce: ByteArray,
+        messagePlaintext: ByteArray,
+        aad: ByteArray?
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    actual fun decrypt(
+        algorithm: Algorithm,
+        key: ByteArray,
+        nonce: ByteArray,
+        messageCiphertext: ByteArray,
+        aad: ByteArray?
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    actual fun checkSignature(
+        publicKey: EcPublicKey,
+        message: ByteArray,
+        algorithm: Algorithm,
+        signature: EcSignature
+    ) {
+    }
+
+    actual fun createEcPrivateKey(curve: EcCurve): EcPrivateKey {
+        TODO("Not yet implemented")
+    }
+
+    actual fun sign(
+        key: EcPrivateKey,
+        signatureAlgorithm: Algorithm,
+        message: ByteArray
+    ): EcSignature {
+        TODO("Not yet implemented")
+    }
+
+    actual fun keyAgreement(
+        key: EcPrivateKey,
+        otherKey: EcPublicKey
+    ): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun ecPublicKeyToPem(publicKey: EcPublicKey): String {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun ecPublicKeyFromPem(
+        pemEncoding: String,
+        curve: EcCurve
+    ): EcPublicKey {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun ecPrivateKeyToPem(privateKey: EcPrivateKey): String {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun ecPrivateKeyFromPem(
+        pemEncoding: String,
+        publicKey: EcPublicKey
+    ): EcPrivateKey {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun uuidGetRandom(): UUID {
+        TODO("Not yet implemented")
+    }
+
+    internal actual fun validateCertChain(certChain: X509CertChain): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/datetime/dateTimeUtils.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/datetime/dateTimeUtils.web.kt
@@ -1,0 +1,15 @@
+package org.multipaz.datetime
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+
+actual fun LocalDate.formatLocalized(dateStyle: FormatStyle): String {
+    TODO("Not yet implemented")
+}
+
+actual fun LocalDateTime.formatLocalized(
+    dateStyle: FormatStyle,
+    timeStyle: FormatStyle
+): String {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/device/DeviceCheck.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/device/DeviceCheck.web.kt
@@ -1,0 +1,21 @@
+package org.multipaz.device
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.securearea.SecureArea
+
+actual object DeviceCheck {
+    actual suspend fun generateAttestation(
+        secureArea: SecureArea,
+        challenge: ByteString
+    ): DeviceAttestationResult {
+        TODO("Not yet implemented")
+    }
+
+    actual suspend fun generateAssertion(
+        secureArea: SecureArea,
+        deviceAttestationId: String,
+        assertion: Assertion
+    ): DeviceAssertion {
+        TODO("Not yet implemented")
+    }
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.web.kt
@@ -1,0 +1,12 @@
+package org.multipaz.mdoc.transport
+
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
+
+internal actual fun defaultMdocTransportFactoryCreateTransport(
+    connectionMethod: MdocConnectionMethod,
+    role: MdocRole,
+    options: MdocTransportOptions
+): MdocTransport {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/nfc/NfcTagReader.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/nfc/NfcTagReader.web.kt
@@ -1,0 +1,5 @@
+package org.multipaz.nfc
+
+internal actual fun nfcGetPlatformReaders(): List<NfcTagReader> {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.web.kt
@@ -1,0 +1,23 @@
+package org.multipaz.securearea.cloud
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.crypto.Algorithm
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+import org.multipaz.storage.Storage
+
+internal actual suspend fun cloudSecureAreaGetPlatformSecureArea(
+    storage: Storage,
+    partitionId: String
+): SecureArea {
+    TODO("Not yet implemented")
+}
+
+internal actual fun cloudSecureAreaGetPlatformSecureAreaCreateKeySettings(
+    challenge: ByteString,
+    algorithm: Algorithm,
+    userAuthenticationRequired: Boolean,
+    userAuthenticationTypes: Set<CloudUserAuthType>
+): CreateKeySettings {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/util/Compression.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/util/Compression.web.kt
@@ -1,0 +1,9 @@
+package org.multipaz.util
+
+actual fun ByteArray.deflate(compressionLevel: Int): ByteArray {
+    TODO("Not yet implemented")
+}
+
+actual fun ByteArray.inflate(): ByteArray {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/util/Logger.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/util/Logger.web.kt
@@ -1,0 +1,5 @@
+package org.multipaz.util
+
+internal actual fun getPlatformLogPrinter(): Logger.LogPrinter {
+    TODO("Not yet implemented")
+}

--- a/multipaz/src/webMain/kotlin/org/multipaz/util/Platform.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/util/Platform.web.kt
@@ -1,0 +1,22 @@
+package org.multipaz.util
+
+import org.multipaz.prompt.PromptModel
+import org.multipaz.securearea.SecureArea
+import org.multipaz.storage.Storage
+
+actual object Platform {
+    actual val name: String
+        get() = TODO("Not yet implemented")
+    actual val version: String
+        get() = TODO("Not yet implemented")
+    actual val promptModel: PromptModel
+        get() = TODO("Not yet implemented")
+    actual val storage: Storage
+        get() = TODO("Not yet implemented")
+    actual val nonBackedUpStorage: Storage
+        get() = TODO("Not yet implemented")
+
+    actual suspend fun getSecureArea(): SecureArea {
+        TODO("Not yet implemented")
+    }
+}

--- a/multipaz/src/webTest/kotlin/org/multipaz/testUtil.web.kt
+++ b/multipaz/src/webTest/kotlin/org/multipaz/testUtil.web.kt
@@ -1,0 +1,4 @@
+package org.multipaz
+
+actual fun testUtilSetupCryptoProvider() {
+}

--- a/multipazctl/build.gradle.kts
+++ b/multipazctl/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     alias(libs.plugins.ktor)
 }
 
+application {
+    mainClass.set("org.multipaz.multipazctl.MultipazCtl")
+}
+
 kotlin {
     jvmToolchain(17)
     compilerOptions {
@@ -32,10 +36,9 @@ tasks.register("runMultipazCtl", JavaExec::class) {
     workingDir = project.rootDir
 }
 
-project.setProperty("mainClassName", "org.multipaz.multipazctl.MultipazCtl")
-
 ktor {
 }
+
 subprojects {
 	apply(plugin = "org.jetbrains.dokka")
 }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -112,7 +112,7 @@ kotlin {
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.coil.compose)
-                implementation(libs.coil.ktor2)
+                implementation(libs.coil.ktor3)
             }
         }
     }

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppCredentialManagerPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppCredentialManagerPresentmentActivity.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.remember
 import coil3.ImageLoader
 import coil3.compose.LocalPlatformContext
 import coil3.imageLoader
-import coil3.network.ktor2.KtorNetworkFetcherFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
 import org.multipaz.compose.digitalcredentials.CredentialManagerPresentmentActivity
 import org.multipaz.testapp.ui.AppTheme

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcPresentmentActivity.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import coil3.ImageLoader
 import coil3.compose.LocalPlatformContext
-import coil3.network.ktor2.KtorNetworkFetcherFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
 import org.multipaz.compose.mdoc.MdocNfcPresentmentActivity
 import org.multipaz.testapp.ui.AppTheme

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppUriSchemePresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppUriSchemePresentmentActivity.kt
@@ -2,7 +2,7 @@ package org.multipaz.testapp
 
 import androidx.compose.runtime.Composable
 import coil3.ImageLoader
-import coil3.network.ktor2.KtorNetworkFetcherFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
 import org.multipaz.compose.presentment.UriSchemePresentmentActivity
 import org.multipaz.testapp.ui.AppTheme

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -38,7 +38,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import coil3.ImageLoader
 import coil3.compose.LocalPlatformContext
-import coil3.network.ktor2.KtorNetworkFetcherFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
 import io.ktor.http.decodeURLPart
 import kotlinx.coroutines.CoroutineScope

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
@@ -12,6 +12,7 @@ import org.multipaz.util.fromBase64Url
 import io.ktor.network.sockets.Socket
 import io.ktor.network.sockets.openReadChannel
 import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.readUTF8Line
 import io.ktor.utils.io.writeStringUtf8
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -14,6 +14,7 @@ import org.multipaz.util.toBase64Url
 import io.ktor.network.sockets.Socket
 import io.ktor.network.sockets.openReadChannel
 import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.readUTF8Line
 import io.ktor.utils.io.writeStringUtf8
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import io.github.z4kn4fein.semver.Version
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import org.multipaz.compose.cards.InfoCard
 import org.multipaz.testapp.BuildConfig
@@ -50,7 +50,7 @@ fun AppUpdateCard() {
             val httpClient = HttpClient(platformHttpClientEngineFactory().create())
             val response = httpClient.get(updateUrl)
             if (response.status == HttpStatusCode.OK) {
-                latestVersionString.value = response.readBytes().decodeToString().trim()
+                latestVersionString.value = response.readRawBytes().decodeToString().trim()
                 Logger.i(TAG, "Latest available version from $updateWebsiteUrl is ${latestVersionString.value} " +
                         "and our version is $currentVersion")
             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
-import io.ktor.client.statement.readBytes
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -114,11 +114,11 @@ private fun StatusListCheckSection(
                             val type = response.contentType()
                             val statusList = when (type) {
                                 STATUSLIST_JWT -> StatusList.fromJwt(
-                                    jwt = response.readBytes().decodeToString(),
+                                    jwt = response.readRawBytes().decodeToString(),
                                     publicKey = cert.ecPublicKey
                                 )
                                 STATUSLIST_CWT -> StatusList.fromCwt(
-                                    cwt = response.readBytes(),
+                                    cwt = response.readRawBytes(),
                                     publicKey = cert.ecPublicKey
                                 )
                                 else -> throw IllegalStateException("Unknown type: $type")
@@ -180,7 +180,7 @@ fun IdentifierListCheckSection(
                         val cert = status.certificate ?: certChain.certificates.first()
                         try {
                             val identifierList = IdentifierList.fromCwt(
-                                cwt = response.readBytes(),
+                                cwt = response.readRawBytes(),
                                 publicKey = cert.ecPublicKey
                             )
                             statusText.value = if (identifierList.contains(status.id)) {


### PR DESCRIPTION
For now just stub out all the platform dependencies such as e.g. `Crypto`. Also add an example application similar to http://cbor.me for showcasing calling Multipaz from JavaScript. This can be run by invoking `./gradlew multipaz:jsBrowserDevelopmentRun` from a shell.

One nice thing about having an additional target like this is that it helps catching use of things like `runBlocking` and `Dispatchers.IO` which shouldn't be hardcoded in the library. This change includes fixes to remove these uses.

Another nice thing about this is that in the future we can set up something like tools.multipaz.org for decoding Cbor, ASN1, Ndef, and also inspecting/generating things like certificates, keys. The cool thing is that none of this would ever leave the browser b/c it's entirely implemented in JavaScript.

This includes updating Ktor to the 3.x series since the 2.x series isn't available for JavaScript.

Test: Manually tested.