### PR TITLE
Add support for creating SdJwt using a DisclosureMetadata.

### DIFF
--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.ksp)
     alias(libs.plugins.buildconfig)
-    alias(libs.plugins.kotlinSerialization)
     id("maven-publish")
 }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/DisclosureMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/DisclosureMetadata.kt
@@ -1,6 +1,13 @@
 package org.multipaz.sdjwt
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Used to describe which claims in a JSON Object are Selectively Disclosable.
@@ -14,7 +21,6 @@ import kotlinx.serialization.Serializable
  * @param discloseAll is a convenience to make all claimNames and all array elements individually
  * disclosable.
  */
-@Serializable
 data class DisclosureMetadata(
     val claimNames: List<String> = emptyList(),
     val arrayDisclosures: List<ArrayDisclosure> = emptyList(),
@@ -22,41 +28,115 @@ data class DisclosureMetadata(
 ) {
 
     /**
+     * Create a [JsonObject] from this [DisclosureMetadata].
+     *
+     * @return [JsonObject] representing the [DisclosureMetadata].
+     */
+    fun toJsonObject() = buildJsonObject {
+        if (claimNames.isNotEmpty()) {
+            put("claimNames", JsonArray(claimNames.map { JsonPrimitive(it) }))
+        }
+        if (arrayDisclosures.isNotEmpty()) {
+            put("arrayDisclosures", JsonArray(arrayDisclosures.map { it.toJsonObject() }))
+        }
+        if (discloseAll) {
+            put("discloseAll", JsonPrimitive(true))
+        }
+    }
+
+    /**
      * Object containing which individual elements in an array are selectively disclosable.
      *
-     * @param claimName the claim name of the
-     * @param indices the indices that are Selectively Disclosable. If null then all elements will
+     * @param claimName the claim name of the array.
+     * @param indices the indices that are Selectively Disclosable. If empty then all elements will
      * be Selectively Disclosable.
      */
-    @Serializable
     data class ArrayDisclosure(
         val claimName: String,
-        val indices: List<Int>? = null,
+        val indices: List<Int> = emptyList(),
     ) {
-        fun isIndexSelectivelyDisclosable(index: Int) = indices == null || indices.contains(index)
+
+        /**
+         * Method for determining is a particular index is selectively disclosable.
+         *
+         * @param index the of the element.
+         * @return true if the index should be selectively disclosable, otherwise false.
+         */
+        fun isIndexSelectivelyDisclosable(index: Int) = indices.isEmpty() || indices.contains(index)
+
+        /**
+         * @return a [JsonObject] representing this [ArrayDisclosure].
+         */
+        fun toJsonObject() = buildJsonObject {
+            put("claimName", JsonPrimitive(claimName))
+            put("indices", JsonArray(indices.map { JsonPrimitive(it) }))
+        }
     }
 
     companion object {
+        /**
+         *  A [DisclosureMetadata] that indicates all claims and arrays in the object should be
+         *  selectively disclosable.
+         */
         val All = DisclosureMetadata(discloseAll = true)
 
         /**
-         * Creates a list of [DisclosureMetadata.ArrayDisclosure] that allow each element in each
-         * array to be Selectively Disclosed.
+         * Creates a list of [ArrayDisclosure] that allow each element in each array to be
+         * Selectively Disclosable.
+         *
+         * @param claimName the repeated names of each array whose elements should be selectively
+         *        disclosable.
+         * @return the list of [ArrayDisclosure].
          */
-        fun listOfArrayDisclosures(vararg fieldName: String): List<ArrayDisclosure>
-            = (fieldName).map { ArrayDisclosure(it) }
+        fun listOfArrayDisclosures(vararg claimName: String): List<ArrayDisclosure>
+            = (claimName).map { ArrayDisclosure(it) }
 
-        /** Extension for determining if a Claim should be made Selectively Disclosable. */
+        /**
+         * Extension for determining if a Claim should be made Selectively Disclosable.
+         *
+         * @receiver the [DisclosureMetadata] to check.
+         * @return true if the claim should be selectively disclosable, otherwise false. Returns
+         *         false when the receiver is null.
+         */
         fun DisclosureMetadata?.isClaimSelectivelyDisclosable(claimName: String) =
             this != null && (discloseAll || claimNames.contains(claimName))
 
         /**
          * Extension for determining if an Index in an JSON Array should be made Selectively
          * Disclosable.
+         *
+         * @receiver the [DisclosureMetadata] to check.
+         * @return true if the index should be selectively disclosable, otherwise false. Returns
+         *         false when the receiver is null.
          */
         fun DisclosureMetadata?.isIndexSelectivelyDisclosable(claimName: String, index: Int) =
             this != null && (discloseAll || arrayDisclosures.find { it.claimName == claimName }
                 ?.isIndexSelectivelyDisclosable(index) == true)
+
+        /**
+         *  @receiver the [JsonObject] representing a [DisclosureMetadata].
+         *  @return a [DisclosureMetadata] from this [JsonObject].
+         */
+        fun JsonObject.toDisclosureMetadata(): DisclosureMetadata {
+            val claimNames = get("claimNames")?.jsonArray?.map { it.jsonPrimitive.content }
+            val arrayDisclosures =
+                get("arrayDisclosures")?.jsonArray?.map { it.jsonObject.toArrayDisclosure() }
+            val discloseAll = get("discloseAll")?.jsonPrimitive?.content == "true"
+            return DisclosureMetadata(
+                claimNames?.toList() ?: emptyList(),
+                arrayDisclosures ?: emptyList(),
+                discloseAll,
+            )
+        }
+
+        /**
+         * @receiver the [JsonObject] representing a [ArrayDisclosure].
+         * @return a [ArrayDisclosure] from this [JsonObject].
+         */
+        fun JsonObject.toArrayDisclosure(): ArrayDisclosure {
+            val claimName = get("claimName")?.jsonPrimitive?.content ?: ""
+            val indices = get("indices")?.jsonArray?.map { it.jsonPrimitive.int }
+            return ArrayDisclosure(claimName, indices?.toList() ?: emptyList())
+        }
     }
 }
-

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/DisclosureUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/DisclosureUtil.kt
@@ -2,6 +2,7 @@ package org.multipaz.sdjwt
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -13,7 +14,13 @@ import org.multipaz.util.toBase64Url
 /** Helper extensions related to disclosures. */
 object DisclosureUtil {
 
-    /** Creates a digest from a disclosure, using the provided digest algorithm. */
+    /**
+     * Creates a digest from a disclosure, using the provided digest algorithm.
+     *
+     * @receiver the [JsonArray] representing the disclosure.
+     * @param digestAlgorithm the digest algorithm to use.
+     * @return the [String] digest of the [JsonArray].
+     */
     suspend fun JsonArray.toDigest(digestAlgorithm: Algorithm) = Crypto.digest(
         digestAlgorithm,
         toString()
@@ -22,12 +29,24 @@ object DisclosureUtil {
             .encodeToByteArray()
     ).toBase64Url()
 
-    /** Creates the appropriate JSON Object for a Digest being inserted into a [JsonArray]. */
+    /**
+     * Creates the appropriate JSON Object for a Digest being inserted into a [JsonArray].
+     *
+     * @receiver the [JsonArray] representing the array disclosure.
+     * @param digestAlgorithm the digest algorithm to use.
+     * @return the [JsonObject] to insert into a [JsonArray] as a digest in place of the element.
+     */
     suspend fun JsonArray.toArrayDigestElement(digestAlgorithm: Algorithm) = buildJsonObject {
         put("...", JsonPrimitive(toDigest(digestAlgorithm)))
     }
 
-    /** Creates the appropriate JSON Primitive for a Digest being inserted into a JSON Object. */
+    /**
+     * Creates the appropriate JSON Primitive for a Digest being inserted into a JSON Object.
+     *
+     * @receiver the [JsonArray] representing the array disclosure.
+     * @param digestAlgorithm the digest algorithm to use.
+     * @return the [JsonPrimitive] to add as the digest for a property.
+     */
     suspend fun JsonArray.toClaimDigestElement(digestAlgorithm: Algorithm) = JsonPrimitive(
         toDigest(digestAlgorithm)
     )
@@ -35,6 +54,11 @@ object DisclosureUtil {
     /**
      * Creates and inserts the digests for selectively disclosable object properties into a
      * JSON Object as defined SD-JWT 4.2.4.1.
+     *
+     * @receiver the [JsonObjectBuilder] to insert the digest clai into.
+     * @param disclosures the list of [JsonArray]s representing the  disclosures.
+     * @param digestAlgorithm the digest algorithm to use.
+     * @return the [JsonObjectBuilder].
      */
     suspend fun JsonObjectBuilder.putClaimDisclosureDigests(
         disclosures: List<JsonArray>,
@@ -49,19 +73,32 @@ object DisclosureUtil {
         return this
     }
 
-    /** Creates a disclosure for a [JsonElement] in a [JsonArray] as defined by SD-JWT 4.2.2. */
+    /**
+     * Creates a disclosure for a [JsonElement] in a [JsonArray] as defined by SD-JWT 4.2.2.
+     *
+     * @receiver the [JsonElement] to turn into an Array Disclosures.
+     * @param salt the salt to use in the disclosure.
+     * @return the [JsonArray] representing the disclosure.
+     */
     fun JsonElement.toArrayDisclosure(salt: String) = buildJsonArray {
         add(JsonPrimitive(salt))
         add(this@toArrayDisclosure)
     }
 
-    /** Creates a disclosure for a [JsonElement] Object Property as defined by SD-JWT 4.2.1. */
+    /**
+     *  Creates a disclosure for a [JsonElement] Object Property as defined by SD-JWT 4.2.1.
+     *
+     *  @receiver the [JsonElement] to turn into a Claim Disclosure.
+     *  @param claimName the name of the claim.
+     *  @param salt the salt to use in the disclosure.
+     *  @return the [JsonArray] representing the disclosure.
+     */
     fun JsonElement.toClaimDisclosure(
-        fieldName: String,
+        claimName: String,
         salt: String
     ) = buildJsonArray {
         add(JsonPrimitive(salt))
-        add(JsonPrimitive(fieldName))
+        add(JsonPrimitive(claimName))
         add(this@toClaimDisclosure)
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentmentTest.kt
@@ -394,9 +394,6 @@ class DigitalCredentialsPresentmentTest {
             expectedSdJwtResponse =
                 """
                     {
-                      "x5c": [
-                        "${Base64.encode(documentStoreTestHarness.dsKey.certChain.certificates[0].encoded.toByteArray())}"
-                      ],
                       "iss": "https://example-issuer.com",
                       "vct": "urn:eudi:pid:1",
                       "family_name": "Mustermann",

--- a/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/DisclosureMetadataTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/DisclosureMetadataTest.kt
@@ -1,9 +1,9 @@
 package org.multipaz.sdjwt
 
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import org.multipaz.sdjwt.DisclosureMetadata.Companion.isClaimSelectivelyDisclosable
 import org.multipaz.sdjwt.DisclosureMetadata.Companion.isIndexSelectivelyDisclosable
+import org.multipaz.sdjwt.DisclosureMetadata.Companion.toDisclosureMetadata
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -21,7 +21,7 @@ class DisclosureMetadataTest {
             )
         )
 
-        val actual = Json.decodeFromString<DisclosureMetadata>(Json.encodeToString(expected))
+        val actual = expected.toJsonObject().toDisclosureMetadata()
 
         assertEquals(expected, actual)
     }
@@ -85,7 +85,7 @@ class DisclosureMetadataTest {
     }
 
     @Test
-    fun isIndexSelectivelyDisclosable_presentWithNullIndices_returnsTrue() = runTest {
+    fun isIndexSelectivelyDisclosable_presentWithEmptyIndices_returnsTrue() = runTest {
         val metadata = DisclosureMetadata(
             arrayDisclosures = listOf(
                 DisclosureMetadata.ArrayDisclosure("claim1")

--- a/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
@@ -1718,7 +1718,7 @@ class SdJwtTest {
                         "18": true,
                         "21": true,
                         "65": false,
-                        "_sd": ${Json.encodeToString(DisclosureMetadata.All)}
+                        "_sd": ${DisclosureMetadata.All.toJsonObject()}
                       },
                       "nationalities": [
                         "DE",
@@ -1728,7 +1728,6 @@ class SdJwtTest {
                      "vct": "urn:eudi:pid:de:1",
                      "iss": "https://pid-issuer.bund.de.example",
                      "_sd": ${
-                    Json.encodeToString(
                         DisclosureMetadata(
                             claimNames = listOf(
                                 "given_name",
@@ -1738,8 +1737,7 @@ class SdJwtTest {
                                 "nationalities"
                             ),
                             arrayDisclosures = listOfArrayDisclosures("nationalities")
-                        )
-                    )
+                        ).toJsonObject()
                 }
                     }                    
                 """.trimIndent().trim()
@@ -1905,7 +1903,7 @@ class SdJwtTest {
                         "18": true,
                         "21": true,
                         "65": false,
-                        "_sd": ${Json.encodeToString(DisclosureMetadata(claimNames = listOf("12", "14", "21")))}
+                        "_sd": ${DisclosureMetadata(claimNames = listOf("12", "14", "21")).toJsonObject()}
                       },
                       "nationalities": [
                         "DE",
@@ -1915,23 +1913,21 @@ class SdJwtTest {
                      "vct": "urn:eudi:pid:de:1",
                      "iss": "https://pid-issuer.bund.de.example",
                      "_sd": ${
-                    Json.encodeToString(
-                        DisclosureMetadata(
-                            claimNames = listOf(
-                                "given_name",
-                                "family_name",
-                                "age_birth_year",
-                                "age_equal_or_over",
-                            ),
-                            arrayDisclosures = listOf(
-                                DisclosureMetadata.ArrayDisclosure(
-                                    "nationalities",
-                                    listOf(0, 2)
-                                )
-                            )
-                        )
-                    )
-                }
+                         DisclosureMetadata(
+                             claimNames = listOf(
+                                 "given_name",
+                                 "family_name",
+                                 "age_birth_year",
+                                 "age_equal_or_over",
+                                 ),
+                             arrayDisclosures = listOf(
+                                 DisclosureMetadata.ArrayDisclosure(
+                                     "nationalities",
+                                     listOf(0, 2)
+                                 )
+                             )
+                         ).toJsonObject()
+                     }
                     }                    
                 """.trimIndent().trim()
             ).jsonObject


### PR DESCRIPTION
This is used to support creation of SdJwts for nested claims that are not either fully Selectively Disclosed or always visible.

This uses the "_sd" claim to place an object that will be replaced as part of the create call. It supports individually disclosing object properties by name and array elements by index. It also has shorthands for all elements of an array and all properties in an object.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR