### PR TITLE
Expose setDeviceEngagmement publicly

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelperTest.kt
@@ -1,0 +1,53 @@
+package com.android.identity.android.mdoc.deviceretrieval
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.multipaz.cbor.Simple
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import java.util.concurrent.Executor
+
+@RunWith(AndroidJUnit4::class)
+class VerificationHelperTest {
+
+    @Test
+    fun testSetDeviceEngagement_ManualInjection() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val executor = Executor { it.run() }
+
+        val listener = object : VerificationHelper.Listener {
+            override fun onReaderEngagementReady(readerEngagement: ByteArray) {}
+            override fun onDeviceEngagementReceived(connectionMethods: List<MdocConnectionMethod>) {}
+            override fun onMoveIntoNfcField() {}
+            override fun onDeviceConnected() {}
+            override fun onResponseReceived(deviceResponseBytes: ByteArray) {}
+            override fun onDeviceDisconnected(transportSpecificTermination: Boolean) {}
+            override fun onError(error: Throwable) {
+                throw RuntimeException(error)
+            }
+        }
+
+        val helper = VerificationHelper.Builder(context, listener, executor).build()
+
+        // ISO 18013-5 Annex D Device Engagement Test Vector (Hex)
+        val hex = "a30063312e30018201d818584ba4010220012158205a88d182bce5f42efa59943f33359d2" +
+                "e8a968ff289d93e5fa444b624343167fe225820b16e8cf858ddc7690407ba61d4c338237a" +
+                "8cfcf3de6aa672fc60a557aa32fc670281830201a300f401f50b5045efef742b2c4837a9a" +
+                "3b0e1d05a6917"
+
+        val engagementBytes = hex.chunked(2)
+            .map { it.toInt(16).toByte() }
+            .toByteArray()
+
+        helper.setDeviceEngagement(
+            engagementBytes,
+            Simple.NULL,
+            VerificationHelper.EngagementMethod.QR_CODE
+        )
+
+        assertNotNull(helper.sessionTranscript)
+    }
+}

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
@@ -699,7 +699,33 @@ class VerificationHelper internal constructor(
         transceiverThread.start()
     }
 
-    private fun setDeviceEngagement(
+    /**
+     * Set device engagement data acquired from a secondary source; a source other than
+     * Android NFC or QR code.
+     *
+     * This method initializes the session state, including the reader ephemeral key
+     * and the session transcript.
+     *
+     * After calling this method, the caller is responsible for parsing the connection
+     * methods from the engagement data and calling [reportDeviceEngagementReceived],
+     * which will then trigger the [Listener.onDeviceEngagementReceived] callback.
+     *
+     * This method must be called before [connect].
+     *
+     * @param deviceEngagement, a [ByteArray], the raw CBOR-encoded
+     *   [org.multipaz.mdoc.engagement.DeviceEngagement]
+     *   structure as defined in ISO 18013-5. This contains the device's public key and supported
+     *   connection methods.
+     * @param handover, a [DataItem], the raw CBOR-encoded ISO 18013-5 handover structure to
+     *   be included in the Session Transcript. For QR code engagement, this is typically
+     *   [org.multipaz.cbor.Simple.NULL]. For NFC, it contains the hashes of the handover select
+     *   and handover request messages.
+     * @param engagementMethod, an [EngagementMethod], the [EngagementMethod] used to retrieve the
+     *  engagement data, used for tracking the provenance of the session.
+     *
+     * @throws IllegalStateException if called after [connect].
+     */
+    fun setDeviceEngagement(
         deviceEngagement: ByteArray,
         handover: DataItem,
         engagementMethod: EngagementMethod


### PR DESCRIPTION
Allow for device engagement data obtained from an external source to be injected into the verification flow.

We specifically use this to add verification functionality to Android devices with only payment card NFC / without proper Android NFC. A proprietary SDK is used to retrieve the engagement data. The now-public method here is used to feed it into multipaz and continue the verification flow.

For reference, this is sample code how we're utilizing this method.
```
        val handover = buildCborArray {
          add(Bstr(data.handoverSelect))
          add(Bstr(data.handoverRequest))
        }

        // TODO: Invoke reflectively for now 
        // verificationHelper.setDeviceEngagement(
        setDeviceEngagementReflectively(
            data.deviceEngagement,
            handover,
            VerificationHelper.EngagementMethod.NFC_NEGOTIATED_HANDOVER
        )

        // Map proprietary connection methods to multipaz 
        val connectionMethods = data.connectionMethods.map { info ->
          MdocConnectionMethodBle(
              info.peripheralServerMode,
              info.centralClientMode,
              null,
              UUID.fromString(info.uuid.toString())
          )
        }

        verification.reportDeviceEngagementReceived(connectionMethods)
```

Wasn't sure if a unit test was required since this is just making an existing, tested code path public. However, I added a simple one.

Thank you for your consideration.

# Testing

See unit test.

We also have this working end-end with our payment NFC hardware / SDK, which I can't reasonably demonstrate unfortunately.