### PR TITLE
Use PresentmentActivity for Credman and URI scheme presentations on Android.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -1,14 +1,12 @@
 package org.multipaz.compose.digitalcredentials
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.core.graphics.drawable.toDrawable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.credentials.DigitalCredential
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.credentials.GetCredentialResponse
@@ -32,15 +30,16 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.prompt.PresentmentActivityContent
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.context.initializeApplication
 import org.multipaz.digitalcredentials.getAppOrigin
 import org.multipaz.digitalcredentials.lookupForCredmanId
+import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.presentment.digitalCredentialsPresentment
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.util.Logger
-import java.lang.IllegalStateException
 
 /**
  * Base class for activity used for Android Credential Manager presentments using the W3C Digital Credentials API.
@@ -79,39 +78,54 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
 
     private val promptModel = AndroidPromptModel.Builder().apply { addCommonDialogs() }.build()
 
+    val presentmentModel = PresentmentModel()
+
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeApplication(this.applicationContext)
         enableEdgeToEdge()
 
-        window.setBackgroundDrawable(android.graphics.Color.TRANSPARENT.toDrawable())
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            setTranslucent(true)
-        }
+        window.isNavigationBarContrastEnforced = false
 
         val imageLoader = ImageLoader.Builder(applicationContext).components {
             add(KtorNetworkFetcherFactory(HttpClient(Android.create())))
         }.build()
 
         val startChannel = Channel<Unit>()
-
         setContent {
             val currentBranding = Branding.Current.collectAsState().value
             currentBranding.theme {
+                val coroutineScope = rememberCoroutineScope()
+
                 PromptDialogs(
                     promptModel = promptModel,
                     imageLoader = imageLoader,
                 )
-                LaunchedEffect(true) {
-                    startChannel.send(Unit)
-                }
-            }
-        }
 
-        CoroutineScope(Dispatchers.Main + promptModel).launch {
-            startChannel.receive()  // wait until PromptModel is bound
-            startPresentment(getSettings())
+                // Only start presentation once we're fully faded in
+                PresentmentActivityContent(
+                    window = window,
+                    getPresentmentModel = {
+                        val settings = getSettings()
+                        presentmentModel.reset(
+                            source = settings.source,
+                            preselectedDocuments = emptyList(),
+                            showDocumentChooser = null
+                        )
+
+                        CoroutineScope(Dispatchers.IO + promptModel).launch {
+                            // wait until we're faded in
+                            startChannel.receive()
+                            startPresentment(settings = settings)
+                        }
+
+                        presentmentModel
+                    },
+                    onFadedIn = { coroutineScope.launch { startChannel.send(Unit) } },
+                    onFinish = { _ -> finish() }
+                )
+            }
         }
     }
 
@@ -140,13 +154,17 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
             val requestForSelectedEntry = json["requests"]!!.jsonArray.find {
                 (it as JsonObject)["protocol"]!!.jsonPrimitive.content == selectionInfo.protocol
             }!!.jsonObject
+            presentmentModel.setWaitingForUserInput()
             val response = digitalCredentialsPresentment(
                 protocol = requestForSelectedEntry["protocol"]!!.jsonPrimitive.content,
                 data = requestForSelectedEntry["data"]!!.jsonObject,
                 appId = callingPackageName,
                 origin = origin,
                 preselectedDocuments = documents,
-                source = settings.source
+                source = settings.source,
+                onDocumentsInFocus = { documents ->
+                    presentmentModel.setDocumentsSelected(documents)
+                }
             )
             val jsonString = Json.encodeToString(response)
             Logger.i(TAG, "Size of JSON response: ${jsonString.length} bytes")
@@ -154,6 +172,7 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
             val credentialManagerResponse = GetCredentialResponse(DigitalCredential(jsonString))
             PendingIntentHandler.setGetCredentialResponse(resultData, credentialManagerResponse)
             setResult(RESULT_OK, resultData)
+            presentmentModel.setCompleted(error = null)
         } catch (e: Throwable) {
             Logger.i(TAG, "Error processing request", e)
             val resultData = Intent()
@@ -163,8 +182,7 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
             )
             PendingIntentHandler.setGetCredentialException(resultData, credentialManagerException)
             setResult(RESULT_OK, resultData)
-        } finally {
-            finish()
+            presentmentModel.setCompleted(error = e)
         }
     }
 

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
@@ -34,7 +34,7 @@ import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.ResponseApdu
 import org.multipaz.presentment.Iso18013Presentment
-import org.multipaz.presentment.PresentmentCanceled
+import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.PromptModel
@@ -355,7 +355,7 @@ abstract class MdocNdefService: HostApduService() {
         } catch (e: Throwable) {
             Logger.w(TAG, "Caught error while performing 18013-5 transaction", e)
             if (e is CancellationException) {
-                settings.presentmentModel?.setCompleted(PresentmentCanceled("Presentment was cancelled"))
+                settings.presentmentModel?.setCompleted(PresentmentCanceledException("Presentment was cancelled"))
             } else {
                 settings.presentmentModel?.setCompleted(e)
             }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.android.kt
@@ -30,7 +30,7 @@ import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.advertise
 import org.multipaz.mdoc.transport.waitForConnection
 import org.multipaz.presentment.Iso18013Presentment
-import org.multipaz.presentment.PresentmentCanceled
+import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.PromptModel
@@ -181,7 +181,7 @@ private fun MdocProximityQrPresentmentAndroid(
                         } catch (e: Throwable) {
                             if (e is CancellationException) {
                                 PresentmentActivity.presentmentModel.setCompleted(
-                                    PresentmentCanceled("Presentment was cancelled")
+                                    PresentmentCanceledException("Presentment was cancelled")
                                 )
                             } else {
                                 PresentmentActivity.presentmentModel.setCompleted(e)

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
@@ -1,32 +1,33 @@
 package org.multipaz.compose.presentment
 
 import android.content.Intent
-import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.collectAsState
-import androidx.core.graphics.drawable.toDrawable
-import androidx.fragment.app.FragmentActivity
-import io.ktor.client.engine.HttpClientEngineFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import org.multipaz.compose.prompt.PromptDialogs
-import org.multipaz.context.initializeApplication
-import org.multipaz.presentment.PresentmentSource
-import org.multipaz.util.Logger
-import java.net.URL
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.core.net.toUri
+import androidx.fragment.app.FragmentActivity
 import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.android.Android
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.prompt.PresentmentActivityContent
+import org.multipaz.compose.prompt.PromptDialogs
+import org.multipaz.context.initializeApplication
+import org.multipaz.presentment.PresentmentModel
+import org.multipaz.presentment.PresentmentSource
 import org.multipaz.presentment.uriSchemePresentment
 import org.multipaz.prompt.AndroidPromptModel
+import org.multipaz.util.Logger
+import java.net.URL
 
 /**
  * Base class for activity used for credential presentments using URI schemes.
@@ -61,33 +62,79 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
 
     private val promptModel = AndroidPromptModel.Builder().apply { addCommonDialogs() }.build()
 
+    val presentmentModel = PresentmentModel()
+
+    var openRedirectUri: String? = null
+
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeApplication(this.applicationContext)
         enableEdgeToEdge()
 
-        window.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            setTranslucent(true)
-        }
+        window.isNavigationBarContrastEnforced = false
 
-        if (intent.action == Intent.ACTION_VIEW) {
-            val url = intent.dataString
-            // This may or may not be set. For example in Chrome it only works
-            // if the website is using Referrer-Policy: unsafe-url
-            //
-            // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
-            //
-            @Suppress("DEPRECATION")
-            var referrerUrl: String? = intent.extras?.get(Intent.EXTRA_REFERRER).toString()
-            if (referrerUrl == "null") {
-                referrerUrl = null
-            }
-            if (url != null) {
-                CoroutineScope(Dispatchers.Main + promptModel).launch {
-                    startPresentment(url, referrerUrl, getSettings())
-                }
+        val imageLoader = ImageLoader.Builder(applicationContext).components {
+            add(KtorNetworkFetcherFactory(HttpClient(Android.create())))
+        }.build()
+
+        val startChannel = Channel<Unit>()
+        setContent {
+            val currentBranding = Branding.Current.collectAsState().value
+            currentBranding.theme {
+                val coroutineScope = rememberCoroutineScope()
+
+                PromptDialogs(
+                    promptModel = promptModel,
+                    imageLoader = imageLoader,
+                )
+
+                // Only start presentation once we're fully faded in
+                PresentmentActivityContent(
+                    window = window,
+                    getPresentmentModel = {
+                        val settings = getSettings()
+                        presentmentModel.reset(
+                            source = settings.source,
+                            preselectedDocuments = emptyList(),
+                            showDocumentChooser = null
+                        )
+
+                        CoroutineScope(Dispatchers.IO + promptModel).launch {
+                            // wait until we're faded in
+                            startChannel.receive()
+
+                            val url = intent.dataString
+                            // This may or may not be set. For example in Chrome it only works
+                            // if the website is using Referrer-Policy: unsafe-url
+                            //
+                            // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
+                            //
+                            @Suppress("DEPRECATION")
+                            var referrerUrl: String? = intent.extras?.get(Intent.EXTRA_REFERRER).toString()
+                            if (referrerUrl == "null") {
+                                referrerUrl = null
+                            }
+                            if (url != null) {
+                                startPresentment(
+                                    url = url,
+                                    referrerUrl = referrerUrl,
+                                    settings = settings
+                                )
+                            }
+                        }
+
+                        presentmentModel
+                    },
+                    onFadedIn = { coroutineScope.launch { startChannel.send(Unit) } },
+                    onFinish = { _ ->
+                        // Open the redirect URI in a browser...
+                        openRedirectUri?.let {
+                            startActivity(Intent(Intent.ACTION_VIEW, it.toUri()))
+                        }
+                        finish()
+                    }
+                )
             }
         }
     }
@@ -97,44 +144,25 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
         referrerUrl: String?,
         settings: Settings
     ) {
-        val imageLoader = ImageLoader.Builder(applicationContext).components {
-            add(KtorNetworkFetcherFactory(HttpClient(Android.create())))
-        }.build()
-
-        setContent {
-            val currentBranding = Branding.Current.collectAsState().value
-            currentBranding.theme {
-                PromptDialogs(
-                    promptModel = promptModel,
-                    imageLoader = imageLoader,
-                )
-            }
-        }
-
         val origin = referrerUrl?.let {
             val url = URL(it)
             "${url.protocol}://${url.host}${if (url.port != -1) ":${url.port}" else ""}"
         }
         try {
-            val redirectUri = uriSchemePresentment(
+            presentmentModel.setWaitingForUserInput()
+            openRedirectUri = uriSchemePresentment(
                 source = settings.source,
                 uri = url,
                 origin = origin,
                 httpClientEngineFactory = settings.httpClientEngineFactory,
+                onDocumentsInFocus = { documents ->
+                    presentmentModel.setDocumentsSelected(documents)
+                }
             )
-            if (redirectUri != null) {
-                // Open the redirect URI in a browser...
-                startActivity(
-                    Intent(
-                        Intent.ACTION_VIEW,
-                        redirectUri.toUri()
-                    )
-                )
-            }
+            presentmentModel.setCompleted(error = null)
         } catch (e: Throwable) {
             Logger.i(TAG, "Error processing request", e)
-        } finally {
-            finish()
+            presentmentModel.setCompleted(error = e)
         }
     }
 

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -79,7 +79,8 @@ import org.multipaz.context.initializeApplication
 import org.multipaz.document.Document
 import org.multipaz.multipaz_compose.generated.resources.Res
 import org.multipaz.presentment.DocumentChooserData
-import org.multipaz.presentment.PresentmentCanceled
+import org.multipaz.presentment.PresentmentCanceledException
+import org.multipaz.presentment.PresentmentCannotSatisfyRequestException
 import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.AndroidPromptModel
@@ -175,7 +176,7 @@ class PresentmentActivity: FragmentActivity() {
                     when (state) {
                         is PresentmentModel.State.CanceledByUser -> {
                             presentmentModel.setCompleted(
-                                PresentmentCanceled(null)
+                                PresentmentCanceledException(null)
                             )
                             modelWatcherJob?.cancel()
                             modelWatcherJob = null
@@ -261,11 +262,15 @@ class PresentmentActivity: FragmentActivity() {
         setContent {
             val currentBranding = Branding.Current.collectAsState().value
             currentBranding.theme {
+                PromptDialogs(
+                    promptModel = promptModel,
+                    imageLoader = imageLoader,
+                )
+
                 PresentmentActivityContent(
                     window = window,
-                    imageLoader = imageLoader,
-                    promptModel = promptModel,
-                    presentmentModel = presentmentModel,
+                    getPresentmentModel = { presentmentModel },
+                    onFadedIn = {},
                     onFinish = { switchToAppOnFinishPendingIntent ->
                         switchToAppOnFinishPendingIntent?.send()
                         finish()
@@ -276,34 +281,44 @@ class PresentmentActivity: FragmentActivity() {
     }
 }
 
+/**
+ * A full-screen composable for credential presentment.
+ *
+ * The [getPresentmentModel] function will be called a single time the first time the composable is shown.
+ *
+ * @param window the [Window] of the activity.
+ * @param getPresentmentModel a function to return the [PresentmentModel] to use.
+ * @param onFadedIn called when the composable has fully faded in.
+ * @param onFinish called when the presentment is finished and fully faded out. The passed-in [PendingIntent]
+ * is non-null if the user clicked the "Open Wallet" button.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun PresentmentActivityContent(
     window: Window,
-    imageLoader: ImageLoader,
-    promptModel: PromptModel,
-    presentmentModel: PresentmentModel,
+    getPresentmentModel: suspend () -> PresentmentModel,
+    onFadedIn: () -> Unit,
     onFinish: (switchToAppOnFinishPendingIntent: PendingIntent?) -> Unit
 ) {
+    var presentmentModel by remember { mutableStateOf<PresentmentModel?>(null) }
+    var documentModel by remember { mutableStateOf<DocumentModel?>(null) }
     var switchToAppOnFinishPendingIntent by remember { mutableStateOf<PendingIntent?>(null) }
     val coroutineScope = rememberCoroutineScope()
-    var documentModel by remember { mutableStateOf<DocumentModel?>(null) }
-    val state = presentmentModel.state.collectAsState().value
-    val numRequestsServed = presentmentModel.numRequestsServed.collectAsState().value
     val currentBranding = Branding.Current.collectAsState().value
 
     var startFadeIn by remember { mutableStateOf(false) }
     val fadeInAlpha by animateFloatAsState(
         targetValue = if (startFadeIn) 1.0f else 0.0f,
         animationSpec = tween(
-            durationMillis = 500
-        )
+            durationMillis = 300
+        ),
+        finishedListener = { onFadedIn() }
     )
     var startFadeOut by remember { mutableStateOf(false) }
     val fadeOutAlpha by animateFloatAsState(
         targetValue = if (startFadeOut) 0.0f else 1.0f,
         animationSpec = tween(
-            durationMillis = 500
+            durationMillis = 300
         ),
         finishedListener = { onFinish(switchToAppOnFinishPendingIntent) }
     )
@@ -311,15 +326,19 @@ internal fun PresentmentActivityContent(
 
     // We do the initializations that require suspend functions here and fade in when done...
     LaunchedEffect(Unit) {
+        presentmentModel = getPresentmentModel()
         documentModel = DocumentModel.create(
-            documentStore = presentmentModel.source.documentStore,
-            documentTypeRepository = presentmentModel.source.documentTypeRepository
+            documentStore = presentmentModel!!.source.documentStore,
+            documentTypeRepository = presentmentModel!!.source.documentTypeRepository
         )
         startFadeIn = true
     }
     if (!startFadeIn) {
         return
     }
+
+    val state = presentmentModel!!.state.collectAsState().value
+    val numRequestsServed = presentmentModel!!.numRequestsServed.collectAsState().value
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         window.setBackgroundBlurRadius((80.0 * fadeOutAlpha * fadeInAlpha).roundToInt())
@@ -359,7 +378,7 @@ internal fun PresentmentActivityContent(
         CompositionLocalProvider(
             LocalContentColor provides MaterialTheme.colorScheme.onSurface
         ) {
-            val docsToShow = presentmentModel.documentsSelected.collectAsState().value
+            val docsToShow = presentmentModel!!.documentsSelected.collectAsState().value
             val selectedDocIdFromCardChooser = remember { mutableStateOf<String?>(null) }
 
             Column(
@@ -373,11 +392,6 @@ internal fun PresentmentActivityContent(
                     ),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                PromptDialogs(
-                    promptModel = promptModel,
-                    imageLoader = imageLoader,
-                )
-
                 if (state is PresentmentModel.State.Reset && state.documentChooserData != null) {
                     ShowCardChooser(
                         documentModel = documentModel!!,
@@ -406,7 +420,7 @@ internal fun PresentmentActivityContent(
                                             coroutineScope.launch {
                                                 switchToAppOnFinishPendingIntent =
                                                     state.documentChooserData!!.openAppPendingIntentFn(
-                                                        presentmentModel.source.documentStore.lookupDocument(
+                                                        presentmentModel!!.source.documentStore.lookupDocument(
                                                             selectedDocIdFromCardChooser.value!!
                                                         )!!
                                                     )
@@ -453,17 +467,25 @@ internal fun PresentmentActivityContent(
                                 }
                                 is PresentmentModel.State.Completed -> {
                                     if (state.error != null) {
-                                        if (state.error!! !is PresentmentCanceled) {
-                                            ShowFailure(applicationContext.getString(
-                                                R.string.presentment_activity_something_went_wrong
-                                            ))
-                                        } else {
-                                            if (state.error!!.message != null) {
+                                        when (state.error!!) {
+                                            is PresentmentCanceledException -> {
+                                                if (state.error!!.message != null) {
+                                                    ShowFailure(applicationContext.getString(
+                                                        R.string.presentment_activity_canceled
+                                                    ))
+                                                } else {
+                                                    startFadeOut = true
+                                                }
+                                            }
+                                            is PresentmentCannotSatisfyRequestException -> {
                                                 ShowFailure(applicationContext.getString(
-                                                    R.string.presentment_activity_canceled
+                                                    R.string.presentment_activity_cannot_satisfy_request
                                                 ))
-                                            } else {
-                                                startFadeOut = true
+                                            }
+                                            else -> {
+                                                ShowFailure(applicationContext.getString(
+                                                    R.string.presentment_activity_something_went_wrong
+                                                ))
                                             }
                                         }
                                     } else {

--- a/multipaz-compose/src/androidMain/res/values/strings.xml
+++ b/multipaz-compose/src/androidMain/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="presentment_activity_info_was_shared">The info was shared</string>
     <string name="presentment_activity_something_went_wrong">Something went wrong</string>
     <string name="presentment_activity_canceled">Cancelled</string>
+    <string name="presentment_activity_cannot_satisfy_request">Cannot satisfy request</string>
     <string name="presentment_activity_open_wallet">Open %1$s</string>
     <string name="presentment_activity_app_name_default">Wallet</string>
     <string name="presentment_activity_no_documents_available">No documents available</string>

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -38,10 +38,12 @@ import org.multipaz.mdoc.response.MdocDocument
 import org.multipaz.mdoc.response.buildDeviceResponse
 import org.multipaz.mdoc.zkp.ZkSystem
 import org.multipaz.mdoc.zkp.ZkSystemSpec
+import org.multipaz.openid.dcql.DcqlCredentialQueryException
 import org.multipaz.openid.dcql.DcqlQuery
 import org.multipaz.presentment.CredentialMatchSourceOpenID4VP
 import org.multipaz.presentment.CredentialPresentmentSetOptionMemberMatch
-import org.multipaz.presentment.PresentmentCanceled
+import org.multipaz.presentment.PresentmentCanceledException
+import org.multipaz.presentment.PresentmentCannotSatisfyRequestException
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.request.JsonRequestedClaim
 import org.multipaz.request.MdocRequestedClaim
@@ -277,12 +279,14 @@ object OpenID4VP {
      * @param requesterCertChain the X.509 certificate chain if the request is signed or `null`
      *   if the request is not signed.
      * @return the generated response according to OpenID4VP Section 8 Response.
-     * @throws PresentmentCanceled if the user canceled in a consent prompt.
+     * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+     * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
      */
     @Throws(
         CancellationException::class,
         IllegalStateException::class,
-        PresentmentCanceled::class
+        PresentmentCanceledException::class,
+        PresentmentCannotSatisfyRequestException::class
     )
     @OptIn(ExperimentalEncodingApi::class)
     suspend fun generateResponse(
@@ -293,6 +297,7 @@ object OpenID4VP {
         origin: String?,
         request: JsonObject,
         requesterCertChain: X509CertChain?,
+        onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): JsonObject {
         Logger.iJson(TAG, "request", request)
 
@@ -309,6 +314,7 @@ object OpenID4VP {
                     ?: throw IllegalArgumentException("No response_uri set for $responseModeText")
                 Pair(uri, ResponseMode.DIRECT_POST)
             }
+
             else -> throw IllegalArgumentException("Unexpected response_mode $responseModeText")
         }
         // TODO: in the future, maybe flat out reject requests that doesn't use encrypted response
@@ -401,9 +407,13 @@ object OpenID4VP {
 
         val vpTokens = mutableMapOf<String, String>()
         val dcqlQuery = DcqlQuery.fromJson(request["dcql_query"]!!.jsonObject)
-        val dcqlResponse = dcqlQuery.execute(
-            presentmentSource = source,
-        )
+        val dcqlResponse = try {
+            dcqlQuery.execute(
+                presentmentSource = source,
+            )
+        } catch (e: DcqlCredentialQueryException) {
+            throw PresentmentCannotSatisfyRequestException("Unable to satisfy the request", e)
+        }
 
         val requester = Requester(
             certChain = requesterCertChain,
@@ -416,14 +426,14 @@ object OpenID4VP {
         }
         // TODO: incorporate transaction data into the consent prompt
         val selection = source.showConsentPrompt(
-            requester,
-            source.resolveTrust(requester),
-            dcqlResponse,
-            preselectedDocuments,
-            { selection -> },
+            requester = requester,
+            trustMetadata = source.resolveTrust(requester),
+            credentialPresentmentData = dcqlResponse,
+            preselectedDocuments = preselectedDocuments,
+            onDocumentsInFocus = onDocumentsInFocus
         )
         if (selection == null) {
-            throw PresentmentCanceled("User canceled at document selection time")
+            throw PresentmentCanceledException("User canceled at document selection time")
         }
 
         var usingZk = false
@@ -519,7 +529,8 @@ object OpenID4VP {
         nonce: String,
         reReaderPublicKey: EcPublicKey?,
         responseUri: String?,
-        requestIsForZk: Boolean
+        requestIsForZk: Boolean,
+        onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
         var zkSystemMatch: ZkSystem? = null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -46,14 +46,16 @@ private const val TAG = "Iso180135Presentment"
  * @param onSendingResponse called when sending a response to the remote reader.
  * @throws MdocTransportClosedException if [transport] was closed.
  * @throws Iso18013PresentmentTimeoutException if the reader didn't send a message without the given [timeout].
- * @throws PresentmentCanceled if the user canceled in a consent prompt.
+ * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+ * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
 @Throws(
     CancellationException::class,
     IllegalStateException::class,
     MdocTransportClosedException::class,
     Iso18013PresentmentTimeoutException::class,
-    PresentmentCanceled::class
+    PresentmentCanceledException::class,
+    PresentmentCannotSatisfyRequestException::class
 )
 suspend fun Iso18013Presentment(
     transport: MdocTransport,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentCanceledException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentCanceledException.kt
@@ -5,4 +5,4 @@ package org.multipaz.presentment
  *
  * @property message message to display or `null`.
  */
-class PresentmentCanceled(message: String?): Exception(message)
+class PresentmentCanceledException(message: String?): Exception(message)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentCannotSatisfyRequestException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentCannotSatisfyRequestException.kt
@@ -1,0 +1,9 @@
+package org.multipaz.presentment
+
+/**
+ * Thrown when it's not possible to satisfy the request.
+ *
+ * @property message message to display or `null`.
+ * @property cause the cause.
+ */
+class PresentmentCannotSatisfyRequestException(message: String?, cause: Throwable): Exception(message, cause)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
@@ -133,7 +133,7 @@ class PresentmentModel {
      * This moves the model into the [State.CanceledByUser] state.
      *
      * The mechanism should watch for this, cancel the transaction, and call [setCompleted] passing a
-     * [PresentmentCanceled] error.
+     * [PresentmentCanceledException] error.
      */
     fun setCanceledByUser() {
         mutableState.value = State.CanceledByUser

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -43,16 +43,20 @@ private const val TAG = "digitalCredentialsPresentment"
  * @param preselectedDocuments the list of documents the user may have preselected earlier (for
  *   example an OS-provided credential picker like Android's Credential Manager) or the empty list
  *   if the user didn't preselect.
+ * @param source the source of truth used for presentment.
+ * @param onDocumentsInFocus called with the documents currently selected for the user, including when
+ *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
  * @return a string with JSON with the result, this is a JSON object containing the `protocol` and `data` fields in [DigitalCredential](https://www.w3.org/TR/digital-credentials/#the-digitalcredential-interface) interface.
  * @throws PromptDismissedException if the user dismissed a prompt.
  * @throws PromptModelNotAvailableException if `coroutineContext` does not have [PromptModel].
  * @throws PromptUiNotAvailableException if the UI layer hasn't bound any UI for [PromptModel].
- * @throws PresentmentCanceled if the user canceled in a consent prompt.
+ * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+ * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
 @Throws(
     CancellationException::class,
     IllegalStateException::class,
-    PresentmentCanceled::class
+    PresentmentCanceledException::class
 )
 suspend fun digitalCredentialsPresentment(
     protocol: String,
@@ -61,6 +65,7 @@ suspend fun digitalCredentialsPresentment(
     origin: String,
     preselectedDocuments: List<Document>,
     source: PresentmentSource,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
 ): String {
     return Json.encodeToString(
         digitalCredentialsPresentment(
@@ -70,6 +75,7 @@ suspend fun digitalCredentialsPresentment(
             origin = origin,
             preselectedDocuments = preselectedDocuments,
             source = source,
+            onDocumentsInFocus = onDocumentsInFocus
         )
     )
 }
@@ -84,16 +90,21 @@ suspend fun digitalCredentialsPresentment(
  * @param preselectedDocuments the list of documents the user may have preselected earlier (for
  *   example an OS-provided credential picker like Android's Credential Manager) or the empty list
  *   if the user didn't preselect.
+ * @param source the source of truth used for presentment.
+ * @param onDocumentsInFocus called with the documents currently selected for the user, including when
+ *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
  * @return JSON with the result, this is a JSON object containing the `protocol` and `data` fields in [DigitalCredential](https://www.w3.org/TR/digital-credentials/#the-digitalcredential-interface) interface.
  * @throws PromptDismissedException if the user dismissed a prompt.
  * @throws PromptModelNotAvailableException if `coroutineContext` does not have [PromptModel].
  * @throws PromptUiNotAvailableException if the UI layer hasn't bound any UI for [PromptModel].
- * @throws PresentmentCanceled if the user canceled in a consent prompt.
+ * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+ * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
 @Throws(
     CancellationException::class,
     IllegalStateException::class,
-    PresentmentCanceled::class
+    PresentmentCanceledException::class,
+    PresentmentCannotSatisfyRequestException::class
 )
 suspend fun digitalCredentialsPresentment(
     protocol: String,
@@ -102,6 +113,7 @@ suspend fun digitalCredentialsPresentment(
     origin: String,
     preselectedDocuments: List<Document>,
     source: PresentmentSource,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
 ): JsonObject {
     when (protocol) {
         "openid4vp", "openid4vp-v1-unsigned", "openid4vp-v1-signed" -> {
@@ -112,6 +124,7 @@ suspend fun digitalCredentialsPresentment(
                 origin = origin,
                 preselectedDocuments = preselectedDocuments,
                 source = source,
+                onDocumentsInFocus = onDocumentsInFocus
             )
         }
         "org.iso.mdoc", "org-iso-mdoc" -> {
@@ -122,6 +135,7 @@ suspend fun digitalCredentialsPresentment(
                 origin = origin,
                 preselectedDocuments = preselectedDocuments,
                 source = source,
+                onDocumentsInFocus = onDocumentsInFocus
             )
         }
         else -> {
@@ -138,6 +152,7 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
     origin: String,
     preselectedDocuments: List<Document>,
     source: PresentmentSource,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit
 ): JsonObject {
     val version = when (protocol) {
         "openid4vp" -> OpenID4VP.Version.DRAFT_24
@@ -169,6 +184,7 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
         origin = origin,
         request = req,
         requesterCertChain = requesterCertChain,
+        onDocumentsInFocus = onDocumentsInFocus
     )
     return buildJsonObject {
         put("protocol", protocol)
@@ -184,6 +200,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
     origin: String,
     preselectedDocuments: List<Document>,
     source: PresentmentSource,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit
 ): JsonObject {
     val arfRequest = data
     val deviceRequestBase64 = arfRequest["deviceRequest"]!!.jsonPrimitive.content
@@ -225,7 +242,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         requesterOrigin = origin,
         preselectedDocuments = preselectedDocuments,
         onWaitingForUserInput = {},
-        onDocumentsInFocus = {},
+        onDocumentsInFocus = onDocumentsInFocus,
     )
 
     val encrypter = Hpke.getEncrypter(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -8,6 +8,7 @@ import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.devicesigned.buildDeviceNamespaces
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.response.DeviceResponse
+import org.multipaz.mdoc.response.Iso18015ResponseException
 import org.multipaz.mdoc.response.MdocDocument
 import org.multipaz.mdoc.response.buildDeviceResponse
 import org.multipaz.mdoc.transport.MdocTransportClosedException
@@ -37,14 +38,16 @@ private const val TAG = "mdocPresentment"
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
  *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
  * @return a [DeviceResponse].
- * @throws PresentmentCanceled if the user canceled in a consent prompt.
+ * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+ * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
 @Throws(
     CancellationException::class,
     IllegalStateException::class,
     MdocTransportClosedException::class,
     Iso18013PresentmentTimeoutException::class,
-    PresentmentCanceled::class
+    PresentmentCanceledException::class,
+    PresentmentCannotSatisfyRequestException::class
 )
 suspend fun mdocPresentment(
     deviceRequest: DeviceRequest,
@@ -68,6 +71,8 @@ suspend fun mdocPresentment(
                 presentmentSource = source,
                 keyAgreementPossible = keyAgreementPossible
             )
+        } catch (e: Iso18015ResponseException) {
+            throw PresentmentCannotSatisfyRequestException("Error satisfying the request", e)
         } catch (e: Throwable) {
             throw IllegalStateException("Error satisfying request", e)
         }
@@ -85,7 +90,7 @@ suspend fun mdocPresentment(
             onDocumentsInFocus = onDocumentsInFocus
         )
         if (selection == null) {
-            throw PresentmentCanceled("User canceled consent prompt")
+            throw PresentmentCanceledException("User canceled consent prompt")
         }
 
         for (match in selection.matches) {
@@ -141,89 +146,5 @@ suspend fun mdocPresentment(
             }
             match.credential.increaseUsageCount()
         }
-
-
-        /*
-        for (docRequest in deviceRequest.docRequests) {
-            val zkRequested = docRequest.docRequestInfo?.zkRequest != null
-
-            val request = docRequest.toMdocRequest(
-                documentTypeRepository = source.documentTypeRepository,
-                mdocCredential = null
-            )
-
-            val presentmentData = docRequest.getPresentmentData(
-                documentTypeRepository = source.documentTypeRepository,
-                source = source,
-                keyAgreementPossible = keyAgreementPossible
-            )
-            if (presentmentData == null) {
-                Logger.w(TAG, "No document found for docType ${docRequest.docType}")
-                // No document was found
-                continue
-            }
-            onWaitingForUserInput()
-            val selection = source.showConsentPrompt(
-                requester = request.requester,
-                trustMetadata = source.resolveTrust(request.requester),
-                credentialPresentmentData = presentmentData,
-                preselectedDocuments = emptyList(),
-                onDocumentsInFocus = onDocumentsInFocus
-            )
-            if (selection == null) {
-                throw PresentmentCanceled("User canceled consent prompt")
-            }
-            val mdocCredential = selection.matches[0].credential as MdocCredential
-
-            var zkSystemMatch: ZkSystem? = null
-            var zkSystemSpec: ZkSystemSpec? = null
-            if (zkRequested) {
-                val requesterSupportedZkSpecs = docRequest.docRequestInfo!!.zkRequest!!.systemSpecs
-                val zkSystemRepository = source.zkSystemRepository
-                if (zkSystemRepository != null) {
-                    // Find the first ZK System that the requester supports and matches the document
-                    for (zkSpec in requesterSupportedZkSpecs) {
-                        val zkSystem = zkSystemRepository.lookup(zkSpec.system)
-                        if (zkSystem == null) {
-                            continue
-                        }
-                        val matchingZkSystemSpec = zkSystem.getMatchingSystemSpec(
-                            zkSystemSpecs = requesterSupportedZkSpecs,
-                            requestedClaims = request.requestedClaims
-                        )
-                        if (matchingZkSystemSpec != null) {
-                            zkSystemMatch = zkSystem
-                            zkSystemSpec = matchingZkSystemSpec
-                            break
-                        }
-                    }
-                }
-            }
-
-            if (zkRequested && zkSystemSpec == null) {
-                Logger.w(TAG, "Reader requested ZK proof but no compatible ZkSpec was found.")
-            }
-
-            val document = MdocDocument.fromPresentment(
-                sessionTranscript = sessionTranscript,
-                eReaderKey = eReaderKey,
-                credential = mdocCredential,
-                requestedClaims = request.requestedClaims,
-                deviceNamespaces = buildDeviceNamespaces {},
-                errors = mapOf()
-            )
-            if (zkSystemMatch != null) {
-                val zkDocument = zkSystemMatch.generateProof(
-                    zkSystemSpec = zkSystemSpec!!,
-                    document = document,
-                    sessionTranscript = sessionTranscript
-                )
-                addZkDocument(zkDocument)
-            } else {
-                addDocument(document)
-            }
-            mdocCredential.increaseUsageCount()
-        }
-         */
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -29,6 +29,7 @@ import org.multipaz.cbor.buildCborMap
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.JsonWebSignature
+import org.multipaz.document.Document
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.engagement.Capability
 import org.multipaz.mdoc.engagement.DeviceEngagement
@@ -37,11 +38,13 @@ import org.multipaz.mdoc.origininfo.OriginInfoDomain
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.sessionencryption.SessionEncryption
+import org.multipaz.mdoc.transport.MdocTransportClosedException
 import org.multipaz.openid.OpenID4VP
 import org.multipaz.util.Constants
 import org.multipaz.util.Logger
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TAG = "uriSchemePresentment"
 
@@ -52,20 +55,32 @@ private const val TAG = "uriSchemePresentment"
  * @param uri the referrer.
  * @param origin the origin.
  * @param httpClientEngineFactory a [HttpClientEngineFactory].
+ * @param onDocumentsInFocus called with the documents currently selected for the user, including when
+ *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
  * @return the redirect URI, caller should open this in the user's default browser or `null` if this is not required.
+ * @throws PresentmentCanceledException if the user canceled in a consent prompt.
+ * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
+@Throws(
+    CancellationException::class,
+    IllegalStateException::class,
+    PresentmentCanceledException::class,
+    PresentmentCannotSatisfyRequestException::class
+)
 suspend fun uriSchemePresentment(
     source: PresentmentSource,
     uri: String,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
 ): String? {
     if (uri.startsWith("mdoc://")) {
         return mdocUriSchemePresentment(
             source = source,
             uri = uri,
             origin = origin,
-            httpClientEngineFactory = httpClientEngineFactory
+            httpClientEngineFactory = httpClientEngineFactory,
+            onDocumentsInFocus = onDocumentsInFocus
         )
     }
     val parameters = uri.parseUrlEncodedParameters()
@@ -109,6 +124,7 @@ suspend fun uriSchemePresentment(
         origin = origin ?: "",
         request = requestObject,
         requesterCertChain = requesterChain,
+        onDocumentsInFocus = onDocumentsInFocus
     )
 
     val responseCs = when (requestObject["response_mode"]!!.jsonPrimitive.content) {
@@ -147,12 +163,13 @@ private suspend fun mdocUriSchemePresentment(
     uri: String,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
+    onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
 ): String? {
     val url = Url(uri)
     val readerEngagementEncoded = url.host.fromBase64Url()
     val readerEngagementDataItem = Cbor.decode(readerEngagementEncoded)
 
-    // ReaderEnagement is really the same as DeviceEngagement so just re-use the parser
+    // ReaderEngagement is really the same as DeviceEngagement so just re-use the parser
     val readerEngagement = DeviceEngagement.fromDataItem(readerEngagementDataItem)
     val eReaderKey = readerEngagement.eDeviceKey
 
@@ -254,7 +271,7 @@ private suspend fun mdocUriSchemePresentment(
             requesterOrigin = origin ?: "",
             preselectedDocuments = emptyList(),
             onWaitingForUserInput = {},
-            onDocumentsInFocus = {}
+            onDocumentsInFocus = onDocumentsInFocus
         )
         messageToPost = sessionEncryption.encryptMessage(
             messagePlaintext = Cbor.encode(deviceResponse.toDataItem()),

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -124,7 +124,7 @@
             android:name=".TestAppCredentialManagerPresentmentActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:theme="@android:style/Theme.Translucent"
+            android:theme="@style/NavigationActivityTheme"
             android:launchMode="singleInstance"
             android:excludeFromRecents="true">
             <intent-filter>
@@ -138,7 +138,7 @@
             android:name=".TestAppUriSchemePresentmentActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:theme="@android:style/Theme.Translucent"
+            android:theme="@style/NavigationActivityTheme"
             android:launchMode="singleInstance"
             android:excludeFromRecents="true">
             <intent-filter>

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
@@ -10,7 +10,7 @@ import org.multipaz.document.Document
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.presentment.PresentmentModel
-import org.multipaz.presentment.PresentmentCanceled
+import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.showBiometricPrompt
@@ -52,7 +52,7 @@ actual suspend fun launchAndroidPresentmentActivity(
                     },
                 )
                 if (selection == null) {
-                    throw PresentmentCanceled("Presentment cancelled because user dismissed consent prompt")
+                    throw PresentmentCanceledException("Presentment cancelled because user dismissed consent prompt")
                 }
             } else {
                 PresentmentActivity.presentmentModel.setDocumentsSelected(
@@ -68,7 +68,7 @@ actual suspend fun launchAndroidPresentmentActivity(
                     userAuthenticationTypes = setOf(UserAuthenticationType.BIOMETRIC, UserAuthenticationType.LSKF),
                     requireConfirmation = paData.authRequireConfirmation
                 )) {
-                    throw PresentmentCanceled("Presentment cancelled because user dismissed biometric prompt")
+                    throw PresentmentCanceledException("Presentment cancelled because user dismissed biometric prompt")
                 }
             }
 
@@ -77,7 +77,7 @@ actual suspend fun launchAndroidPresentmentActivity(
             PresentmentActivity.presentmentModel.setCompleted(null)
         } catch (e: Throwable) {
             if (e is CancellationException) {
-                PresentmentActivity.presentmentModel.setCompleted(PresentmentCanceled("Presentment was cancelled"))
+                PresentmentActivity.presentmentModel.setCompleted(PresentmentCanceledException("Presentment was cancelled"))
             } else {
                 PresentmentActivity.presentmentModel.setCompleted(e)
             }


### PR DESCRIPTION
Also rename `PresentmentCanceled` to `PresentmentCancelledException` and introduce `PresentmentCannotSatisfyRequestException` which is thrown if a document request cannot be satisified and handle this by show an exclamation mark and the string "Cannot satisfy request" in `PresentmentActivity`

See https://youtu.be/nbNL2e7Ckjs for a demo.

Test: Manually tested.
