### PR TITLE
Add support for ISO/IEC TS 18013-7 Annex A on the wallet side.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
@@ -17,10 +17,10 @@ package com.android.identity.android.mdoc.transport
 
 import android.os.ConditionVariable
 import androidx.test.platform.app.InstrumentationRegistry
-import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.util.fromHex
 import org.junit.Assert
 import org.junit.Test
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.kt
@@ -17,9 +17,9 @@ package com.android.identity.android.mdoc.transport
 
 import android.content.Context
 import android.os.Build
-import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import java.util.ArrayDeque

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportHttp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportHttp.kt
@@ -18,7 +18,6 @@ package com.android.identity.android.mdoc.transport
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.text.format.Formatter
-import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
 import com.android.volley.DefaultRetryPolicy
@@ -28,6 +27,7 @@ import com.android.volley.RequestQueue
 import com.android.volley.Response
 import com.android.volley.toolbox.HttpHeaderParser
 import com.android.volley.toolbox.Volley
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStream

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
@@ -122,13 +122,15 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
                 origin = origin,
                 httpClientEngineFactory = settings.httpClientEngineFactory,
             )
-            // Open the redirect URI in a browser...
-            startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    redirectUri.toUri()
+            if (redirectUri != null) {
+                // Open the redirect URI in a browser...
+                startActivity(
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        redirectUri.toUri()
+                    )
                 )
-            )
+            }
         } catch (e: Throwable) {
             Logger.i(TAG, "Error processing request", e)
         } finally {

--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="credential_presentment_button_more">More</string>
     <string name="credential_presentment_button_share">Share</string>
     <string name="credential_presentment_headline_share_with_unknown_requester">Unknown requester</string>
+    <string name="credential_presentment_headline_share_with_unknown_website">Unknown website</string>
     <string name="credential_presentment_share_with_known_requester">This data will be shared with %1$s:</string>
     <string name="credential_presentment_share_with_unknown_requester">This data will be shared:</string>
     <string name="credential_presentment_share_and_stored_by_known_requester">This data will be stored by %1$s:</string>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -106,6 +106,7 @@ import org.multipaz.multipaz_compose.generated.resources.credential_presentment_
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_select_document
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_data_element_icon_description
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_headline_share_with_unknown_requester
+import org.multipaz.multipaz_compose.generated.resources.credential_presentment_headline_share_with_unknown_website
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_info_verifier_in_trust_list
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_info_verifier_in_trust_list_app
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_info_verifier_in_trust_list_website
@@ -470,7 +471,9 @@ private fun ConsentPage(
         )
     } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
         RequesterDisplayData(
-            name = requester.origin,
+            name = requester.origin!!.ifEmpty {
+                stringResource(Res.string.credential_presentment_headline_share_with_unknown_website)
+            },
         )
     } else if (appInfo != null) {
         RequesterDisplayData(
@@ -1243,4 +1246,5 @@ private fun RelyingPartySection(
     }
 }
 
-private fun isWebOrigin(origin: String) = origin.startsWith("http://") || origin.startsWith("https://")
+private fun isWebOrigin(origin: String) =
+    origin.isEmpty() || origin.startsWith("http://") || origin.startsWith("https://")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
@@ -76,6 +76,10 @@ abstract class MdocConnectionMethod {
                 MdocConnectionMethodWifiAware.METHOD_TYPE -> return MdocConnectionMethodWifiAware.fromDeviceEngagement(
                     encodedDeviceRetrievalMethod
                 )
+
+                MdocConnectionMethodHttp.METHOD_TYPE -> return MdocConnectionMethodHttp.fromDeviceEngagement(
+                    encodedDeviceRetrievalMethod
+                )
             }
             Logger.w(TAG, "Unsupported ConnectionMethod type $type in DeviceEngagement")
             return null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodHttp.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodHttp.kt
@@ -1,4 +1,4 @@
-package com.android.identity.android.mdoc.connectionmethod
+package org.multipaz.mdoc.connectionmethod
 
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.addCborMap

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/DeviceEngagement.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/DeviceEngagement.kt
@@ -13,7 +13,6 @@ import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod.Companion.fromDeviceEngagement
 import org.multipaz.mdoc.origininfo.OriginInfo
 import org.multipaz.util.Logger
 
@@ -42,11 +41,6 @@ data class DeviceEngagement private constructor(
 ) {
 
     init {
-        if (originInfos.isEmpty() && capabilities.isEmpty()) {
-            check(version == "1.0") {
-                "DeviceEngagement version must be 1.0 when originInfos and capabilities are both empty"
-            }
-        }
         if (originInfos.isNotEmpty() || capabilities.isNotEmpty()) {
             check(version >= "1.1") {
                 "DeviceEngagement version must be 1.1 or higher when originInfos or capabilities are non-empty"
@@ -109,7 +103,7 @@ data class DeviceEngagement private constructor(
             val connectionMethods = mutableListOf<MdocConnectionMethod>()
             if (connectionMethodsArray != null) {
                 for (cmDataItem in (connectionMethodsArray as CborArray).items) {
-                    val connectionMethod = fromDeviceEngagement(
+                    val connectionMethod = MdocConnectionMethod.fromDeviceEngagement(
                         Cbor.encode(cmDataItem)
                     )
                     if (connectionMethod != null) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/origininfo/OriginInfoDomain.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/origininfo/OriginInfoDomain.kt
@@ -19,12 +19,12 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborMap
 
-data class OriginInfoDomain(val url: String) : OriginInfo() {
+data class OriginInfoDomain(val domain: String) : OriginInfo() {
     override fun toDataItem() = buildCborMap {
         put("cat", CAT)
         put("type", TYPE)
         putCborMap("details") {
-            put("domain", url)
+            put("domain", domain)
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
+import io.ktor.http.Url
 import io.ktor.http.contentType
 import io.ktor.http.formUrlEncode
 import io.ktor.http.parseUrlEncodedParameters
@@ -19,8 +20,27 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.JsonWebSignature
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
+import org.multipaz.mdoc.engagement.Capability
+import org.multipaz.mdoc.engagement.DeviceEngagement
+import org.multipaz.mdoc.engagement.buildDeviceEngagement
+import org.multipaz.mdoc.origininfo.OriginInfoDomain
+import org.multipaz.mdoc.request.DeviceRequest
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.sessionencryption.SessionEncryption
 import org.multipaz.openid.OpenID4VP
+import org.multipaz.util.Constants
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 
 private const val TAG = "uriSchemePresentment"
@@ -32,14 +52,22 @@ private const val TAG = "uriSchemePresentment"
  * @param uri the referrer.
  * @param origin the origin.
  * @param httpClientEngineFactory a [HttpClientEngineFactory].
- * @return the redirect URI, caller should open this in the user's default browser.
+ * @return the redirect URI, caller should open this in the user's default browser or `null` if this is not required.
  */
 suspend fun uriSchemePresentment(
     source: PresentmentSource,
     uri: String,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
-): String {
+): String? {
+    if (uri.startsWith("mdoc://")) {
+        return mdocUriSchemePresentment(
+            source = source,
+            uri = uri,
+            origin = origin,
+            httpClientEngineFactory = httpClientEngineFactory
+        )
+    }
     val parameters = uri.parseUrlEncodedParameters()
     // TODO: maybe also support `request` in addition to `request_uri`, that is, the case
     //   where the request is passed by value instead of reference
@@ -78,7 +106,7 @@ suspend fun uriSchemePresentment(
         preselectedDocuments = listOf(),
         source = source,
         appId = null, // TODO: maybe pass the browser's appId if we can
-        origin = origin,
+        origin = origin ?: "",
         request = requestObject,
         requesterCertChain = requesterChain,
     )
@@ -112,4 +140,126 @@ suspend fun uriSchemePresentment(
     val postResponseBody = Json.decodeFromString<JsonObject>(bodyText)
     val redirectUri = postResponseBody["redirect_uri"]!!.jsonPrimitive.content
     return redirectUri
+}
+
+private suspend fun mdocUriSchemePresentment(
+    source: PresentmentSource,
+    uri: String,
+    origin: String?,
+    httpClientEngineFactory: HttpClientEngineFactory<*>,
+): String? {
+    val url = Url(uri)
+    val readerEngagementEncoded = url.host.fromBase64Url()
+    val readerEngagementDataItem = Cbor.decode(readerEngagementEncoded)
+
+    // ReaderEnagement is really the same as DeviceEngagement so just re-use the parser
+    val readerEngagement = DeviceEngagement.fromDataItem(readerEngagementDataItem)
+    val eReaderKey = readerEngagement.eDeviceKey
+
+    val httpRetrievalMethod = readerEngagement.connectionMethods.find { it is MdocConnectionMethodHttp } as MdocConnectionMethodHttp?
+    if (httpRetrievalMethod == null) {
+        throw IllegalArgumentException("No MdocConnectionMethodHttp method found")
+    }
+    val readerUrl = httpRetrievalMethod.uri
+
+    // TODO: handle this curve not being supported...
+    val eDeviceKey = Crypto.createEcPrivateKey(eReaderKey.curve)
+    val deviceEngagement = buildDeviceEngagement(
+        eDeviceKey = eDeviceKey.publicKey,
+    ) {
+        addCapability(Capability.READER_AUTH_ALL_SUPPORT, Simple.TRUE)
+        addCapability(Capability.EXTENDED_REQUEST_SUPPORT, Simple.TRUE)
+        if (origin != null) {
+            addOriginInfo(OriginInfoDomain(domain = Url(origin).host))
+        } else {
+            // From A.3.2:
+            //
+            //   The value of the “domain” element may be an empty string. This signifies that the mdoc did not
+            //   receive the value of the domain, or did not receive it from a source trusted by the mdoc.
+            //
+            addOriginInfo(OriginInfoDomain(domain = ""))
+        }
+    }
+
+    val httpClient = HttpClient(httpClientEngineFactory) {
+        install(HttpTimeout)
+    }
+    val deviceEngagementBytesDataItem = Tagged(
+        tagNumber = Tagged.ENCODED_CBOR,
+        taggedItem = Bstr(Cbor.encode(deviceEngagement.toDataItem()))
+    )
+    val deviceEngagementMessage = buildCborMap {
+        put("deviceEngagementBytes", deviceEngagementBytesDataItem)
+    }
+
+    val engagementToApp = Bstr(
+        Crypto.digest(Algorithm.SHA256, Cbor.encode(
+            Tagged(
+                tagNumber = Tagged.ENCODED_CBOR,
+                taggedItem = Bstr(readerEngagementEncoded)
+            ))
+        )
+    )
+
+    val sessionTranscript = buildCborArray {
+        add(deviceEngagementBytesDataItem)
+        add(Cbor.decode(readerEngagement.eDeviceKeyBytes.toByteArray()))
+        add(engagementToApp)
+    }
+
+    val sessionEncryption = SessionEncryption(
+        role = MdocRole.MDOC,
+        eSelfKey = eDeviceKey,
+        remotePublicKey = eReaderKey,
+        encodedSessionTranscript = Cbor.encode(sessionTranscript)
+    )
+
+    var messageToPost = Cbor.encode(deviceEngagementMessage)
+    do {
+        val initialResponse = httpClient.post(readerUrl) {
+            contentType(ContentType.Application.Cbor)
+            setBody(messageToPost)
+        }
+        if (initialResponse.status != HttpStatusCode.OK) {
+            throw IllegalStateException("Unexpected HTTP response ${initialResponse.status} from reader")
+        }
+        val sessionMessage = initialResponse.body<ByteArray>()
+
+        val (messageFromReader, messageFromReaderStatus) =
+            sessionEncryption.decryptMessage(sessionMessage)
+        if (messageFromReaderStatus != null) {
+            when (messageFromReaderStatus) {
+                Constants.SESSION_DATA_STATUS_SESSION_TERMINATION -> {
+                    Logger.i(TAG, "Received session termination message")
+                    break
+                }
+                else -> {
+                    throw IllegalStateException("Unexpected status $messageFromReaderStatus")
+                }
+            }
+        }
+        if (messageFromReader == null) {
+            throw IllegalStateException("No data in message from reader")
+        }
+
+        val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(messageFromReader))
+        deviceRequest.verifyReaderAuthentication(sessionTranscript)
+        val deviceResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = eReaderKey,
+            sessionTranscript = sessionTranscript,
+            source = source,
+            keyAgreementPossible = emptyList(), // TODO: support MacKeys
+            requesterAppId = null, // TODO: maybe pass the browser's appId if we can
+            requesterOrigin = origin ?: "",
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        messageToPost = sessionEncryption.encryptMessage(
+            messagePlaintext = Cbor.encode(deviceResponse.toDataItem()),
+            statusCode = null
+        )
+    } while (true)
+    return null
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
@@ -12,6 +12,7 @@ import org.multipaz.crypto.X509CertChain
  *   this may be a website origin such as https://www.example.com. Otherwise this is set to the origin
  *   for the native application, for example on Android this will be of the form
  *   "android:apk-key-hash:<sha256_hash-of-apk-signing-cert>".
+ *   If empty it means that the requester is a website but the origin wasn't passed from the web browser.
  */
 data class Requester(
     val certChain: X509CertChain? = null,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodTest.kt
@@ -35,8 +35,8 @@ class MdocConnectionMethodTest {
         val cm = MdocConnectionMethodNfc(4096, 32768)
         val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodNfc?
         assertNotNull(decoded)
-        assertEquals(decoded.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
-        assertEquals(decoded.responseDataFieldMaxLength, decoded.responseDataFieldMaxLength)
+        assertEquals(cm.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
+        assertEquals(cm.responseDataFieldMaxLength, decoded.responseDataFieldMaxLength)
         assertEquals(
             """[
   1,
@@ -50,6 +50,25 @@ class MdocConnectionMethodTest {
         val ndefRecord = cm.toNdefRecord(listOf(), MdocRole.MDOC, false)!!.first
         val decodedNfc = MdocConnectionMethodNfc.fromNdefRecord(ndefRecord, MdocRole.MDOC)!!
         assertEquals(cm, decodedNfc)
+    }
+
+    @Test
+    fun testConnectionMethodHttp() {
+        val cm = MdocConnectionMethodHttp(uri = "https://www.example.com/foobar")
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodHttp?
+        assertNotNull(decoded)
+        assertEquals(cm.uri, decoded.uri)
+        assertEquals(
+            """
+                [
+                  4,
+                  1,
+                  {
+                    0: "https://www.example.com/foobar"
+                  }
+                ]
+            """.trimIndent(), Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
+        )
     }
 
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/origininfo/OriginInfoTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/origininfo/OriginInfoTest.kt
@@ -25,7 +25,7 @@ class OriginInfoTest {
     fun testOriginInfoDomainOrigin() {
         val info = OriginInfoDomain("https://foo.com/bar")
         val decoded = OriginInfoDomain.fromDataItem(info.toDataItem())
-        assertEquals("https://foo.com/bar", decoded!!.url)
+        assertEquals("https://foo.com/bar", decoded!!.domain)
         assertEquals(
             """
                 {

--- a/samples/SwiftTestApp/SwiftTestApp/Info.plist
+++ b/samples/SwiftTestApp/SwiftTestApp/Info.plist
@@ -44,8 +44,16 @@
 				<string>openid4vp</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.multipaz.iso.mdoc</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mdoc</string>
+			</array>
+		</dict>
 	</array>
-	<key>CFBundleIdentifier</key>
-	<string>samples/SwiftTestApp/SwiftTestApp/Info.plist</string>
 </dict>
 </plist>

--- a/samples/testapp/iosApp/TestApp/Info.plist
+++ b/samples/testapp/iosApp/TestApp/Info.plist
@@ -70,6 +70,16 @@
 				<string>openid4vp</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.multipaz.iso.mdoc</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mdoc</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -148,6 +148,8 @@
                 <!--  Various OpenID4VP schemes -->
                 <data android:scheme="haip-vp"/>
                 <data android:scheme="openid4vp"/>
+                <!-- ISO/IEC TS 18013-7:2025 Annex A (and later) -->
+                <data android:scheme="mdoc"/>
                 <!-- Accept all hosts for any of the defined schemes above -->
                 <data android:host="*"/>
             </intent-filter>

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -784,9 +784,11 @@ class App private constructor (val promptModel: PromptModel) {
                     credentialOffers.send(url)
                 }
             }
-        } else if (url.startsWith(HAIP_VP_URL_SCHEME) || url.startsWith(OPENID4VP_URL_SCHEME)) {
-            // On Android OpenID4VP is handled by a dedicated activity, so this code
-            // is called only on iOS
+        } else if (
+            url.startsWith(HAIP_VP_URL_SCHEME) ||
+            url.startsWith(OPENID4VP_URL_SCHEME) ||
+            url.startsWith(MDOC_URL_SCHEME)) {
+            // On Android, URI schemes are handled by a dedicated activity, so this code is called only on iOS
             uriSchemePresentation(url)
         } else if (url.startsWith(ProvisioningSupport.APP_LINK_BASE_URL)) {
             CoroutineScope(Dispatchers.Default).launch {
@@ -808,7 +810,9 @@ class App private constructor (val promptModel: PromptModel) {
                     httpClientEngineFactory = TestAppConfiguration.httpClientEngineFactory,
                 )
                 // Open the redirect URI in a browser...
-                urlsToOpen.send(redirectUri)
+                if (redirectUri != null) {
+                    urlsToOpen.send(redirectUri)
+                }
             } catch (e: Throwable) {
                 Logger.i(TAG, "Error processing request", e)
             }
@@ -823,6 +827,7 @@ class App private constructor (val promptModel: PromptModel) {
         private const val HAIP_VCI_URL_SCHEME = "haip-vci://"
         private const val OPENID4VP_URL_SCHEME = "openid4vp://"
         private const val HAIP_VP_URL_SCHEME = "haip-vp://"
+        private const val MDOC_URL_SCHEME = "mdoc://"
 
         private var app: App? = null
         fun getInstance(): App {


### PR DESCRIPTION
This adds back support for 18013-7 Annex A as a wallet, like we used to support previously.

Tested against https://reader.rdw.mdoc.online/TestAnnexA2.html

A future commit will add support for this on the reader side as well.

Demo: https://youtu.be/SLXxMcc8anE

Test: Manually tested on Android and iOS versions of Multipaz Test App.
