### PR TITLE
Disable JS and WasmJS in our CI.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,26 +27,26 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build -x test
+      run: ./gradlew build -x test -Pdisable.web.targets=true
     - name: Run unit tests
-      run: ./gradlew test
-#    - name: Enable KVM
-#      run: |
-#        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-#        sudo udevadm control --reload-rules
-#        sudo udevadm trigger --name-match=kvm
-#    - name: Run unit tests on Android Emulator API 34
-#      uses: reactivecircus/android-emulator-runner@v2
-#      with:
-#        api-level: 34
-#        arch: x86_64
-#        script: |
-#          ./gradlew connectedCheck
-#          mkdir -p build/reports/logcat
-#          adb logcat -d > build/reports/logcat/logcat.txt || touch build/reports/logcat/logcat.txt
-#    - name: Upload Logcat Output
-#      if: always()
-#      uses: actions/upload-artifact@v4
-#      with:
-#        name: android-logcat
-#        path: build/reports/logcat/logcat.txt
+      run: ./gradlew test -Pdisable.web.targets=true
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: Run unit tests on Android Emulator API 34
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 34
+        arch: x86_64
+        script: |
+          ./gradlew connectedCheck -Pdisable.web.targets=true
+          mkdir -p build/reports/logcat
+          adb logcat -d > build/reports/logcat/logcat.txt || touch build/reports/logcat/logcat.txt
+    - name: Upload Logcat Output
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-logcat
+        path: build/reports/logcat/logcat.txt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 kotlin.code.style=official
 
+disable.web.targets=false
+
 #Gradle
 org.gradle.jvmargs=-Xmx4G -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4G"
 

--- a/multipaz-compose/build.gradle.kts
+++ b/multipaz-compose/build.gradle.kts
@@ -20,6 +20,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 kotlin {
     jvmToolchain(17)
 
@@ -40,22 +42,24 @@ kotlin {
         publishLibraryVariants("release")
     }
 
-    js {
-        outputModuleName = "multipaz-compose"
-        browser {
-            // Currently disabled, see https://youtrack.jetbrains.com/issue/CMP-4906
-            testTask { enabled = false }
+    if (!disableWebTargets) {
+        js {
+            outputModuleName = "multipaz-compose"
+            browser {
+                // Currently disabled, see https://youtrack.jetbrains.com/issue/CMP-4906
+                testTask { enabled = false }
+            }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    wasmJs {
-        outputModuleName = "multipaz-compose"
-        browser {
-            // Currently disabled, see https://youtrack.jetbrains.com/issue/CMP-4906
-            testTask { enabled = false }
+        wasmJs {
+            outputModuleName = "multipaz-compose"
+            browser {
+                // Currently disabled, see https://youtrack.jetbrains.com/issue/CMP-4906
+                testTask { enabled = false }
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(

--- a/multipaz-dcapi/build.gradle.kts
+++ b/multipaz-dcapi/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 kotlin {
     jvmToolchain(17)
 
@@ -29,17 +31,19 @@ kotlin {
         publishLibraryVariants("release")
     }
 
-    js {
-        outputModuleName = "multipaz-dcapi"
-        browser {
+    if (!disableWebTargets) {
+        js {
+            outputModuleName = "multipaz-dcapi"
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    wasmJs {
-        browser {
+        wasmJs {
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(

--- a/multipaz-doctypes/build.gradle.kts
+++ b/multipaz-doctypes/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 kotlin {
     jvmToolchain(17)
 
@@ -20,18 +22,20 @@ kotlin {
 
     jvm()
 
-    js {
-        outputModuleName = "multipaz-doctypes"
-        browser {
+    if (!disableWebTargets) {
+        js {
+            outputModuleName = "multipaz-doctypes"
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    wasmJs {
-        outputModuleName = "multipaz-doctypes"
-        browser {
+        wasmJs {
+            outputModuleName = "multipaz-doctypes"
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(
@@ -82,9 +86,11 @@ kotlin {
             }
         }
 
-        val jsTest by getting {
-            dependencies {
-                implementation(libs.kotlin.wrappers.web)
+        if (!disableWebTargets) {
+            val jsTest by getting {
+                dependencies {
+                    implementation(libs.kotlin.wrappers.web)
+                }
             }
         }
     }

--- a/multipaz-longfellow/build.gradle.kts
+++ b/multipaz-longfellow/build.gradle.kts
@@ -15,6 +15,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 kotlin {
     jvmToolchain(17)
 
@@ -34,22 +36,24 @@ kotlin {
         publishLibraryVariants("release")
     }
 
-    js {
-        outputModuleName = "multipaz-longfellow"
-        browser {
-            // Longfellow is currently not implemented for this target
-            testTask { enabled = false }
+    if (!disableWebTargets) {
+        js {
+            outputModuleName = "multipaz-longfellow"
+            browser {
+                // Longfellow is currently not implemented for this target
+                testTask { enabled = false }
+            }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    wasmJs {
-        outputModuleName = "multipaz-longfellow"
-        browser {
-            // Longfellow is currently not implemented for this target
-            testTask { enabled = false }
+        wasmJs {
+            outputModuleName = "multipaz-longfellow"
+            browser {
+                // Longfellow is currently not implemented for this target
+                testTask { enabled = false }
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(

--- a/multipaz-server-frontend/build.gradle.kts
+++ b/multipaz-server-frontend/build.gradle.kts
@@ -4,37 +4,43 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
 }
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 kotlin {
-    js(IR) {
-        // This is for running in the browser, not server/node.js
-        browser {
-            commonWebpackConfig {
-                cssSupport { enabled.set(true) }
-                outputFileName = "multipaz-web.js"
-            }
-            runTask {
-                devServerProperty.set(KotlinWebpackConfig.DevServer(
-                    port = 3000,
-                    open = false,
-                    static = mutableListOf(
-                        file("src/jsMain/resources").path
+    if (!disableWebTargets) {
+        js(IR) {
+            // This is for running in the browser, not server/node.js
+            browser {
+                commonWebpackConfig {
+                    cssSupport { enabled.set(true) }
+                    outputFileName = "multipaz-web.js"
+                }
+                runTask {
+                    devServerProperty.set(
+                        KotlinWebpackConfig.DevServer(
+                            port = 3000,
+                            open = false,
+                            static = mutableListOf(
+                                file("src/jsMain/resources").path
+                            )
+                        )
                     )
-                ))
+                }
             }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    sourceSets {
-        val jsMain by getting {
-            dependencies {
-                // Multipaz library (provides Crypto, toBase64Url, etc.)
-                implementation(project(":multipaz"))
+        sourceSets {
+            val jsMain by getting {
+                dependencies {
+                    // Multipaz library (provides Crypto, toBase64Url, etc.)
+                    implementation(project(":multipaz"))
 
-                // Kotlin React wrappers
-                implementation(libs.kotlin.wrappers.react)
-                implementation(libs.kotlin.wrappers.react.dom)
-                implementation(libs.kotlin.wrappers.emotion.react.js)
+                    // Kotlin React wrappers
+                    implementation(libs.kotlin.wrappers.react)
+                    implementation(libs.kotlin.wrappers.react.dom)
+                    implementation(libs.kotlin.wrappers.emotion.react.js)
+                }
             }
         }
     }

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 buildConfig {
     packageName("org.multipaz.util")
     buildConfigField("VERSION", projectVersionName)
@@ -46,18 +48,20 @@ kotlin {
         publishLibraryVariants("release")
     }
 
-    js {
-        outputModuleName = "multipaz"
-        browser {
+    if (!disableWebTargets) {
+        js {
+            outputModuleName = "multipaz"
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
-    }
 
-    wasmJs {
-        outputModuleName = "multipaz"
-        browser {
+        wasmJs {
+            outputModuleName = "multipaz"
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(
@@ -209,10 +213,12 @@ kotlin {
             }
         }
 
-        val webMain by getting {
-            dependencies {
-                implementation(libs.kotlin.wrappers.web)
-                implementation(libs.kotlinx.browser)
+        if (!disableWebTargets) {
+            val webMain by getting {
+                dependencies {
+                    implementation(libs.kotlin.wrappers.web)
+                    implementation(libs.kotlinx.browser)
+                }
             }
         }
     }
@@ -236,8 +242,10 @@ tasks["compileKotlinIosX64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosSimulatorArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinJvm"].dependsOn("kspCommonMainKotlinMetadata")
-tasks["compileKotlinJs"].dependsOn("kspCommonMainKotlinMetadata")
-tasks["compileKotlinWasmJs"].dependsOn("kspCommonMainKotlinMetadata")
+if (!disableWebTargets) {
+    tasks["compileKotlinJs"].dependsOn("kspCommonMainKotlinMetadata")
+    tasks["compileKotlinWasmJs"].dependsOn("kspCommonMainKotlinMetadata")
+}
 
 tasks.withType<Test> {
     testLogging {

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
 val projectVersionCode: Int by rootProject.extra
 val projectVersionName: String by rootProject.extra
 
+val disableWebTargets = project.properties["disable.web.targets"]?.toString()?.toBoolean() ?: false
+
 // If changing it here, it must also be changed in XCode "Signing and Capabilities", under
 // "Associated Domains"
 val applinkHost = "apps.multipaz.org"
@@ -45,10 +47,12 @@ kotlin {
         }
     }
 
-    wasmJs {
-        browser {
+    if (!disableWebTargets) {
+        wasmJs {
+            browser {
+            }
+            binaries.executable()
         }
-        binaries.executable()
     }
 
     listOf(
@@ -118,9 +122,11 @@ kotlin {
             }
         }
 
-        val wasmJsMain by getting {
-            dependencies {
-                implementation(libs.ktor.client.js)
+        if (!disableWebTargets) {
+            val wasmJsMain by getting {
+                dependencies {
+                    implementation(libs.ktor.client.js)
+                }
             }
         }
 
@@ -230,5 +236,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
 tasks["compileKotlinIosX64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosArm64"].dependsOn("kspCommonMainKotlinMetadata")
 tasks["compileKotlinIosSimulatorArm64"].dependsOn("kspCommonMainKotlinMetadata")
-tasks["compileKotlinWasmJs"].dependsOn("kspCommonMainKotlinMetadata")
-
+if (!disableWebTargets) {
+    tasks["compileKotlinWasmJs"].dependsOn("kspCommonMainKotlinMetadata")
+}


### PR DESCRIPTION
They use a lot of memory and disk so the runner usually falls over with OOM or ENOSPC. Turn back emulator tests, mostly to see if that maybe now works (we had to turn it off in #1439).

Test: Manually tested.
