### PR TITLE
A clean-up pass for provisioning-related APIs.

### DIFF
--- a/multipaz-backend-server/src/main/java/org/multipaz/backend/openid4vci/OpenID4VCIBackendImpl.kt
+++ b/multipaz-backend-server/src/main/java/org/multipaz/backend/openid4vci/OpenID4VCIBackendImpl.kt
@@ -4,7 +4,7 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.device.DeviceAttestationAndroid
-import org.multipaz.provisioning.openid4vci.KeyIdAndAttestation
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackendUtil
 import org.multipaz.rpc.annotation.RpcState
@@ -52,20 +52,20 @@ class OpenID4VCIBackendImpl: OpenID4VCIBackend, RpcAuthInspector by RpcAuthBacke
     }
 
     override suspend fun createJwtKeyAttestation(
-        keyIdAndAttestations: List<KeyIdAndAttestation>,
+        credentialKeyAttestations: List<CredentialKeyAttestation>,
         challenge: String,
         userAuthentication: List<String>?,
         keyStorage: List<String>?
     ): String {
         validateKeyAttestations(
-            keyAttestations = keyIdAndAttestations.map { it.keyAttestation },
+            keyAttestations = credentialKeyAttestations.map { it.keyAttestation },
             challenge = challenge.encodeToByteString()
         )
         val keyAttestationKey = getServerIdentity(ServerIdentity.KEY_ATTESTATION)
         return OpenID4VCIBackendUtil.createJwtKeyAttestation(
             signingKey = keyAttestationKey,
             attestationIssuer = keyAttestationKey.subject,
-            keysToAttest = keyIdAndAttestations,
+            keysToAttest = credentialKeyAttestations,
             challenge = challenge,
             userAuthentication = userAuthentication,
             keyStorage = keyStorage

--- a/multipaz-dcapi/src/commonTest/kotlin/org/multipaz/presentment/model/DocumentStoreTestHarness.kt
+++ b/multipaz-dcapi/src/commonTest/kotlin/org/multipaz/presentment/model/DocumentStoreTestHarness.kt
@@ -2,6 +2,8 @@ package org.multipaz.presentment.model
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -517,11 +519,7 @@ class DocumentStoreTestHarness {
         )
 
         // Now that we have issuer-provided authentication data we certify the authentication key.
-        mdocCredential.certify(
-            issuerProvidedAuthenticationData,
-            validFrom,
-            validUntil
-        )
+        mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
     }
 
     private suspend fun addSdJwtVcCredential(
@@ -598,11 +596,7 @@ class DocumentStoreTestHarness {
                 put("exp", validUntil.epochSeconds)
             },
         )
-        credential.certify(
-            sdJwt.compactSerialization.encodeToByteArray(),
-            validFrom,
-            validUntil
-        )
+        credential.certify(sdJwt.compactSerialization.encodeToByteString())
     }
 
 }

--- a/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci-server/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -42,7 +42,7 @@ import org.multipaz.provisioning.AuthorizationChallenge
 import org.multipaz.provisioning.AuthorizationResponse
 import org.multipaz.provisioning.KeyBindingInfo
 import org.multipaz.provisioning.Provisioning
-import org.multipaz.provisioning.openid4vci.KeyIdAndAttestation
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.provisioning.openid4vci.OpenID4VCI
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackendUtil
@@ -213,9 +213,9 @@ class ProvisioningClientTest {
             val keyInfo = secureArea.createKey(null, CreateKeySettings())
 
             val credentials = provisioningClient.obtainCredentials(KeyBindingInfo.Attestation(
-                listOf(KeyIdAndAttestation("foo", keyInfo.attestation))))
+                listOf(CredentialKeyAttestation("foo", keyInfo.attestation))))
 
-            Assert.assertEquals(1, credentials.serializedCredentials.size)
+            Assert.assertEquals(1, credentials.certifications.size)
         }
     }
 
@@ -284,9 +284,9 @@ class ProvisioningClientTest {
             val keyInfo = secureArea.createKey(null, CreateKeySettings())
 
             val credentials = provisioningClient.obtainCredentials(KeyBindingInfo.Attestation(
-                    listOf(KeyIdAndAttestation("bar", keyInfo.attestation))))
+                    listOf(CredentialKeyAttestation("bar", keyInfo.attestation))))
 
-            Assert.assertEquals(1, credentials.serializedCredentials.size)
+            Assert.assertEquals(1, credentials.certifications.size)
 
             val authorizationData = provisioningClient.getAuthorizationData()!!
 
@@ -295,8 +295,8 @@ class ProvisioningClientTest {
             refreshClient.getKeyBindingChallenge()
             val refreshKeyInfo = secureArea.createKey(null, CreateKeySettings())
             val refreshed = refreshClient.obtainCredentials(KeyBindingInfo.Attestation(
-                listOf(KeyIdAndAttestation("refresh", refreshKeyInfo.attestation))))
-            Assert.assertEquals(1, refreshed.serializedCredentials.size)
+                listOf(CredentialKeyAttestation("refresh", refreshKeyInfo.attestation))))
+            Assert.assertEquals(1, refreshed.certifications.size)
 
             // Clean up authorization data
             Provisioning.cleanupAuthorizationData(
@@ -309,7 +309,7 @@ class ProvisioningClientTest {
             val exception = assertThrows<Exception>("Should not succeed, keys were deleted") {
                 refreshClient.obtainCredentials(
                     KeyBindingInfo.Attestation(
-                        listOf(KeyIdAndAttestation("fail", failingKeyInfo.attestation))
+                        listOf(CredentialKeyAttestation("fail", failingKeyInfo.attestation))
                     )
                 )
             }
@@ -376,13 +376,13 @@ class ProvisioningClientTest {
         }
 
         override suspend fun createJwtKeyAttestation(
-            keyIdAndAttestations: List<KeyIdAndAttestation>,
+            credentialKeyAttestations: List<CredentialKeyAttestation>,
             challenge: String,
             userAuthentication: List<String>?,
             keyStorage: List<String>?
         ): String {
             // Generate key attestation
-            val keyList = keyIdAndAttestations.map { it.keyAttestation.publicKey }
+            val keyList = credentialKeyAttestations.map { it.keyAttestation.publicKey }
 
             val alg = localAttestationPrivateKey.curve.defaultSigningAlgorithmFullySpecified.joseAlgorithmIdentifier
             val head = buildJsonObject {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -16,6 +16,7 @@
 
 package org.multipaz.documenttype
 
+import kotlinx.io.bytestring.ByteString
 import kotlin.time.Instant
 import org.multipaz.cbor.DataItem
 import kotlinx.serialization.json.JsonElement
@@ -432,11 +433,7 @@ class DocumentType private constructor(
         )
 
         // Now that we have issuer-provided authentication data we ccan ertify the authentication key.
-        mdocCredential.certify(
-            issuerProvidedAuthenticationData,
-            validFrom,
-            validUntil
-        )
+        mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
         return mdocCredential
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/util/MdocUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/util/MdocUtil.kt
@@ -797,7 +797,7 @@ private fun filterConsentFields(
     if (credential == null) {
         return list
     }
-    val staticAuthData = StaticAuthDataParser(credential.issuerProvidedData).parse()
+    val staticAuthData = StaticAuthDataParser(credential.issuerProvidedData.toByteArray()).parse()
     val availableDataElements = calcAvailableDataElements(staticAuthData.digestIdMapping)
     return list.filter { mdocConsentField ->
         availableDataElements[mdocConsentField.namespaceName]

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -1,5 +1,6 @@
 package org.multipaz.openid
 
+import kotlinx.io.bytestring.decodeToString
 import kotlin.time.Clock
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.JsonObject

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
@@ -1,0 +1,104 @@
+package org.multipaz.provisioning
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.credential.Credential
+import org.multipaz.credential.SecureAreaBoundCredential
+import org.multipaz.document.Document
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+
+/**
+ * Interface to manage [Document] and [Credential] instances during provisioning.
+ *
+ * [DocumentProvisioningHandler] provides default implementation for this interface.
+ */
+interface AbstractDocumentProvisioningHandler {
+
+    /**
+     * Creates a new [Document] to do initial credential provisioning.
+     *
+     * @param credentialMetadata information about the credentials that will be provisioned
+     * @param issuerMetadata information about the credential issuer
+     * @param documentAuthorizationData data that can be used to provision additional credentials
+     *  (e.g. for credential refresh)
+     * @return new [Document] to hold the provisioned credentials.
+     */
+    suspend fun createDocument(
+        credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata,
+        documentAuthorizationData: ByteString?
+    ): Document
+
+    /**
+     * Update the [Document] data.
+     *
+     * This is called after some credentials have been issued.
+     * @param document [Document] that is being updated
+     * @param display provides updated card art and credential title if provided by the issuer
+     * @param documentAuthorizationData updated data that can be used to provision additional
+     *  credentials (e.g. for credential refresh)
+     */
+    suspend fun updateDocument(
+        document: Document,
+        display: Display?,
+        documentAuthorizationData: ByteString?
+    )
+
+    /**
+     * Clean up after failed initial provisioning (e.g. by deleting the document)
+     *
+     * @param document [Document] for which the initial provisioning failed
+     * @param err provisioning error
+     */
+    suspend fun cleanupDocumentOnError(document: Document, err: Throwable)
+
+    /**
+     * Creates a set of pending key-bound credentials.
+     *
+     * Provisioning will call [Credential.certify] method on these credentials once the data
+     * comes from the issuer. When pending credentials are created, it is very important that their
+     * keys are created with appropriate settings, as this is what anchors the whole security model
+     * of Digital Credential ecosystem. Parameter [createKeySettings] should be seen as providing
+     * the minimal requirements. In particular, [CreateKeySettings.algorithm] should and
+     * [CreateKeySettings.nonce] must be honored. In some cases, implementations may want or need
+     * to use custom and/or [SecureArea]-specific [CreateKeySettings] to have better control over
+     * key properties.
+     *
+     * TODO: propagate more metadata about issuer key requirements through [CredentialMetadata].
+     *
+     * It is up to the implementation to determine the number of credentials to create, but it
+     * should generally not exceed issuer limit given in [CredentialMetadata.maxBatchSize].
+     *
+     * @param document [Document] for which credentials are being issued
+     * @param credentialMetadata information about credentials being issued
+     * @param createKeySettings suggested settings for the key to which credentials are bound
+     * @return a list of pending key-bound credentials
+     */
+    suspend fun createKeyBoundCredentials(
+        document: Document,
+        credentialMetadata: CredentialMetadata,
+        createKeySettings: CreateKeySettings
+    ): List<SecureAreaBoundCredential>
+
+    /**
+     * Creates a pending keyless credential.
+     *
+     * @param document [Document] for which the credential is being issued
+     * @param credentialMetadata information about the credential being issued
+     * @return pending keyless credential
+     */
+    suspend fun createKeylessCredential(
+        document: Document,
+        credentialMetadata: CredentialMetadata,
+    ): Credential
+
+    /**
+     * Clean up after failed not-initial (e.g. credential refresh) provisioning.
+     *
+     * The simplest way is to remove pending credentials.
+     *
+     * @param pendingCredentials list of credentials that could not be provisioned
+     * @param err provisioning error
+     */
+    suspend fun cleanupCredentialsOnError(pendingCredentials: List<Credential>, err: Throwable)
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialCertification.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialCertification.kt
@@ -1,0 +1,21 @@
+package org.multipaz.provisioning
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.credential.Credential
+
+/**
+ * Data necessary to certify a credential during provisioning.
+ *
+ * See [Credential.certify].
+ *
+ * @property credentialId identifier of the credential that will be certified
+ * @property issuerData issuer-provided data to certify the credential
+ */
+@CborSerializable
+data class CredentialCertification(
+    val credentialId: String,
+    val issuerData: ByteString
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialKeyAttestation.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialKeyAttestation.kt
@@ -1,4 +1,4 @@
-package org.multipaz.provisioning.openid4vci
+package org.multipaz.provisioning
 
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.securearea.KeyAttestation
@@ -7,8 +7,8 @@ import org.multipaz.securearea.KeyAttestation
  * Public key id and its attestation.
  */
 @CborSerializable
-class KeyIdAndAttestation(
-    val keyId: String,
+class CredentialKeyAttestation(
+    val credentialId: String,
     val keyAttestation: KeyAttestation
 ) {
     companion object

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Credentials.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Credentials.kt
@@ -1,14 +1,12 @@
 package org.multipaz.provisioning
 
-import kotlinx.io.bytestring.ByteString
-
 /**
  * Provisioned credentials and optional credential metadata.
  *
- * @property serializedCredentials serialized credential data.
+ * @property certifications credential certification data.
  * @property display updated credential name and card art if any.
  */
 data class Credentials(
-    val serializedCredentials: List<ByteString>,
+    val certifications: List<CredentialCertification>,
     val display: Display?
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
@@ -1,0 +1,177 @@
+package org.multipaz.provisioning
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.credential.Credential
+import org.multipaz.credential.SecureAreaBoundCredential
+import org.multipaz.document.AbstractDocumentMetadata
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentStore
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
+import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+import kotlin.math.min
+
+/**
+ * Implementation of [AbstractDocumentMetadataHandler] suitable for most uses.
+ *
+ * TODO: integrate with credential replacement logic
+ *
+ * @param secureArea credentials will be bound to keys from this [SecureArea]
+ * @param documentStore new [Document] will be created in this [DocumentStore]
+ * @param mdocCredentialDomain credential domain for (key-bound) ISO mdoc credentials
+ * @param sdJwtCredentialDomain credential domain for key-bound IETF SD-JWT credentials
+ * @param keylessCredentialDomain credential domain for keyless IETF SD-JWT credentials
+ * @param batchSize number of key-bound credentials to request in one batch (but not exceeding
+ *  issuer-imposed limit)
+ * @param metadataHandler interface that initializes and updates document metadata; it may be
+ *  provided if [DocumentStore] uses an [AbstractDocumentMetadata] factory (see
+ *  [DocumentStore.Builder.setDocumentMetadataFactory]).
+ */
+class DocumentProvisioningHandler(
+    val secureArea: SecureArea,
+    val documentStore: DocumentStore,
+    val mdocCredentialDomain: String = "mdoc_user_auth",
+    val sdJwtCredentialDomain: String = "sdjwt_user_auth",
+    val keylessCredentialDomain: String = "sdjwt_keyless",
+    val batchSize: Int = 3,
+    val metadataHandler: AbstractDocumentMetadataHandler? = null
+): AbstractDocumentProvisioningHandler {
+    override suspend fun createDocument(
+        credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata,
+        documentAuthorizationData: ByteString?
+    ): Document =
+        documentStore.createDocument(
+            displayName = credentialMetadata.display.text,
+            typeDisplayName = credentialMetadata.display.text,
+            cardArt = credentialMetadata.display.logo,
+            issuerLogo = issuerMetadata.display.logo,
+            authorizationData = documentAuthorizationData,
+            metadata = metadataHandler?.initializeDocumentMetadata(
+                credentialDisplay = credentialMetadata.display,
+                issuerDisplay = issuerMetadata.display,
+                authorizationData = documentAuthorizationData
+            )
+        )
+
+    override suspend fun updateDocument(
+        document: Document,
+        display: Display?,
+        documentAuthorizationData: ByteString?
+    ) {
+        document.edit {
+            if (!provisioned && document.getCertifiedCredentials().isNotEmpty()) {
+                provisioned = true
+            }
+            documentAuthorizationData?.let {
+                authorizationData = documentAuthorizationData
+            }
+            if (display != null) {
+                displayName = display.text
+                display.logo?.let { cardArt = it }
+                metadataHandler?.apply {
+                    metadata = updateDocumentMetadata(
+                        document = document,
+                        credentialDisplay = display
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun cleanupDocumentOnError(document: Document, err: Throwable) {
+        documentStore.deleteDocument(document.identifier)
+    }
+
+    override suspend fun cleanupCredentialsOnError(
+        pendingCredentials: List<Credential>,
+        err: Throwable
+    ) {
+        pendingCredentials.forEach { it.document.deleteCredential(it.identifier) }
+    }
+
+    override suspend fun createKeyBoundCredentials(
+        document: Document,
+        credentialMetadata: CredentialMetadata,
+        createKeySettings: CreateKeySettings
+    ): List<SecureAreaBoundCredential> {
+        if (document.getPendingCredentials().isNotEmpty()) {
+            // Not all credentials were certified yet, wait for them to be certified first.
+            // This should only happen for issuers that support offline certification. If you get
+            // here in other cases, you probably should have cleared up pending credentials before
+            // attempting to obtain more credentials from the issuer.
+            return listOf()
+        }
+        val credentialCount = min(credentialMetadata.maxBatchSize, batchSize)
+        return when (val format = credentialMetadata.format) {
+            is CredentialFormat.Mdoc -> {
+                (0..<credentialCount).map {
+                    MdocCredential.create(
+                        document = document,
+                        asReplacementForIdentifier = null,
+                        domain = mdocCredentialDomain,
+                        secureArea = secureArea,
+                        docType = format.docType,
+                        createKeySettings = createKeySettings
+                    )
+                }
+            }
+
+            is CredentialFormat.SdJwt -> {
+                (0..<credentialCount).map {
+                    KeyBoundSdJwtVcCredential.create(
+                        document = document,
+                        asReplacementForIdentifier = null,
+                        domain = sdJwtCredentialDomain,
+                        secureArea = secureArea,
+                        vct = format.vct,
+                        createKeySettings = createKeySettings
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun createKeylessCredential(
+        document: Document,
+        credentialMetadata: CredentialMetadata
+    ): Credential =
+        KeylessSdJwtVcCredential.create(
+            document,
+            null,
+            keylessCredentialDomain,
+            (credentialMetadata.format as CredentialFormat.SdJwt).vct
+        )
+
+    /**
+     * Manager document metadata when the document is created and when the metadata is updated
+     * from the server.
+     */
+    interface AbstractDocumentMetadataHandler {
+        /**
+         * Initializes metadata object when the document is first created.
+         *
+         * @param credentialDisplay display data from the issuer's credential configuration
+         * @param issuerDisplay display data for the issuer itself
+         * @param authorizationData data for creating a provisioning session later
+         */
+        suspend fun initializeDocumentMetadata(
+            credentialDisplay: Display,
+            issuerDisplay: Display,
+            authorizationData: ByteString?
+        ): AbstractDocumentMetadata?
+
+        /**
+         * Updates metadata for the existing document.
+         *
+         * @param document document being updated
+         * @param credentialDisplay customized display data for the provisioned credentials
+         */
+        suspend fun updateDocumentMetadata(
+            document: Document,
+            credentialDisplay: Display
+        ): AbstractDocumentMetadata?
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/KeyBindingInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/KeyBindingInfo.kt
@@ -1,6 +1,5 @@
 package org.multipaz.provisioning
 
-import org.multipaz.provisioning.openid4vci.KeyIdAndAttestation
 import org.multipaz.securearea.KeyAttestation
 
 /**
@@ -10,13 +9,17 @@ sealed class KeyBindingInfo {
     /** Credential is not bound to keys. */
     data object Keyless: KeyBindingInfo()
 
-    /** Keys are supplied using Openid4Vci-defined proof-of-possession JWT */
+    /**
+     * Keys are supplied using Openid4Vci-defined proof-of-possession JWT.
+     *
+     * `kid` header claim in JWT must correspond to the pending credential id.
+     */
     data class OpenidProofOfPossession(
         val jwtList: List<String>
     ): KeyBindingInfo()
 
     /** Keys are supplied using [KeyAttestation] objects */
     data class Attestation(
-        val attestations: List<KeyIdAndAttestation>
+        val attestations: List<CredentialKeyAttestation>
     ): KeyBindingInfo()
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackend.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackend.kt
@@ -1,5 +1,6 @@
 package org.multipaz.provisioning.openid4vci
 
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.provisioning.ProvisioningClient
 import org.multipaz.rpc.annotation.RpcInterface
 import org.multipaz.rpc.annotation.RpcMethod
@@ -46,7 +47,7 @@ interface OpenID4VCIBackend {
      */
     @RpcMethod
     suspend fun createJwtKeyAttestation(
-        keyIdAndAttestations: List<KeyIdAndAttestation>,
+        credentialKeyAttestations: List<CredentialKeyAttestation>,
         challenge: String,
         userAuthentication: List<String>? = null,
         keyStorage: List<String>? = null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIBackendUtil.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.securearea.KeyAttestation
 import org.multipaz.util.toBase64Url
@@ -104,7 +105,7 @@ object OpenID4VCIBackendUtil {
     suspend fun createJwtKeyAttestation(
         signingKey: AsymmetricKey,
         attestationIssuer: String,
-        keysToAttest: List<KeyIdAndAttestation>,
+        keysToAttest: List<CredentialKeyAttestation>,
         challenge: String,
         userAuthentication: List<String>? = null,
         keyStorage: List<String>? = null
@@ -117,7 +118,7 @@ object OpenID4VCIBackendUtil {
         put("attested_keys", JsonArray(
             keysToAttest.map {
                 it.keyAttestation.publicKey.toJwk(buildJsonObject {
-                    put("kid", it.keyId)
+                    put("kid", it.credentialId)
                 })
             }
         ))

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
@@ -4,11 +4,13 @@ import org.multipaz.cbor.CborBuilder
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.MapBuilder
 import org.multipaz.claim.JsonClaim
+import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
+import kotlin.time.Instant
 
 /**
  * A SD-JWT VC credential, according to [draft-ietf-oauth-sd-jwt-vc-03]
@@ -166,8 +168,7 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
      */
     constructor(
         document: Document
-    ) : super(document) {
-    }
+    ) : super(document)
 
     override suspend fun deserialize(dataItem: DataItem) {
         super.deserialize(dataItem)
@@ -185,4 +186,7 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
     override suspend fun getClaims(documentTypeRepository: DocumentTypeRepository?): List<JsonClaim> {
         return getClaimsImpl(documentTypeRepository)
     }
+
+    override suspend fun extractValidityFromIssuerData(): Pair<Instant, Instant> =
+        extractValidityFromIssuerDataImpl()
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
@@ -8,6 +8,7 @@ import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.securearea.SecureArea
+import kotlin.time.Instant
 
 class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
     override lateinit var vct: String
@@ -55,6 +56,13 @@ class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
         builder.put("vct", vct)
     }
 
+    override suspend fun getClaims(documentTypeRepository: DocumentTypeRepository?): List<JsonClaim> {
+        return getClaimsImpl(documentTypeRepository)
+    }
+
+    override suspend fun extractValidityFromIssuerData(): Pair<Instant, Instant> =
+        extractValidityFromIssuerDataImpl()
+
     companion object {
         const val CREDENTIAL_TYPE: String = "KeylessSdJwtVcCredential"
 
@@ -82,9 +90,5 @@ class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
                 addToDocument()
             }
         }
-    }
-
-    override suspend fun getClaims(documentTypeRepository: DocumentTypeRepository?): List<JsonClaim> {
-        return getClaimsImpl(documentTypeRepository)
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -47,6 +47,7 @@ import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.crypto.AsymmetricKey
 import kotlin.time.Clock
@@ -214,11 +215,7 @@ class DeviceResponseGeneratorTest {
             ).generate()
 
             // Now that we have issuer-provided authentication data we certify the authentication key.
-            mdocCredential.certify(
-                issuerProvidedAuthenticationData,
-                timeValidityBegin,
-                timeValidityEnd
-            )
+            mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
         }
     }
 
@@ -239,7 +236,7 @@ class DeviceResponseGeneratorTest {
         val request = DocumentRequest(dataElements)
         val encodedSessionTranscript = Cbor.encode(Tstr("Doesn't matter"))
 
-        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData)
+        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData.toByteArray())
             .parse()
         val mergedIssuerNamespaces: Map<String, List<ByteArray>> =
             MdocUtil.mergeIssuerNamesSpaces(
@@ -361,7 +358,7 @@ class DeviceResponseGeneratorTest {
         )
         val request = DocumentRequest(dataElements)
         val encodedSessionTranscript = Cbor.encode(Tstr("Doesn't matter"))
-        val staticAuthData = StaticAuthDataParser(mdocCredentialMac.issuerProvidedData)
+        val staticAuthData = StaticAuthDataParser(mdocCredentialMac.issuerProvidedData.toByteArray())
             .parse()
         val eReaderKey = AsymmetricKey.anonymous(
             privateKey = Crypto.createEcPrivateKey(EcCurve.P256),
@@ -458,7 +455,7 @@ class DeviceResponseGeneratorTest {
         )
         val request = DocumentRequest(dataElements)
         val encodedSessionTranscript = Cbor.encode(Tstr("Doesn't matter"))
-        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData)
+        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData.toByteArray())
             .parse()
         val mergedIssuerNamespaces: Map<String, List<ByteArray>> = MdocUtil.mergeIssuerNamesSpaces(
             request,
@@ -579,7 +576,7 @@ class DeviceResponseGeneratorTest {
         provisionDocument()
 
         val encodedSessionTranscript = Cbor.encode(Tstr("Doesn't matter"))
-        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData)
+        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData.toByteArray())
             .parse()
 
         // Check that DeviceSigned works.
@@ -676,7 +673,7 @@ class DeviceResponseGeneratorTest {
         val request = DocumentRequest(dataElements)
         val encodedSessionTranscript = Cbor.encode(Tstr("Doesn't matter"))
 
-        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData)
+        val staticAuthData = StaticAuthDataParser(mdocCredentialSign.issuerProvidedData.toByteArray())
             .parse()
         val mergedIssuerNamespaces: Map<String, List<ByteArray>> =
             MdocUtil.mergeIssuerNamesSpaces(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/DocumentStoreTestHarness.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/DocumentStoreTestHarness.kt
@@ -2,6 +2,8 @@ package org.multipaz.presentment.model
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -517,11 +519,7 @@ class DocumentStoreTestHarness {
         )
 
         // Now that we have issuer-provided authentication data we certify the authentication key.
-        mdocCredential.certify(
-            issuerProvidedAuthenticationData,
-            validFrom,
-            validUntil
-        )
+        mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
     }
 
     private suspend fun addSdJwtVcCredential(
@@ -598,11 +596,7 @@ class DocumentStoreTestHarness {
                 put("exp", validUntil.epochSeconds)
             },
         )
-        credential.certify(
-            sdJwt.compactSerialization.encodeToByteArray(),
-            validFrom,
-            validUntil
-        )
+        credential.certify(sdJwt.compactSerialization.encodeToByteString())
     }
 
 }

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/provisioning/openid4vci/OpenIDBackendUtilTest.kt
@@ -12,6 +12,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.webtoken.WebTokenCheck
 import org.multipaz.webtoken.validateJwt
 import org.multipaz.rpc.backend.BackendEnvironment
@@ -96,7 +97,7 @@ class OpenIDBackendUtilTest {
             val attestationJwt = OpenID4VCIBackendUtil.createJwtKeyAttestation(
                 signingKey = AsymmetricKey.NamedExplicit("my-kid", signingKey),
                 attestationIssuer = "my-iss",
-                keysToAttest = listOf(KeyIdAndAttestation("foo", attestedKeyInfo.attestation)),
+                keysToAttest = listOf(CredentialKeyAttestation("foo", attestedKeyInfo.attestation)),
                 challenge = NONCE
             )
             val body = validateJwt(

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -102,6 +102,7 @@ import org.multipaz.presentment.model.uriSchemePresentment
 import org.multipaz.prompt.PromptModel
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.promptModelSilentConsent
+import org.multipaz.provisioning.DocumentProvisioningHandler
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.request.Requester
 import org.multipaz.secure_area_test_app.ui.CloudSecureAreaScreen
@@ -383,13 +384,17 @@ class App private constructor (val promptModel: PromptModel) {
     }
 
     private suspend fun provisioningModelInit() {
+        val secureArea = Platform.getSecureArea(TestAppConfiguration.storage)
         provisioningModel = ProvisioningModel(
-            documentStore = documentStore,
-            secureArea = Platform.getSecureArea(TestAppConfiguration.storage),
+            documentProvisioningHandler = DocumentProvisioningHandler(
+                documentStore = documentStore,
+                secureArea = secureArea
+            ),
             httpClient = HttpClient(TestAppConfiguration.httpClientEngineFactory) {
                 followRedirects = false
             },
-            promptModel = promptModel
+            promptModel = promptModel,
+            authorizationSecureArea = secureArea
         )
         provisioningSupport = ProvisioningSupport(
             storage = TestAppConfiguration.storage,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -507,11 +507,7 @@ object TestAppUtils {
                     put("exp", validUntil.epochSeconds)
                 },
             )
-            credential.certify(
-                sdJwt.compactSerialization.encodeToByteArray(),
-                validFrom,
-                validUntil
-            )
+            credential.certify(sdJwt.compactSerialization.encodeToByteString())
         }
     }
 
@@ -766,11 +762,7 @@ object TestAppUtils {
                 )
 
                 // Now that we have issuer-provided authentication data we certify the authentication key.
-                mdocCredential.certify(
-                    issuerProvidedAuthenticationData,
-                    validFrom,
-                    validUntil
-                )
+                mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
             }
         }
 
@@ -906,11 +898,7 @@ object TestAppUtils {
             )
 
             // Now that we have issuer-provided authentication data we certify the authentication key.
-            mdocCredential.certify(
-                issuerProvidedAuthenticationData,
-                validFrom,
-                validUntil
-            )
+            mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
         }
         return openid4vciAttestationCompactSerialization
     }
@@ -1006,11 +994,7 @@ object TestAppUtils {
                         put("exp", validUntil.epochSeconds)
                     },
                 )
-                credential.certify(
-                    sdJwt.compactSerialization.encodeToByteArray(),
-                    validFrom,
-                    validUntil
-                )
+                credential.certify(sdJwt.compactSerialization.encodeToByteString())
             }
         }
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/OpenID4VCILocalBackend.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/OpenID4VCILocalBackend.kt
@@ -1,7 +1,7 @@
 package org.multipaz.testapp.provisioning
 
 import org.multipaz.crypto.AsymmetricKey
-import org.multipaz.provisioning.openid4vci.KeyIdAndAttestation
+import org.multipaz.provisioning.CredentialKeyAttestation
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackendUtil
 import org.multipaz.securearea.KeyAttestation
@@ -28,14 +28,14 @@ class OpenID4VCILocalBackend: OpenID4VCIBackend {
         )
 
     override suspend fun createJwtKeyAttestation(
-        keyIdAndAttestations: List<KeyIdAndAttestation>,
+        credentialKeyAttestations: List<CredentialKeyAttestation>,
         challenge: String,
         userAuthentication: List<String>?,
         keyStorage: List<String>?
     ): String = OpenID4VCIBackendUtil.createJwtKeyAttestation(
         signingKey = attestationKey,
         attestationIssuer = attestationKey.subject,
-        keysToAttest = keyIdAndAttestations,
+        keysToAttest = credentialKeyAttestations,
         challenge = challenge,
         userAuthentication = userAuthentication,
         keyStorage = keyStorage,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -1196,10 +1197,6 @@ private suspend fun DocumentStore.provisionSdJwtVc(
             put("exp", validUntil.epochSeconds)
         },
     )
-    credential.certify(
-        sdJwt.compactSerialization.encodeToByteArray(),
-        validFrom,
-        validUntil
-    )
+    credential.certify(sdJwt.compactSerialization.encodeToByteString())
     return document
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
@@ -75,7 +75,7 @@ fun CredentialViewerScreen(
                 RevocationStatusSection(credentialInfo.credential)
                 when (credentialInfo.credential) {
                     is MdocCredential -> {
-                        val issuerSigned = Cbor.decode(credentialInfo.credential.issuerProvidedData)
+                        val issuerSigned = Cbor.decode(credentialInfo.credential.issuerProvidedData.toByteArray())
                         val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
                         val msoBytes = issuerAuth.payload!!
                         KeyValuePairText("MSO size", "${msoBytes.size} bytes")


### PR DESCRIPTION
 - factored out provisioning document management into a separate interface which can handle domains, details of credential creation, domains, error clean-up, etc.
 - default implementation for this interface
 - tweaks to APIs to support delayed/off-line issuance (this is not yet available in openid4vci as it stands) + new unit test for this
 - removed validity start/end parameters from `Credential.certify`, these are now extracted from the credential itself
 - a bit of helper object/field name harmonization

Test: manual testing with testapp, new unit test

Fixes #1466
