### PR TITLE
Credential refresh support in ProvisioningClient and ProvisioningModel.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/AbstractDocumentMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/AbstractDocumentMetadata.kt
@@ -1,6 +1,9 @@
 package org.multipaz.document
 
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.storage.Storage
 
 /**
  * Interface that all objects returned in [Document.metadata] must implement.
@@ -33,6 +36,12 @@ interface AbstractDocumentMetadata {
     val issuerLogo: ByteString?
 
     /**
+     * Saved authorization data to refresh credentials, possibly without requiring
+     * user to re-authorize.
+     */
+    val authorizationData: ByteString?
+
+    /**
      * Additional data the application wishes to store.
      */
     val other: ByteString?
@@ -61,6 +70,20 @@ interface AbstractDocumentMetadata {
         typeDisplayName: String?,
         cardArt: ByteString?,
         issuerLogo: ByteString?,
+        authorizationData: ByteString?,
         other: ByteString?
+    )
+
+    /**
+     * Delete this metadata, called when the document to which it belongs is going away.
+     *
+     * In particular, data that resides in the storage and the secure area should be deleted.
+     *
+     * @param secureAreaRepository secure area repository to look up an appropriate [SecureArea]
+     * @param storage interface to the storage
+     */
+    suspend fun cleanup(
+        secureAreaRepository: SecureAreaRepository,
+        storage: Storage
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Provisioning.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Provisioning.kt
@@ -1,0 +1,86 @@
+package org.multipaz.provisioning
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.CborMap
+import org.multipaz.cbor.Tstr
+import org.multipaz.provisioning.openid4vci.OpenID4VCIClientPreferences
+import org.multipaz.provisioning.openid4vci.OpenID4VCIProvisioningClient
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.storage.Storage
+import org.multipaz.util.Logger
+
+/**
+ * Object that dispatches general provisioning-related operations to correct protocol handlers
+ * (for Multipaz-implemented protocols).
+ */
+object Provisioning {
+    /**
+     * Creates [ProvisioningClient] from authorization data obtained from a previous provisioning
+     * session.
+     *
+     * @param authorizationData authorization data, see [ProvisioningClient.getAuthorizationData]
+     */
+    suspend fun createClientFromAuthorizationData(
+        authorizationData: ByteString
+    ): ProvisioningClient {
+        val parsedAuthorizationData = parseAuthorizationData(authorizationData)
+        return when (val t = parsedAuthorizationData["type"].asTstr) {
+            "openid4vci" -> {
+                val clientPreferences =
+                    BackendEnvironment.getInterface(OpenID4VCIClientPreferences::class)!!
+                OpenID4VCIProvisioningClient.createFromAuthorizationData(
+                    authorizationData = parsedAuthorizationData,
+                    clientPreferences = clientPreferences
+                )
+            }
+            else -> throw IllegalArgumentException("Unknown authorization data type: '$t'")
+        }
+    }
+
+    /**
+     * Cleans up storage and/or private keys that authorization data holds.
+     *
+     * @param authorizationData authorization data, see [ProvisioningClient.getAuthorizationData]
+     * @param secureAreaRepository where to search for the relevant [SecureArea]
+     * @param storage interface to persistent storage
+     */
+    suspend fun cleanupAuthorizationData(
+        authorizationData: ByteString,
+        secureAreaRepository: SecureAreaRepository,
+        storage: Storage
+    ) {
+        val parsedAuthorizationData = try {
+            parseAuthorizationData(authorizationData)
+        } catch (err: IllegalArgumentException) {
+            Logger.e(TAG, "Failed to clean-up authorization data: could not parse", err)
+            return
+        }
+        return when (val t = parsedAuthorizationData["type"].asTstr) {
+            "openid4vci" ->
+                OpenID4VCIProvisioningClient.cleanupAuthorizationData(
+                    authorizationData = parsedAuthorizationData,
+                    secureAreaRepository = secureAreaRepository,
+                    storage = storage
+                )
+            else -> {
+                Logger.e(TAG, "Failed to clean-up authorization data of unknown type '$t'")
+            }
+        }
+    }
+
+    private fun parseAuthorizationData(authorizationData: ByteString): CborMap {
+        val parsedAuthorizationData = Cbor.decode(authorizationData.toByteArray())
+        if (parsedAuthorizationData !is CborMap || !parsedAuthorizationData.hasKey("type")) {
+            throw IllegalArgumentException("Not a valid authorization data")
+        }
+        if (parsedAuthorizationData["type"] !is Tstr) {
+            throw IllegalArgumentException("Invalid authorization data type")
+        }
+        return parsedAuthorizationData
+    }
+
+    private const val TAG = "Provisioning"
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningClient.kt
@@ -1,5 +1,6 @@
 package org.multipaz.provisioning
 
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.securearea.SecureArea
 
 /**
@@ -43,6 +44,17 @@ interface ProvisioningClient {
     suspend fun authorize(response: AuthorizationResponse)
 
     /**
+     * Saves authorization data for future use.
+     *
+     * Once the client is authorized (i.e. [getAuthorizationChallenges] returns an empty list)
+     * the "authorization" can sometimes be saved for use at some future time.
+     *
+     * @return provisioning-protocol-specific serialized data, if saving it is supported, `null`
+     *  otherwise.
+     */
+    suspend fun getAuthorizationData(): ByteString?
+
+    /**
      * Returns a challenge for the key(s) to which the credential(s) will be bound.
      *
      * For the key-bound credentials, the issuing server typically requires freshly-minted
@@ -57,8 +69,8 @@ interface ProvisioningClient {
     /**
      * Obtains credentials using key binding information.
      *
-     * [keyInfo] key binding information, required type is determined by
-     * [CredentialMetadata.keyBindingType].
+     * @param keyInfo key binding information, required type is determined by
+     *  [CredentialMetadata.keyBindingType].
      */
     suspend fun obtainCredentials(keyInfo: KeyBindingInfo): Credentials
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -29,9 +29,8 @@ internal sealed class CredentialOffer {
     data class Grantless(
         override val issuerUri: String,
         override val configurationId: String,
-    ): CredentialOffer() {
-        override val authorizationServer: String? get() = null
-    }
+        override val authorizationServer: String? = null
+    ): CredentialOffer()
 
     /**
      * Credential offer with Grant Type `urn:ietf:params:oauth:grant-type:pre-authorized_code`.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIAuthorizationData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIAuthorizationData.kt
@@ -1,0 +1,24 @@
+package org.multipaz.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+
+/**
+ * Data structure that holds OpenID4VCI session authorization data.
+ *
+ * This data enables the client to fetch more credentials from the issuing server. This object
+ * is serialized and written to the disk, so be careful changing its schema!
+ */
+@CborSerializable(schemaHash = "tSadM4JcWvdA3nqneHBRndJAVEbWdmRFofbJYGqORLA")
+internal class OpenID4VCIAuthorizationData(
+    val issuerUri: String,
+    val configurationId: String,
+    val secureAreaId: String,
+    val authorizationServer: String?,
+    var refreshToken: String? = null,
+    var dpopKeyAlias: String? = null,
+    var walletAttestationKeyAlias: String? = null,
+    var walletAttestation: String? = null,
+    var type: String = "openid4vci"
+) {
+    companion object
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
@@ -127,7 +127,7 @@ class DocumentStoreTest {
         runCurrent()
         assertEquals(DocumentUpdated(doc2.identifier), events.last())
 
-        doc1.simpleMetadata.setMetadata("foo", "bar", null, null, null)
+        doc1.simpleMetadata.setMetadata("foo", "bar", null, null, null, null)
         runCurrent()
         assertEquals(DocumentUpdated(doc1.identifier), events.last())
 
@@ -453,14 +453,14 @@ class DocumentStoreTest {
         }
         val document = documentStore.createDocument {
             val appData = it as DocumentMetadata
-            appData.setMetadata("init", "", null, null, null)
+            appData.setMetadata("init", "", null, null, null, null)
         }
         val appData = document.simpleMetadata
         assertFalse(appData.provisioned)
         assertEquals("init", appData.displayName)
         appData.markAsProvisioned()
         assertTrue(appData.provisioned)
-        appData.setMetadata("foo", "bar", ByteString(1, 2, 3), null, null)
+        appData.setMetadata("foo", "bar", ByteString(1, 2, 3), null, null, null)
         assertEquals("foo", appData.displayName)
         assertEquals(ByteString(1, 2, 3), appData.cardArt)
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/TestDocumentMetadata.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/TestDocumentMetadata.kt
@@ -5,6 +5,8 @@ import org.multipaz.document.NameSpacedData
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.isEmpty
 import org.multipaz.document.AbstractDocumentMetadata
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.storage.Storage
 import kotlin.concurrent.Volatile
 
 class TestDocumentMetadata private constructor(
@@ -20,6 +22,8 @@ class TestDocumentMetadata private constructor(
     override val cardArt: ByteString?
         get() = null
     override val issuerLogo: ByteString?
+        get() = null
+    override val authorizationData: ByteString?
         get() = null
     override val other: ByteString?
         get() = null
@@ -44,7 +48,14 @@ class TestDocumentMetadata private constructor(
         typeDisplayName: String?,
         cardArt: ByteString?,
         issuerLogo: ByteString?,
+        authorizationData: ByteString?,
         other: ByteString?
+    ) {
+    }
+
+    override suspend fun cleanup(
+        secureAreaRepository: SecureAreaRepository,
+        storage: Storage
     ) {
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
@@ -18,6 +18,7 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.toDataItem
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
@@ -133,6 +134,8 @@ class ProvisioningModelTest {
         }.await()
         val docMetadata = doc.metadata as DocumentMetadata
         assertTrue(docMetadata.provisioned)
+        assertEquals("foobar_auth",
+            docMetadata.authorizationData!!.toByteArray().decodeToString())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -216,6 +219,9 @@ class ProvisioningModelTest {
             }
             authorizationResponse = response
         }
+
+        override suspend fun getAuthorizationData(): ByteString =
+            ByteString("foobar_auth".encodeToByteArray())
 
         override suspend fun getKeyBindingChallenge(): String = "test_challenge"
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -895,6 +895,14 @@ class App private constructor (val promptModel: PromptModel) {
                                         credentialId = credentialId
                                     )
                                 )
+                            },
+                            onProvisionMore = { document, authorizationData ->
+                                provisioningModel.launchOpenID4VCIRefreshCredentials(
+                                    document,
+                                    authorizationData,
+                                    provisioningSupport.getOpenID4VCIClientPreferences(),
+                                    provisioningSupport.getOpenID4VCIBackend()
+                                )
                             }
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +23,9 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.document.DocumentModel
+import org.multipaz.document.Document
 import org.multipaz.testapp.rememberInhibitNfcObserveMode
 
 @Composable
@@ -31,6 +34,7 @@ fun DocumentViewerScreen(
     documentId: String,
     showToast: (message: String) -> Unit,
     onViewCredential: (documentId: String, credentialId: String) -> Unit,
+    onProvisionMore: (document: Document, authorizationData: ByteString) -> Unit
 ) {
     val documentInfos = documentModel.documentInfos.collectAsState().value
     val documentInfo = documentInfos[documentId]
@@ -41,6 +45,7 @@ fun DocumentViewerScreen(
         if (documentInfo == null) {
             Text("No document for identifier ${documentId}")
         } else {
+            val metadata = documentInfo.document.metadata
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center
@@ -58,7 +63,7 @@ fun DocumentViewerScreen(
             ) {
                 Text(
                     modifier = Modifier.padding(8.dp),
-                    text = documentInfo.document.metadata.typeDisplayName ?: "(typeDisplayName not set)",
+                    text = metadata.typeDisplayName ?: "(typeDisplayName not set)",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary
                 )
@@ -74,15 +79,15 @@ fun DocumentViewerScreen(
             ) {
                 KeyValuePairText(
                     keyText = "Provisioned",
-                    valueText = if (documentInfo.document.metadata.provisioned) "Yes" else "No"
+                    valueText = if (metadata.provisioned) "Yes" else "No"
                 )
                 KeyValuePairText(
                     keyText = "Document Type",
-                    valueText = documentInfo.document.metadata.typeDisplayName ?: "(typeDisplayName not set)"
+                    valueText = metadata.typeDisplayName ?: "(typeDisplayName not set)"
                 )
                 KeyValuePairText(
                     keyText = "Document Name",
-                    valueText = documentInfo.document.metadata.displayName ?: "(displayName not set)"
+                    valueText = metadata.displayName ?: "(displayName not set)"
                 )
                 Text(
                     text = "Credentials",
@@ -120,6 +125,13 @@ fun DocumentViewerScreen(
                                 }
                             }
                         )
+                    }
+                }
+                metadata.authorizationData?.let { authorizationData ->
+                    Button(onClick = {
+                        onProvisionMore(documentInfo.document, authorizationData)
+                    }) {
+                        Text("Provision more credentials")
                     }
                 }
             }


### PR DESCRIPTION
Added ability to save authorization data from the provisioning session and to initialize a new provisioning session from it at a later time to obtain refreshed credentials. Added functionality to store authorization data in the document metadata and to clean it up when the document is deleted. Added a button in the testapp document view to fetch more credentials. Updated default metadata implementation. Updated unit tests.

Fixes #1482

Test: new unit test functionality, manual testing with testapp.