### PR TITLE
Improve OpenID4VCI interoperability for mixed server behavior

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
@@ -20,7 +20,8 @@ internal data class AuthorizationConfiguration(
     val tokenEndpoint: String,
     val dpopSigningAlgorithm: Algorithm,
     val clientAttestationSigningAlgorithm: Algorithm,
-    val clientAuthentication: ClientAuthenticationType
+    val clientAuthentication: ClientAuthenticationType,
+    val supportsDPoP: Boolean
 ) {
     companion object: JsonParsing("Authorization server metadata") {
         suspend fun get(url: String, clientPreferences: OpenID4VCIClientPreferences): AuthorizationConfiguration {
@@ -67,9 +68,16 @@ internal data class AuthorizationConfiguration(
                 }
             }
 
-            val dpopSigningAlgorithm = preferredAlgorithm(
-                available = metadata.arrayOrNull("dpop_signing_alg_values_supported"),
-                clientPreferences = clientPreferences)
+            val dpopAlgorithms = metadata.arrayOrNull("dpop_signing_alg_values_supported")
+            val supportsDPoP = dpopAlgorithms?.isNotEmpty() == true
+            val dpopSigningAlgorithm = if (supportsDPoP) {
+                preferredAlgorithm(
+                    available = dpopAlgorithms,
+                    clientPreferences = clientPreferences
+                )
+            } else {
+                Algorithm.ESP256
+            }
             val clientAttestationSigningAlgorithm = preferredAlgorithm(
                 available = metadata.arrayOrNull("client_attestation_pop_signing_alg_values_supported"),
                 clientPreferences = clientPreferences
@@ -85,7 +93,7 @@ internal data class AuthorizationConfiguration(
                         when (val auth = authMethod.content) {
                             "private_key_jwt" -> clientAssertionSupported = true
                             "attest_jwt_client_auth" -> walletAttestationSupported = true
-                            "none" -> noAuthentication = true
+                            "none", "public" -> noAuthentication = true
                             else -> Logger.w(TAG, "Unknown auth method: '$auth'")
                         }
                     }
@@ -109,7 +117,8 @@ internal data class AuthorizationConfiguration(
                 tokenEndpoint = tokenEndpoint,
                 dpopSigningAlgorithm = dpopSigningAlgorithm,
                 clientAttestationSigningAlgorithm = clientAttestationSigningAlgorithm,
-                clientAuthentication = clientAuthentication
+                clientAuthentication = clientAuthentication,
+                supportsDPoP = supportsDPoP
             )
         }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
@@ -93,7 +93,22 @@ internal data class AuthorizationConfiguration(
                         when (val auth = authMethod.content) {
                             "private_key_jwt" -> clientAssertionSupported = true
                             "attest_jwt_client_auth" -> walletAttestationSupported = true
-                            "none", "public" -> noAuthentication = true
+                            "none" -> noAuthentication = true
+                            "public" -> {
+                                if (clientPreferences.interopOptions.allowPublicTokenEndpointAuthMethodAlias) {
+                                    Logger.w(
+                                        TAG,
+                                        "Accepting non-standard token auth metadata value 'public' as 'none'"
+                                    )
+                                    noAuthentication = true
+                                } else {
+                                    Logger.w(
+                                        TAG,
+                                        "Ignoring non-standard token auth metadata value 'public' " +
+                                            "(enable interop option to accept it)"
+                                    )
+                                }
+                            }
                             else -> Logger.w(TAG, "Unknown auth method: '$auth'")
                         }
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -5,10 +5,12 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
+import io.ktor.http.encodeURLParameter
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.provisioning.SecretCodeRequest
@@ -78,7 +80,29 @@ internal sealed class CredentialOffer {
                     }
                     credentialOfferString = response.readRawBytes().decodeToString()
                 }
-                val json = Json.parseToJsonElement(credentialOfferString).jsonObject
+                val normalized = credentialOfferString.trim()
+                if (normalized.startsWith("openid-credential-offer:") ||
+                    normalized.startsWith("haip-vci:")
+                ) {
+                    return parseCredentialOffer(normalizeOfferScheme(normalized))
+                }
+                if (normalized.startsWith("http://") || normalized.startsWith("https://")) {
+                    val offerUri =
+                        "openid-credential-offer://?credential_offer_uri=${normalized.encodeURLParameter()}"
+                    return parseCredentialOffer(offerUri)
+                }
+                val parsed = runCatching { Json.parseToJsonElement(normalized) }.getOrNull()
+                val json = when (parsed) {
+                    is JsonObject -> parsed
+                    is JsonPrimitive -> {
+                        if (!parsed.isString) {
+                            throw IllegalStateException("credential offer is not a JSON object")
+                        }
+                        Json.parseToJsonElement(parsed.content).jsonObject
+                    }
+                    null -> throw IllegalStateException("credential offer is not a JSON object")
+                    else -> throw IllegalStateException("credential offer is not a JSON object")
+                }
                 return parseJson(json)
             } catch (err: CancellationException) {
                 throw err
@@ -133,6 +157,18 @@ internal sealed class CredentialOffer {
                     length = obj.integerOrNull("length") ?: Int.MAX_VALUE,
                     isNumeric = obj.stringOrNull("input_mode") != "text"
                 )
+            }
+        }
+
+        private fun normalizeOfferScheme(offer: String): String {
+            return when {
+                offer.startsWith("openid-credential-offer://") -> offer
+                offer.startsWith("openid-credential-offer:") ->
+                    offer.replaceFirst("openid-credential-offer:", "openid-credential-offer://")
+                offer.startsWith("haip-vci://") -> offer
+                offer.startsWith("haip-vci:") ->
+                    offer.replaceFirst("haip-vci:", "haip-vci://")
+                else -> offer
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -64,10 +64,36 @@ internal sealed class CredentialOffer {
          * a [CredentialOffer].
          */
         suspend fun parseCredentialOffer(
-            offerUri: String
+            offerUri: String,
+            interopOptions: OpenID4VCIInteropOptions = OpenID4VCIInteropOptions()
         ): CredentialOffer {
             try {
-                val params = Url(offerUri).parameters
+                val input = offerUri.trim()
+                if (interopOptions.allowLenientCredentialOfferParsing &&
+                    (input.startsWith("http://") || input.startsWith("https://"))
+                ) {
+                    Logger.w(
+                        TAG,
+                        "Treating plain offer URL as credential_offer_uri (lenient interop mode)"
+                    )
+                    val rewritten =
+                        "openid-credential-offer://?credential_offer_uri=${input.encodeURLParameter()}"
+                    return parseCredentialOffer(rewritten, interopOptions)
+                }
+                val normalizedOfferUri = if (interopOptions.allowLenientCredentialOfferParsing) {
+                    normalizeOfferScheme(input).also { normalized ->
+                        if (normalized != input) {
+                            Logger.w(
+                                TAG,
+                                "Normalizing non-standard credential offer URI scheme (lenient interop mode)"
+                            )
+                        }
+                    }
+                } else {
+                    input
+                }
+
+                val params = Url(normalizedOfferUri).parameters
                 var credentialOfferString = params["credential_offer"]
                 if (credentialOfferString == null) {
                     val url = params["credential_offer_uri"]
@@ -80,29 +106,39 @@ internal sealed class CredentialOffer {
                     }
                     credentialOfferString = response.readRawBytes().decodeToString()
                 }
-                val normalized = credentialOfferString.trim()
-                if (normalized.startsWith("openid-credential-offer:") ||
-                    normalized.startsWith("haip-vci:")
-                ) {
-                    return parseCredentialOffer(normalizeOfferScheme(normalized))
-                }
-                if (normalized.startsWith("http://") || normalized.startsWith("https://")) {
-                    val offerUri =
-                        "openid-credential-offer://?credential_offer_uri=${normalized.encodeURLParameter()}"
-                    return parseCredentialOffer(offerUri)
-                }
-                val parsed = runCatching { Json.parseToJsonElement(normalized) }.getOrNull()
-                val json = when (parsed) {
-                    is JsonObject -> parsed
-                    is JsonPrimitive -> {
-                        if (!parsed.isString) {
-                            throw IllegalStateException("credential offer is not a JSON object")
-                        }
-                        Json.parseToJsonElement(parsed.content).jsonObject
+                if (interopOptions.allowLenientCredentialOfferParsing) {
+                    val normalizedPayload = credentialOfferString.trim()
+                    if (normalizedPayload.startsWith("openid-credential-offer:") ||
+                        normalizedPayload.startsWith("haip-vci:")
+                    ) {
+                        Logger.w(
+                            TAG,
+                            "Parsing nested credential offer URI payload (lenient interop mode)"
+                        )
+                        return parseCredentialOffer(
+                            offerUri = normalizeOfferScheme(normalizedPayload),
+                            interopOptions = interopOptions
+                        )
                     }
-                    null -> throw IllegalStateException("credential offer is not a JSON object")
-                    else -> throw IllegalStateException("credential offer is not a JSON object")
+                    if (normalizedPayload.startsWith("http://") ||
+                        normalizedPayload.startsWith("https://")
+                    ) {
+                        Logger.w(
+                            TAG,
+                            "Treating nested plain offer URL payload as credential_offer_uri (lenient interop mode)"
+                        )
+                        val rewritten =
+                            "openid-credential-offer://?credential_offer_uri=${normalizedPayload.encodeURLParameter()}"
+                        return parseCredentialOffer(
+                            offerUri = rewritten,
+                            interopOptions = interopOptions
+                        )
+                    }
                 }
+                val json = parseCredentialOfferJson(
+                    payload = credentialOfferString,
+                    interopOptions = interopOptions
+                )
                 return parseJson(json)
             } catch (err: CancellationException) {
                 throw err
@@ -160,6 +196,36 @@ internal sealed class CredentialOffer {
             }
         }
 
+        private fun parseCredentialOfferJson(
+            payload: String,
+            interopOptions: OpenID4VCIInteropOptions
+        ): JsonObject {
+            val normalizedPayload = payload.trim()
+            val parsed = runCatching { Json.parseToJsonElement(normalizedPayload) }.getOrNull()
+            if (parsed is JsonObject) {
+                return parsed
+            }
+            if (!interopOptions.allowLenientCredentialOfferParsing) {
+                throw IllegalStateException("credential offer is not a JSON object")
+            }
+            return when (parsed) {
+                is JsonPrimitive -> {
+                    if (!parsed.isString) {
+                        throw IllegalStateException("credential offer is not a JSON object")
+                    }
+                    Logger.w(
+                        TAG,
+                        "Parsing string-wrapped credential offer JSON (lenient interop mode)"
+                    )
+                    Json.parseToJsonElement(parsed.content).jsonObject
+                }
+                null -> {
+                    throw IllegalStateException("credential offer is not a JSON object")
+                }
+                else -> throw IllegalStateException("credential offer is not a JSON object")
+            }
+        }
+
         private fun normalizeOfferScheme(offer: String): String {
             return when {
                 offer.startsWith("openid-credential-offer://") -> offer
@@ -171,5 +237,7 @@ internal sealed class CredentialOffer {
                 else -> offer
             }
         }
+
+        private const val TAG = "CredentialOffer"
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIClientPreferences.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIClientPreferences.kt
@@ -14,5 +14,7 @@ data class OpenID4VCIClientPreferences(
     /** List of locales in the order of preference that this client supports */
     val locales: List<String>,
     /** Digital signing algorithms that this client supports */
-    val signingAlgorithms: List<Algorithm>
+    val signingAlgorithms: List<Algorithm>,
+    /** Optional compatibility switches for known non-standard server behavior. */
+    val interopOptions: OpenID4VCIInteropOptions = OpenID4VCIInteropOptions()
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIInteropOptions.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIInteropOptions.kt
@@ -1,0 +1,32 @@
+package org.multipaz.provisioning.openid4vci
+
+/**
+ * Opt-in compatibility switches for non-standard OpenID4VCI server behavior.
+ *
+ * All flags are disabled by default to keep strict, spec-first behavior.
+ */
+data class OpenID4VCIInteropOptions(
+    /**
+     * Treat `token_endpoint_auth_methods_supported=["public"]` as equivalent to `none`.
+     *
+     * This is non-standard metadata aliasing and should only be enabled for specific servers.
+     */
+    val allowPublicTokenEndpointAuthMethodAlias: Boolean = false,
+
+    /**
+     * Accept HTTP `200 OK` as success for PAR in addition to standard `201 Created`.
+     */
+    val allowParHttpStatusOk: Boolean = false,
+
+    /**
+     * Enable tolerant credential offer parsing for known non-standard input forms
+     * (legacy scheme normalization, plain URL coercion, string-wrapped JSON).
+     */
+    val allowLenientCredentialOfferParsing: Boolean = false,
+
+    /**
+     * Enable nonce endpoint fallback sequence `DPoP -> Bearer -> none` plus GET retry for
+     * HTML/non-JSON responses.
+     */
+    val allowNonceEndpointAuthFallback: Boolean = false
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -1,7 +1,10 @@
 package org.multipaz.provisioning.openid4vci
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.accept
 import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -66,6 +69,7 @@ internal class OpenID4VCIProvisioningClient(
     val secureArea: SecureArea,
     val authorizationData: OpenID4VCIAuthorizationData
 ): ProvisioningClient {
+    private enum class NonceAuthMode { DPOP, BEARER, NONE }
     var pkceCodeVerifier: String? = null
     var token: String? = null
     var tokenExpiration: Instant? = null
@@ -134,17 +138,78 @@ internal class OpenID4VCIProvisioningClient(
         if (credentialConfiguration.keyBindingType == KeyBindingType.Keyless) {
             throw IllegalStateException("getKeyBindingChallenge must not be called for keyless credentials")
         }
+        keyChallenge?.let { return it }
         // obtain c_nonce (serves as challenge for the device-bound key)
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
-        val nonceResponse = httpClient.post(issuerConfiguration.nonceEndpoint!!) {}
-        if (nonceResponse.status != HttpStatusCode.OK) {
+        val tokenSnapshot = token
+        val useDpop = authorizationConfiguration.supportsDPoP
+        val authHost = runCatching { Url(authorizationConfiguration.identifier).host }.getOrNull()
+        val nonceHost = runCatching { Url(issuerConfiguration.nonceEndpoint!!).host }.getOrNull()
+        val allowNonceDpop = useDpop && authHost != null && nonceHost == authHost
+
+        suspend fun requestNonce(mode: NonceAuthMode): Pair<HttpResponse, String> {
+            val dpopKeyLocal = if (tokenSnapshot != null && mode == NonceAuthMode.DPOP) getDPopKey() else null
+            // Pre-generate DPoP token in suspend context so it can be used in non-suspend applyAuth
+            val dpopToken = if (mode == NonceAuthMode.DPOP && tokenSnapshot != null && dpopKeyLocal != null) {
+                OpenID4VCIUtil.generateDPoP(
+                    dpopKey = dpopKeyLocal,
+                    clientId = clientPreferences.clientId,
+                    requestUrl = issuerConfiguration.nonceEndpoint!!,
+                    dpopNonce = issuerDPoPNonce,
+                    accessToken = tokenSnapshot
+                )
+            } else null
+            fun HttpRequestBuilder.applyAuth() {
+                when (mode) {
+                    NonceAuthMode.DPOP -> if (dpopToken != null) {
+                        headers {
+                            append("Authorization", "DPoP $tokenSnapshot")
+                            append("DPoP", dpopToken)
+                        }
+                    }
+                    NonceAuthMode.BEARER -> if (tokenSnapshot != null) {
+                        headers { append("Authorization", "Bearer $tokenSnapshot") }
+                    }
+                    NonceAuthMode.NONE -> {}
+                }
+                accept(ContentType.Application.Json)
+            }
+            val response = httpClient.post(issuerConfiguration.nonceEndpoint!!) {
+                applyAuth()
+                contentType(ContentType.Application.Json)
+            }
+            var bodyText = response.readRawBytes().decodeToString()
+            if (bodyText.trimStart().startsWith("<")) {
+                val retryResponse = httpClient.get(issuerConfiguration.nonceEndpoint!!) {
+                    applyAuth()
+                }
+                bodyText = retryResponse.readRawBytes().decodeToString()
+                return retryResponse to bodyText
+            }
+            return response to bodyText
+        }
+
+        val modes = buildList {
+            if (allowNonceDpop) add(NonceAuthMode.DPOP)
+            if (tokenSnapshot != null) add(NonceAuthMode.BEARER)
+            add(NonceAuthMode.NONE)
+        }
+
+        var cNonce: String? = null
+        for (mode in modes) {
+            val (resp, bodyText) = requestNonce(mode)
+            val trimmed = bodyText.trimStart()
+            val isHtml = trimmed.startsWith("<")
+            if (resp.status == HttpStatusCode.OK && !isHtml) {
+                resp.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
+                cNonce = Json.parseToJsonElement(bodyText).jsonObject.string("c_nonce")
+                break
+            }
+        }
+
+        if (cNonce == null) {
             throw IllegalStateException("Error getting a nonce")
         }
-        Logger.i(TAG, "Got successful response for nonce request")
-        // A fresh DPoP nonce might or might not be given
-        nonceResponse.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
-        val responseText = nonceResponse.readRawBytes().decodeToString()
-        val cNonce = Json.parseToJsonElement(responseText).jsonObject.string("c_nonce")
         keyChallenge = cNonce
         return cNonce
     }
@@ -159,19 +224,28 @@ internal class OpenID4VCIProvisioningClient(
         val credentialMetadata =
             issuerConfiguration.provisioningMetadata.credentials[credentialOffer.configurationId]!!
         val keyProofs = buildKeyProofs(keyInfo)
-        val dpopKey = getDPopKey()
+        val useDpop = authorizationConfiguration.supportsDPoP
+        val dpopKey = if (useDpop) getDPopKey() else null
         while (true) {
-            val dpop = OpenID4VCIUtil.generateDPoP(
-                dpopKey = dpopKey,
-                clientId = clientPreferences.clientId,
-                requestUrl = issuerConfiguration.credentialEndpoint,
-                dpopNonce = issuerDPoPNonce,
-                accessToken = token
-            )
+            val dpop = if (useDpop && dpopKey != null) {
+                OpenID4VCIUtil.generateDPoP(
+                    dpopKey = dpopKey,
+                    clientId = clientPreferences.clientId,
+                    requestUrl = issuerConfiguration.credentialEndpoint,
+                    dpopNonce = issuerDPoPNonce,
+                    accessToken = token
+                )
+            } else {
+                null
+            }
             credentialResponse = httpClient.post(issuerConfiguration.credentialEndpoint) {
                 headers {
-                    append("Authorization", "DPoP $token")
-                    append("DPoP", dpop)
+                    if (dpop != null) {
+                        append("Authorization", "DPoP $token")
+                        append("DPoP", dpop)
+                    } else {
+                        append("Authorization", "Bearer $token")
+                    }
                     contentType(ContentType.Application.Json)
                 }
                 setBody(buildJsonObject {
@@ -297,17 +371,22 @@ internal class OpenID4VCIProvisioningClient(
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
         var response: HttpResponse
         var retryCount = 0
-        val dpopKey = getDPopKey()
+        val useDpop = authorizationConfiguration.supportsDPoP
+        val dpopKey = if (useDpop) getDPopKey() else null
 
         while (true) {
             // retry loop for DPoP nonce
-            val dpop = OpenID4VCIUtil.generateDPoP(
-                dpopKey = dpopKey,
-                clientId = clientPreferences.clientId,
-                requestUrl = authorizationConfiguration.pushedAuthorizationRequestEndpoint,
-                dpopNonce = authorizationDPoPNonce,
-                accessToken = null
-            )
+            val dpop = if (useDpop && dpopKey != null) {
+                OpenID4VCIUtil.generateDPoP(
+                    dpopKey = dpopKey,
+                    clientId = clientPreferences.clientId,
+                    requestUrl = authorizationConfiguration.pushedAuthorizationRequestEndpoint,
+                    dpopNonce = authorizationDPoPNonce,
+                    accessToken = null
+                )
+            } else {
+                null
+            }
             val walletAttestationPoP = if (authorizationConfiguration.clientAuthentication == ClientAuthenticationType.CLIENT_ATTESTATION) {
                 val key = obtainWalletAttestation()
                 OpenID4VCIUtil.createWalletAttestationPoP(
@@ -362,7 +441,9 @@ internal class OpenID4VCIProvisioningClient(
                 }
             ) {
                 headers {
-                    append("DPoP", dpop)
+                    if (dpop != null) {
+                        append("DPoP", dpop)
+                    }
                     if (authorizationData.walletAttestation != null) {
                         append("OAuth-Client-Attestation", authorizationData.walletAttestation!!)
                         append("OAuth-Client-Attestation-PoP", walletAttestationPoP!!)
@@ -371,7 +452,7 @@ internal class OpenID4VCIProvisioningClient(
             }
             response.headers["DPoP-Nonce"]?.let { authorizationDPoPNonce = it }
             response.headers["OAuth-Client-Attestation-Challenge"]?.let { clientAttestationChallenge = it }
-            if (response.status == HttpStatusCode.Created) {
+            if (response.status == HttpStatusCode.Created || response.status == HttpStatusCode.OK) {
                 break
             }
             val responseText = response.readRawBytes().decodeToString()
@@ -449,18 +530,23 @@ internal class OpenID4VCIProvisioningClient(
         }
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
         var retried = false
-        val dpopKey = getDPopKey()
+        val useDpop = authorizationConfiguration.supportsDPoP
+        val dpopKey = if (useDpop) getDPopKey() else null
 
         // When dpop nonce is null, this loop will run twice, first request will return with error,
         // but will provide fresh, dpop nonce and the second request will get fresh access data.
         while (true) {
-            val dpop = OpenID4VCIUtil.generateDPoP(
-                dpopKey = dpopKey,
-                clientId = clientPreferences.clientId,
-                requestUrl = authorizationConfiguration.tokenEndpoint,
-                dpopNonce = authorizationDPoPNonce,
-                accessToken = null
-            )
+            val dpop = if (useDpop && dpopKey != null) {
+                OpenID4VCIUtil.generateDPoP(
+                    dpopKey = dpopKey,
+                    clientId = clientPreferences.clientId,
+                    requestUrl = authorizationConfiguration.tokenEndpoint,
+                    dpopNonce = authorizationDPoPNonce,
+                    accessToken = null
+                )
+            } else {
+                null
+            }
             val walletAttestationPoP = if (authorizationConfiguration.clientAuthentication == ClientAuthenticationType.CLIENT_ATTESTATION) {
                 val key = if (authorizationData.walletAttestation == null) {
                     // For pre-authorized code case, this is where the session is initialized.
@@ -523,7 +609,9 @@ internal class OpenID4VCIProvisioningClient(
                 }
             ) {
                 headers {
-                    append("DPoP", dpop)
+                    if (dpop != null) {
+                        append("DPoP", dpop)
+                    }
                     append("Content-Type", "application/x-www-form-urlencoded")
                     if (authorizationData.walletAttestation != null) {
                         append("OAuth-Client-Attestation", authorizationData.walletAttestation!!)
@@ -566,6 +654,9 @@ internal class OpenID4VCIProvisioningClient(
             token = tokenResponse.string("access_token")
             val duration = tokenResponse.integer("expires_in")
             tokenExpiration = Clock.System.now() + duration.seconds
+            tokenResponse.stringOrNull("c_nonce")?.let { cNonce ->
+                keyChallenge = cNonce
+            }
             val refreshToken = tokenResponse.stringOrNull("refresh_token")
             if (refreshToken != null) {
                 authorizationData.refreshToken = refreshToken

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -141,6 +141,23 @@ internal class OpenID4VCIProvisioningClient(
         keyChallenge?.let { return it }
         // obtain c_nonce (serves as challenge for the device-bound key)
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+        if (!clientPreferences.interopOptions.allowNonceEndpointAuthFallback) {
+            val nonceResponse = httpClient.post(issuerConfiguration.nonceEndpoint!!) {}
+            if (nonceResponse.status != HttpStatusCode.OK) {
+                throw IllegalStateException("Error getting a nonce")
+            }
+            Logger.i(TAG, "Got successful response for nonce request")
+            // A fresh DPoP nonce might or might not be given
+            nonceResponse.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
+            val responseText = nonceResponse.readRawBytes().decodeToString()
+            val cNonce = Json.parseToJsonElement(responseText).jsonObject.string("c_nonce")
+            keyChallenge = cNonce
+            return cNonce
+        }
+        Logger.w(
+            TAG,
+            "Using non-standard nonce endpoint auth fallback sequence (DPoP -> Bearer -> none)"
+        )
         val tokenSnapshot = token
         val useDpop = authorizationConfiguration.supportsDPoP
         val authHost = runCatching { Url(authorizationConfiguration.identifier).host }.getOrNull()
@@ -180,6 +197,10 @@ internal class OpenID4VCIProvisioningClient(
             }
             var bodyText = response.readRawBytes().decodeToString()
             if (bodyText.trimStart().startsWith("<")) {
+                Logger.w(
+                    TAG,
+                    "Nonce endpoint returned HTML to POST request; retrying with GET (lenient interop mode)"
+                )
                 val retryResponse = httpClient.get(issuerConfiguration.nonceEndpoint!!) {
                     applyAuth()
                 }
@@ -201,6 +222,12 @@ internal class OpenID4VCIProvisioningClient(
             val trimmed = bodyText.trimStart()
             val isHtml = trimmed.startsWith("<")
             if (resp.status == HttpStatusCode.OK && !isHtml) {
+                if (mode != NonceAuthMode.DPOP) {
+                    Logger.w(
+                        TAG,
+                        "Accepted nonce response via fallback auth mode '$mode' (lenient interop mode)"
+                    )
+                }
                 resp.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
                 cNonce = Json.parseToJsonElement(bodyText).jsonObject.string("c_nonce")
                 break
@@ -468,7 +495,16 @@ internal class OpenID4VCIProvisioningClient(
             }
             response.headers["DPoP-Nonce"]?.let { authorizationDPoPNonce = it }
             response.headers["OAuth-Client-Attestation-Challenge"]?.let { clientAttestationChallenge = it }
-            if (response.status == HttpStatusCode.Created || response.status == HttpStatusCode.OK) {
+            if (response.status == HttpStatusCode.Created) {
+                break
+            }
+            if (response.status == HttpStatusCode.OK &&
+                clientPreferences.interopOptions.allowParHttpStatusOk
+            ) {
+                Logger.w(
+                    TAG,
+                    "Accepting non-standard PAR success status 200 OK (interop option enabled)"
+                )
                 break
             }
             val responseText = response.readRawBytes().decodeToString()
@@ -761,7 +797,10 @@ internal class OpenID4VCIProvisioningClient(
             offerUri: String,
             clientPreferences: OpenID4VCIClientPreferences,
         ): OpenID4VCIProvisioningClient {
-            val credentialOffer = CredentialOffer.parseCredentialOffer(offerUri)
+            val credentialOffer = CredentialOffer.parseCredentialOffer(
+                offerUri = offerUri,
+                interopOptions = clientPreferences.interopOptions
+            )
             val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
             return create(
                 secureArea = secureArea,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -335,9 +335,25 @@ internal class OpenID4VCIProvisioningClient(
         when (keyInfo) {
             KeyBindingInfo.Keyless -> listOf("")
             is KeyBindingInfo.OpenidProofOfPossession -> keyInfo.jwtList.map { jwt ->
-                val header = Json.parseToJsonElement(jwt.take(jwt.indexOf('.') - 1))
-                // 'kid' must be present and corresponds to the credential id
-                header.jsonObject["kid"]!!.jsonPrimitive.content
+                val headerSegment = jwt.substringBefore('.')
+                val headerJson = headerSegment.fromBase64Url().decodeToString()
+                val header = Json.parseToJsonElement(headerJson).jsonObject
+                // Prefer top-level kid, fallback to jwk.kid for proof JWTs.
+                val topLevelKid = header["kid"]?.jsonPrimitive?.content
+                if (!topLevelKid.isNullOrBlank()) {
+                    topLevelKid
+                } else {
+                    val jwkKid = header["jwk"]
+                        ?.jsonObject
+                        ?.get("kid")
+                        ?.jsonPrimitive
+                        ?.content
+                    if (!jwkKid.isNullOrBlank()) {
+                        jwkKid
+                    } else {
+                        throw IllegalStateException("No kid in proof JWT header")
+                    }
+                }
             }
             is KeyBindingInfo.Attestation -> keyInfo.attestations.map { it.credentialId }
         }


### PR DESCRIPTION
## Summary
This PR keeps OpenID4VCI behavior strict-by-default and moves non-standard interoperability handling behind explicit opt-in settings.

Fixes #1541

## Design principles
- Keep the default path spec-first.
- Make every non-standard relaxation explicit and configurable.
- Emit warning logs whenever a non-standard path is accepted.

## What changed
- `OpenID4VCIInteropOptions` (new)
  - Added explicit opt-in switches for non-standard behavior:
    - `allowPublicTokenEndpointAuthMethodAlias`
    - `allowParHttpStatusOk`
    - `allowLenientCredentialOfferParsing`
    - `allowNonceEndpointAuthFallback`
  - Defaults for all switches are `false`.

- `OpenID4VCIClientPreferences`
  - Added `interopOptions` field (default: strict, all disabled).

- `AuthorizationConfiguration`
  - `token_endpoint_auth_methods_supported: ["public"]` is only treated as `none` when
    `allowPublicTokenEndpointAuthMethodAlias=true`.
  - Logs a warning when this non-standard alias is accepted.

- `OpenID4VCIProvisioningClient`
  - PAR accepts `201 Created` by default.
  - `200 OK` for PAR is accepted only when `allowParHttpStatusOk=true`, with warning log.
  - Nonce endpoint fallback sequence (`DPoP -> Bearer -> none`, including GET retry for HTML)
    is enabled only when `allowNonceEndpointAuthFallback=true`, with warning logs.
  - Keeps metadata-driven DPoP capability handling and token-response `c_nonce` reuse.
  - Keeps proof JWT header decoding fix (`kid` fallback to `jwk.kid`).

- `CredentialOffer`
  - Lenient parsing (scheme normalization, plain URL coercion, string-wrapped JSON)
    is enabled only when `allowLenientCredentialOfferParsing=true`, with warning logs.
  - Default parsing remains strict.

## Real-world use cases behind each opt-in
- `allowPublicTokenEndpointAuthMethodAlias`: for deployments that publish `public` instead of `none`.
- `allowParHttpStatusOk`: for AS implementations that return `200` for successful PAR.
- `allowLenientCredentialOfferParsing`: for integrations receiving non-canonical offer wrappers.
- `allowNonceEndpointAuthFallback`: for issuer nonce endpoints with inconsistent auth/content behavior.

## Security and maintenance notes
- No non-standard relaxation is enabled implicitly.
- Non-standard acceptance paths are visible through warning logs.
- The default behavior remains suitable for strict conformance testing.

## Testing
- `./gradlew :multipaz-openid4vci-server:test --tests org.multipaz.openid4vci.server.ProvisioningClientTest`
