### PR TITLE
Assigned distinct redirect urls based on package name on Android.

### DIFF
--- a/multipaz-backend-server/src/main/java/org/multipaz/backend/server/ApplicationExt.kt
+++ b/multipaz-backend-server/src/main/java/org/multipaz/backend/server/ApplicationExt.kt
@@ -135,7 +135,10 @@ private suspend fun generateAppleAppSiteAssociationJson(): JsonElement {
                     put("appIDs", appIds)
                     putJsonArray("components") {
                         addJsonObject {
-                            put("/", "/landing/")
+                            put("/", "/redirect/")
+                        }
+                        addJsonObject {
+                            put("/", "/landing/")  // legacy name
                         }
                     }
                 }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -18,10 +18,15 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+// If changing it here, it must also be changed in XCode "Signing and Capabilities", under
+// "Associated Domains"
+val applinkHost = "apps.multipaz.org"
+
 buildConfig {
     packageName("org.multipaz.testapp")
     buildConfigField("TEST_APP_UPDATE_URL", System.getenv("TEST_APP_UPDATE_URL") ?: "")
     buildConfigField("TEST_APP_UPDATE_WEBSITE_URL", System.getenv("TEST_APP_UPDATE_WEBSITE_URL") ?: "")
+    buildConfigField("APPLINK_HOST", applinkHost)
     useKotlinOutput { internalVisibility = false }
 }
 
@@ -142,6 +147,7 @@ android {
 
     defaultConfig {
         applicationId = "org.multipaz.testapp"
+        manifestPlaceholders["applinkHost"] = applinkHost
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = projectVersionCode

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -67,7 +67,7 @@
             <!-- Deep Link Configuration -->
             
             <!-- 1. HTTPS App Links (default) - Requires .well-known/assetlinks.json -->
-            <!-- Examples: https://apps.multipaz.org/landing/ -->
+            <!-- Examples: https://apps.multipaz.org/redirect/org.multipaz.testapp/ -->
             <!-- Must match ProvisioningSupport.APP_LINK_SERVER -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -77,11 +77,13 @@
                 <!--
                 Do not include other schemes, only https. If domain is changed here, it
                 also MUST be changed in ProvisioningSupport class.
+
+                applinkHost is configured in Gradle
                  -->
                 <data
                     android:scheme="https"
-                    android:host="apps.multipaz.org"
-                    android:pathPattern="/landing/.*"/>
+                    android:host="${applinkHost}"
+                    android:pathPattern="/redirect/${applicationId}/"/>
             </intent-filter>
 
             <!-- 2. Custom URI Scheme - App-specific URLs -->

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
@@ -27,6 +27,9 @@ private const val TAG = "PlatformAndroid"
 
 actual val platformAppName = applicationContext.getString(R.string.app_name)
 
+// Redirect paths should differ by flavor.
+actual val platformRedirectPath: String = "/redirect/${applicationContext.packageName}/"
+
 actual val platformAppIcon = if (platformAppName.endsWith("(Red)")) {
     Res.drawable.app_icon_red
 } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
@@ -1,15 +1,7 @@
 package org.multipaz.testapp
 
-import androidx.compose.ui.graphics.painter.Painter
 import io.ktor.client.engine.HttpClientEngineFactory
-import org.multipaz.securearea.CreateKeySettings
-import org.multipaz.securearea.SecureArea
-import org.multipaz.securearea.SecureAreaProvider
-import org.multipaz.storage.Storage
-import kotlin.time.Instant
-import kotlinx.io.bytestring.ByteString
 import org.jetbrains.compose.resources.DrawableResource
-import org.multipaz.crypto.Algorithm
 import org.multipaz.nfc.NfcTagReader
 import org.multipaz.prompt.PromptModel
 
@@ -22,6 +14,8 @@ enum class Platform(val displayName: String) {
 expect val platformAppName: String
 
 expect val platformAppIcon: DrawableResource
+
+expect val platformRedirectPath: String
 
 expect val platformPromptModel: PromptModel
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/ProvisioningSupport.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/ProvisioningSupport.kt
@@ -16,7 +16,9 @@ import org.multipaz.rpc.handler.RpcExceptionMap
 import org.multipaz.rpc.transport.HttpTransport
 import org.multipaz.securearea.SecureArea
 import org.multipaz.storage.Storage
+import org.multipaz.testapp.BuildConfig
 import org.multipaz.testapp.platformHttpClientEngineFactory
+import org.multipaz.testapp.platformRedirectPath
 import org.multipaz.util.Logger
 
 /**
@@ -32,8 +34,8 @@ class ProvisioningSupport(
     val secureArea: SecureArea,
 ) {
     companion object {
-        const val APP_LINK_SERVER = "https://apps.multipaz.org"
-        const val APP_LINK_BASE_URL = "$APP_LINK_SERVER/landing/"
+        const val APP_LINK_SERVER = "https://${BuildConfig.APPLINK_HOST}"
+        val APP_LINK_BASE_URL = "$APP_LINK_SERVER$platformRedirectPath"
 
         private const val TAG = "ProvisioningSupport"
 

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/PlatformIos.kt
@@ -62,6 +62,10 @@ actual val platformAppName = "Multipaz Test App"
 
 actual val platformAppIcon = Res.drawable.app_icon
 
+// No flavors for iOS, just use generic name.
+// TODO: replace with "/redirect/" for consistency with Android once we configure it on the server.
+actual val platformRedirectPath: String get() = "/landing/"
+
 actual val platformPromptModel: PromptModel by lazy {
     IosPromptModel.Builder().apply { addCommonDialogs() }.build()
 }

--- a/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/Platform.wasmJs.kt
+++ b/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/Platform.wasmJs.kt
@@ -18,6 +18,8 @@ actual val platformPromptModel: PromptModel by lazy {
 
 actual val platform = Platform.WASMJS
 
+actual val platformRedirectPath: String = "/redirect/"
+
 actual suspend fun platformInit() {
     // Nothing to do
 }


### PR DESCRIPTION
This allows different apps and/or different flavors of the same app to work out-of-the box on Android.

Also renamed "landing" to more descriptive "redirect" in the redirect path on Android; on iOS we will need to stage it and do a bit later after tweaking the server config.

Test: manual testing, including iOS.

Fixes #1465
