### PR TITLE
update dokka to v2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.apache.commons.io.output.ByteArrayOutputStream
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 
 // For `versionCode` we just use the number of commits.
 val projectVersionCode: Int by extra {
@@ -66,17 +66,16 @@ plugins {
     alias(libs.plugins.parcelable) apply false
     alias(libs.plugins.buildconfig) apply false
     alias(libs.plugins.skie) apply false
-    id("org.jetbrains.dokka") version "2.0.0"
+
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
-subprojects {
-    apply(plugin = "org.jetbrains.dokka")
-}
-
-tasks.named("dokkaHtmlMultiModule") {
-    dependsOn(
-        ":samples:dokkaHtmlMultiModule",
-        ":multipaz:dokkaHtmlMultiModule",
-        ":multipaz-dcapi:dokkaHtmlMultiModule",
-    )
+dependencies {
+    dokka(project(":multipaz"))
+    dokka(project(":multipaz-compose"))
+    dokka(project(":multipaz-dcapi"))
+    dokka(project(":multipaz-doctypes"))
+    dokka(project(":multipaz-longfellow"))
+    dokka(project(":multipaz-cbor-rpc"))
+    dokka(project(":multipaz-android-legacy"))
 }

--- a/multipaz-android-legacy/build.gradle.kts
+++ b/multipaz-android-legacy/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     id("kotlin-android")
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -92,6 +93,3 @@ publishing {
     }
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-backend-server/build.gradle.kts
+++ b/multipaz-backend-server/build.gradle.kts
@@ -48,6 +48,3 @@ dependencies {
 ktor {
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-cbor-rpc/build.gradle.kts
+++ b/multipaz-cbor-rpc/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -55,6 +56,3 @@ publishing {
     }
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-compose/build.gradle.kts
+++ b/multipaz-compose/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -195,6 +196,3 @@ publishing {
 
 tasks.named("generateResourceAccessorsForAndroidMain").configure { dependsOn("sourceReleaseJar") }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-csa-server/build.gradle.kts
+++ b/multipaz-csa-server/build.gradle.kts
@@ -52,6 +52,3 @@ dependencies {
 ktor {
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-csa/build.gradle.kts
+++ b/multipaz-csa/build.gradle.kts
@@ -28,6 +28,3 @@ dependencies {
     testImplementation(libs.kotlin.test)
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-dcapi/build.gradle.kts
+++ b/multipaz-dcapi/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra

--- a/multipaz-doctypes/build.gradle.kts
+++ b/multipaz-doctypes/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -109,6 +110,3 @@ publishing {
     }
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-longfellow/build.gradle.kts
+++ b/multipaz-longfellow/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.ksp)
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -193,6 +194,3 @@ tasks.withType<Test>().configureEach {
     }
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-openid4vci-server/build.gradle.kts
+++ b/multipaz-openid4vci-server/build.gradle.kts
@@ -53,6 +53,3 @@ dependencies {
 ktor {
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-records-server/build.gradle.kts
+++ b/multipaz-records-server/build.gradle.kts
@@ -51,6 +51,3 @@ dependencies {
 
 ktor {
 }
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-server/build.gradle.kts
+++ b/multipaz-server/build.gradle.kts
@@ -39,6 +39,3 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz-verifier-server/build.gradle.kts
+++ b/multipaz-verifier-server/build.gradle.kts
@@ -52,6 +52,3 @@ dependencies {
 
 ktor {
 }
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz/SwiftBridge/build.gradle.kts
+++ b/multipaz/SwiftBridge/build.gradle.kts
@@ -33,6 +33,3 @@ tasks.create<Delete>("clean") {
     delete("$projectDir/build")
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.buildconfig)
     id("maven-publish")
+    id("org.jetbrains.dokka") version "2.1.0"
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -296,6 +297,3 @@ publishing {
     }
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/multipazctl/build.gradle.kts
+++ b/multipazctl/build.gradle.kts
@@ -39,6 +39,3 @@ tasks.register("runMultipazCtl", JavaExec::class) {
 ktor {
 }
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -230,6 +230,3 @@ tasks["compileKotlinIosArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosSimulatorArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinWasmJs"].dependsOn("kspCommonMainKotlinMetadata")
 
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}

--- a/xcframework/build.gradle.kts
+++ b/xcframework/build.gradle.kts
@@ -66,6 +66,3 @@ kotlin {
         }
     }
 }
-subprojects {
-	apply(plugin = "org.jetbrains.dokka")
-}


### PR DESCRIPTION
fixes https://github.com/openwallet-foundation/multipaz/issues/1229

This PR migrates the DOKKA plugin to v2.1.0 and also updates the docs to only list the following submodules.

* multipaz
* multipaz-compose
* multipaz-dcapi
* multipaz-doctypes
* multipaz-longfellow
* multipaz-cbor- rpc
* multipaz-android-legacy

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR