### PR TITLE
Removed default enrollment server.

### DIFF
--- a/multipaz-server-deployment/README.md
+++ b/multipaz-server-deployment/README.md
@@ -229,7 +229,7 @@ This may be useful if you are trying to troubleshoot a build problem.
 ./gradlew :multipaz-backend-server:buildFatJar
 ./gradlew :multipaz-records-server:buildFatJar
 ./gradlew :multipaz-csa-server:buildFatJar
-./gradlew :multipaz-server-frontend:jsBrowserProductionWebpack
+./gradlew :multipaz-server-frontend:jsBrowserDistribution
 
 # 2. Build the container image
 podman build -f multipaz-server-deployment/docker/Dockerfile -t multipaz/server-bundle:latest .

--- a/multipaz-server/src/main/java/org/multipaz/server/common/ConfigurationExt.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/ConfigurationExt.kt
@@ -14,5 +14,4 @@ val Configuration.serverPort: Int get() =
 val Configuration.baseUrl: String get() = getValue("base_url")
         ?: ("http://" + (serverHost ?: "localhost") + ":" + serverPort)
 
-val Configuration.enrollmentServerUrl: String get() =
-    getValue("enrollment_server_url") ?: "https://issuer.multipaz.org/records"
+val Configuration.enrollmentServerUrl: String? get() = getValue("enrollment_server_url")

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
@@ -247,7 +247,6 @@ class EnrollmentImpl: Enrollment, RpcAuthInspector by serverAuth {
                 // ServerIdentityRecord has been created and inserted in enrollmentsMap.
                 check(enrollmentsMap.containsKey(serverIdentity))
                 CoroutineScope(Dispatchers.IO).async {
-                    val selfEnrollProp = configuration.getValue("self_enroll")
                     val baseUrl = configuration.baseUrl
                     val enrollmentUrl = configuration.enrollmentServerUrl
                     // If no enrollment record is found, check if we are running on localhost
@@ -255,8 +254,8 @@ class EnrollmentImpl: Enrollment, RpcAuthInspector by serverAuth {
                     // records server is also on localhost. When self-enrolling, the root
                     // certificate will not be trusted (unless a trusted key/certificate is
                     // specified in the config file, which is not generally recommended).
-                    val selfEnroll = selfEnrollProp?.let { it == "true" }
-                        ?: (LOCALHOST.matchEntire(baseUrl) != null &&
+                    val selfEnroll = enrollmentUrl == null ||
+                        (LOCALHOST.matchEntire(baseUrl) != null &&
                                 LOCALHOST.matchEntire(enrollmentUrl) == null)
                     if (selfEnroll) {
                         Logger.i(TAG, "Self-enrolling '$serverIdentity'")

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
@@ -147,9 +147,9 @@ enum class ServerIdentity(
  *
  * Otherwise, an previously-created identity is looked up in the database.
  *
- * Otherwise, if "self_enroll" setting is set to `true` or the server is running with
- * localhost url, a new private key is generated and a certificate is created locally on this
- * server (signed using key obtained using `getRootIdentity` function).
+ * Otherwise, if "enrollment_server_url" setting is null or points to non-localhost url when the
+ * server's baseUrl is a localhost url, a new private key is generated and a certificate is created
+ * locally on this server (signed using key obtained using `getRootIdentity` function).
  *
  * Otherwise, a request is made to an enrollment server (set by "enrollment_server_url" setting,
  * "https://issuer.multipaz.org/records" by default) to issue a new certificate using


### PR DESCRIPTION
Services are now self-enrolling by default (i.e. they generate their own self-signed root certificates).

Test: unit test, manual testing with testapp

Fixes #1512
