### PR TITLE
Don't force KMP resources on apps.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.graphics.drawable.toDrawable
 import androidx.credentials.DigitalCredential
 import androidx.credentials.ExperimentalDigitalCredentialApi
@@ -27,8 +28,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.presentment.Presentment
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.context.initializeApplication
@@ -72,7 +71,7 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
      */
     data class Settings(
         val appName: String,
-        val appIcon: DrawableResource,
+        val appIcon: @Composable () -> Painter,
         val promptModel: PromptModel,
         val applicationTheme: @Composable (content: @Composable () -> Unit) -> Unit,
         val documentTypeRepository: DocumentTypeRepository,
@@ -180,7 +179,7 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
                 PromptDialogs(settings.promptModel)
                 Presentment(
                     appName = settings.appName,
-                    appIconPainter = painterResource(settings.appIcon),
+                    appIconPainter = settings.appIcon(),
                     presentmentModel = presentmentModel,
                     presentmentSource = settings.presentmentSource,
                     documentTypeRepository = settings.documentTypeRepository,

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcPresentmentActivity.kt
@@ -8,13 +8,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.fragment.app.FragmentActivity
 import coil3.ImageLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.mdoc.MdocNdefService.Companion.presentmentModel
 import org.multipaz.compose.presentment.Presentment
 import org.multipaz.compose.prompt.PromptDialogs
@@ -45,7 +44,7 @@ abstract class MdocNfcPresentmentActivity : FragmentActivity() {
      */
     data class Settings(
         val appName: String,
-        val appIcon: DrawableResource,
+        val appIcon: @Composable () -> Painter,
         val promptModel: PromptModel,
         val applicationTheme: @Composable (content: @Composable () -> Unit) -> Unit,
         val documentTypeRepository: DocumentTypeRepository,
@@ -79,7 +78,7 @@ abstract class MdocNfcPresentmentActivity : FragmentActivity() {
                     Presentment(
                         modifier = Modifier.consumeWindowInsets(innerPadding),
                         appName = settings.appName,
-                        appIconPainter = painterResource(settings.appIcon),
+                        appIconPainter = settings.appIcon(),
                         presentmentModel = presentmentModel,
                         presentmentSource = settings.presentmentSource,
                         documentTypeRepository = settings.documentTypeRepository,

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
@@ -7,14 +7,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.FragmentActivity
 import io.ktor.client.engine.HttpClientEngineFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.context.initializeApplication
 import org.multipaz.documenttype.DocumentTypeRepository
@@ -53,7 +52,7 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
      */
     data class Settings(
         val appName: String,
-        val appIcon: DrawableResource,
+        val appIcon: @Composable () -> Painter,
         val promptModel: PromptModel,
         val applicationTheme: @Composable (content: @Composable () -> Unit) -> Unit,
         val documentTypeRepository: DocumentTypeRepository,
@@ -148,7 +147,7 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
                 PromptDialogs(settings.promptModel)
                 Presentment(
                     appName = settings.appName,
-                    appIconPainter = painterResource(settings.appIcon),
+                    appIconPainter = settings.appIcon(),
                     presentmentModel = presentmentModel,
                     presentmentSource = settings.presentmentSource,
                     documentTypeRepository = settings.documentTypeRepository,

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppCredentialManagerPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppCredentialManagerPresentmentActivity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
+import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.digitalcredentials.CredentialManagerPresentmentActivity
 import org.multipaz.testapp.ui.AppTheme
 
@@ -23,7 +24,7 @@ class TestAppCredentialManagerPresentmentActivity: CredentialManagerPresentmentA
 
         return Settings(
             appName = TestAppConfiguration.appName,
-            appIcon = TestAppConfiguration.appIcon,
+            appIcon = @Composable { painterResource(TestAppConfiguration.appIcon) },
             promptModel = app.promptModel,
             applicationTheme = @Composable { AppTheme(it) },
             documentTypeRepository = app.documentTypeRepository,

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcPresentmentActivity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
+import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.mdoc.MdocNfcPresentmentActivity
 import org.multipaz.testapp.ui.AppTheme
 
@@ -16,7 +17,7 @@ class TestAppMdocNfcPresentmentActivity : MdocNfcPresentmentActivity() {
         }.build()
         return Settings(
             appName = TestAppConfiguration.appName,
-            appIcon = TestAppConfiguration.appIcon,
+            appIcon = @Composable { painterResource(TestAppConfiguration.appIcon) },
             promptModel = app.promptModel,
             applicationTheme = @Composable { AppTheme(it) },
             documentTypeRepository = app.documentTypeRepository,

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppUriSchemePresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppUriSchemePresentmentActivity.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
+import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.presentment.UriSchemePresentmentActivity
 import org.multipaz.testapp.ui.AppTheme
 
@@ -16,7 +17,7 @@ class TestAppUriSchemePresentmentActivity: UriSchemePresentmentActivity() {
         }.build()
         return Settings(
             appName = TestAppConfiguration.appName,
-            appIcon = TestAppConfiguration.appIcon,
+            appIcon = @Composable { painterResource(TestAppConfiguration.appIcon) },
             promptModel = app.promptModel,
             applicationTheme = @Composable { AppTheme(it) },
             documentTypeRepository = app.documentTypeRepository,


### PR DESCRIPTION
It should be possible to use multipaz-compose in Android apps using Android resources and not KMP resources. As such, we shouldn't be passing around things like `DrawableResource` since that's a KMP resource construct. Change `CredentialManagerPresentmentActivity`, `MdocNfcPresentmentActivity`, and `UriSchemePresentmentActivity` so their settings classes take a `@Composable () -> Painter` lambda instead.

Fixes #1459.

Test: Manually tested.
