### PR TITLE
Add function to validate Android Keystore implementations.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreCreateKeySettings.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreCreateKeySettings.kt
@@ -48,7 +48,7 @@ class AndroidKeystoreCreateKeySettings private constructor(
 ) : CreateKeySettings(algorithm, attestationChallenge, userAuthenticationRequired, userAuthenticationTimeout, validFrom, validUntil) {
 
     /**
-     * A builder for [CreateKeySettings].
+     * A builder for [AndroidKeystoreCreateKeySettings].
      *
      * @param attestationChallenge challenge to include in attestation for the key.
      */
@@ -199,4 +199,20 @@ class AndroidKeystoreCreateKeySettings private constructor(
             )
         }
     }
+}
+
+/**
+ * Builds a [AndroidKeystoreCreateKeySettings].
+ *
+ * @param attestationChallenge challenge to include in attestation for the key.
+ * @param builderAction the builder action.
+ * @return a [AndroidKeystoreCreateKeySettings].
+ */
+inline fun buildAndroidKeystoreCreateKeySettings(
+    attestationChallenge: ByteString,
+    builderAction: AndroidKeystoreCreateKeySettings.Builder.() -> Unit
+): AndroidKeystoreCreateKeySettings {
+    val builder = AndroidKeystoreCreateKeySettings.Builder(attestationChallenge)
+    builder.builderAction()
+    return builder.build()
 }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -24,6 +24,7 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyInfo
 import android.security.keystore.KeyProperties
 import android.security.keystore.UserNotAuthenticatedException
+import androidx.annotation.RequiresApi
 import org.multipaz.context.applicationContext
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.EcCurve
@@ -41,10 +42,15 @@ import kotlinx.coroutines.withContext
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.buildByteString
+import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.asn1.ASN1Sequence
+import org.multipaz.crypto.Crypto
+import org.multipaz.device.AndroidKeystoreSecurityLevel
 import org.multipaz.prompt.Reason
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.util.validateAndroidKeyAttestation
 import java.io.IOException
 import java.security.InvalidAlgorithmParameterException
 import java.security.KeyFactory
@@ -63,6 +69,7 @@ import java.security.spec.InvalidKeySpecException
 import java.sql.Date
 import javax.crypto.KeyAgreement
 import kotlin.coroutines.coroutineContext
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -769,6 +776,112 @@ class AndroidKeystoreSecureArea private constructor(
          */
         val strongBoxCurve25519Supported: Boolean
             get() = sbFeatureLevel >= 200
+
+        /**
+         * Tests if the implementation properly supports key attestations and ECDSA signatures with Curve P-256.
+         *
+         * Key attestations and ECDSA signatures with Curve P-256 are used for ISO mdoc credentials
+         * and this function will check if this is implemented correctly on the device.
+         *
+         * Tests include check that
+         * - key attestations are correct and chains up to the well-known Google root.
+         * - the attestation is for the correct app.
+         * - the attestation says the device is in the Verified Boot GREEN state.
+         * - keys created can can properly sign messages by verifying the signature. Messages of
+         *   varying sizes from 16 bytes to 128 KiB and with random content are tested.
+         *
+         * If the checks pass no exception is thrown. If one of the checks fail [IllegalStateException] is
+         * thrown and the `message` and `cause` fields contains more details.
+         *
+         * This can be slow, observed times on 2025-era hardware is ~200 milliseconds for TEE and
+         * ~2000 milliseconds for StrongBox.
+         *
+         * @param useStrongBox `false` to test normal TEE implementation, `true` to test StrongBox.
+         * @throws IllegalArgumentException if [useStrongBox] is `true` but [strongBoxSupported] is `false`.
+         * @throws IllegalStateException if one of the checks fail.
+         */
+        @RequiresApi(Build.VERSION_CODES.P)
+        suspend fun testKeyAttestationsAndEcdsaSigning(
+            useStrongBox: Boolean
+        ) {
+            if (useStrongBox) {
+                require(strongBoxSupported) { "testStrongBox is true but device does not support StrongBox" }
+            }
+            val storage = EphemeralStorage()
+            val secureArea = create(storage = storage)
+            var keyAliasToCleanUp: String? = null
+            try {
+                val attestationChallenge = "Challenge".encodeToByteString()
+                val keyInfo = try {
+                    secureArea.createKey(
+                        alias = null,
+                        createKeySettings = buildAndroidKeystoreCreateKeySettings(attestationChallenge) {
+                            setAlgorithm(Algorithm.ESP256)
+                            setUseStrongBox(useStrongBox)
+                        }
+                    )
+                } catch (e: Throwable) {
+                    throw IllegalStateException("Error creating key: ${e.message}", e)
+                }
+                keyAliasToCleanUp = keyInfo.alias
+
+                val signatureCertificateDigests = mutableSetOf<ByteString>()
+                val pkg = applicationContext.packageManager
+                    .getPackageInfo(applicationContext.packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+                pkg.signingInfo!!.apkContentsSigners.forEach { signatureInfo ->
+                    signatureCertificateDigests.add(
+                        ByteString(Crypto.digest(Algorithm.SHA256, signatureInfo.toByteArray()))
+                    )
+                }
+
+                try {
+                    validateAndroidKeyAttestation(
+                        chain = keyInfo.attestation.certChain!!,
+                        challenge = attestationChallenge,
+                        requireGmsAttestation = true,
+                        requireVerifiedBootGreen = true,
+                        requireKeyMintSecurityLevel = if (useStrongBox) {
+                            AndroidKeystoreSecurityLevel.STRONG_BOX
+                        } else {
+                            AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT
+                        },
+                        requireAppSignatureCertificateDigests = signatureCertificateDigests,
+                        requireAppPackages = setOf(pkg.packageName)
+                    )
+                } catch (e: Throwable) {
+                    throw IllegalStateException("Error validating attestation: ${e.message}", e)
+                }
+
+                for (messageLen in listOf(16, 64, 256, 1024, 4*1024, 64*1024, 128*1024)) {
+                    val message = Random.Default.nextBytes(messageLen)
+                    val signature = try {
+                        secureArea.sign(
+                            alias = keyInfo.alias,
+                            dataToSign = message,
+                            unlockReason = Reason.Unspecified
+                        )
+                    } catch (e: Throwable) {
+                        throw IllegalStateException("Error signing message of $messageLen bytes", e)
+                    }
+                    try {
+                        Crypto.checkSignature(
+                            publicKey = keyInfo.publicKey,
+                            message = message,
+                            algorithm = Algorithm.ESP256,
+                            signature = signature
+                        )
+                    } catch (e: Throwable) {
+                        throw IllegalStateException("Error verifying signature for message of $messageLen bytes", e)
+                    }
+                }
+            } catch (e: Throwable) {
+                throw IllegalStateException("Test failed: ${e.message}", e)
+            } finally {
+                if (keyAliasToCleanUp != null) {
+                    secureArea.deleteKey(keyAliasToCleanUp)
+                }
+            }
+        }
     }
 
     companion object {

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -122,6 +122,35 @@ actual fun AndroidKeystoreSecureAreaScreen(
             }
         }
 
+        for (n in listOf(0, 1)) {
+            val useStrongBox = if (n == 0) false else true
+            val buttonText = if (useStrongBox) "StrongBox Sanity Check" else "Sanity Check"
+            item {
+                TextButton(onClick = {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        coroutineScope.launch {
+                            val t0 = Clock.System.now()
+                            try {
+                                androidKeystoreCapabilities.testKeyAttestationsAndEcdsaSigning(useStrongBox)
+                                val durationMsec = (Clock.System.now() - t0).inWholeMilliseconds
+                                showToast("Sanity check passed ($durationMsec msec)")
+                            } catch (e: Throwable) {
+                                val durationMsec = (Clock.System.now() - t0).inWholeMilliseconds
+                                e.printStackTrace()
+                                showToast("Sanity check failed ($durationMsec msec): ${e.message}")
+                            }
+                        }
+                    } else {
+                        showToast("This is only available on API 28 or later, you are running API ${Build.VERSION.SDK_INT}")
+                    }
+                }) {
+                    Text(
+                        text = buttonText, fontSize = 15.sp
+                    )
+                }
+            }
+        }
+
         item {
             TextButton(onClick = {
                 coroutineScope.launch {


### PR DESCRIPTION
This adds a `testKeyAttestationsAndEcdsaSigning()` method to `AndroidKeystoreSecureArea.Capabilities` which verifies correctness/accuracy of both key attestations and also Curve P-256 ECDSA signing operations. For the key attestation checks it does all the checks that the server-side is supposed to do.

This is exposed in the TestApp as buttons that can be pressed to check TEE and StrongBox but is ultimately intended to be used by production wallet apps to do a sanity-check that the device properly supports StrongBox before actually using it.

Test: Manually tested.
