### PR TITLE
Swift consent prompt enhancements.

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="credential_presentment_verifier_icon_description">Verifier icon</string>
     <string name="credential_presentment_data_element_icon_description">Data element icon</string>
     <string name="credential_presentment_warning_icon_description">Warning icon</string>
-    <string name="credential_presentment_choose_an_option">Choose an option</string>
+    <string name="credential_presentment_select_document">Select document</string>
     <string name="credential_presentment_requester_information">Requester information</string>
 
     <!-- CertificateViewer -->

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -1,7 +1,15 @@
 package org.multipaz.compose.presentment
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -33,11 +41,13 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -56,6 +66,7 @@ import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.decodeToImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
@@ -74,6 +85,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.claim.Claim
@@ -90,7 +102,7 @@ import org.multipaz.multipaz_compose.generated.resources.Res
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_cancel
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_more
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_share
-import org.multipaz.multipaz_compose.generated.resources.credential_presentment_choose_an_option
+import org.multipaz.multipaz_compose.generated.resources.credential_presentment_select_document
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_data_element_icon_description
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_headline_share_with_unknown_requester
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_info_verifier_in_trust_list
@@ -215,11 +227,11 @@ private fun setMatch(
  * @param trustMetadata [TrustMetadata] conveying the level of trust in the requester, if any.
  * @param credentialPresentmentData the combinations of credentials and claims that the user can select.
  * @param preselectedDocuments the list of documents the user may have preselected earlier (for
- *   example an OS-provided credential picker like Android's Credential Manager) or the empty list
- *   if the user didn't preselect.
+ * example an OS-provided credential picker like Android's Credential Manager) or the empty list
+ * if the user didn't preselect.
  * @param imageLoader a [ImageLoader].
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
- *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
+ * first shown. If the user selects a different set of documents in the prompt, this will be called again.
  * @param onConfirm called when the user presses the "Share" button, returns the user's selection.
  * @param onCancel called when the sheet is dismissed.
  */
@@ -249,7 +261,6 @@ fun Consent(
         }
     }
     val combinations = remember { credentialPresentmentData.generateCombinations(preselectedDocuments) }
-    val selectMatchCombinationAndElement = remember { mutableStateOf<Pair<Int, Int>?>(null) }
     val matchSelectionLists = remember {
         val initialSelections = combinations.map { List(it.elements.size) { 0 } }
         mutableStateOf(initialSelections)
@@ -310,10 +321,6 @@ fun Consent(
                     imageLoader = imageLoader,
                     combinations = combinations,
                     matchSelectionLists = matchSelectionLists,
-                    onChooseMatch = { combinationNum, elementNum ->
-                        selectMatchCombinationAndElement.value = Pair(combinationNum, elementNum)
-                        navController.navigate("selectMatch")
-                    },
                     onShowRequesterInfo = {
                         navController.navigate("showRequesterInfo")
                     },
@@ -330,26 +337,6 @@ fun Consent(
                     onBackClicked = {
                         navController.navigateUp()
                     },
-                )
-            }
-            composable("selectMatch") {
-                val (combinationNum, elementNum) = selectMatchCombinationAndElement.value!!
-                ChooseMatchPage(
-                    combinations = combinations,
-                    combinationNum = combinationNum,
-                    elementNum = elementNum,
-                    onBackClicked = {
-                        navController.navigateUp()
-                    },
-                    onMatchClicked = { matchNumber ->
-                        matchSelectionLists.value = setMatch(
-                            oldValue = matchSelectionLists.value,
-                            combinationNum = combinationNum,
-                            elementNum = elementNum,
-                            newMatchNum = matchNumber
-                        )
-                        navController.navigateUp()
-                    }
                 )
             }
         }
@@ -448,64 +435,6 @@ private fun ShowRequesterInfoPage(
     }
 }
 
-@Composable
-private fun ChooseMatchPage(
-    combinations: List<Combination>,
-    combinationNum: Int,
-    elementNum: Int,
-    onBackClicked: () -> Unit,
-    onMatchClicked: (matchNumber: Int) -> Unit
-) {
-    Column(
-        modifier = Modifier.padding(8.dp),
-        verticalArrangement = Arrangement.Bottom
-    ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(
-                8.dp,
-            ),
-            verticalAlignment = Alignment.Companion.CenterVertically
-        ) {
-            IconButton(onClick = onBackClicked) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = null
-                )
-            }
-
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.Start
-            ) {
-                Text(
-                    text = stringResource(Res.string.credential_presentment_choose_an_option),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleLarge,
-                )
-            }
-        }
-
-        val entries = mutableListOf<@Composable () -> Unit>()
-
-        combinations[combinationNum].elements[elementNum].matches.forEachIndexed { matchNum, match ->
-            entries.add {
-                CredentialViewer(
-                    modifier = Modifier.clickable { onMatchClicked(matchNum) },
-                    credential = match.credential,
-                    showOptionsButton = false,
-                    onOptionsButtonClicked = {}
-                )
-            }
-        }
-
-        EntryList(
-            title = null,
-            entries = entries
-        )
-
-    }
-}
-
 private data class RequesterDisplayData(
     val name: String? = null,
     val icon: ImageBitmap? = null,
@@ -522,13 +451,14 @@ private fun ConsentPage(
     imageLoader: ImageLoader?,
     combinations: List<Combination>,
     matchSelectionLists: MutableState<List<List<Int>>>,
-    onChooseMatch: (combinationNum: Int, elementNum: Int) -> Unit,
     onShowRequesterInfo: () -> Unit,
     onConfirm: (selection: CredentialPresentmentSelection) -> Unit,
     onCancel: () -> Unit,
     pagerState: PagerState
 ) {
     val scrollState = rememberScrollState()
+    var isFlipped by remember { mutableStateOf(false) }
+    var activeElementIndex by remember { mutableStateOf(0) }
 
     val requesterDisplayData = if (trustMetadata != null) {
         RequesterDisplayData(
@@ -560,86 +490,251 @@ private fun ConsentPage(
         )
 
         Column(
-            modifier = Modifier.padding(top = 12.dp)
+            modifier = Modifier.padding(top = 12.dp).weight(1f, fill = false)
         ) {
             Column(
                 modifier = Modifier
                     .focusGroup()
                     .verticalScroll(scrollState)
-                    .weight(0.9f, false)
             ) {
                 HorizontalPager(
                     state = pagerState,
+                    userScrollEnabled = !isFlipped
                 ) { page ->
                     // Add a very slight drop shadow to make the main box stand out.
-                    Column(
-                        modifier = Modifier
-                            .padding(10.dp)
-                            .dropShadow(
-                                shape = RoundedCornerShape(10.dp),
-                                shadow = Shadow(
-                                    radius = 10.dp,
-                                    spread = 5.dp,
-                                    color = Color.Black.copy(alpha = 0.035f),
-                                    offset = DpOffset(x = 0.dp, 2.dp)
-                                )
-                            ),
-                    ) {
-                        CredentialSetViewer(
-                            combinations = combinations,
-                            combinationNum = page,
-                            matchSelectionLists = matchSelectionLists,
-                            requester = requester,
-                            requesterDisplayData = requesterDisplayData,
-                            trustMetadata = trustMetadata,
-                            appInfo = appInfo,
-                            onChooseMatch = onChooseMatch
-                        )
-                    }
-                }
-            }
-
-            if (combinations.size > 1) {
-                Row(
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier
-                        .align(Alignment.Companion.End)
-                        .wrapContentHeight()
-                        .fillMaxWidth()
-                        .height(PAGER_INDICATOR_HEIGHT)
-                        .padding(PAGER_INDICATOR_PADDING),
-                ) {
-                    repeat(pagerState.pageCount) { iteration ->
-                        val color =
-                            if (pagerState.currentPage == iteration) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .2f)
+                    Box(modifier = Modifier.padding(10.dp)) {
+                        FlipCard(
+                            isFlipped = isFlipped,
+                            front = {
+                                Column(
+                                    modifier = Modifier
+                                        .dropShadow(
+                                            shape = RoundedCornerShape(10.dp),
+                                            shadow = Shadow(
+                                                radius = 10.dp,
+                                                spread = 5.dp,
+                                                color = Color.Black.copy(alpha = 0.035f),
+                                                offset = DpOffset(x = 0.dp, 2.dp)
+                                            )
+                                        ),
+                                ) {
+                                    CredentialSetViewer(
+                                        combinations = combinations,
+                                        combinationNum = page,
+                                        matchSelectionLists = matchSelectionLists,
+                                        requester = requester,
+                                        requesterDisplayData = requesterDisplayData,
+                                        trustMetadata = trustMetadata,
+                                        appInfo = appInfo,
+                                        onChooseMatch = { _, elementNum ->
+                                            activeElementIndex = elementNum
+                                            isFlipped = true
+                                        }
+                                    )
+                                }
+                            },
+                            back = {
+                                Column(
+                                    modifier = Modifier
+                                        .dropShadow(
+                                            shape = RoundedCornerShape(10.dp),
+                                            shadow = Shadow(
+                                                radius = 10.dp,
+                                                spread = 5.dp,
+                                                color = Color.Black.copy(alpha = 0.035f),
+                                                offset = DpOffset(x = 0.dp, 2.dp)
+                                            )
+                                        )
+                                ) {
+                                    DocumentSelectionView(
+                                        combinations = combinations,
+                                        combinationNum = page,
+                                        elementNum = activeElementIndex,
+                                        initialSelection = matchSelectionLists.value[page][activeElementIndex],
+                                        onBack = { isFlipped = false },
+                                        onMatchSelected = { matchIndex ->
+                                            matchSelectionLists.value = setMatch(
+                                                oldValue = matchSelectionLists.value,
+                                                combinationNum = page,
+                                                elementNum = activeElementIndex,
+                                                newMatchNum = matchIndex
+                                            )
+                                            isFlipped = false
+                                        }
+                                    )
+                                }
                             }
-                        Box(
-                            modifier = Modifier
-                                .padding(2.dp)
-                                .clip(CircleShape)
-                                .background(color)
-                                .size(8.dp)
                         )
                     }
                 }
             }
+        }
 
-            ButtonSection(
-                onConfirm = {
-                    onConfirm(CredentialPresentmentSelection(
-                        matches = matchSelectionLists.value[pagerState.currentPage].mapIndexed { n, selectedMatch ->
-                            combinations[pagerState.currentPage].elements[n].matches[selectedMatch]
-                        },
-                    ))
-                },
-                onCancel = onCancel,
-                scrollState = scrollState
-            )
+        AnimatedVisibility(
+            visible = !isFlipped,
+            enter = slideInVertically { it } + fadeIn(),
+            exit = slideOutVertically { it } + fadeOut()
+        ) {
+            Column {
+                if (combinations.size > 1) {
+                    Row(
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier
+                            .wrapContentHeight()
+                            .fillMaxWidth()
+                            .height(PAGER_INDICATOR_HEIGHT)
+                            .padding(PAGER_INDICATOR_PADDING),
+                    ) {
+                        repeat(pagerState.pageCount) { iteration ->
+                            val color =
+                                if (pagerState.currentPage == iteration) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .2f)
+                                }
+                            Box(
+                                modifier = Modifier
+                                    .padding(2.dp)
+                                    .clip(CircleShape)
+                                    .background(color)
+                                    .size(8.dp)
+                            )
+                        }
+                    }
+                }
+
+                ButtonSection(
+                    onConfirm = {
+                        onConfirm(
+                            CredentialPresentmentSelection(
+                                matches = matchSelectionLists.value[pagerState.currentPage].mapIndexed { n, selectedMatch ->
+                                    combinations[pagerState.currentPage].elements[n].matches[selectedMatch]
+                                },
+                            )
+                        )
+                    },
+                    onCancel = onCancel,
+                    scrollState = scrollState
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun FlipCard(
+    isFlipped: Boolean,
+    modifier: Modifier = Modifier,
+    front: @Composable () -> Unit,
+    back: @Composable () -> Unit,
+) {
+    val rotation by animateFloatAsState(
+        targetValue = if (isFlipped) 180f else 0f,
+        animationSpec = tween(
+            durationMillis = 400,
+            easing = FastOutSlowInEasing
+        ),
+        label = "cardFlip"
+    )
+
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                rotationY = rotation
+                cameraDistance = 12f * density
+            }
+    ) {
+        if (rotation <= 90f) {
+            Box(Modifier.fillMaxWidth()) {
+                front()
+            }
+        } else {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer {
+                        rotationY = 180f
+                    }
+            ) {
+                back()
+            }
+        }
+    }
+}
+
+@Composable
+private fun DocumentSelectionView(
+    combinations: List<Combination>,
+    combinationNum: Int,
+    elementNum: Int,
+    initialSelection: Int,
+    onBack: () -> Unit,
+    onMatchSelected: (Int) -> Unit
+) {
+    val entries = mutableListOf<@Composable () -> Unit>()
+    var selectedMatchIndex by remember { mutableStateOf(initialSelection) }
+    val coroutineScope = rememberCoroutineScope()
+
+    // Back Face Header
+    entries.add {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = null
+                )
+            }
+            Text(
+                text = stringResource(Res.string.credential_presentment_select_document),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center
+            )
+            Spacer(Modifier.size(48.dp)) // Balance the icon
+        }
+    }
+
+    // List of matches
+    val element = combinations[combinationNum].elements[elementNum]
+    element.matches.forEachIndexed { matchIndex, match ->
+        entries.add {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        if (selectedMatchIndex != matchIndex) {
+                            selectedMatchIndex = matchIndex
+                            coroutineScope.launch {
+                                delay(200)
+                                onMatchSelected(matchIndex)
+                            }
+                        }
+                    },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                CredentialViewer(
+                    credential = match.credential,
+                    showOptionsButton = false,
+                    modifier = Modifier.weight(1.0f),
+                    onOptionsButtonClicked = {}
+                )
+                RadioButton(
+                    selected = (selectedMatchIndex == matchIndex),
+                    onClick = null // Handled by row click
+                )
+            }
+        }
+    }
+
+    EntryList(
+        modifier = Modifier,
+        title = null,
+        entries = entries
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -808,17 +903,18 @@ private fun CredentialViewer(
                 }
                 cardArtBitmap?.let {
                     Box(
-                        modifier = modifier.size(40.dp),
+                        modifier = Modifier.size(60.dp),
                         contentAlignment = Alignment.Center
                     ) {
                         Image(
                             bitmap = it,
                             contentDescription = null,
+                            contentScale = ContentScale.Fit
                         )
                     }
                 }
                 Column(
-                    modifier = Modifier.padding(start = 16.dp).weight(1.0f)
+                    modifier = Modifier.padding(start = 5.dp).weight(1.0f)
                 ) {
                     Text(
                         text = credential.document.displayName

--- a/multipaz-swift/Sources/MultipazSwift/Consent.swift
+++ b/multipaz-swift/Sources/MultipazSwift/Consent.swift
@@ -66,6 +66,7 @@ struct RequestedDocumentSection : View {
     let retainedClaims: [Claim]
     let notRetainedClaims: [Claim]
     let showOptionsButton: Bool
+    let onOptionsTapped: () -> Void
 
     var body: some View {
         HStack(alignment: .center) {
@@ -89,8 +90,7 @@ struct RequestedDocumentSection : View {
             if showOptionsButton {
                 Spacer()
                 Button(action: {
-                    // TODO: go to screen to allow user to select document
-                    print("Chevron tapped")
+                    onOptionsTapped()
                 }) {
                     Image(systemName: "chevron.down.circle")
                         .imageScale(.large)
@@ -206,25 +206,43 @@ struct CombinationSection: View {
     let requester: Requester
     let trustMetadata: TrustMetadata?
     fileprivate let combination: Combination
+    let matchSelections: [Int]
+    let onShowOptions: (Int) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             
             ForEach(0..<combination.elements.count, id: \.self) { idx in
                 let element = combination.elements[idx]
-                // TODO: add ability to select match if more than one...
-                let match = element.matches.first!
-
+                let matchIndex = idx < matchSelections.count ? matchSelections[idx] : 0
+                let match = element.matches[matchIndex]
+                
                 let retainedClaims = Array(match.claims.filter( {
-                    ($0.key as! MdocRequestedClaim).intentToRetain == true
+                    if $0 is MdocClaim {
+                        ($0.key as! MdocRequestedClaim).intentToRetain == true
+                    } else {
+                        false
+                    }
                 }).values).sorted(by: { a, b in
-                    (a as! MdocClaim).dataElementName < (b as! MdocClaim).dataElementName
+                    if a is MdocClaim {
+                        (a as! MdocClaim).dataElementName < (b as! MdocClaim).dataElementName
+                    } else {
+                        (a as! JsonClaim).displayName < (b as! JsonClaim).displayName
+                    }
                 })
 
                 let notRetainedClaims = Array(match.claims.filter( {
-                    ($0.key as! MdocRequestedClaim).intentToRetain == false
+                    if $0 is MdocClaim {
+                        ($0.key as! MdocRequestedClaim).intentToRetain == false
+                    } else {
+                        true
+                    }
                 }).values).sorted(by: { a, b in
-                    (a as! MdocClaim).dataElementName < (b as! MdocClaim).dataElementName
+                    if a is MdocClaim {
+                        (a as! MdocClaim).dataElementName < (b as! MdocClaim).dataElementName
+                    } else {
+                        (a as! JsonClaim).displayName < (b as! JsonClaim).displayName
+                    }
                 })
 
                 RequestedDocumentSection(
@@ -232,7 +250,8 @@ struct CombinationSection: View {
                     document: match.credential.document,
                     retainedClaims: retainedClaims,
                     notRetainedClaims: notRetainedClaims,
-                    showOptionsButton: element.matches.count > 1
+                    showOptionsButton: element.matches.count > 1,
+                    onOptionsTapped: { onShowOptions(idx) }
                 )
             }
 
@@ -361,7 +380,8 @@ private struct ShowRequesterInfo: View {
     let maxHeight: CGFloat
     let requester: Requester
     @State private var currentPage: Int = 0
-    @State private var tabHeight: CGFloat = 300
+    // Store heights for each page index
+    @State private var pageHeights: [Int: CGFloat] = [:]
 
     var body: some View {
         VStack {
@@ -373,11 +393,15 @@ private struct ShowRequesterInfo: View {
                         ForEach(0..<certificates.count, id: \.self) { index in
                             X509CertViewer(certificate: certificates[index])
                                 .tag(index)
-                                .readHeight(to: $tabHeight)
+                                .measurePageHeight(index)
                         }
                     }
                     .tabViewStyle(.page(indexDisplayMode: .never))
-                    .frame(height: tabHeight)
+                    // Dynamically size based on the current page's measured height
+                    .frame(height: pageHeights[currentPage] ?? 300)
+                    .onPreferenceChange(PageHeightsKey.self) { heights in
+                        self.pageHeights = heights
+                    }
                 }
             } footer: { isAtBottom, scrollDown in
                 let certificates = requester.certChain!.certificates
@@ -404,27 +428,36 @@ private struct ShowRequesterInfo: View {
 }
 
 extension View {
-    /// Reads the height of a view and pushes it to a Binding.
-    fileprivate func readHeight(to binding: Binding<CGFloat>) -> some View {
+    /// Applies the standard card styling used in the consent flow
+    fileprivate func cardStyle() -> some View {
+        self
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(uiColor: .secondarySystemGroupedBackground))
+                    .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
+            )
+    }
+    
+    /// Measures the height of a page and tags it with the index using PreferenceKey
+    fileprivate func measurePageHeight(_ index: Int) -> some View {
         background(
             GeometryReader { proxy in
                 Color.clear
-                    .preference(key: TabLayerHeightKey.self, value: proxy.size.height)
+                    .preference(
+                        key: PageHeightsKey.self,
+                        value: [index: proxy.size.height]
+                    )
             }
         )
-        .onPreferenceChange(TabLayerHeightKey.self) { height in
-            // Only update if the change is significant to avoid layout loops
-            if abs(binding.wrappedValue - height) > 1 {
-                binding.wrappedValue = height
-            }
-        }
     }
 }
 
-private struct TabLayerHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
+/// A PreferenceKey that aggregates heights for multiple pages in a dictionary.
+private struct PageHeightsKey: PreferenceKey {
+    static let defaultValue: [Int: CGFloat] = [:]
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue()) { (_, new) in new }
     }
 }
 
@@ -439,6 +472,24 @@ private struct ConsentMain: View {
     let onConfirm: (_: CredentialPresentmentSelection) -> Void
     let onCancel: () -> Void
 
+    @State private var isFlipped = false
+    @State private var activeElementIndex = 0
+    @State private var currentPage: Int = 0
+    
+    // Tracks selections: [CombinationIndex][ElementIndex] -> MatchIndex
+    @State private var allMatchSelections: [[Int]] = []
+    
+    // Store heights for each page index
+    @State private var pageHeights: [Int: CGFloat] = [:]
+
+    private func ensureSelectionsInitialized() {
+        if allMatchSelections.isEmpty {
+            allMatchSelections = combinations.map { combination in
+                Array(repeating: 0, count: combination.elements.count)
+            }
+        }
+    }
+
     var body: some View {
         SmartSheet(maxHeight: maxHeight) {
             RelyingPartySection(
@@ -447,56 +498,235 @@ private struct ConsentMain: View {
                 onRequesterClicked: onRequesterClicked
             )
             .padding()
+            .onAppear { ensureSelectionsInitialized() }
         } content: {
             VStack(spacing: 10) {
-                VStack {
-                    let combination = combinations.first!
-                    CombinationSection(
-                        rpName: rpName,
-                        requester: requester,
-                        trustMetadata: trustMetadata,
-                        combination: combination
-                    )
-                }
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(Color(uiColor: .secondarySystemGroupedBackground))
-                        .shadow(color: Color.black.opacity(0.1), radius: 8, x: 0, y: 4)
-                )
-                .padding(.vertical, 20)
-            }
-            .padding(.horizontal)
-        } footer: { isAtBottom, scrollDown in
-            HStack(spacing: 10) {
-                Button(action : { onCancel() }) {
-                    Text("Cancel")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .buttonBorderShape(.capsule)
-                .controlSize(.large)
-                
-                let buttonText = if (isAtBottom) {
-                    "Share"
-                } else {
-                    "More"
-                }
-                Button(action : {
-                    if (!isAtBottom) {
-                        scrollDown()
-                    } else {
-                        onConfirm(credentialPresentmentData.select(preselectedDocuments: []))
+                if !allMatchSelections.isEmpty {
+                    TabView(selection: $currentPage) {
+                        ForEach(0..<combinations.count, id: \.self) { index in
+                            let combination = combinations[index]
+                            let currentSelections = allMatchSelections[index]
+                            
+                            FlipView(
+                                isFlipped: isFlipped,
+                                front: {
+                                    CombinationSection(
+                                        rpName: rpName,
+                                        requester: requester,
+                                        trustMetadata: trustMetadata,
+                                        combination: combination,
+                                        matchSelections: currentSelections,
+                                        onShowOptions: { elementIdx in
+                                            activeElementIndex = elementIdx
+                                            withAnimation {
+                                                isFlipped = true
+                                            }
+                                        }
+                                    )
+                                    .cardStyle()
+                                },
+                                back: {
+                                    DocumentSelectionView(
+                                        combination: combination,
+                                        elementIndex: activeElementIndex,
+                                        initialSelection: currentSelections.indices.contains(activeElementIndex) ? currentSelections[activeElementIndex] : 0,
+                                        onBack: {
+                                            withAnimation {
+                                                isFlipped = false
+                                            }
+                                        },
+                                        onSelect: { newIndex in
+                                            allMatchSelections[index][activeElementIndex] = newIndex
+                                            withAnimation {
+                                                isFlipped = false
+                                            }
+                                        }
+                                    )
+                                    .cardStyle()
+                                }
+                            )
+                            .padding(.vertical, 20)
+                            .padding(.horizontal)
+                            .tag(index)
+                            .measurePageHeight(index)
+                        }
                     }
-                }) {
-                    Text(buttonText)
-                        .frame(maxWidth: .infinity)
+                    .tabViewStyle(.page(indexDisplayMode: .never))
+                    // Dynamically size the TabView to the height of the CURRENT page.
+                    .frame(height: pageHeights[currentPage] ?? 300)
+                    .onPreferenceChange(PageHeightsKey.self) { heights in
+                        self.pageHeights = heights
+                    }
+                } else {
+                     // Loading state or empty
+                     ProgressView()
+                        .frame(height: 200)
                 }
-                .buttonStyle(.borderedProminent)
-                .buttonBorderShape(.capsule)
-                .controlSize(.large)
             }
-            .padding()
+        } footer: { isAtBottom, scrollDown in
+            VStack(spacing: 0) {
+                // Pager Indicators
+                if !isFlipped && combinations.count > 1 {
+                    HStack(spacing: 4) {
+                        ForEach(0..<combinations.count, id: \.self) { index in
+                            Circle()
+                                .fill(
+                                    index == currentPage
+                                    ? Color.blue
+                                    : Color.primary.opacity(0.2)
+                                )
+                                .frame(width: 8, height: 8)
+                        }
+                    }
+                    .padding(.bottom, 12)
+                }
+                
+                if !isFlipped {
+                    HStack(spacing: 10) {
+                        Button(action : { onCancel() }) {
+                            Text("Cancel")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .buttonBorderShape(.capsule)
+                        .controlSize(.large)
+                        
+                        let buttonText = if (isAtBottom) {
+                            "Share"
+                        } else {
+                            "More"
+                        }
+                        Button(action : {
+                            if (!isAtBottom) {
+                                scrollDown()
+                            } else {
+                                if combinations.indices.contains(currentPage), allMatchSelections.indices.contains(currentPage) {
+                                    let combination = combinations[currentPage]
+                                    let selections = allMatchSelections[currentPage]
+                                    
+                                    var selectedMatches: [CredentialPresentmentSetOptionMemberMatch] = []
+                                    for (idx, element) in combination.elements.enumerated() {
+                                        let matchIdx = idx < selections.count ? selections[idx] : 0
+                                        selectedMatches.append(element.matches[matchIdx])
+                                    }
+                                    onConfirm(CredentialPresentmentSelection(matches: selectedMatches))
+                                }
+                            }
+                        }) {
+                            Text(buttonText)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .buttonBorderShape(.capsule)
+                        .controlSize(.large)
+                    }
+                    .padding()
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+        }
+    }
+}
+
+private struct FlipView<Front: View, Back: View>: View {
+    var isFlipped: Bool
+    var front: () -> Front
+    var back: () -> Back
+    
+    init(isFlipped: Bool, @ViewBuilder front: @escaping () -> Front, @ViewBuilder back: @escaping () -> Back) {
+        self.isFlipped = isFlipped
+        self.front = front
+        self.back = back
+    }
+    
+    var body: some View {
+        ZStack {
+            front()
+                .opacity(isFlipped ? 0 : 1)
+            back()
+                .opacity(isFlipped ? 1 : 0)
+                .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+        }
+        .rotation3DEffect(.degrees(isFlipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+    }
+}
+
+private struct DocumentSelectionView: View {
+    let combination: Combination
+    let elementIndex: Int
+    let initialSelection: Int
+    let onBack: () -> Void
+    let onSelect: (Int) -> Void
+
+    @State private var selectedIndex: Int
+    
+    init(combination: Combination, elementIndex: Int, initialSelection: Int, onBack: @escaping () -> Void, onSelect: @escaping (Int) -> Void) {
+        self.combination = combination
+        self.elementIndex = elementIndex
+        self.initialSelection = initialSelection
+        self.onBack = onBack
+        self.onSelect = onSelect
+        _selectedIndex = State(initialValue: initialSelection)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            ZStack {
+                HStack {
+                    Button(action: onBack) {
+                        Image(systemName: "arrow.backward")
+                            .imageScale(.large)
+                    }
+                    Spacer()
+                }
+                Text("Select document")
+                    .font(.headline)
+            }
+            .padding(.bottom, 10)
+
+            Divider()
+
+            // List of matches
+            if elementIndex < combination.elements.count {
+                let element = combination.elements[elementIndex]
+                ForEach(0..<element.matches.count, id: \.self) { idx in
+                    let match = element.matches[idx]
+                    VStack {
+                        HStack {
+                            Image(uiImage: match.credential.document.renderCardArt())
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 40)
+                            
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(match.credential.document.displayName ?? "Unknown Document")
+                                    .font(.body)
+                                    .fontWeight(.medium)
+                                if let type = match.credential.document.typeDisplayName {
+                                    Text(type)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            
+                            Image(systemName: selectedIndex == idx ? "circle.inset.filled" : "circle")
+                                .imageScale(.large)
+                                .foregroundStyle(selectedIndex == idx ? .blue : .gray)
+                        }
+                        .padding(.vertical, 8)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            selectedIndex = idx
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                onSelect(idx)
+                            }
+                        }
+                        Divider()
+                    }
+                }
+            }
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
@@ -17,6 +17,7 @@ import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
 import org.multipaz.sdjwt.credential.SdJwtVcCredential
 import org.multipaz.util.Logger
+import kotlin.coroutines.cancellation.CancellationException
 
 private data class QueryResponse(
     val credentialQuery: DcqlCredentialQuery,
@@ -64,7 +65,8 @@ data class DcqlQuery(
      * If successful, this returns a [DcqlResponse] object which contains a [DcqlResponse] which is also
      * a [org.multipaz.presentment.CredentialPresentmentData]. The intent is that the application can show
      * an user interface for the user to select which combination of credentials to return, see
-     * [CredentialPresentmentModalBottomSheet] in the `multipaz-compose` library for an example.
+     * [Consent] composable in `multipaz-compose` and [Consent] view in `multipaz-swift` for examples
+     * of how to do this.
      *
      * If the query cannot be satisfied, [DcqlCredentialQueryException] is thrown.
      *
@@ -74,6 +76,7 @@ data class DcqlQuery(
      * @return the resulting [DcqlResponse] if the query was successful.
      * @throws [DcqlCredentialQueryException] if it's not possible satisfy the query.
      */
+    @Throws(DcqlCredentialQueryException::class, CancellationException::class)
     suspend fun execute(
         presentmentSource: PresentmentSource,
         keyAgreementPossible: List<EcCurve> = emptyList()
@@ -294,6 +297,16 @@ data class DcqlQuery(
     companion object {
         private const val TAG = "DcqlQuery"
 
+        /**
+         * Parses a DCQL according to OpenID4VP.
+         *
+         * Reference: OpenID4VP 1.0 Section 6
+         *
+         * @param dcql a [JsonObject] with the DCQL.
+         * @return a [DcqlQuery] object
+         * @throws IllegalArgumentException if the given DCQL isn't well-formed.
+         */
+        @Throws(IllegalArgumentException::class)
         fun fromJsonString(dcql: String): DcqlQuery = fromJson(Json.decodeFromString<JsonObject>(dcql))
 
         /**
@@ -305,6 +318,7 @@ data class DcqlQuery(
          * @return a [DcqlQuery] object
          * @throws IllegalArgumentException if the given DCQL isn't well-formed.
          */
+        @Throws(IllegalArgumentException::class)
         fun fromJson(dcql: JsonObject): DcqlQuery {
             val dcqlCredentialQueries = mutableListOf<DcqlCredentialQuery>()
             val dcqlCredentialSetQueries = mutableListOf<DcqlCredentialSetQuery>()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/model/digitalCredentialsPresentment.kt
@@ -34,6 +34,8 @@ private const val TAG = "digitalCredentialsPresentment"
 /**
  * Present credentials according to the [W3C Digital Credentials API](https://www.w3.org/TR/digital-credentials/).
  *
+ * Note: this variant with [String] instead of [JsonObject] only exists for interoperability with Swift.
+ *
  * @param protocol the `protocol` field in the [DigitalCredentialGetRequest](https://www.w3.org/TR/digital-credentials/#the-digitalcredentialgetrequest-dictionary) dictionary.
  * @param data a string with JSON from the `data` field in the [DigitalCredentialGetRequest](https://www.w3.org/TR/digital-credentials/#the-digitalcredentialgetrequest-dictionary) dictionary.
  * @param appId the id of the application making the request, if available, for example `com.example.app` on Android or `<teamId>.<bundleId>` on iOS.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -44,8 +44,7 @@ import kotlin.time.Duration
 private const val TAG = "SdJwt"
 
 /**
- * A SD-JWT according to
- * [draft-ietf-oauth-selective-disclosure-jwt](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/).
+ * A SD-JWT according to [RFC 9901](https://datatracker.ietf.org/doc/rfc9901/).
  *
  * When a [SdJwt] instance is initialized, cursory checks on the provided string with the compact serialization are
  * performed. Full verification of the SD-JWT can be performed using the [verify] method which also returns
@@ -368,6 +367,8 @@ class SdJwt private constructor(
          * This implementation uses [DisclosureMetadata] in the "_sd" claim of each nested
          * JsonObject in the [claims] parameter to describe which claims to disclose.
          *
+         * Note: this variant with [String] instead of [JsonObject] only exists for interoperability with Swift.
+         *
          * @param issuerKey the key to sign the issuerSigned JWT with. If this is a [AsymmetricKey.X509Certified]
          *   the certificate chain will be included in the `x5c` claim and always be disclosed.
          * @param kbKey if set, a `cnf` claim with this public key will be included in the Issuer-signed JWT.
@@ -375,6 +376,46 @@ class SdJwt private constructor(
          * @param digestAlgorithm the hash algorithm to use, e.g. [Algorithm.SHA256].
          * @param random the [Random] to use to generate salts.
          * @param saltSizeNumBits number of bits to use for each salt.
+         * @param creationTime the time the SD-JWT was created, pass [Instant.DISTANT_PAST] to not set `iat` claim.
+         * @param expiresIn the duration in which the SD-JWT expire or `null`.
+         */
+        suspend fun createFromMetadata(
+            issuerKey: AsymmetricKey,
+            kbKey: EcPublicKey?,
+            claims: String,
+            digestAlgorithm: Algorithm = Algorithm.SHA256,
+            random: Random = Random.Default,
+            saltSizeNumBits: Int = 128,
+            creationTime: Instant = Instant.DISTANT_PAST,
+            expiresIn: Duration? = null
+        ): SdJwt {
+            return createFromMetadata(
+                issuerKey = issuerKey,
+                kbKey = kbKey,
+                claims = Json.decodeFromString<JsonObject>(claims),
+                digestAlgorithm = digestAlgorithm,
+                random = random,
+                saltSizeNumBits = saltSizeNumBits,
+                creationTime = creationTime,
+                expiresIn = expiresIn
+            )
+        }
+
+        /**
+         * Creates a SD-JWT.
+         *
+         * This implementation uses [DisclosureMetadata] in the "_sd" claim of each nested
+         * JsonObject in the [claims] parameter to describe which claims to disclose.
+         *
+         * @param issuerKey the key to sign the issuerSigned JWT with. If this is a [AsymmetricKey.X509Certified]
+         *   the certificate chain will be included in the `x5c` claim and always be disclosed.
+         * @param kbKey if set, a `cnf` claim with this public key will be included in the Issuer-signed JWT.
+         * @param claims the object with claims that can be selectively disclosed.
+         * @param digestAlgorithm the hash algorithm to use, e.g. [Algorithm.SHA256].
+         * @param random the [Random] to use to generate salts.
+         * @param saltSizeNumBits number of bits to use for each salt.
+         * @param creationTime the time the SD-JWT was created, pass [Instant.DISTANT_PAST] to not set `iat` claim.
+         * @param expiresIn the duration in which the SD-JWT expire or `null`.
          */
         suspend fun createFromMetadata(
             issuerKey: AsymmetricKey,
@@ -383,7 +424,7 @@ class SdJwt private constructor(
             digestAlgorithm: Algorithm = Algorithm.SHA256,
             random: Random = Random.Default,
             saltSizeNumBits: Int = 128,
-            creationTime: Instant = Instant.DISTANT_PAST,  // TODO: switch to System.Clock.now()?
+            creationTime: Instant = Instant.DISTANT_PAST,
             expiresIn: Duration? = null
         ): SdJwt {
             require(claims["iss"] != null) { "Must include `iss`" }
@@ -509,6 +550,8 @@ class SdJwt private constructor(
          *
          * This implementation uses recursive disclosures for all claims in the [claims] parameter.
          *
+         * Note: this variant with [String] instead of [JsonObject] only exists for interoperability with Swift.
+         *
          * @param issuerKey the key to sign the issuerSigned JWT with. If this is a [AsymmetricKey.X509Certified]
          *   the certificate chain will be included in the `x5c` claim and always be disclosed.
          * @param kbKey if set, a `cnf` claim with this public key will be included in the Issuer-signed JWT.
@@ -518,6 +561,49 @@ class SdJwt private constructor(
          * @param digestAlgorithm the hash algorithm to use, e.g. [Algorithm.SHA256].
          * @param random the [Random] to use to generate salts.
          * @param saltSizeNumBits number of bits to use for each salt.
+         * @param creationTime the time the SD-JWT was created, pass [Instant.DISTANT_PAST] to not set `iat` claim.
+         * @param expiresIn the duration in which the SD-JWT expire or `null`.
+         */
+        suspend fun create(
+            issuerKey: AsymmetricKey,
+            kbKey: EcPublicKey?,
+            claims: String,
+            nonSdClaims: String,
+            digestAlgorithm: Algorithm = Algorithm.SHA256,
+            random: Random = Random.Default,
+            saltSizeNumBits: Int = 128,
+            creationTime: Instant = Instant.DISTANT_PAST,
+            expiresIn: Duration? = null
+        ): SdJwt {
+            return create(
+                issuerKey = issuerKey,
+                kbKey = kbKey,
+                claims = Json.decodeFromString<JsonObject>(claims),
+                nonSdClaims = Json.decodeFromString<JsonObject>(nonSdClaims),
+                digestAlgorithm = digestAlgorithm,
+                random = random,
+                saltSizeNumBits = saltSizeNumBits,
+                creationTime = creationTime,
+                expiresIn = expiresIn
+            )
+        }
+
+        /**
+         * Creates a SD-JWT.
+         *
+         * This implementation uses recursive disclosures for all claims in the [claims] parameter.
+         *
+         * @param issuerKey the key to sign the issuerSigned JWT with. If this is a [AsymmetricKey.X509Certified]
+         *   the certificate chain will be included in the `x5c` claim and always be disclosed.
+         * @param kbKey if set, a `cnf` claim with this public key will be included in the Issuer-signed JWT.
+         * @param claims the object with claims that can be selectively disclosed.
+         * @param nonSdClaims claims to include in the Issuer-signed JWT which are always disclosed. This must at least
+         *   include the `iss` claim and may include more such as `vct`, `sub`, `iat`, `nbf`, `exp`.
+         * @param digestAlgorithm the hash algorithm to use, e.g. [Algorithm.SHA256].
+         * @param random the [Random] to use to generate salts.
+         * @param saltSizeNumBits number of bits to use for each salt.
+         * @param creationTime the time the SD-JWT was created, pass [Instant.DISTANT_PAST] to not set `iat` claim.
+         * @param expiresIn the duration in which the SD-JWT expire or `null`.
          */
         suspend fun create(
             issuerKey: AsymmetricKey,
@@ -527,7 +613,7 @@ class SdJwt private constructor(
             digestAlgorithm: Algorithm = Algorithm.SHA256,
             random: Random = Random.Default,
             saltSizeNumBits: Int = 128,
-            creationTime: Instant = Instant.DISTANT_PAST,  // TODO: switch to System.Clock.now()?
+            creationTime: Instant = Instant.DISTANT_PAST,
             expiresIn: Duration? = null
         ): SdJwt {
             require(nonSdClaims["iss"] != null) { "Must include `iss` claim in nonSdClaims" }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
@@ -15,8 +15,7 @@ import org.multipaz.util.toBase64Url
 
 
 /**
- * A SD-JWT+KB according to
- * [draft-ietf-oauth-selective-disclosure-jwt](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/).
+ * A SD-JWT+KB according to [RFC 9901](https://datatracker.ietf.org/doc/rfc9901/).
  *
  * When a [SdJwtKb] instance is initialized, cursory checks on the provided string with compact serialization
  * are performed. Full verification of the SD-JWT+KB can be done using the [verify] method.

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -10,6 +10,7 @@ private enum RequestType: String, CaseIterable {
     case mdlNameAndAddressPartiallyStored = "mDL: Name and address (partially stored)"
     case mdlNameAndAddressAllStored = "mDL: Name and address (all stored)"
     case photoIdMandatory = "PhotoID: Mandatory data elements (two docs)"
+    case openid4vpComplexExampleFromAppendixD = "Complex example from OpenID4VP Appendix D"
     case boardingPassAndMdl = "Boarding pass AND mDL"
     case boardingPassOrMdl = "Boarding pass OR mDL"
 }
@@ -283,7 +284,19 @@ private func calcConsentData(
         domain: "mdoc",
         randomProvider: KotlinRandom.companion
     )
-
+    
+    try! await addCredentialsForOpenID4VPComplexExample(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: AsymmetricKey.X509CertifiedExplicit(
+            certChain: X509CertChain(certificates: [dsCert]),
+            privateKey: dsKey,
+            algorithm: Algorithm.esp256
+        ),
+    )
     
     let mdlDocType = DrivingLicense.shared.getDocumentType()
     let photoIdDocType = PhotoID.shared.getDocumentType()
@@ -303,6 +316,86 @@ private func calcConsentData(
         mdlDocType.cannedRequests.first(where: { cr in cr.id == "name-and-address-all-stored" })!.mdocRequest!.toDcqlString()
     case .photoIdMandatory:
         photoIdDocType.cannedRequests.first(where: { cr in cr.id == "mandatory" })!.mdocRequest!.toDcqlString()
+    case .openid4vpComplexExampleFromAppendixD:
+        """
+            {
+              "credentials": [
+                {
+                  "id": "pid",
+                  "format": "dc+sd-jwt",
+                  "meta": {
+                    "vct_values": ["https://credentials.example.com/identity_credential"]
+                  },
+                  "claims": [
+                    {"path": ["given_name"]},
+                    {"path": ["family_name"]},
+                    {"path": ["address", "street_address"]}
+                  ]
+                },
+                {
+                  "id": "other_pid",
+                  "format": "dc+sd-jwt",
+                  "meta": {
+                    "vct_values": ["https://othercredentials.example/pid"]
+                  },
+                  "claims": [
+                    {"path": ["given_name"]},
+                    {"path": ["family_name"]},
+                    {"path": ["address", "street_address"]}
+                  ]
+                },
+                {
+                  "id": "pid_reduced_cred_1",
+                  "format": "dc+sd-jwt",
+                  "meta": {
+                    "vct_values": ["https://credentials.example.com/reduced_identity_credential"]
+                  },
+                  "claims": [
+                    {"path": ["family_name"]},
+                    {"path": ["given_name"]}
+                  ]
+                },
+                {
+                  "id": "pid_reduced_cred_2",
+                  "format": "dc+sd-jwt",
+                  "meta": {
+                    "vct_values": ["https://cred.example/residence_credential"]
+                  },
+                  "claims": [
+                    {"path": ["postal_code"]},
+                    {"path": ["locality"]},
+                    {"path": ["region"]}
+                  ]
+                },
+                {
+                  "id": "nice_to_have",
+                  "format": "dc+sd-jwt",
+                  "meta": {
+                    "vct_values": ["https://company.example/company_rewards"]
+                  },
+                  "claims": [
+                    {"path": ["rewards_number"]}
+                  ]
+                }
+              ],
+              "credential_sets": [
+                {
+                  "options": [
+                    [ "pid" ],
+                    [ "other_pid" ],
+                    [ "pid_reduced_cred_1", "pid_reduced_cred_2" ]
+                  ]
+                },
+                {
+                  "required": false,
+                  "options": [
+                    [ "nice_to_have" ]
+                  ]
+                }
+              ]
+            }
+
+        """
     case .boardingPassAndMdl:
         """
             {
@@ -488,10 +581,11 @@ private func calcConsentData(
                 onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
             )
         },
-        domainMdocSignature: "mdoc"
+        domainMdocSignature: "mdoc",
+        domainKeyBoundSdJwt: "sdjwt"
     )
 
-    let query = DcqlQuery.companion.fromJsonString(dcql: dcqlString)
+    let query = try! DcqlQuery.companion.fromJsonString(dcql: dcqlString)
     let presentmentData = try! await query.execute(presentmentSource: source, keyAgreementPossible: [])
     
     return ConsentData(
@@ -508,4 +602,292 @@ private func getIsRunningOnSimulator() -> Bool {
 #else
     return false
 #endif
+}
+
+private func addCredentialsForOpenID4VPComplexExample(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    try await addCredPid(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+    try await addCredPidMax(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+    try await addCredOtherPid(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+    try await addCredPidReduced1(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+    try await addCredPidReduced2(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+    try await addCredCompanyRewards(
+        documentStore: documentStore,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredPid(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "given_name": "Erika",
+        "family_name": "Mustermann",
+        "address": [
+            "street_address": "Sample Street 123"
+        ]
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-pid",
+        vct: "https://credentials.example.com/identity_credential",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredPidMax(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "given_name": "Max",
+        "family_name": "Mustermann",
+        "address": [
+            "street_address": "Sample Street 456"
+        ]
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-pid-max",
+        vct: "https://credentials.example.com/identity_credential",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredOtherPid(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "given_name": "Erika",
+        "family_name": "Mustermann",
+        "address": [
+            "street_address": "Sample Street 123"
+        ]
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-other-pid",
+        vct: "https://othercredentials.example/pid",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredPidReduced1(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "given_name": "Erika",
+        "family_name": "Mustermann"
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-pid-reduced1",
+        vct: "https://credentials.example.com/reduced_identity_credential",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredPidReduced2(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "postal_code": 90210,
+        "locality": "Beverly Hills",
+        "region": "Los Angeles Basin"
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-pid-reduced2",
+        vct: "https://cred.example/residence_credential",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+private func addCredCompanyRewards(
+    documentStore: DocumentStore,
+    secureArea: SecureArea,
+    signedAt: Date,
+    validFrom: Date,
+    validUntil: Date,
+    dsKey: AsymmetricKey
+) async throws {
+    let claims: [String: Any] = [
+        "rewards_number": 24601
+    ]
+    
+    let _ = try await documentStore.provisionSdJwtVc(
+        displayName: "my-reward-card",
+        vct: "https://company.example/company_rewards",
+        claims: claims,
+        secureArea: secureArea,
+        signedAt: signedAt,
+        validFrom: validFrom,
+        validUntil: validUntil,
+        dsKey: dsKey
+    )
+}
+
+// MARK: - DocumentStore Extension
+
+extension DocumentStore {
+    
+    fileprivate func provisionSdJwtVc(
+        displayName: String,
+        vct: String,
+        claims: [String: Any],
+        secureArea: SecureArea,
+        signedAt: Date,
+        validFrom: Date,
+        validUntil: Date,
+        dsKey: AsymmetricKey
+    ) async throws -> Document {
+        
+        let document = try await self.createDocument(
+            displayName: displayName,
+            typeDisplayName: vct,
+            cardArt: nil,
+            issuerLogo: nil,
+            authorizationData: nil,
+            created: Date.now.toKotlinInstant(),
+            metadata: nil
+        )
+        
+        let credential = try await KeyBoundSdJwtVcCredential.Companion.shared.create(
+            document: document,
+            asReplacementForIdentifier: nil,
+            domain: "sdjwt",
+            secureArea: secureArea,
+            vct: vct,
+            createKeySettings: SoftwareCreateKeySettings.Builder().build()
+        )
+
+        let nonSdClaims: [String: Any] = [
+            "iss": "https://example-issuer.com",
+            "vct": credential.vct,
+            "iat": signedAt.toKotlinInstant().epochSeconds,
+            "nbf": validFrom.toKotlinInstant().epochSeconds,
+            "exp": validUntil.toKotlinInstant().epochSeconds
+        ]
+        
+        let keyInfo = try await credential.secureArea.getKeyInfo(alias: credential.alias)
+        let sdJwt = try await SdJwt.Companion.shared.create(
+            issuerKey: dsKey,
+            kbKey: keyInfo.publicKey,
+            claims: String(
+                data: try JSONSerialization.data(withJSONObject: claims, options: []),
+                encoding: .utf8
+            )!,
+            nonSdClaims: String(
+                data: try JSONSerialization.data(withJSONObject: nonSdClaims, options: []),
+                encoding: .utf8
+            )!,
+            digestAlgorithm: Algorithm.sha256,
+            random: KotlinRandom.companion,
+            saltSizeNumBits: 128,
+            creationTime: KotlinInstant.companion.DISTANT_PAST,
+            expiresIn: nil
+        )
+        
+        try await credential.certify(
+            issuerProvidedAuthenticationData:
+                ByteStringBuilder(initialCapacity: 0)
+                .appendString(string: sdJwt.compactSerialization)
+                .toByteString()
+        )
+        return document
+    }
 }


### PR DESCRIPTION
- Make it possible pick a document when multiple matches are available and implement this in the Swift consent prompt by a 3D animation which flips the hovered white card. Also update the Compose consent prompt to do the same.

- Add support for multiple combinations by allowing the user to swipe back and forth, just like in the Compose version.

- Add support for SD-JWT credentials in the Swift consent prompt.

With these changes the Swift and Compose consent prompts are now at feature parity. For testing, add the "Complex example from OpenID4VP Appendix D" to the Swift Testapp, just like in Compose.

Test: Manually test on Android and iOS.
