### PR TITLE
Changed provisioning UI to be a bottom sheet instead of a full-screen panel.

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -90,8 +90,8 @@
     <string name="passphrase_prompt_too_many_attempts">Too many wrong passphrases attempted, try again later</string>
 
     <!-- Provisioning -->
+    <string name="provisioning_title">Provisioning</string>
     <string name="provisioning_authorization_failed">Authorization failed</string>
-    <string name="provisioning_idle">Waiting</string>
     <string name="provisioning_initial">Starting provisioning...</string>
     <string name="provisioning_connected">Connected to the back-end</string>
     <string name="provisioning_processing_authorization">Processing authorization...</string>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -14,8 +17,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.PassphraseEntryField
@@ -27,7 +32,7 @@ import org.multipaz.multipaz_compose.generated.resources.provisioning_browser
 import org.multipaz.multipaz_compose.generated.resources.provisioning_connected
 import org.multipaz.multipaz_compose.generated.resources.provisioning_credentials_issued
 import org.multipaz.multipaz_compose.generated.resources.provisioning_error
-import org.multipaz.multipaz_compose.generated.resources.provisioning_idle
+import org.multipaz.multipaz_compose.generated.resources.provisioning_title
 import org.multipaz.multipaz_compose.generated.resources.provisioning_initial
 import org.multipaz.multipaz_compose.generated.resources.provisioning_processing_authorization
 import org.multipaz.multipaz_compose.generated.resources.provisioning_requestion_credentials
@@ -36,15 +41,19 @@ import org.multipaz.provisioning.AuthorizationChallenge
 import org.multipaz.provisioning.AuthorizationException
 import org.multipaz.provisioning.AuthorizationResponse
 import org.multipaz.securearea.PassphraseConstraints
+import kotlin.time.Duration.Companion.seconds
 
 /**
- * UI Panel (implemented as Compose [Column]) that interacts with the user and
- * drives credential provisioning in the given [ProvisioningModel].
+ * Bottom sheet that interacts with the user and drives credential provisioning in the given
+ * [ProvisioningModel], only visible when model state is not [ProvisioningModel.Idle].
+ *
+ * If the bottom sheet is dismissed, the provisioning session is canceled.
  *
  * When OpenId-style user authorization is launched, user interacts with the browser, at
  * the end of this interaction, browser is navigated to a redirect URL that the app should
  * intercept. Meanwhile [waitForRedirectLinkInvocation] is invoked (asynchronously), it should
- * return the redirect URL once it was navigated to. Although an exotic possibility, multiple
+ * return the redirect URL once it was navigated to. Although an exotic possibility (and not
+ * supported using [ProvisioningBottomSheet] as UI), multiple
  * authorization sessions can run in parallel (each with its own model). Each authorization
  * session is assigned a unique state value (passed as url parameter on the redirect url). It is
  * important that url with the correct state parameter value is returned by
@@ -56,79 +65,109 @@ import org.multipaz.securearea.PassphraseConstraints
  * @param waitForRedirectLinkInvocation wait for redirect url with the given state parameter
  *     being navigated to in the browser.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun Provisioning(
+fun ProvisioningBottomSheet(
     modifier: Modifier = Modifier,
     provisioningModel: ProvisioningModel,
     waitForRedirectLinkInvocation: suspend (state: String) -> String
 ) {
     val provisioningState = provisioningModel.state.collectAsState().value
-    Column(modifier = modifier) {
-        when (provisioningState) {
-            is ProvisioningModel.Authorizing -> {
-                Authorize(
-                    provisioningModel = provisioningModel,
-                    waitForRedirectLinkInvocation = waitForRedirectLinkInvocation,
-                    challenges = provisioningState.authorizationChallenges
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    if (provisioningState !== ProvisioningModel.Idle) {
+        ModalBottomSheet(
+            modifier = modifier,
+            onDismissRequest = { provisioningModel.cancel() },
+            sheetState = sheetState,
+            dragHandle = {},
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp).fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = stringResource(Res.string.provisioning_title),
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineMedium,
                 )
-            }
 
-            is ProvisioningModel.Error -> if (provisioningState.err is AuthorizationException) {
-                Text(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(8.dp),
-                    style = MaterialTheme.typography.titleLarge,
-                    text = stringResource(Res.string.provisioning_authorization_failed)
-                )
-                val err = provisioningState.err as AuthorizationException
-                Text(
-                    modifier = Modifier.padding(4.dp),
-                    style = MaterialTheme.typography.bodyMedium,
-                    text = stringResource(
-                        Res.string.provisioning_error,
-                        err.code
-                    )
-                )
-                err.description?.let {
-                    Text(
-                        modifier = Modifier.padding(4.dp),
-                        style = MaterialTheme.typography.bodyMedium,
-                        text = it
-                    )
+                when (provisioningState) {
+                    is ProvisioningModel.Authorizing -> {
+                        Authorize(
+                            provisioningModel = provisioningModel,
+                            waitForRedirectLinkInvocation = waitForRedirectLinkInvocation,
+                            challenges = provisioningState.authorizationChallenges
+                        )
+                    }
+
+                    is ProvisioningModel.Error -> {
+                        if (provisioningState.err is AuthorizationException) {
+                            Text(
+                                modifier = Modifier
+                                    .align(Alignment.CenterHorizontally)
+                                    .padding(8.dp),
+                                text = stringResource(Res.string.provisioning_authorization_failed)
+                            )
+                            val err = provisioningState.err as AuthorizationException
+                            Text(
+                                modifier = Modifier.padding(4.dp),
+                                text = stringResource(
+                                    Res.string.provisioning_error,
+                                    err.code
+                                )
+                            )
+                            err.description?.let {
+                                Text(
+                                    modifier = Modifier.padding(4.dp),
+                                    text = it
+                                )
+                            }
+                        } else {
+                            Text(
+                                modifier = Modifier
+                                    .align(Alignment.CenterHorizontally)
+                                    .padding(8.dp),
+                                text = stringResource(
+                                    Res.string.provisioning_error,
+                                    provisioningState.err.message ?: "unknown"
+                                )
+                            )
+                        }
+                        LaunchedEffect(true) {
+                            delay(3.seconds)
+                            provisioningModel.cancel()  // resets to Idle
+                        }
+                    }
+
+                    else -> {
+                        val text = stringResource(
+                            when (provisioningState) {
+                                ProvisioningModel.Idle -> throw IllegalStateException()
+                                ProvisioningModel.Initial -> Res.string.provisioning_initial
+                                ProvisioningModel.Connected -> Res.string.provisioning_connected
+                                ProvisioningModel.ProcessingAuthorization -> Res.string.provisioning_processing_authorization
+                                ProvisioningModel.Authorized -> Res.string.provisioning_authorized
+                                ProvisioningModel.RequestingCredentials -> Res.string.provisioning_requestion_credentials
+                                ProvisioningModel.CredentialsIssued -> Res.string.provisioning_credentials_issued
+                                is ProvisioningModel.Error -> throw IllegalStateException()
+                                is ProvisioningModel.Authorizing -> throw IllegalStateException()
+                            }
+                        )
+                        Text(
+                            modifier = Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .padding(8.dp),
+                            text = text
+                        )
+                        if (provisioningState == ProvisioningModel.CredentialsIssued) {
+                            LaunchedEffect(true) {
+                                delay(3.seconds)
+                                provisioningModel.cancel()  // resets to Idle
+                            }
+                        }
+                    }
                 }
-            } else {
-                Text(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(8.dp),
-                    style = MaterialTheme.typography.titleLarge,
-                    text = stringResource(
-                        Res.string.provisioning_error,
-                        provisioningState.err.message ?: "unknown"
-                    )
-                )
-            }
-
-            else -> {
-                val text = stringResource(when (provisioningState) {
-                    ProvisioningModel.Idle -> Res.string.provisioning_idle
-                    ProvisioningModel.Initial -> Res.string.provisioning_initial
-                    ProvisioningModel.Connected -> Res.string.provisioning_connected
-                    ProvisioningModel.ProcessingAuthorization -> Res.string.provisioning_processing_authorization
-                    ProvisioningModel.Authorized -> Res.string.provisioning_authorized
-                    ProvisioningModel.RequestingCredentials -> Res.string.provisioning_requestion_credentials
-                    ProvisioningModel.CredentialsIssued -> Res.string.provisioning_credentials_issued
-                    is ProvisioningModel.Error -> throw IllegalStateException()
-                    is ProvisioningModel.Authorizing -> throw IllegalStateException()
-                })
-                Text(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(8.dp),
-                    style = MaterialTheme.typography.titleLarge,
-                    text = text
-                )
             }
         }
     }
@@ -182,8 +221,7 @@ private fun EvidenceRequestWebView(
             Text(
                 text = stringResource(Res.string.provisioning_browser),
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(8.dp),
-                style = MaterialTheme.typography.bodyLarge
+                modifier = Modifier.padding(8.dp)
             )
         }
     }
@@ -206,7 +244,6 @@ private fun EvidenceRequestSecretText(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(8.dp),
-            style = MaterialTheme.typography.titleLarge,
             text = passphraseRequest.description
         )
         if (challenge.retry) {
@@ -214,7 +251,6 @@ private fun EvidenceRequestSecretText(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(8.dp),
-                style = MaterialTheme.typography.titleLarge,
                 text = stringResource(Res.string.provisioning_retry)
             )
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -3,13 +3,11 @@ package org.multipaz.testapp
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,7 +25,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -47,9 +44,7 @@ import io.ktor.http.protocolWithAuthority
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -73,7 +68,7 @@ import org.multipaz.certext.fromCbor
 import org.multipaz.compose.branding.Branding
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.prompt.PromptDialogs
-import org.multipaz.compose.provisioning.Provisioning
+import org.multipaz.compose.provisioning.ProvisioningBottomSheet
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -100,7 +95,6 @@ import org.multipaz.mdoc.vical.SignedVical
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.longfellow.LongfellowZkSystem
 import org.multipaz.nfc.ExternalNfcReaderStore
-import org.multipaz.nfc.NfcTagReader
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.presentment.SimplePresentmentSource
 import org.multipaz.presentment.uriSchemePresentment
@@ -161,7 +155,6 @@ import org.multipaz.util.fromHexByteString
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.toHex
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Application singleton.
@@ -886,7 +879,6 @@ class App private constructor (val promptModel: PromptModel) {
                         clientPreferences = provisioningSupport.getOpenID4VCIClientPreferences(),
                         backend = provisioningSupport.getOpenID4VCIBackend()
                     )
-                    navController.navigate(ProvisioningTestDestination)
                 }
             }
         }
@@ -905,6 +897,12 @@ class App private constructor (val promptModel: PromptModel) {
             PromptDialogs(
                 promptModel = promptModel,
                 imageLoader = imageLoader
+            )
+            ProvisioningBottomSheet(
+                provisioningModel = provisioningModel,
+                waitForRedirectLinkInvocation = { state ->
+                    provisioningSupport.waitForAppLinkInvocation(state)
+                }
             )
             NavHost(
                 navController = navController,
@@ -936,7 +934,6 @@ class App private constructor (val promptModel: PromptModel) {
                             },
                             onClickPassphraseEntryField = { navController.navigate(PassphraseEntryFieldDestination) },
                             onClickPassphrasePrompt = { navController.navigate(PassphrasePromptDestination) },
-                            onClickProvisioningTestField = { navController.navigate(ProvisioningTestDestination) },
                             onClickConsentSheetList = { navController.navigate(ConsentPromptDestination) },
                             onClickQrCodes = { navController.navigate(QrCodesDestination) },
                             onClickNfc = { navController.navigate(NfcDestination) },
@@ -1151,42 +1148,6 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<PassphrasePromptDestination> { backStackEntry ->
                     WithAppBar(navController, "PassphrasePrompt use-cases") {
                         PassphrasePromptScreen(showToast = { message -> showToast(message) })
-                    }
-                }
-                composable<ProvisioningTestDestination> { backStackEntry ->
-                    WithAppBar(navController, "Provisioning Test") {
-                        val coroutineScope = rememberCoroutineScope()
-                        val provisioningState = provisioningModel.state.collectAsState().value
-                        LaunchedEffect(provisioningState) {
-                            if (provisioningState == ProvisioningModel.CredentialsIssued) {
-                                delay(1.seconds)
-                                navController.navigate(DocumentStoreDestination)
-                            }
-                        }
-                        Column(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Spacer(modifier = Modifier.weight(1.0f))
-                            Provisioning(
-                                provisioningModel = provisioningModel,
-                                waitForRedirectLinkInvocation = { state ->
-                                    provisioningSupport.waitForAppLinkInvocation(state)
-                                }
-                            )
-                            Spacer(modifier = Modifier.weight(1.0f))
-                            Button(onClick = {
-                                provisioningModel.cancel()
-                                coroutineScope.launch {
-                                    delay(1.seconds)
-                                    navController.navigateUp()
-                                }
-                            }) {
-                                Text("Cancel Provisioning")
-                            }
-                            Spacer(modifier = Modifier.weight(1.0f))
-                        }
                     }
                 }
                 composable<ConsentPromptDestination> { backStackEntry ->

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -65,9 +65,6 @@ data object PassphraseEntryFieldDestination: Destination()
 data object PassphrasePromptDestination: Destination()
 
 @Serializable
-data object ProvisioningTestDestination: Destination()
-
-@Serializable
 data object ConsentPromptDestination: Destination()
 
 @Serializable

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -39,7 +39,6 @@ fun StartScreen(
     onClickSecureEnclaveSecureArea: () -> Unit = {},
     onClickPassphraseEntryField: () -> Unit = {},
     onClickPassphrasePrompt: () -> Unit = {},
-    onClickProvisioningTestField: () -> Unit = {},
     onClickConsentSheetList: () -> Unit = {},
     onClickQrCodes: () -> Unit = {},
     onClickNfc: () -> Unit = {},


### PR DESCRIPTION
Changed provisioning UI to be a bottom sheet instead of a full-screen panel.

Also renamed the compose function as it needs to be called in a different place in the UI stack. This way dependent apps will be forced to re-integrate it.

Test: manual testing with testapp and openid4vci server. 
Fixes #1571
