### PR TITLE
Add legacy support for synchronous DeviceRequestParser.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Cose.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Cose.kt
@@ -1,0 +1,412 @@
+package com.android.identity.android.legacy
+
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.toDataItem
+import org.multipaz.cose.CoseLabel
+import org.multipaz.cose.CoseMac0
+import org.multipaz.cose.CoseNumberLabel
+import org.multipaz.cose.CoseSign1
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.EcSignature
+import org.multipaz.crypto.SignatureVerificationException
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.securearea.KeyUnlockData
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.SecureArea
+
+/**
+ * COSE support routines.
+ *
+ * This package includes support for COSE as specified in
+ * [RFC 9052](https://datatracker.ietf.org/doc/rfc9052/).
+ */
+object Cose {
+
+    /**
+     * The COSE Key common parameter for the key type (tstr / int).
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters
+     */
+    const val COSE_KEY_KTY: Long = 1
+
+    /**
+     * The COSE Key common parameter for the key id (bstr).
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters
+     */
+    const val COSE_KEY_KID: Long = 2
+
+    /**
+     * The COSE Key type parameter for the EC curve (int / tstr).
+     *
+     * Values are from https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters
+     */
+    const val COSE_KEY_PARAM_CRV: Long = -1
+
+    /**
+     * The COSE Key type parameter for the X coordinate (bstr).
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters
+     */
+    const val COSE_KEY_PARAM_X: Long = -2
+
+    /**
+     * The COSE Key type parameter for the Y coordinate (bstr / bool).
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters
+     */
+    const val COSE_KEY_PARAM_Y: Long = -3
+
+    /**
+     * The COSE Key type parameter for the private key (bstr).
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters
+     */
+    const val COSE_KEY_PARAM_D: Long = -4
+
+    /**
+     * The COSE Key Type for OKP.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type
+     */
+    const val COSE_KEY_TYPE_OKP: Long = 1
+
+    /**
+     * The COSE Key Type for EC2.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#key-type
+     */
+    const val COSE_KEY_TYPE_EC2: Long = 2
+
+    /**
+     * The COSE label for conveying an algorithm.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml#header-parameters
+     */
+    const val COSE_LABEL_ALG = 1L
+
+    /**
+     * The COSE label for conveying the token type (tstr or uint) similar to JWT `typ`.
+     *
+     * Note: this is not the content type of the data in COSE body, instead this this the type of
+     * the overall COSE token.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml
+     */
+    const val COSE_LABEL_TYP: Long = 16L
+
+    /**
+     * The COSE label for conveying the key id (bstr) in the COSE header.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml
+     */
+    const val COSE_LABEL_KID: Long = 4L
+
+    /**
+     * The COSE label for conveying an X.509 certificate chain.
+     *
+     * Reference: https://www.iana.org/assignments/cose/cose.xhtml
+     */
+    const val COSE_LABEL_X5CHAIN = 33L
+
+    private fun coseBuildToBeSigned(
+        encodedProtectedHeaders: ByteArray,
+        dataToBeSigned: ByteArray,
+    ): ByteArray {
+        return Cbor.encode(
+            buildCborArray {
+                add("Signature1")
+                add(encodedProtectedHeaders)
+
+                // We currently don't support Externally Supplied Data (RFC 8152 section 4.3)
+                // so external_aad is the empty bstr
+                val emptyExternalAad = ByteArray(0)
+                add(emptyExternalAad)
+
+                // Next field is the payload, independently of how it's transported (RFC
+                // 8152 section 4.4).
+                add(dataToBeSigned)
+            }
+        )
+    }
+
+    /**
+     * Checks a COSE_Sign1 signature.
+     *
+     * @param publicKey the public to check with.
+     * @param detachedData detached data, if any.
+     * @param signature the COSE_Sign1 object.
+     * @param signatureAlgorithm the signature algorithm to use.
+     * @throws IllegalArgumentException if not exactly one of `detachedData` and `signature.payload` are non-`null`.
+     * @throws SignatureVerificationException if the signature check fails.
+     */
+    fun coseSign1Check(
+        publicKey: EcPublicKey,
+        detachedData: ByteArray?,
+        signature: CoseSign1,
+        signatureAlgorithm: Algorithm
+    ) {
+        require(
+            (detachedData != null && signature.payload == null) ||
+                    (detachedData == null && signature.payload != null)
+        )
+        val encodedProtectedHeaders =
+            if (signature.protectedHeaders.isNotEmpty()) {
+                Cbor.encode(
+                    buildCborMap {
+                        signature.protectedHeaders.forEach { (label, di) -> put(label.toDataItem(), di) }
+                    }
+                )
+            } else {
+                byteArrayOf()
+            }
+        val toBeSigned = coseBuildToBeSigned(
+            encodedProtectedHeaders = encodedProtectedHeaders,
+            dataToBeSigned = detachedData ?: signature.payload!!
+        )
+        Crypto.checkSignature(
+            publicKey,
+            toBeSigned,
+            signatureAlgorithm,
+            EcSignature.fromCoseEncoded(signature.signature))
+    }
+
+    /**
+     * Creates a COSE_Sign1 signature.
+     *
+     * By default, the [Cose.COSE_LABEL_ALG] header is included in the protected header with the
+     * algorithm specified in the key. If [protectedHeaders] already contain [Cose.COSE_LABEL_ALG]
+     * it will not be replaced.
+     *
+     * The app can include additional headers, for example if certification is needed, [Cose.COSE_LABEL_X5CHAIN]
+     * can be included in either the unprotected or protected header.
+     *
+     * @param signingKey key to sign with.
+     * @param message the data to sign.
+     * @param includeMessageInPayload whether to include the message in the COSE_Sign1 payload.
+     * @param protectedHeaders the protected headers to include.
+     * @param unprotectedHeaders the unprotected headers to include.
+     */
+    suspend fun coseSign1Sign(
+        signingKey: AsymmetricKey,
+        message: ByteArray,
+        includeMessageInPayload: Boolean,
+        protectedHeaders: Map<CoseLabel, DataItem>,
+        unprotectedHeaders: Map<CoseLabel, DataItem>,
+    ): CoseSign1 {
+        val adjustedProtectedHeaders = mutableMapOf<CoseLabel, DataItem>()
+        adjustedProtectedHeaders.putAll(protectedHeaders)
+
+        // This is important - our key likely has a fully defined algorithm (e.g. ESP256) but
+        // it's likely the receiver doesn't understand this. So downgrade to a non-fully-defined
+        // algorithm via EcCurve.defaultSigningAlgorithm (e.g. ES256) unless the caller already
+        // explicitly set the algorithm.
+        //
+        if (!protectedHeaders.containsKey(CoseNumberLabel(COSE_LABEL_ALG))) {
+            val signingAlgorithmToConvey = signingKey.algorithm
+            check(signingAlgorithmToConvey.coseAlgorithmIdentifier != null) {
+                "Key algorithm doesn't have a COSE identifier"
+            }
+            adjustedProtectedHeaders[CoseNumberLabel(COSE_LABEL_ALG)] =
+                signingAlgorithmToConvey.coseAlgorithmIdentifier!!.toDataItem()
+        }
+
+        val encodedProtectedHeaders = Cbor.encode(
+            buildCborMap {
+                adjustedProtectedHeaders.forEach { (label, di) -> put(label.toDataItem(), di) }
+            }
+        )
+        val toBeSigned = coseBuildToBeSigned(encodedProtectedHeaders, message)
+        val signature = signingKey.sign(toBeSigned)
+
+        return CoseSign1(
+            protectedHeaders = adjustedProtectedHeaders.toMap(),
+            unprotectedHeaders = unprotectedHeaders,
+            signature = signature.toCoseEncoded(),
+            payload = if (includeMessageInPayload) message else null
+        )
+    }
+
+    /**
+     * Creates a COSE_Sign1 signature.
+     *
+     * By default, the [Cose.COSE_LABEL_ALG] header is included in the protected header with the non-fully-defined
+     * [Algorithm] set of the key. For example for a key with [Algorithm.ESP256], the value [Algorithm.ES256]
+     * is included. If [protectedHeaders] already contain [Cose.COSE_LABEL_ALG] it will not be replaced.
+     *
+     * The app can include additional headers, for example if certification is needed, [Cose.COSE_LABEL_X5CHAIN]
+     * can be included in either the unprotected or protected header.
+     *
+     * This function signs with a key in a Secure Area, for signing with a software-based
+     * [EcPrivateKey], see the other function with the same name but taking a [EcPrivateKey]
+     * instead.
+     *
+     * This method remains for compatibility. New code should used
+     * [AsymmetricKey]-based method instead.
+     *
+     * @param secureArea the [SecureArea] holding the private key.
+     * @param alias the alias for the private key to use to sign with.
+     * @param message the data to sign.
+     * @param includeMessageInPayload whether to include the message in the COSE_Sign1 payload.
+     * @param protectedHeaders the protected headers to include.
+     * @param unprotectedHeaders the unprotected headers to include.
+     * @param keyUnlockData a [KeyUnlockData] for unlocking the key in the [SecureArea].
+     */
+    @Deprecated(message = "Use SigningKey-based method instead")
+    suspend fun coseSign1Sign(
+        secureArea: SecureArea,
+        alias: String,
+        message: ByteArray,
+        includeMessageInPayload: Boolean,
+        protectedHeaders: Map<CoseLabel, DataItem>,
+        unprotectedHeaders: Map<CoseLabel, DataItem>,
+        unlockReason: Reason = Reason.Unspecified
+    ): CoseSign1 {
+        val adjustedProtectedHeaders = mutableMapOf<CoseLabel, DataItem>()
+        adjustedProtectedHeaders.putAll(protectedHeaders)
+
+        // This is important - our key likely has a fully defined algorithm (e.g. ESP256) but
+        // it's likely the receiver doesn't understand this. So downgrade to a non-fully-defined
+        // algorithm via EcCurve.defaultSigningAlgorithm (e.g. ES256) unless the caller already
+        // explicitly set the algorithm.
+        //
+        if (!protectedHeaders.containsKey(CoseNumberLabel(COSE_LABEL_ALG))) {
+            val keyInfo = secureArea.getKeyInfo(alias)
+            val signingAlgorithmToConvey = keyInfo.algorithm.curve!!.defaultSigningAlgorithm
+            check(signingAlgorithmToConvey.coseAlgorithmIdentifier != null) {
+                "Key algorithm doesn't have a COSE identifier"
+            }
+            adjustedProtectedHeaders[CoseNumberLabel(COSE_LABEL_ALG)] =
+                signingAlgorithmToConvey.coseAlgorithmIdentifier!!.toDataItem()
+        }
+
+        val encodedProtectedHeaders = Cbor.encode(
+            buildCborMap {
+                adjustedProtectedHeaders.forEach { (label, di) -> put(label.toDataItem(), di) }
+            }
+        )
+        val toBeSigned = coseBuildToBeSigned(encodedProtectedHeaders, message)
+        val signature = secureArea.sign(alias, toBeSigned, unlockReason)
+
+        return CoseSign1(
+            protectedHeaders = adjustedProtectedHeaders.toMap(),
+            unprotectedHeaders = unprotectedHeaders,
+            signature = signature.toCoseEncoded(),
+            payload = if (includeMessageInPayload) message else null
+        )
+    }
+
+    /**
+     * Creates a COSE_Sign1 signature.
+     *
+     * By default, no headers are added. Applications likely want to include [Cose.COSE_LABEL_ALG]
+     * in the protected header and if certification is needed, [Cose.COSE_LABEL_X5CHAIN] in
+     * either the unprotected or protected header.
+     *
+     * This function signs with a software-based [EcPrivateKey], for using a key in a
+     * Secure Area see the other function with the same name but taking a [SecureArea]
+     * and alias.
+     *
+     * This method remains for compatibility. New code should used
+     * [AsymmetricKey]-based method instead.
+     *
+     * @param key the private key to sign with.
+     * @param dataToSign the data to sign.
+     * @param includeDataInPayload whether to include the message in the COSE_Sign1 payload.
+     * @param signatureAlgorithm the signature algorithm to use.
+     * @param protectedHeaders the protected headers to include.
+     * @param unprotectedHeaders the unprotected headers to include.
+     */
+    @Deprecated(message = "Use SigningKey-based method instead")
+    fun coseSign1Sign(
+        key: EcPrivateKey,
+        dataToSign: ByteArray,
+        includeDataInPayload: Boolean,
+        signatureAlgorithm: Algorithm,
+        protectedHeaders: Map<CoseLabel, DataItem>,
+        unprotectedHeaders: Map<CoseLabel, DataItem>
+    ): CoseSign1 {
+        val encodedProtectedHeaders = if (protectedHeaders.size > 0) {
+            Cbor.encode(
+                buildCborMap {
+                    protectedHeaders.forEach { (label, di) -> put(label.toDataItem(), di) }
+                }
+            )
+        } else {
+            byteArrayOf()
+        }
+        val toBeSigned = coseBuildToBeSigned(encodedProtectedHeaders, dataToSign)
+        val signature = Crypto.sign(key, signatureAlgorithm, toBeSigned)
+
+        return CoseSign1(
+            protectedHeaders = protectedHeaders,
+            unprotectedHeaders = unprotectedHeaders,
+            signature = signature.toCoseEncoded(),
+            payload = if (includeDataInPayload) dataToSign else null
+        )
+    }
+
+    /**
+     * Creates a COSE_Mac0 message authentication code.
+     *
+     * By default, no headers are added. Applications likely want to include [Cose.COSE_LABEL_ALG]
+     * in the protected header.
+     *
+     * @param algorithm the algorithm to use, e.g. [Algorithm.HMAC_SHA256].
+     * @param key the bytes of the symmetric key to use.
+     * @param message the message.
+     * @param includeMessageInPayload whether to include the message in the payload.
+     * @param protectedHeaders the protected headers to include.
+     * @param unprotectedHeaders the unprotected headers to include.
+     */
+    fun coseMac0(
+        algorithm: Algorithm,
+        key: ByteArray,
+        message: ByteArray,
+        includeMessageInPayload: Boolean,
+        protectedHeaders: Map<CoseLabel, DataItem>,
+        unprotectedHeaders: Map<CoseLabel, DataItem>,
+    ): CoseMac0 {
+        val encodedProtectedHeaders = if (protectedHeaders.size > 0) {
+            Cbor.encode(
+                buildCborMap {
+                    protectedHeaders.forEach { (label, di) -> put(label.toDataItem(), di) }
+                }
+            )
+        } else {
+            byteArrayOf()
+        }
+        val toBeMACed = coseBuildToBeMACed(encodedProtectedHeaders, message)
+        val mac = Crypto.mac(algorithm, key, toBeMACed)
+        return CoseMac0(
+            protectedHeaders = protectedHeaders,
+            unprotectedHeaders = unprotectedHeaders,
+            tag = mac,
+            payload = if (includeMessageInPayload) message else null
+        )
+    }
+
+    private fun coseBuildToBeMACed(
+        encodedProtectedHeaders: ByteArray,
+        data: ByteArray,
+    ): ByteArray {
+        return Cbor.encode(
+            buildCborArray {
+                add("MAC0")
+                add(encodedProtectedHeaders)
+                // We currently don't support Externally Supplied Data (RFC 8152 section 4.3)
+                // so external_aad is the empty bstr
+                val emptyExternalAad = ByteArray(0)
+                add(emptyExternalAad)
+                add(data)
+            }
+        )
+    }
+}

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/DeviceRequestParser.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/DeviceRequestParser.kt
@@ -1,0 +1,383 @@
+package com.android.identity.android.legacy
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cose.CoseNumberLabel
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.mdoc.zkp.ZkSystemSpec
+import kotlin.collections.iterator
+
+/**
+ * Legacy helper class implementation for parsing the bytes of `DeviceRequest`
+ * [CBOR](http://cbor.io/)
+ * as specified in ISO/IEC 18013-5:2021 section 8.3 Device Retrieval.
+ * Used to support certain upstream implementations not using suspendable functions.
+ *
+ * @param encodedDeviceRequest the bytes of the `DeviceRequest` CBOR.
+ * @param encodedSessionTranscript the bytes of `SessionTranscript`.
+ */
+@Deprecated(message = "This class is deprecated, use DeviceRequest instead.")
+class DeviceRequestParser(
+    private val encodedDeviceRequest: ByteArray,
+    private val encodedSessionTranscript: ByteArray
+) {
+    private var skipReaderAuthParseAndCheck = false
+
+    /**
+     * Sets a flag to skip force skip parsing the reader auth structure.
+     *
+     * This flag is useful when the user knows that:
+     * - they will ignore the reader auth result (optional in 18013-5)
+     * - and explicitly don't want to parse it
+     *
+     * For example, if this code is to be used in production and there is uncertainty about which
+     * devices will have which security providers, and there is concern about running into parsing
+     * / validating issues.
+     *
+     * By default this value is set to false.
+     *
+     * @param skipReaderAuthParseAndCheck a flag to skip force skip parsing the reader auth structure.
+     * @return the `DeviceRequestParser`.
+     */
+    fun setSkipReaderAuthParseAndCheck(skipReaderAuthParseAndCheck: Boolean) = apply {
+        this.skipReaderAuthParseAndCheck = skipReaderAuthParseAndCheck
+    }
+
+    /**
+     * Parses the device request.
+     *
+     *
+     * This parser will successfully parse requests where the request is signed by the reader
+     * but the signature check fails. The method [DocRequest.readerAuthenticated]
+     * can used to get additional information whether `ItemsRequest` was authenticated.
+     *
+     * A `GeneralSecurityException` may be thrown if there issues within the default
+     * security provider. Use `setSkipReaderAuthParseAndCheck` to skip some usage of
+     * security provider in reader auth parsing.
+     *
+     * @return a [DeviceRequestParser.DeviceRequest] with the parsed data.
+     * @throws IllegalArgumentException if the given data isn't valid CBOR or not conforming
+     * to the CDDL for its type.
+     * @throws IllegalStateException    if required data hasn't been set using the setter
+     * methods on this class.
+     */
+    fun parse(): DeviceRequest = DeviceRequest().apply {
+        parse(
+            encodedDeviceRequest,
+            Cbor.decode(encodedSessionTranscript),
+            skipReaderAuthParseAndCheck
+        )
+    }
+
+    /**
+     * An object used to represent data parsed from `DeviceRequest`
+     * [CBOR](http://cbor.io/)
+     * as specified in *ISO/IEC 18013-5* section 8.3 *Device Retrieval*.
+     */
+    class DeviceRequest internal constructor() {
+        private val _docRequests = mutableListOf<DocRequest>()
+
+        /**
+         * The document requests in the `DeviceRequest` CBOR.
+         */
+        val docRequests: List<DocRequest>
+            get() = _docRequests
+
+        /**
+         * The version string set in the `DeviceRequest` CBOR.
+         */
+        lateinit var version: String
+
+        internal fun parse(
+            encodedDeviceRequest: ByteArray,
+            sessionTranscript: DataItem,
+            skipReaderAuthParseAndCheck: Boolean
+        ) {
+            val request = Cbor.decode(encodedDeviceRequest)
+            version = request["version"].asTstr
+            require(version.compareTo("1.0") >= 0) { "Given version '$version' not >= '1.0'" }
+            var readerCertChain: X509CertChain? = null
+            request.getOrNull("docRequests")?.let { docRequests ->
+                val docRequestsDataItems = docRequests.asArray
+                for (docRequestDataItem in docRequestsDataItems) {
+                    val itemsRequestBytesDataItem = docRequestDataItem["itemsRequest"]
+                    val itemsRequest = itemsRequestBytesDataItem.asTaggedEncodedCbor
+                    val readerAuth = docRequestDataItem.getOrNull("readerAuth")
+                    var encodedReaderAuth: ByteArray? = null
+                    var readerAuthenticated = false
+                    if (!skipReaderAuthParseAndCheck && readerAuth != null) {
+                        coseSign1CheckNoDuplicateHeaderParams(readerAuth);
+
+                        encodedReaderAuth = Cbor.encode(readerAuth)
+                        val readerAuthCoseSign1 = readerAuth.asCoseSign1
+                        val readerCertChainDataItem =
+                            readerAuthCoseSign1.unprotectedHeaders[CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN)]
+                        val signatureAlgorithm = Algorithm.fromCoseAlgorithmIdentifier(
+                            readerAuthCoseSign1.protectedHeaders[
+                                CoseNumberLabel(Cose.COSE_LABEL_ALG)
+                            ]!!.asNumber.toInt()
+                        )
+                        readerCertChain = readerCertChainDataItem!!.asX509CertChain
+                        readerAuthenticated = try {
+                            val readerKey = readerCertChain!!.certificates[0].ecPublicKey
+                            val encodedReaderAuthentication = Cbor.encode(
+                                buildCborArray {
+                                    add("ReaderAuthentication")
+                                    add(sessionTranscript)
+                                    add(itemsRequestBytesDataItem)
+                                }
+                            )
+                            val readerAuthenticationBytes =
+                                Cbor.encode(Tagged(24, Bstr(encodedReaderAuthentication)))
+                            Cose.coseSign1Check(
+                                readerKey,
+                                readerAuthenticationBytes,
+                                readerAuthCoseSign1,
+                                signatureAlgorithm
+                            )
+                            true
+                        } catch (_: Throwable) {
+                            false
+                        }
+                    }
+                    val zkSystemSpecs: MutableList<ZkSystemSpec> = mutableListOf()
+                    val requestInfo: MutableMap<String, ByteArray> = HashMap()
+                    itemsRequest.getOrNull("requestInfo")?.let { requestInfoDataItem ->
+                        for (keyDataItem in requestInfoDataItem.asMap.keys) {
+                            val key = keyDataItem.asTstr
+                            val encodedValue = Cbor.encode(requestInfoDataItem[keyDataItem])
+                            requestInfo[key] = encodedValue
+                        }
+
+                        val zkSpecDataItems = itemsRequest.getOrNull("requestInfo")?.getOrNull("zkRequest")?.getOrNull("systemSpecs")
+                        if (zkSpecDataItems != null) {
+                            for (zkSpecDataItem in zkSpecDataItems.asArray) {
+                                val id = zkSpecDataItem.getOrNull("id") ?: continue
+                                val system = zkSpecDataItem.getOrNull("system") ?: continue
+
+                                val spec = ZkSystemSpec(id.asTstr, system.asTstr)
+                                val paramsMap = zkSpecDataItem.getOrNull("params")?.asMap
+                                if (paramsMap != null) {
+                                    for ((k,v) in paramsMap) {
+                                        spec.addParam(k.asTstr, v)
+                                    }
+                                }
+                                zkSystemSpecs.add(spec)
+                            }
+                        }
+                    }
+                    val docType = itemsRequest["docType"].asTstr
+                    val builder = DocRequest.Builder(
+                        docType,
+                        Cbor.encode(itemsRequest),
+                        requestInfo,
+                        encodedReaderAuth,
+                        readerCertChain,
+                        readerAuthenticated,
+                        zkSystemSpecs
+                    )
+
+                    // parse nameSpaces
+                    val nameSpaces = itemsRequest["nameSpaces"]
+                    parseNamespaces(nameSpaces, builder)
+                    _docRequests.add(builder.build())
+                }
+            }
+        }
+
+        private fun cborMapExtractMapNumberKeys(map: Map<DataItem, DataItem>): Collection<Long> =
+            map.keys.map { it.asNumber }
+
+        private fun coseSign1CheckNoDuplicateHeaderParams(coseSign1: DataItem) {
+            val items = coseSign1.asArray
+            if (items.size < 4) {
+                throw IllegalArgumentException("Expected at least four items in COSE_Sign1 array")
+            }
+
+            val encodedProtectedHeaders = items.elementAt(0).asBstr
+            val protectedHeaders = Cbor.decode(encodedProtectedHeaders).asMap
+            val protectedNumberKeys = cborMapExtractMapNumberKeys(protectedHeaders)
+
+            val unprotectedHeaders = items.elementAt(1).asMap
+            val unprotectedNumberKeys = cborMapExtractMapNumberKeys(unprotectedHeaders)
+
+            if (protectedNumberKeys.intersect(unprotectedNumberKeys.toSet()).isNotEmpty()) {
+                throw IllegalArgumentException(
+                    "CoseSIGN1 contains duplicate protected and unprotected headers.")
+            }
+        }
+
+        private fun parseNamespaces(nameSpaces: DataItem, builder: DocRequest.Builder) {
+            for ((nameSpaceDataItem, itemsMap) in nameSpaces.asMap) {
+                val nameSpace = nameSpaceDataItem.asTstr
+                for ((itemKeyDataItem, itemValDataItem) in itemsMap.asMap) {
+                    val itemKey = itemKeyDataItem.asTstr
+                    val intentToRetain = itemValDataItem.asBoolean
+                    builder.addEntry(nameSpace, itemKey, intentToRetain)
+                }
+            }
+        }
+
+        companion object {
+            private const val TAG = "DeviceRequest"
+        }
+    }
+
+    /**
+     * An object used to represent data parsed from the `DocRequest`
+     * [CBOR](http://cbor.io/) (part of `DeviceRequest`)
+     * as specified in *ISO/IEC 18013-5* section 8.3 *Device Retrieval*.
+     */
+    class DocRequest internal constructor(
+        /**
+         * The document type (commonly referred to as `docType`) in the request.
+         */
+        val docType: String,
+
+        /**
+         * The bytes of the `ItemsRequest` CBOR.
+         */
+        val itemsRequest: ByteArray,
+
+        /**
+         * The requestInfo associated with the document request, if set.
+         *
+         * This is a map from strings into encoded CBOR.
+         *
+         * @return the request info map or the empty collection if not present in the request.
+         */
+        val requestInfo: Map<String, ByteArray>,
+
+        /**
+         * The bytes of the `ReaderAuth` CBOR.
+         *
+         * @return the bytes of `ReaderAuth` or `null` if the reader didn't
+         * sign the document request.
+         */
+        val readerAuth: ByteArray?,
+
+        /**
+         * The certificate chain for the reader which signed the request or null if reader
+         * authentication isn't used.
+         */
+        val readerCertificateChain: X509CertChain?,
+
+        /**
+         * Whether `ItemsRequest` was authenticated.
+         *
+         * This is `true` if and only if the `ItemsRequest` CBOR was signed by the leaf
+         * certificate in the certificate chain presented by the reader.
+         *
+         * If `true` is returned it only means that the signature was well-formed,
+         * not that the key-pair used to make the signature is trusted. Applications may
+         * examine the certificate chain presented by the reader to determine if they
+         * trust any of the public keys in there.
+         */
+        val readerAuthenticated: Boolean,
+
+        /**
+         * The Zk System Specs
+         *
+         * @return the Zk System Specs
+         */
+        val zkSystemSpecs: List<ZkSystemSpec>
+
+    ) {
+
+        internal val requestMap = mutableMapOf<String, MutableMap<String, Boolean>>()
+
+
+        /**
+         * Gets the names of namespaces that the reader requested.
+         */
+        val namespaces: List<String>
+            get() = requestMap.keys.toList()
+
+        /**
+         * Gets the names of data elements in the given namespace.
+         *
+         * @param namespaceName the name of the namespace.
+         * @return A list of data element names
+         * @throws IllegalArgumentException if the given namespace wasn't requested.
+         */
+        fun getEntryNames(namespaceName: String): List<String> {
+            val innerMap = requestMap[namespaceName]
+                ?: throw IllegalArgumentException("Namespace wasn't requested")
+            return innerMap.keys.toList()
+        }
+
+        /**
+         * Gets the intent-to-retain value set by the reader for a data element in the request.
+         *
+         * @param namespaceName the name of the namespace.
+         * @param entryName     the name of the data element
+         * @return whether the reader intents to retain the value.
+         * @throws IllegalArgumentException if the given data element or namespace wasn't
+         * requested.
+         */
+        fun getIntentToRetain(
+            namespaceName: String,
+            entryName: String
+        ): Boolean {
+            val innerMap = requestMap[namespaceName]
+                ?: throw IllegalArgumentException("Namespace wasn't requested")
+            return innerMap[entryName]
+                ?: throw IllegalArgumentException("Data element wasn't requested")
+        }
+
+        internal class Builder(
+            docType: String, encodedItemsRequest: ByteArray,
+            requestInfo: Map<String, ByteArray>,
+            encodedReaderAuth: ByteArray?,
+            readerCertChain: X509CertChain?,
+            readerAuthenticated: Boolean,
+            zkSystemSpecs: List<ZkSystemSpec> = emptyList()
+        ) {
+            private val result = DocRequest(
+                docType,
+                encodedItemsRequest,
+                requestInfo,
+                encodedReaderAuth,
+                readerCertChain,
+                readerAuthenticated,
+                zkSystemSpecs
+            )
+            fun addEntry(
+                namespaceName: String,
+                entryName: String,
+                intentToRetain: Boolean
+            ) = apply {
+                var innerMap = result.requestMap[namespaceName]
+                if (innerMap == null) {
+                    innerMap = mutableMapOf()
+                    result.requestMap[namespaceName] = innerMap
+                }
+                innerMap[entryName] = intentToRetain
+            }
+
+            fun build(): DocRequest {
+                return result
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extract and copy previous implementation of the DeviceRequestParser and Cose as needed for certain upstream implementations.

Fixes #1530 

- [x] Tests pass (bar the iOS emulator I seem to have broken)