### PR TITLE
Simple client verifier API for general-purpose use.

### DIFF
--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
@@ -1,0 +1,635 @@
+package org.multipaz.verifier.request
+
+import io.ktor.http.ContentType
+import io.ktor.http.Url
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.ByteStringBuilder
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Nint
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.Uint
+import org.multipaz.cbor.addCborArray
+import org.multipaz.cbor.addCborMap
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.Hpke
+import org.multipaz.crypto.JsonWebEncryption
+import org.multipaz.mdoc.response.DeviceResponse
+import org.multipaz.openid.OpenID4VP
+import org.multipaz.openid.TransactionData
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.cache
+import org.multipaz.rpc.handler.InvalidRequestException
+import org.multipaz.rpc.handler.SimpleCipher
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.sdjwt.SdJwtKb
+import org.multipaz.server.common.getBaseUrl
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.trustmanagement.TrustManager
+import org.multipaz.trustmanagement.TrustManagerLocal
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.toBase64
+import org.multipaz.util.toBase64Url
+import org.multipaz.verification.VerificationUtil
+import org.multipaz.verifier.session.RequestedClaim
+import org.multipaz.verifier.session.RequestedDocument
+import org.multipaz.verifier.session.Session
+import org.multipaz.verifier.session.TransactionDataHashes
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
+import kotlin.time.Duration.Companion.minutes
+
+private val defaultExchangeProtocols = listOf("org-iso-mdoc", "openid4vp-v1-signed")
+
+suspend fun makeRequest(call: ApplicationCall) {
+    val request = Json.parseToJsonElement(call.receiveText()) as JsonObject
+    val dcqlQuery = request["dcql"] as? JsonObject
+        ?: throw InvalidRequestException("'dcql' is missing or invalid")
+    val credentials = dcqlQuery["credentials"] as? JsonArray
+        ?: throw InvalidRequestException("'dcql.credentials' is missing or invalid")
+    val exchangeProtocols = (request["protocols"] as? JsonArray)?.map { it.jsonPrimitive.content }
+        ?: defaultExchangeProtocols
+    val transactionData = request["transaction_data"]?.jsonArray?.map {
+        it.toString().encodeToByteArray().toBase64Url()
+    }
+    val nonMdoc = credentials.firstOrNull {
+        it.jsonObject["format"]!!.jsonPrimitive.content != "mso_mdoc"
+    }
+    val protocols = if (transactionData == null && nonMdoc == null) {
+        exchangeProtocols
+    } else {
+        // no support for transaction data yet in org_iso_mdoc
+        // org_iso_mdoc can only handle mdoc credentials
+        exchangeProtocols.filter { it != "org-iso-mdoc" }
+    }
+    val (sessionId, session) = Session.createSession(
+        dcqlQuery = dcqlQuery.toString(),
+        transactionData = transactionData
+    )
+    val encodedSessionId = encodeSessionId(sessionId)
+    val dcRequest = generateRequest(
+        encodedSessionId = encodedSessionId,
+        sessionId = sessionId,
+        session = session,
+        responseMode = OpenID4VP.ResponseMode.DC_API,
+        exchangeProtocols = protocols
+    )
+    call.respondText(
+        contentType = ContentType.Application.Json,
+        text = buildJsonObject {
+            put("session_id", encodedSessionId)
+            put("client_id", getClientId())
+            putJsonObject("dc_request") {
+               put("digital", dcRequest)
+               put("mediation", "required")
+            }
+        }.toString()
+    )
+}
+
+suspend fun processResponse(call: ApplicationCall) {
+    val request = Json.parseToJsonElement(call.receiveText()) as JsonObject
+    val encodedSessionId = (request["session_id"] as? JsonPrimitive)?.content
+        ?: throw InvalidRequestException("'session_id' is missing or invalid")
+    val dcResponse = request["dc_response"] as? JsonObject
+        ?: throw InvalidRequestException("'dc_response' is missing or invalid")
+    val protocol = (dcResponse["protocol"] as? JsonPrimitive)?.content
+        ?: throw InvalidRequestException("'dc_response.protocol' is missing or invalid")
+    val dcData = dcResponse["data"] as? JsonObject
+        ?: throw InvalidRequestException("'dc_response.data' is missing or invalid")
+    val sessionId = decodeSessionId(encodedSessionId)
+    val session = Session.getSession(sessionId)
+        ?: throw InvalidRequestException("Session '$encodedSessionId' is missing or expired")
+    session.responseProtocol = protocol
+    val result = if (protocol == "org-iso-mdoc") {
+        val response = dcData["response"]!!.jsonPrimitive.content.fromBase64Url()
+        session.response = ByteString(response)
+        processIsoMdocResponse(
+            session = session,
+            response = response
+        )
+    } else {
+        val responseText = dcData["response"]!!.jsonPrimitive.content
+        session.response = responseText.encodeToByteString()
+        processOpenID4VPResponseText(
+            session = session,
+            responseText = responseText
+        )
+    }
+    session.result = result.toString()
+    Session.updateSession(sessionId, session)
+    call.respondText(
+        contentType = ContentType.Application.Json,
+        text = buildJsonObject {
+            put("session_id", encodedSessionId)
+            put("result", result)
+        }.toString()
+    )
+}
+
+suspend fun getRequest(call: ApplicationCall, encodedSessionId: String) {
+    val sessionId = decodeSessionId(encodedSessionId)
+    val session = Session.getSession(sessionId)
+        ?: throw InvalidRequestException("Session '$encodedSessionId' is missing or expired")
+    val requestObject = generateRequest(
+        encodedSessionId = encodedSessionId,
+        sessionId = sessionId,
+        session = session,
+        responseMode = OpenID4VP.ResponseMode.DIRECT_POST,
+        exchangeProtocols = listOf()  // N/A for custom url schemes
+    )
+    val signedRequestCs = requestObject["request"]!!.jsonPrimitive.content
+    call.respondText(
+        contentType = ContentType.parse("application/oauth-authz-req+jwt"),
+        text = signedRequestCs
+    )
+}
+
+// Channels to notify pending requests that wait for the result. This only works because we have
+// a single process on a single machine on the server. To run it with multiple machines, sharding
+// by session has to be done.
+val resultChannelMutex = Mutex()
+val resultChannels = mutableMapOf<String, MutableSet<Channel<String>>>()
+
+suspend fun processDirectPost(call: ApplicationCall, encodedSessionId: String) {
+    val sessionId = decodeSessionId(encodedSessionId)
+    val postedData = call.receiveParameters()
+    val responseText = postedData["response"]
+        ?: throw InvalidRequestException("'response' parameter is missing")
+    val session = Session.getSession(sessionId)
+        ?: throw InvalidRequestException("Session '$encodedSessionId' is missing or expired")
+    session.responseProtocol = "openid4vp-v1-signed"
+    session.response = responseText.encodeToByteString()
+    val result = processOpenID4VPResponseText(
+        session = session,
+        responseText = responseText
+    ).toString()
+    session.result = result
+    Session.updateSession(sessionId, session)
+    val channels = resultChannelMutex.withLock {
+        resultChannels[sessionId]?.toMutableSet() ?: setOf()
+    }
+    for (channel in channels) {
+        channel.trySend(result)
+    }
+    call.respondText(
+        contentType = ContentType.Application.Json,
+        text = "{}"
+    )
+}
+
+suspend fun getResult(call: ApplicationCall, encodedSessionId: String) {
+    val sessionId = decodeSessionId(encodedSessionId)
+    val channel = Channel<String>(Channel.RENDEZVOUS)
+    resultChannelMutex.withLock {
+        resultChannels.getOrPut(sessionId) { mutableSetOf() }.add(channel)
+    }
+    val result = try {
+        val session = Session.getSession(sessionId)
+            ?: throw InvalidRequestException("Session '$encodedSessionId' is missing or expired")
+        session.result ?: withTimeout(3.minutes) { channel.receive() }
+    } catch (_: TimeoutCancellationException) {
+        null
+    } finally {
+        resultChannelMutex.withLock {
+            channel.close()
+            val channels = resultChannels[sessionId]!!
+            channels.remove(channel)
+            if (channels.isEmpty()) {
+                resultChannels.remove(sessionId)
+            }
+        }
+    }
+    call.respondText(
+        contentType = ContentType.Application.Json,
+        text = buildJsonObject {
+            if (result == null) {
+                put("status", "not_ready")
+            } else {
+                put("status", "ready")
+                put("session_id", encodedSessionId)
+                put("result", Json.parseToJsonElement(result))
+            }
+        }.toString()
+    )
+}
+
+private suspend fun generateRequest(
+    encodedSessionId: String,
+    sessionId: String,
+    session: Session,
+    responseMode: OpenID4VP.ResponseMode,
+    exchangeProtocols: List<String>,  // needed for DC API
+): JsonObject {
+    val sessionIdentity = session.getIdentity(sessionId)
+    val baseUrl = BackendEnvironment.getBaseUrl()
+    val query = Json.parseToJsonElement(session.dcqlQuery).jsonObject
+    return if (responseMode == OpenID4VP.ResponseMode.DC_API) {
+        VerificationUtil.generateDcRequestDcql(
+            exchangeProtocols = exchangeProtocols,
+            dcql = query,
+            transactionData = session.transactionData ?: listOf(),
+            nonce = session.nonce,
+            origin = baseUrl,
+            clientId = getClientId(),
+            responseEncryptionKey = session.encryptionPrivateKey.publicKey,
+            readerAuthenticationKey = sessionIdentity,
+        )
+    } else {
+        OpenID4VP.generateRequest(
+            version = OpenID4VP.Version.DRAFT_29,
+            nonce = session.nonce.toByteArray().toBase64Url(),
+            origin = baseUrl,
+            clientId = getClientId(),
+            responseEncryptionKey = session.encryptionPrivateKey.publicKey,
+            requestSigningKey = sessionIdentity,
+            responseMode = responseMode,
+            responseUri = if (responseMode == OpenID4VP.ResponseMode.DIRECT_POST) {
+                "$baseUrl/direct_post/$encodedSessionId"
+            } else {
+                null
+            },
+            dclqQuery = Json.parseToJsonElement(session.dcqlQuery).jsonObject,
+            transactionData = session.transactionData ?: listOf()
+        )
+    }
+}
+
+private suspend fun processOpenID4VPResponseText(
+    session: Session,
+    responseText: String
+): JsonObject {
+    val decryptedResponse = JsonWebEncryption.decrypt(
+        responseText,
+        AsymmetricKey.anonymous(
+            privateKey = session.encryptionPrivateKey,
+            algorithm = session.encryptionPrivateKey.curve.defaultKeyAgreementAlgorithm
+        )
+    ).jsonObject
+    val baseUrl = BackendEnvironment.getBaseUrl()
+    val token = decryptedResponse["vp_token"]!!.jsonObject
+    val jwkThumbPrint = session.encryptionPrivateKey.publicKey
+        .toJwkThumbprint(Algorithm.SHA256).toByteArray()
+    val nonce = session.nonce.toByteArray().toBase64Url()
+    val handoverInfo = Cbor.encode(
+        buildCborArray {
+            add(baseUrl)
+            add(nonce)
+            add(jwkThumbPrint)
+        }
+    )
+    val handoverInfoDigest = Crypto.digest(Algorithm.SHA256, handoverInfo)
+    val mdocSessionTranscript by lazy {
+        buildCborArray {
+            add(Simple.NULL) // DeviceEngagementBytes
+            add(Simple.NULL) // EReaderKeyBytes
+            addCborArray {
+                add("OpenID4VPDCAPIHandover")
+                add(handoverInfoDigest)
+            }
+        }
+    }
+    val requestedDocuments = extractRequestedDocuments(
+        dcql = Json.parseToJsonElement(session.dcqlQuery).jsonObject
+    )
+    val documentRequests = requestedDocuments.associateBy { it.id }
+    val transactionDataHashMap = mutableMapOf<String, TransactionDataHashes>()
+    val result = buildJsonObject {
+        for ((id, value) in token) {
+            val documentRequest = documentRequests[id]!!
+            val cbor = documentRequest.format == "mso_mdoc"
+            val responses = value.jsonArray.map { credentialResponse ->
+                val responseText = credentialResponse.jsonPrimitive.content
+                if (cbor) {
+                    val decoded = Cbor.decode(responseText.fromBase64Url())
+                    val responses = processMdocResponse(
+                        credentialResponse = decoded,
+                        mdocSessionTranscript = mdocSessionTranscript,
+                        documentRequests = listOf(documentRequest)
+                    )
+                    check(responses.size == 1)
+                    Pair(responses.first(), null)
+                } else {
+                    processSdJwtResponse(
+                        credentialResponse = responseText,
+                        documentRequest = documentRequest,
+                        sessionNonce = nonce
+                    )
+                }
+            }
+            responses.first().second?.let { transactionDataHashMap.put(id, it) }
+            if (documentRequest.multiple) {
+                put(id, JsonArray(responses.map { it.first }))
+                for (response in responses) {
+                    // Ensures that all responses include exactly the same transaction data hashes
+                    check(responses.first().second == response.second)
+                }
+            } else {
+                check(responses.size == 1)
+                put(id, responses.first().first)
+            }
+        }
+    }
+
+    // Validate that transaction data got acknowledged in the response
+    if (session.transactionData == null) {
+        // No transaction data hashes most have been embedded in the response
+        check(transactionDataHashMap.isEmpty())
+    } else {
+        val transactionDataMap = TransactionData.parse(
+            transactionData = session.transactionData,
+            hashAlgorithmOverrides = transactionDataHashMap.mapValues { (_, transactionDataHashes) ->
+                transactionDataHashes.hashAlgorithm
+            }
+        )
+        check(transactionDataMap.size == transactionDataHashMap.size)
+        for ((id, transactionDataHashes) in transactionDataHashMap) {
+            val transactionDataList = transactionDataMap[id]!!
+            check(transactionDataList.size == transactionDataHashes.hashes.size)
+            for ((transactionData, hash) in transactionDataList.zip(transactionDataHashes.hashes)) {
+                check(transactionData.hash == hash)
+            }
+        }
+    }
+
+    return result
+}
+
+private suspend fun processIsoMdocResponse(
+    session: Session,
+    response: ByteArray
+): JsonObject {
+    val array = Cbor.decode(response).asArray
+    if (array.first().asTstr != "dcapi") {
+        throw IllegalArgumentException("Excepted dcapi as first array element")
+    }
+    val encryptionParameters = array[1].asMap
+    val enc = encryptionParameters[Tstr("enc")]!!.asBstr
+    val cipherText = encryptionParameters[Tstr("cipherText")]!!.asBstr
+
+    val encryptionKey = session.encryptionPrivateKey
+    val encryptionInfo = buildCborArray {
+        add("dcapi")
+        addCborMap {
+            put("nonce", session.nonce.toByteArray())
+            put("recipientPublicKey", encryptionKey.publicKey.toCoseKey().toDataItem())
+        }
+    }
+    val base64EncryptionInfo = Cbor.encode(encryptionInfo).toBase64Url()
+
+    val baseUrl = BackendEnvironment.getBaseUrl()
+    val dcapiInfo = buildCborArray {
+        add(base64EncryptionInfo)
+        add(baseUrl)  // origin
+    }
+
+    val dcapiInfoDigest = Crypto.digest(Algorithm.SHA256, Cbor.encode(dcapiInfo))
+    val sessionTranscript = buildCborArray {
+        add(Simple.NULL) // DeviceEngagementBytes
+        add(Simple.NULL) // EReaderKeyBytes
+        addCborArray {
+            add("dcapi")
+            add(dcapiInfoDigest)
+        }
+    }
+
+    val decrypter = Hpke.getDecrypter(
+        cipherSuite = Hpke.CipherSuite.DHKEM_P256_HKDF_SHA256_HKDF_SHA256_AES_128_GCM,
+        receiverPrivateKey = AsymmetricKey.AnonymousExplicit(encryptionKey),
+        encapsulatedKey = enc,
+        info = Cbor.encode(sessionTranscript)
+    )
+    val deviceResponseRaw = decrypter.decrypt(ciphertext = cipherText, aad = byteArrayOf())
+    val requestedDocuments = extractRequestedDocuments(
+        dcql = Json.parseToJsonElement(session.dcqlQuery).jsonObject
+    )
+    // In ISO world document ids are not used and responses rely on document index
+    // TODO: it is not clear how this would work when there are document sets.
+    val jsonResponses = processMdocResponse(
+        credentialResponse = Cbor.decode(deviceResponseRaw),
+        mdocSessionTranscript = sessionTranscript,
+        documentRequests = requestedDocuments
+    )
+    return buildJsonObject {
+        for ((documentRequest, jsonResponse) in requestedDocuments.zip(jsonResponses)) {
+            put(documentRequest.id, jsonResponse)
+        }
+    }
+}
+
+private suspend fun getTrustManager(): TrustManager =
+    BackendEnvironment.cache(TrustManager::class) { configuration, resources ->
+        // TODO: load from configuration?
+        TrustManagerLocal(EphemeralStorage())
+    }
+
+private suspend fun processMdocResponse(
+    credentialResponse: DataItem,
+    mdocSessionTranscript: DataItem,
+    documentRequests: List<RequestedDocument>
+): List<JsonObject> {
+    val trustManager = getTrustManager()
+    val deviceResponse = DeviceResponse.fromDataItem(credentialResponse)
+    try {
+        deviceResponse.verify(sessionTranscript = mdocSessionTranscript)
+    } catch (err: Exception) {
+        Logger.e(TAG, "Device response verification failed", err)
+    }
+    return deviceResponse.documents.zip(documentRequests).map { (document, request) ->
+        buildJsonObject {
+            try {
+                val trustResult = trustManager.verify(document.issuerCertChain.certificates)
+                put("_trusted", trustResult.isTrusted)
+            } catch (e: Throwable) {
+                Logger.e(TAG, "Trust verification failed", e)
+            }
+
+            for (claim in request.claims) {
+                if (claim.path.size != 2) {
+                    // TODO: nested values in mdoc?
+                    continue
+                }
+                val issuerSignedItemsMap = document.issuerNamespaces.data[claim.path.first().asTstr]
+                    ?: continue
+                val issuerSignedItem = issuerSignedItemsMap[claim.path.last().asTstr]
+                    ?: continue
+                val jsonItem = when (val item = issuerSignedItem.dataElementValue) {
+                    is Tstr -> JsonPrimitive(item.asTstr)
+                    is Bstr -> JsonPrimitive(item.asBstr.toBase64())
+                    is Nint, is Uint -> JsonPrimitive(item.asNumber)
+                    Simple.TRUE -> JsonPrimitive(true)
+                    Simple.FALSE -> JsonPrimitive(false)
+                    Simple.NULL -> JsonPrimitive(null as String?)
+                    else -> JsonPrimitive("<unsupported>")
+                }
+                val id = claim.id ?: claim.path.last().asTstr
+                put(id, jsonItem)
+            }
+        }
+    }
+}
+
+private suspend fun processSdJwtResponse(
+    credentialResponse: String,
+    documentRequest: RequestedDocument,
+    sessionNonce: String
+): Pair<JsonObject, TransactionDataHashes?> {
+    val (sdJwt, sdJwtKb) = if (credentialResponse.endsWith("~")) {
+        Pair(SdJwt.fromCompactSerialization(credentialResponse), null)
+    } else {
+        val sdJwtKb = SdJwtKb.fromCompactSerialization(credentialResponse)
+        Pair(sdJwtKb.sdJwt, sdJwtKb)
+    }
+    if (sdJwtKb == null && sdJwt.jwtBody["cnf"] != null) {
+        throw InvalidRequestException("`cnf` claim present but we got a SD-JWT, not a SD-JWT+KB")
+    }
+    val issuerCert = sdJwt.x5c?.certificates?.first()
+        ?: throw InvalidRequestException("'x5c' not found")
+    val trustManager = getTrustManager()
+    val trustResult = trustManager.verify(sdJwt.x5c!!.certificates)
+    val jsonResult = buildJsonObject {
+        put("_trusted", trustResult.isTrusted)
+
+        val claimMap = sdJwtKb?.verify(
+            issuerKey = issuerCert.ecPublicKey,
+            checkNonce = { nonce -> nonce == sessionNonce },
+            // TODO: check audience, and creationTime
+            checkAudience = { audience -> true },
+            checkCreationTime = { creationTime -> true },
+        )
+            ?: sdJwt.verify(issuerCert.ecPublicKey)
+
+        for (claim in documentRequest.claims) {
+            var value: JsonElement = claimMap
+            for (key in claim.path) {
+                value = when (key) {
+                    is Tstr -> value.jsonObject[key.asTstr]!!
+                    is Uint -> value.jsonArray[key.asNumber.toInt()]
+                    else -> throw IllegalStateException("Unexpected key in claim path")
+                }
+            }
+            val id = claim.id ?: claim.path.last().asTstr
+            put(id, value)
+        }
+    }
+
+    val transactionDataHashes = sdJwtKb?.jwtBody["transaction_data_hashes"]?.let { hashes ->
+        val hashAlgorithm = sdJwtKb.jwtBody["transaction_data_hashes_alg"]?.jsonPrimitive?.content
+        TransactionDataHashes(
+            hashAlgorithm = hashAlgorithm?.let {
+                Algorithm.fromHashAlgorithmIdentifier(hashAlgorithm)
+            } ?: Algorithm.SHA256,
+            hashes = hashes.jsonArray.map { ByteString(it.jsonPrimitive.content.fromBase64Url()) }
+        )
+    }
+
+    return Pair(jsonResult, transactionDataHashes)
+}
+
+private fun extractRequestedDocuments(
+    dcql: JsonObject
+): List<RequestedDocument> {
+    val credentials = dcql["credentials"] as? JsonArray
+        ?: throw InvalidRequestException("'credentials' is missing or invalid in dsql")
+    return credentials.map { credential ->
+        credential as? JsonObject
+            ?: throw InvalidRequestException("credential query most be an object")
+        val id = credential["id"] as? JsonPrimitive
+            ?: throw InvalidRequestException("'id' is missing or invalid")
+        val format = credential["format"] as? JsonPrimitive
+            ?: throw InvalidRequestException("'format' is missing or invalid")
+        val claims = credential["claims"] as? JsonArray
+            ?: throw InvalidRequestException("'claims' is missing or invalid")
+        RequestedDocument(
+            id = id.content,
+            format = format.content,
+            multiple = (credential["multiple"] as JsonPrimitive?)?.booleanOrNull ?: false,
+            claims = claims.map { claim ->
+                claim as? JsonObject
+                    ?: throw InvalidRequestException("claim is not an object")
+                val id = claim["id"] as? JsonPrimitive
+                val path = claim["path"] as? JsonArray
+                    ?: throw InvalidRequestException("'path' is missing or invalid")
+                RequestedClaim(
+                    id = id?.content,
+                    path = path.map {
+                        it as? JsonPrimitive
+                            ?: throw InvalidRequestException("path element is not primitive")
+                        if (it.isString) {
+                            Tstr(it.content)
+                        } else if (it.contentOrNull == null) {
+                            Simple.NULL
+                        } else if (it.long >= 0){
+                            Uint(it.long.toULong())
+                        } else {
+                            throw InvalidRequestException("path element is negative")
+                        }
+                    }
+                )
+            }
+        )
+    }
+}
+
+private suspend fun getClientId(): String {
+    val baseUrl = BackendEnvironment.getBaseUrl()
+    val host = Url(baseUrl).host
+    return "x509_san_dns:$host"
+}
+
+private suspend fun encodeSessionId(sessionId: String): String {
+    val buf = ByteStringBuilder()
+    buf.append(57.toByte())
+    val idBytes = sessionId.fromBase64Url()
+    buf.append(idBytes.size.toByte())
+    buf.append(idBytes)
+    val cipher = BackendEnvironment.getInterface(SimpleCipher::class)!!
+    return cipher.encrypt(buf.toByteString().toByteArray()).toBase64Url()
+}
+
+private suspend fun decodeSessionId(code: String): String {
+    val cipher = BackendEnvironment.getInterface(SimpleCipher::class)!!
+    val buf = cipher.decrypt(code.fromBase64Url())
+    if (buf[0].toInt() != 57) {
+        throw IllegalArgumentException("Not a valid session id")
+    }
+    val len = buf[1].toInt()
+    if (len != buf.size - 2) {
+        throw IllegalArgumentException("Not a valid session id")
+    }
+    return buf.sliceArray(2..<buf.size).toBase64Url()
+}
+
+private const val TAG = "verifyCredentials"
+

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/server/ApplicationExt.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/server/ApplicationExt.kt
@@ -1,7 +1,6 @@
 package org.multipaz.verifier.server
 
 import io.ktor.server.application.Application
-import io.ktor.server.application.call
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
@@ -10,6 +9,11 @@ import org.multipaz.server.common.ServerEnvironment
 import org.multipaz.server.request.push
 import org.multipaz.server.common.serveResources
 import org.multipaz.server.request.certificateAuthority
+import org.multipaz.verifier.request.getRequest
+import org.multipaz.verifier.request.getResult
+import org.multipaz.verifier.request.makeRequest
+import org.multipaz.verifier.request.processDirectPost
+import org.multipaz.verifier.request.processResponse
 import org.multipaz.verifier.request.verifierGet
 import org.multipaz.verifier.request.verifierPost
 
@@ -26,6 +30,21 @@ fun Application.configureRouting(environment: Deferred<ServerEnvironment>) {
         }
         post("/verifier/{command}") {
             verifierPost(call, call.parameters["command"]!!)
+        }
+        post("/make_request") {
+            makeRequest(call)
+        }
+        get("/get_request/{sessionId}") {
+            getRequest(call, call.parameters["sessionId"]!!)
+        }
+        post("/direct_post/{sessionId}") {
+            processDirectPost(call, call.parameters["sessionId"]!!)
+        }
+        get("/get_result/{sessionId}") {
+            getResult(call, call.parameters["sessionId"]!!)
+        }
+        post("/process_response") {
+            processResponse(call)
         }
     }
 }

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/RequestedClaim.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/RequestedClaim.kt
@@ -1,0 +1,12 @@
+package org.multipaz.verifier.session
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializable
+
+@CborSerializable
+data class RequestedClaim(
+    val id: String?,
+    val path: List<DataItem>
+) {
+    companion object
+}

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/RequestedDocument.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/RequestedDocument.kt
@@ -1,0 +1,13 @@
+package org.multipaz.verifier.session
+
+import org.multipaz.cbor.annotation.CborSerializable
+
+@CborSerializable
+data class RequestedDocument(
+    val id: String,
+    val format: String,  // "dc+sd-jwt" or "mso_mdoc"
+    val multiple: Boolean,
+    val claims: List<RequestedClaim>
+) {
+    companion object
+}

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/Session.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/Session.kt
@@ -1,0 +1,169 @@
+package org.multipaz.verifier.session
+
+import io.ktor.http.Url
+import kotlinx.datetime.DateTimePeriod
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.asn1.ASN1
+import org.multipaz.asn1.ASN1Encoding
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.asn1.ASN1Sequence
+import org.multipaz.asn1.ASN1TagClass
+import org.multipaz.asn1.ASN1TaggedObject
+import org.multipaz.asn1.OID
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509Cert
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.crypto.X509KeyUsage
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.server.common.getBaseUrl
+import org.multipaz.server.enrollment.ServerIdentity
+import org.multipaz.server.enrollment.getServerIdentity
+import org.multipaz.storage.StorageTableSpec
+import kotlin.random.Random
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Credential verification session for the server back-end supporting `multipazVerifyCredentials`
+ * JavaScript API.
+ *
+ * @property nonce raw nonce (base64url encoding is used where string is needed)
+ * @property ephemeralPrivateKey private key used to sign the request
+ * @property encryptionPrivateKey private key used for response encryption
+ * @property dcqlQuery JSON-serialized DCQL query
+ * @property transactionData Base64Url-encoded transaction data
+ * @property result verification result (once obtained and verified)
+ */
+@CborSerializable
+data class Session(
+    val nonce: ByteString,
+    val ephemeralPrivateKey: EcPrivateKey,
+    val encryptionPrivateKey: EcPrivateKey,
+    val dcqlQuery: String,
+    val transactionData: List<String>?,
+    var responseProtocol: String? = null,
+    var response: ByteString? = null,
+    var result: String? = null
+) {
+    /**
+     * X509-certifies [ephemeralPrivateKey].
+     */
+    suspend fun getIdentity(id: String): AsymmetricKey.X509Certified {
+        val now = Clock.System.now()
+        val validFrom = now.plus(DateTimePeriod(minutes = -10), TimeZone.currentSystemDefault())
+        val validUntil = now.plus(DateTimePeriod(minutes = 10), TimeZone.currentSystemDefault())
+        val readerKeySubject = "CN=OWF Multipaz Online Verifier Single-Use Reader Key [$id]"
+
+        val readerIdentity = getServerIdentity(ServerIdentity.VERIFIER)
+        val host = Url(BackendEnvironment.getBaseUrl()).host
+        val cert = readerIdentity.certChain.certificates.first()
+        val readerKeyCertificate = X509Cert.Builder(
+            publicKey = ephemeralPrivateKey.publicKey,
+            signingKey = readerIdentity,
+            serialNumber = ASN1Integer(1L),
+            subject = X500Name.fromName(readerKeySubject),
+            issuer = cert.subject,
+            validFrom = validFrom,
+            validUntil = validUntil
+        )
+            .includeSubjectKeyIdentifier()
+            .setAuthorityKeyIdentifierToCertificate(cert)
+            .setKeyUsage(setOf(X509KeyUsage.DIGITAL_SIGNATURE))
+            .addExtension(
+                OID.X509_EXTENSION_SUBJECT_ALT_NAME.oid,
+                false,
+                ASN1.encode(
+                    ASN1Sequence(
+                        listOf(
+                            ASN1TaggedObject(
+                                ASN1TagClass.CONTEXT_SPECIFIC,
+                                ASN1Encoding.PRIMITIVE,
+                                2, // dNSName
+                                host.encodeToByteArray()
+                            )
+                        )
+                    )
+                )
+            )
+            .build()
+
+        return AsymmetricKey.X509CertifiedExplicit(
+            privateKey = ephemeralPrivateKey,
+            certChain = X509CertChain(listOf(readerKeyCertificate) + readerIdentity.certChain.certificates)
+        )
+    }
+
+    companion object {
+        /**
+         * Creates a new session in the storage.
+         *
+         * @param dcqlQuery JSON-encoded DCQL query
+         * @param transactionData Base64Url-encoded transaction data
+         * @return a pair of sessionId and a [Session]
+         */
+        suspend fun createSession(
+            dcqlQuery: String,
+            transactionData: List<String>?
+        ): Pair<String, Session> {
+            val session = Session(
+                nonce = ByteString(Random.nextBytes(15)),
+                ephemeralPrivateKey = Crypto.createEcPrivateKey(EcCurve.P256),
+                encryptionPrivateKey = Crypto.createEcPrivateKey(EcCurve.P256),
+                dcqlQuery = dcqlQuery,
+                transactionData = transactionData
+            )
+            val id = BackendEnvironment.getTable(tableSpec).insert(
+                key = null,
+                data = ByteString(session.toCbor()),
+                expiration = Clock.System.now() + 1.hours
+            )
+            return Pair(id, session)
+        }
+
+        /**
+         * Returns [Session] by its sessionId loading it from the storage.
+         *
+         * @param sessionId session id
+         * @return loaded [Session]
+         */
+        suspend fun getSession(sessionId: String): Session? =
+            BackendEnvironment.getTable(tableSpec).get(sessionId)
+                ?.let { Session.fromCbor(it.toByteArray()) }
+
+        /**
+         * Updates [Session] in the storage.
+         *
+         * @param sessionId session id
+         * @param session updated [Session] value
+         */
+        suspend fun updateSession(sessionId: String, session: Session) {
+            BackendEnvironment.getTable(tableSpec).update(
+                key = sessionId,
+                data = ByteString(session.toCbor())
+            )
+        }
+
+        /**
+         * Deletes a [Session] in the storage
+         *
+         * @param sessionId session id
+         */
+        suspend fun deleteSession(sessionId: String) {
+            BackendEnvironment.getTable(tableSpec).delete(sessionId)
+        }
+
+        private val tableSpec = StorageTableSpec(
+            name = "VerifierLightSessions",
+            supportPartitions = false,
+            supportExpiration = true
+        )
+    }
+}

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/TransactionDataHashes.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/session/TransactionDataHashes.kt
@@ -1,0 +1,12 @@
+package org.multipaz.verifier.session
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.crypto.Algorithm
+
+/**
+ * Transaction data hashes in the credential verification response for a particular credential.
+ */
+data class TransactionDataHashes(
+    val hashAlgorithm: Algorithm,
+    val hashes: List<ByteString>
+)

--- a/multipaz-verifier-server/src/main/resources/resources/www/light.css
+++ b/multipaz-verifier-server/src/main/resources/resources/www/light.css
@@ -1,0 +1,21 @@
+.cred_data {
+    margin: 4px;
+    border: 1px solid black;
+    padding: 3px;
+}
+
+.cred_data h4 {
+    margin: 0px;
+}
+
+.cred_data img {
+    max-width: 100%;
+}
+
+.nest1 { background-color: #FFC; }
+.nest2 { background-color: #FCF; }
+.nest3 { background-color: #CFF; }
+.nest4 { background-color: #FCC; }
+.nest5 { background-color: #CFC; }
+.nest6 { background-color: #CCF; }
+.nest7 { background-color: #CCC; }

--- a/multipaz-verifier-server/src/main/resources/resources/www/light.html
+++ b/multipaz-verifier-server/src/main/resources/resources/www/light.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="referrer" content="unsafe-url">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OWF Multipaz Verifier</title>
+    <script src="verify_credentials.js"></script>
+    <script src="light.js"></script>
+    <link rel="stylesheet" href="light.css">
+</head>
+<body>
+<div>
+<label>Select an example:
+<select id="examples">
+</select>
+<button id="apply_example">Apply</button>
+</label>
+</div>
+<div>
+<label>Query:<br/>
+<textarea id="query" rows="20" cols="80">
+</textarea>
+</label>
+</div>
+<div>
+<label>Transaction Data: <input id="transaction_data_present" type="checkbox"/>
+<br/>
+<textarea id="transaction_data" rows="5" cols="80" style="display:none">
+</textarea>
+</label>
+</div>
+<div>
+DC API Protocols:
+<br/>
+<label><input id="protocol_iso" type="checkbox" checked="checked"/>ISO 18013-7 Annex C</label>
+<br/>
+<label><input id="protocol_openid4vp" type="checkbox" checked="checked"/>OpenID4VP v1</label>
+</div>
+<button onclick="run()">Submit</button>
+<div id="result">
+
+</div>
+</body>
+</html>

--- a/multipaz-verifier-server/src/main/resources/resources/www/light.js
+++ b/multipaz-verifier-server/src/main/resources/resources/www/light.js
@@ -1,0 +1,187 @@
+window.addEventListener("DOMContentLoaded", onLoad);
+
+const examples = {
+    "mDL age verification": {
+        "dcql": {
+            "credentials": [
+                {
+                    "id": "mDL",
+                    "format": "mso_mdoc",
+                    "meta": {
+                        "doctype_value": "org.iso.18013.5.1.mDL"
+                    },
+                    "claims": [
+                        {
+                          "id": "allowed",
+                          "path": [
+                            "org.iso.18013.5.1",
+                            "age_over_21"
+                          ]
+                        },
+                        {
+                          "id": "photo",
+                          "path": [
+                            "org.iso.18013.5.1",
+                            "portrait"
+                          ]
+                        }
+                    ]
+                }
+           ]
+        }
+    },
+    "Movie ticket + EU PID age": {
+        "dcql": {
+          "credentials": [
+            {
+              "id": "pid",
+              "format": "dc+sd-jwt",
+              "meta": {
+                "vct_values": ["urn:eudi:pid:1"]
+              },
+              "claims": [
+                {
+                  "id": "can_go",
+                  "path": [
+                    "age_equal_or_over",
+                    "18"
+                  ]
+                }
+              ]
+            },
+            {
+               "id": "movie",
+               "format": "dc+sd-jwt",
+               "meta": {
+                    "vct_values": [
+                        "https://utopia.example.com/vct/movieticket"
+                    ]
+               },
+               "claims": [
+                    {
+                        "id": "when",
+                        "path": [
+                            "show_date_time"
+                        ],
+                    },
+                    {
+                        "path": [
+                            "movie"
+                        ]
+                    }
+                ]
+            }
+          ]
+        },
+        "transaction_data": [
+            {
+                "type": "org.multipaz.transaction_data.test",
+                "credential_ids": ["pid"]
+            }
+        ]
+    }
+};
+
+function onLoad() {
+    const query = document.getElementById("query");
+    const transactionData = document.getElementById("transaction_data");
+    const transactionDataPresent = document.getElementById("transaction_data_present");
+    const select = document.getElementById("examples");
+    for (let name in examples) {
+        const example = examples[name];
+        const option = document.createElement("option");
+        option.value = name;
+        option.text = name;
+        select.appendChild(option);
+    }
+    transactionDataPresent.addEventListener("change", function() {
+        transactionData.style.display = transactionDataPresent.checked ? "" : "none";
+    });
+    document.getElementById("apply_example").addEventListener("click", function() {
+        const example = examples[select.value];
+        query.value = JSON.stringify(example.dcql, null, 4);
+        if (example.transaction_data) {
+            transactionData.style.display = "";
+            transactionData.value = JSON.stringify(example.transaction_data, null, 4);
+            transactionDataPresent.checked = true;
+        } else {
+            transactionData.style.display = "none";
+            transactionDataPresent.checked = false;
+        }
+    });
+}
+
+async function run() {
+    const query = JSON.parse(document.getElementById("query").value);
+    const protocols = [];
+    if (document.getElementById("protocol_iso").checked) {
+        protocols.push("org-iso-mdoc")
+    }
+    if (document.getElementById("protocol_openid4vp").checked) {
+        protocols.push("openid4vp-v1-signed")
+    }
+    const req = { dcql: query, protocols: protocols };
+    const transactionDataPresent = document.getElementById("transaction_data_present");
+    const transactionDataText = document.getElementById("transaction_data").value;
+    if (transactionDataPresent.checked && transactionDataText.trim().length !== 0) {
+        req["transaction_data"] = JSON.parse(transactionDataText);
+    }
+    const response = await multipazVerifyCredentials(req);
+    const result = document.getElementById("result");
+    result.innerHTML = "";
+    for (let label in response.result) {
+        renderContent(result, label, response.result[label], 0);
+    }
+}
+
+const dataUrlPrefix = "data:image/jpeg;base64,";
+
+function renderContent(div, label, data, depth) {
+    if (typeof data == 'array') {
+        depth++;
+        const container = document.createElement('div');
+        container.setAttribute("class", "cred_data nest" + depth);
+        div.appendChild(container);
+        if (label) {
+            const title = document.createElement("h4");
+            title.textContent = label;
+            container.appendChild(title);
+        }
+        for (let item of data) {
+            renderContent(container, "", item, depth);
+        }
+    } else if (typeof data == 'object') {
+        depth++;
+        const container = document.createElement('div');
+        container.setAttribute("class", "cred_data nest" + depth);
+        div.appendChild(container);
+        if (label) {
+            const title = document.createElement("h4");
+            title.textContent = label;
+            container.appendChild(title);
+        }
+        for (let l in data) {
+            renderContent(container, l, data[l], depth);
+        }
+    } else if (label == 'portrait' || label == 'photo' || label.endsWith("_image")) {
+        const container = document.createElement('div');
+        container.setAttribute("class", "image nest" + depth);
+        div.appendChild(container);
+        if (label) {
+            const title = document.createElement("h4");
+            title.textContent = label;
+            container.appendChild(title);
+        }
+        const image = document.createElement("img");
+        image.src = dataUrlPrefix + data
+        container.appendChild(image);
+    } else {
+        const container = document.createElement('p');
+        container.setAttribute("class", "image nest" + depth);
+        div.appendChild(container);
+        const title = document.createElement("b");
+        title.textContent = label + ": ";
+        container.appendChild(title);
+        container.appendChild(document.createTextNode(data + ""));
+    }
+}

--- a/multipaz-verifier-server/src/main/resources/resources/www/verify_credentials.js
+++ b/multipaz-verifier-server/src/main/resources/resources/www/verify_credentials.js
@@ -1,0 +1,74 @@
+(function() {
+    const scriptUrl = document.currentScript.src;
+    const baseUrl = scriptUrl.substring(scriptUrl, scriptUrl.lastIndexOf('/') + 1);
+
+    const delay = function(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    };
+
+    const useUrlSchema = typeof DigitalCredential == "undefined";
+
+    /**
+     * Asynchronous function to request and verify credentials.
+     *
+     * This function uses DC API using ISO 18013 Annex C and OpenID4VP v1 protocols with fallback
+     * to "haip-vp" URL scheme.
+     *
+     * Note that ISO 18013 Annex C only supports ISO mDoc credential format and does not (yet)
+     * support transaction data, it is turned off if there are non-mDoc documents requested or
+     * transaction data is used.
+     *
+     * Parameters: this function takes a single object parameter with the following fields:
+     * - dcql (required): DCQL query (as Json object), as described in OpenID4VP spec
+     * - transaction_data (optional): transaction data as an array of Json objects as described
+     *   in described in OpenID4VP spec (before Json serialization and Base64Url-encoding).
+     * - protocols (optional): an array of DC API protocols to use in the order of preference, the
+     *   following values are supported: "org-iso-mdoc" (ISO 18013 Annex C), "openid4vp-v1-signed"
+     *   (OpenID4VP v1). Both are enabled by default.
+     */
+    window.multipazVerifyCredentials = async function(request) {
+        const adjustedRequest = {};
+        for (let key in request) {
+            adjustedRequest[key] = request[key];
+        }
+        if (useUrlSchema) {
+            adjustedRequest.protocols = [];
+        }
+        const rq = await(await fetch(baseUrl + "make_request", {
+             method: 'POST',
+             headers: {
+                 'Content-Type': 'application/json',
+             },
+             body: JSON.stringify(adjustedRequest)
+        })).json();
+        const sessionId = rq["session_id"];
+        const clientId = rq["client_id"];
+        const dcRequest = rq["dc_request"];
+        if (useUrlSchema || dcRequest.digital.requests.length == 0) {
+            window.location = "haip-vp://?client_id=" + encodeURIComponent(clientId) +
+                "&request_uri=" + encodeURIComponent(baseUrl + "get_request/" + sessionId);
+            while (true) {
+                // NB: "get_result" does long poll with 3 minute timeout
+                const res = await(await fetch(baseUrl + "get_result/" + sessionId)).json();
+                if (res["status"] != "not_ready") {
+                    return res;
+                }
+                // add a bit of a delay to rate-limit a bit if something goes terribly wrong
+                delay(100);
+            }
+        } else {
+            const dcResponse = await navigator.credentials.get(dcRequest);
+            console.log("Response: " + JSON.stringify(dcResponse));
+            return await(await fetch(baseUrl + "process_response", {
+                    method: 'POST',
+                    headers: {
+                         'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        session_id: sessionId,
+                        dc_response: dcResponse
+                    })
+                })).json();
+        }
+    }
+})();

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -3,8 +3,10 @@ package org.multipaz.openid
 import kotlinx.io.bytestring.decodeToString
 import kotlin.time.Clock
 import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
@@ -79,6 +81,7 @@ object OpenID4VP {
      * @param responseMode the response mode.
      * @param responseUri the response URI or `null`.
      * @param dclqQuery the DCQL query.
+     * @param transactionData strings from `transaction_data` array, see OpenID4VP 1.0 section 8.4.
      * @return the OpenID4VP request.
      */
     suspend fun generateRequest(
@@ -91,6 +94,7 @@ object OpenID4VP {
         responseMode: ResponseMode,
         responseUri: String?,
         dclqQuery: JsonObject,
+        transactionData: List<String> = emptyList()
     ): JsonObject {
         if (version == Version.DRAFT_24) {
             return generateRequestDraft24(
@@ -158,6 +162,11 @@ object OpenID4VP {
                         }
                     }
                 }
+            }
+            if (transactionData.isNotEmpty()) {
+                put("transaction_data", JsonArray(transactionData.map {
+                    JsonPrimitive(it)
+                }))
             }
         }
 
@@ -402,6 +411,10 @@ object OpenID4VP {
             origin = origin
         )
 
+        val transactionDataMap = request["transaction_data"]?.let {
+            TransactionData.parse(it)
+        }
+        // TODO: incorporate transaction data into the consent prompt
         val selection = source.showConsentPrompt(
             requester,
             source.resolveTrust(requester),
@@ -439,7 +452,8 @@ object OpenID4VP {
                     origin = origin,
                     clientId = clientId,
                     nonce = nonce,
-                    responseMode = responseMode
+                    responseMode = responseMode,
+                    transactionData = transactionDataMap?.get(match.source.credentialQuery.id)
                 )
             } else {
                 throw IllegalArgumentException("Expected ISO mdoc or IETF SD-JWT, got neither")
@@ -640,6 +654,7 @@ object OpenID4VP {
         clientId: String,
         nonce: String,
         responseMode: ResponseMode,
+        transactionData: List<TransactionData>?
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
         val sdjwtVcCredential = match.credential as SdJwtVcCredential
@@ -671,9 +686,24 @@ object OpenID4VP {
                     clientId
                 },
                 creationTime = Clock.System.now()
-            ).compactSerialization
+            ) {
+                transactionData?.let { dataArray ->
+                    putJsonArray("transaction_data_hashes") {
+                        dataArray.forEach { data -> add(data.hash.toByteArray().toBase64Url()) }
+                    }
+                    dataArray.firstNotNullOfOrNull { it.hashAlgorithm }?.let { hashAlgorithm ->
+                        // Non-default hash algorithm; ensure all transaction data items are
+                        // using the same one
+                        dataArray.forEach { data ->
+                            check(hashAlgorithm == (data.hashAlgorithm ?: Algorithm.SHA256))
+                        }
+                        put("transaction_data_hashes_alg", hashAlgorithm.hashAlgorithmName)
+                    }
+                }
+            }.compactSerialization
         } else {
             filteredSdJwt.compactSerialization
         }
     }
+
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/TransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/TransactionData.kt
@@ -1,0 +1,96 @@
+package org.multipaz.openid
+
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
+import org.multipaz.util.fromBase64Url
+
+/**
+ * An object that describes transaction data item in the context of OpenID4VP.
+ *
+ * TODO: perhaps we need to make this a base sealed class and have one variant for JSON-based
+ *  workflows and another for CBOR ones?
+ *
+ * @param hash hash of encoded transaction data item, calculated using [hashAlgorithm] or SHA256
+ *  if not explicitly specified
+ * @param hashAlgorithm algorithm, only if it was explicitly specified in transaction data
+ * @param type type of the transaction data item
+ * @param data JSON object that represents the transaction data item
+ */
+class TransactionData(
+    val hash: ByteString,
+    val hashAlgorithm: Algorithm?,
+    val type: String,
+    val data: JsonObject
+) {
+    companion object {
+        /**
+         * Parses encoded transaction data.
+         *
+         * @param transactionData encoded transaction data (array of base64url-encoded items)
+         * @return map of credential id to the list of applicable transaction data items
+         */
+        suspend fun parse(
+            transactionData: JsonElement
+        ): Map<String, List<TransactionData>> {
+            transactionData as? JsonArray
+                ?: throw IllegalArgumentException("Invalid transaction_data")
+            return parse(transactionData.map { it.jsonPrimitive.content })
+        }
+
+        /**
+         * Parses encoded transaction data.
+         *
+         * @param transactionData encoded transaction data (array of base64url-encoded items)
+         * @param hashAlgorithmOverrides map of credential id to the hash algorithm that must be
+         *  used for that specific credential
+         * @return map of credential id to the list of applicable transaction data items
+         */
+        suspend fun parse(
+            transactionData: List<String>,
+            hashAlgorithmOverrides: Map<String, Algorithm?>? = null
+        ): Map<String, List<TransactionData>> {
+            val map = mutableMapOf<String, MutableList<TransactionData>>()
+            for (encoded in transactionData) {
+                val jsonText = encoded.fromBase64Url().decodeToString()
+                val data = Json.parseToJsonElement(jsonText).jsonObject
+                val credentialIds = data["credential_ids"]!!.jsonArray
+                val type = data["type"]!!.jsonPrimitive.content
+                if (type != "org.multipaz.transaction_data.test") {
+                    throw IllegalArgumentException("Unsupported transaction type: '$type'")
+                }
+                val hashAlgorithm = if (hashAlgorithmOverrides != null) {
+                    // hashAlgorithmOverrides is not null when parsing for verification. At that
+                    // point the presenter picked and algorithm, we must use that same algorithm.
+                    hashAlgorithmOverrides[credentialIds.first().jsonPrimitive.content]
+                } else {
+                    data["transaction_data_hashes_alg"]?.let { algs ->
+                        algs.jsonArray.firstNotNullOf { alg ->
+                            (alg as? JsonPrimitive)?.let {
+                                try {
+                                    Algorithm.fromHashAlgorithmIdentifier(it.content)
+                                } catch (_: IllegalArgumentException) {
+                                    null
+                                }
+                            }
+                        }
+                    }
+                }
+                val hash = Crypto.digest(hashAlgorithm ?: Algorithm.SHA256, encoded.encodeToByteArray())
+                val parsed = TransactionData(ByteString(hash), hashAlgorithm, type, data)
+                for (id in credentialIds) {
+                    map.getOrPut(id.jsonPrimitive.content) { mutableListOf() }.add(parsed)
+                }
+            }
+            return map.mapValues { (_, list) -> list.toList() }
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -277,12 +277,14 @@ class SdJwt private constructor(
      * @param nonce the nonce, obtained from the verifier.
      * @param audience the audience, obtained from the verifier.
      * @param creationTime the time the presentation was made.
+     * @param additionalClaimBuilderAction builder block to add extra claims into SD-JWT+KB body
      */
     suspend fun present(
         signingKey: AsymmetricKey,
         nonce: String,
         audience: String,
-        creationTime: Instant = Clock.System.now()
+        creationTime: Instant = Clock.System.now(),
+        additionalClaimBuilderAction: JsonObjectBuilder.() -> Unit = {}
     ): SdJwtKb {
         require(signingKey.publicKey == this.kbKey) {
             "Public part of signing key does not match key in `cnf` claim"
@@ -295,6 +297,7 @@ class SdJwt private constructor(
             put("nonce", nonce)
             put("aud", audience)
             put("sd_hash", Crypto.digest(digestAlg, compactSerialization.encodeToByteArray()).toBase64Url())
+            additionalClaimBuilderAction.invoke(this)
         }
         return SdJwtKb.fromCompactSerialization(compactSerialization + kbJwt)
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -44,7 +44,6 @@ import org.multipaz.mdoc.response.DeviceResponse
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.ZkSystemSpec
 import org.multipaz.openid.OpenID4VP
-import org.multipaz.openid.dcql.DcqlQuery
 import org.multipaz.request.JsonRequestedClaim
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.sdjwt.SdJwt
@@ -154,7 +153,8 @@ object VerificationUtil {
      *   if this is `null` for such protocols
      * @param readerAuthenticationKey an optional key to use for reader authentication and its
      *    certificate chain.
-     * @throws IllegalArgumentException if [dcqlQuery] contains features not supported by [DeviceRequest], for
+     * @param transactionData base64url-encoded transaction data if any.
+     * @throws IllegalArgumentException if [dcql] contains features not supported by [DeviceRequest], for
      *   example a request for credentials that aren't ISO mdocs.
      * @return a [JsonObject] with the request.
      */
@@ -167,6 +167,7 @@ object VerificationUtil {
         clientId: String?,
         responseEncryptionKey: EcPublicKey?,
         readerAuthenticationKey: AsymmetricKey.X509Compatible?,
+        transactionData: List<String> = listOf(),
     ): JsonObject {
         val requests = exchangeProtocols.map { exchangeProtocol ->
             generateSingleRequestDcql(
@@ -177,6 +178,7 @@ object VerificationUtil {
                 clientId = clientId,
                 responseEncryptionKey = responseEncryptionKey,
                 readerAuthenticationKey = readerAuthenticationKey,
+                transactionData = transactionData
             )
         }
         return buildJsonObject {
@@ -192,6 +194,7 @@ object VerificationUtil {
         clientId: String?,
         responseEncryptionKey: EcPublicKey?,
         readerAuthenticationKey: AsymmetricKey.X509Compatible?,
+        transactionData: List<String>,
     ): JsonObject = buildJsonObject {
         put("protocol", exchangeProtocol)
         when (exchangeProtocol) {
@@ -213,7 +216,8 @@ object VerificationUtil {
                         requestSigningKey = readerAuthenticationKey,
                         responseMode = OpenID4VP.ResponseMode.DC_API,
                         responseUri = null,
-                        dclqQuery = dcql
+                        dclqQuery = dcql,
+                        transactionData = transactionData
                     )
                 )
             }
@@ -221,6 +225,9 @@ object VerificationUtil {
             "org-iso-mdoc" -> {
                 if (responseEncryptionKey == null) {
                     throw IllegalArgumentException("Response encryption is mandatory for org-iso-mdoc")
+                }
+                if (transactionData.isNotEmpty()) {
+                    throw IllegalArgumentException("Transaction data is not yet supported")
                 }
                 val encryptionInfo = buildCborArray {
                     add("dcapi")


### PR DESCRIPTION
Our current verifier is geared for testing, allowing one to select protocols, choice of claim sets, and various request options. Create an API that makes appropriate selections that should work for most uses.

Test: manual testing using testapp and http://localhost:8006/light.html