### PR TITLE
Updated `unit-test.yml` workflow to skip the redundant build step.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,8 +26,6 @@ jobs:
         cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build -x test
     - name: Run unit tests
       run: ./gradlew test
 #    - name: Enable KVM


### PR DESCRIPTION
Removed the redundant Build with Gradle step. The ./gradlew test task already compiles necessary dependencies automatically, skipping the heavy Kotlin/Wasm targets that aren't needed for unit tests.

Fixes #[1558](https://github.com/openwallet-foundation/multipaz/issues/1558)

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR