### PR TITLE
Add event logging.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
@@ -115,9 +115,16 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
                             if (referrerUrl == "null") {
                                 referrerUrl = null
                             }
+
+                            val appId = if (referrer?.scheme == "android-app") {
+                                referrer?.host
+                            } else {
+                                null
+                            }
                             if (url != null) {
                                 startPresentment(
                                     url = url,
+                                    appId = appId,
                                     referrerUrl = referrerUrl,
                                     settings = settings
                                 )
@@ -141,6 +148,7 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
 
     private suspend fun startPresentment(
         url: String,
+        appId: String?,
         referrerUrl: String?,
         settings: Settings
     ) {
@@ -153,6 +161,7 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
             openRedirectUri = uriSchemePresentment(
                 source = settings.source,
                 uri = url,
+                appId = appId,
                 origin = origin,
                 httpClientEngineFactory = settings.httpClientEngineFactory,
                 onDocumentsInFocus = { documents ->

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/eventlog/EventLogModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/eventlog/EventLogModel.kt
@@ -1,0 +1,44 @@
+package org.multipaz.compose.eventlog
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import org.multipaz.eventlog.Event
+import org.multipaz.eventlog.EventLog
+
+/**
+ * A UI state holder for [EventLog] designed for Compose Multiplatform.
+ *
+ * This model observes the underlying logger and exposes a reactive [StateFlow] of
+ * events. The [eventLog] is exposed publicly to allow direct invocation of its
+ * suspending mutation functions (like `addEvent` or `deleteEvent`) from the UI's
+ * coroutine scope.
+ *
+ * @property eventLog The underlying persistent event logger.
+ * @property coroutineScope The scope used to run background queries for the state flow.
+ */
+class EventLogModel(
+    val eventLog: EventLog,
+    coroutineScope: CoroutineScope
+) {
+    /**
+     * A reactive stream of the currently stored events.
+     *
+     * - The initial value is `null` while the first database read is in progress.
+     * - It automatically re-queries [EventLog.getEvents] whenever the logger
+     * emits a change notification.
+     * - Uses [SharingStarted.WhileSubscribed] to pause database observations if
+     * the UI is completely hidden, saving resources.
+     */
+    val events: StateFlow<List<Event>?> = eventLog.eventFlow
+        .onStart { emit(Unit) } // Trigger the initial load
+        .map { eventLog.getEvents() }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -469,7 +469,7 @@ private fun ConsentPage(
             iconUrl = trustMetadata.displayIconUrl,
             disclaimer = trustMetadata.disclaimer,
         )
-    } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
+    } else if (requester.isWebOrigin) {
         RequesterDisplayData(
             name = requester.origin!!.ifEmpty {
                 stringResource(Res.string.credential_presentment_headline_share_with_unknown_website)
@@ -789,7 +789,7 @@ private fun CredentialSetViewer(
                     Res.string.credential_presentment_share_with_known_requester,
                     requesterDisplayData.name
                 )
-            } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
+            } else if (requester.isWebOrigin) {
                 stringResource(
                     Res.string.credential_presentment_share_with_known_requester,
                     requester.origin!!
@@ -808,7 +808,7 @@ private fun CredentialSetViewer(
                     Res.string.credential_presentment_share_and_stored_by_known_requester,
                     requesterDisplayData.name
                 )
-            } else if (requester.origin != null && isWebOrigin(requester.origin!!)) {
+            } else if (requester.isWebOrigin) {
                 stringResource(
                     Res.string.credential_presentment_share_and_stored_by_known_requester,
                     requester.origin!!
@@ -963,7 +963,7 @@ private fun RelyingPartyTrailer(
     trustMetadata: TrustMetadata?,
 ) {
     if (trustMetadata != null) {
-        var text = if (requester.origin != null && isWebOrigin(requester.origin!!)) {
+        var text = if (requester.isWebOrigin) {
             stringResource(Res.string.credential_presentment_info_verifier_in_trust_list_website)
         } else if (requester.appId != null) {
             stringResource(Res.string.credential_presentment_info_verifier_in_trust_list_app)
@@ -994,7 +994,7 @@ private fun RelyingPartyTrailer(
             )
         }
     } else {
-        val text = if (requester.origin != null && isWebOrigin(requester.origin!!)) {
+        val text = if (requester.isWebOrigin) {
             stringResource(Res.string.credential_presentment_warning_verifier_not_in_trust_list_website)
         } else if (requester.appId != null) {
             stringResource(Res.string.credential_presentment_warning_verifier_not_in_trust_list_app)
@@ -1245,6 +1245,3 @@ private fun RelyingPartySection(
         )
     }
 }
-
-private fun isWebOrigin(origin: String) =
-    origin.isEmpty() || origin.startsWith("http://") || origin.startsWith("https://")

--- a/multipaz-swift/Sources/MultipazSwift/RequestAuthorizationView.swift
+++ b/multipaz-swift/Sources/MultipazSwift/RequestAuthorizationView.swift
@@ -119,7 +119,8 @@ public struct RequestAuthorizationView : View {
                                     appId: nil,
                                     origin: requestContext.requestingWebsiteOrigin!.getOrigin(),
                                     preselectedDocuments: [],
-                                    source: viewModel.source
+                                    source: viewModel.source,
+                                    onDocumentsInFocus: { documents in }
                                 )
                                 let responseJson = try JSONSerialization.jsonObject(with: responseString.data(using: .utf8)!) as! [String: Any]
                                 let responseData = responseJson["data"] as! [String: Any]

--- a/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
+++ b/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
@@ -11,6 +11,7 @@ extension SimplePresentmentSource.Companion {
     ///   - documetStore: the [DocumentStore] which holds credentials that can be presented.
     ///   - documentTypeRepository: a [DocumentTypeRepository] which holds metadata for document types.
     ///   - zkSystemRepository: the [ZkSystemRepository] to use or `nil`.
+    ///   - eventLog: an [EventLog] for logging events or `nil`.
     ///   - resolveTrustFn: a function which can be used to determine if a requester is trusted.
     ///   - showConsentPromptFn: a [ShowConsentPromptFn] used show a consent prompt is required.
     ///   - preferSignatureToKeyAgreement: whether to use mdoc ECDSA authentication even if mdoc MAC authentication is possible (ISO mdoc only).
@@ -22,6 +23,7 @@ extension SimplePresentmentSource.Companion {
         documentStore: DocumentStore,
         documentTypeRepository: DocumentTypeRepository,
         zkSystemRepository: ZkSystemRepository? = nil,
+        eventLog: EventLog? = nil,
         resolveTrustFn: @escaping @Sendable (
             _ requester: Requester
         ) async -> TrustMetadata?,
@@ -42,6 +44,7 @@ extension SimplePresentmentSource.Companion {
             documentStore: documentStore,
             documentTypeRepository: documentTypeRepository,
             zkSystemRepository: zkSystemRepository,
+            eventLog: eventLog,
             resolveTrustFn: ResolveTrustHandler(f: resolveTrustFn),
             showConsentPromptFn: ShowConsentPromptHandler(f: showConsentPromptFn),
             preferSignatureToKeyAgreement: preferSignatureToKeyAgreement,

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -1806,6 +1806,7 @@ private suspend fun calcDcRequestNew(
             }
             path.add(JsonPrimitive(documentAttribute.identifier))
             JsonRequestedClaim(
+                vctValues = listOf(request.jsonRequest!!.vct),
                 claimPath = JsonArray(path),
             )
         }
@@ -1826,6 +1827,7 @@ private suspend fun calcDcRequestNew(
             namespaceRequest.dataElementsToRequest.forEach { (mdocDataElement, intentToRetain) ->
                 claims.add(
                     MdocRequestedClaim(
+                        docType = request.mdocRequest!!.docType,
                         namespaceName = namespaceRequest.namespace,
                         dataElementName = mdocDataElement.attribute.identifier,
                         intentToRetain = intentToRetain

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/Claim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/Claim.kt
@@ -3,6 +3,7 @@ package org.multipaz.claim
 import org.multipaz.documenttype.DocumentAttribute
 import org.multipaz.request.RequestedClaim
 import kotlinx.datetime.TimeZone
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -14,6 +15,10 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializationImplemented
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.request.JsonRequestedClaim
 import org.multipaz.request.MdocRequestedClaim
 
@@ -23,6 +28,7 @@ import org.multipaz.request.MdocRequestedClaim
  * @property displayName a short human readable string describing the claim.
  * @property attribute a [DocumentAttribute], if the claim is for a well-known attribute.
  */
+@CborSerializationImplemented(schemaId = "")
 sealed class Claim(
     open val displayName: String,
     open val attribute: DocumentAttribute?
@@ -36,6 +42,89 @@ sealed class Claim(
      * @return textual representation of the claim.
      */
     abstract fun render(timeZone: TimeZone = TimeZone.currentSystemDefault()): String
+
+    /**
+     * Serializes [Claim] to CBOR.
+     *
+     * Note that [attribute] won't be serialized.
+     *
+     * @return a [DataItem].
+     */
+    fun toDataItem() = buildCborMap {
+        put("displayName", displayName)
+        when (this@Claim) {
+            is JsonClaim -> {
+                put("type", TYPE_JSON_CLAIM)
+                put("vct", vct)
+                put("claimPath", Json.encodeToString(claimPath))
+                put("value", Json.encodeToString(value))
+            }
+            is MdocClaim -> {
+                put("type", TYPE_MDOC_CLAIM)
+                put("docType", docType)
+                put("namespaceName", namespaceName)
+                put("dataElementName", dataElementName)
+                put("value", value)
+            }
+        }
+    }
+
+    companion object {
+        private const val TYPE_JSON_CLAIM = 0
+        private const val TYPE_MDOC_CLAIM = 1
+
+        /**
+         * Creates a [Claim] previously serialized with [Claim.toDataItem].
+         *
+         * @param dataItem a [DataItem].
+         * @param documentTypeRepository if not `null`, will be used to look up a [DocumentAttribute] for the claim.
+         * @return a [Claim].
+         */
+        fun fromDataItem(
+            dataItem: DataItem,
+            documentTypeRepository: DocumentTypeRepository? = null
+        ): Claim {
+
+            val displayName = dataItem["displayName"].asTstr
+            when (dataItem["type"].asNumber.toInt()) {
+                TYPE_JSON_CLAIM -> {
+                    val vct = dataItem["vct"].asTstr
+                    val claimPath = Json.decodeFromString<JsonArray>(dataItem["claimPath"].asTstr)
+                    val attribute = documentTypeRepository
+                        ?.getDocumentTypeForJson(vct)
+                        ?.jsonDocumentType
+                        ?.claims[claimPath.joinToString(".") { it.jsonPrimitive.content }]
+                    return JsonClaim(
+                        displayName = displayName,
+                        attribute = attribute,
+                        vct = vct,
+                        claimPath = claimPath,
+                        value = Json.decodeFromString<JsonElement>(dataItem["value"].asTstr),
+                    )
+                }
+                TYPE_MDOC_CLAIM -> {
+                    val docType = dataItem["docType"].asTstr
+                    val namespaceName = dataItem["namespaceName"].asTstr
+                    val dataElementName = dataItem["dataElementName"].asTstr
+                    val mdocDocType = documentTypeRepository?.getDocumentTypeForMdoc(docType)
+                        ?: documentTypeRepository?.getDocumentTypeForMdocNamespace(namespaceName)
+                    val attribute = mdocDocType?.mdocDocumentType
+                        ?.namespaces[namespaceName]
+                        ?.dataElements[dataElementName]
+                        ?.attribute
+                    return MdocClaim(
+                        displayName = displayName,
+                        attribute = attribute,
+                        docType = docType,
+                        namespaceName = namespaceName,
+                        dataElementName = dataElementName,
+                        value = dataItem["value"]
+                    )
+                }
+                else -> throw IllegalStateException("Unexpected type")
+            }
+        }
+    }
 }
 
 /**
@@ -165,6 +254,7 @@ private fun jsonFindMatchingClaimValue(
     return JsonClaim(
         displayName = displayName,
         attribute = attribute,
+        vct = ret.vct,
         claimPath = requestedClaim.claimPath,
         value = currentObject
     ).filterValueMatch(requestedClaim.values) as JsonClaim?

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/JsonClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/JsonClaim.kt
@@ -18,12 +18,14 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * A claim in a JSON-based credential.
  *
+ * @property vct the Verifiable Credential Type.
  * @property claimPath the claim name.
  * @property value the value of the claim
  */
 data class JsonClaim(
     override val displayName: String,
     override val attribute: DocumentAttribute?,
+    val vct: String,
     val claimPath: JsonArray,
     val value: JsonElement
 ) : Claim(displayName, attribute) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/MdocClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/MdocClaim.kt
@@ -18,6 +18,7 @@ import kotlinx.datetime.toLocalDateTime
 /**
  * A claim in an ISO mdoc credential.
  *
+ * @property docType the document type.
  * @property namespaceName the mdoc namespace.
  * @property dataElementName the data element name.
  * @property value the value of the claim.
@@ -25,6 +26,7 @@ import kotlinx.datetime.toLocalDateTime
 data class MdocClaim(
     override val displayName: String,
     override val attribute: DocumentAttribute?,
+    val docType: String,
     val namespaceName: String,
     val dataElementName: String,
     val value: DataItem

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentTypeRepository.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentTypeRepository.kt
@@ -16,6 +16,11 @@
 
 package org.multipaz.documenttype
 
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.request.JsonRequestedClaim
+import org.multipaz.request.MdocRequestedClaim
+import org.multipaz.request.RequestedClaim
+
 /**
  * A class that contains the metadata of Document Types.
  *
@@ -78,6 +83,39 @@ class DocumentTypeRepository {
                 if (nsName == mdocNamespace) {
                     return documentType
                 }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Looks up a [DocumentAttribute] for a [RequestedClaim].
+     *
+     * @param requestedClaim a [RequestedClaim].
+     * @return the [DocumentAttribute], if found.
+     */
+    fun getDocumentAttributeForRequestedClaim(requestedClaim: RequestedClaim): DocumentAttribute? {
+        when (requestedClaim) {
+            is JsonRequestedClaim -> {
+                requestedClaim.vctValues.forEach { vct ->
+                    val documentType = getDocumentTypeForJson(vct)
+                        ?: return null
+                    val jsonDocumentType = documentType.jsonDocumentType!!
+                    val identifier = requestedClaim.claimPath.toList().joinToString(".") {
+                        it.jsonPrimitive.content
+                    }
+                    return jsonDocumentType.getDocumentAttribute(identifier)
+                }
+            }
+            is MdocRequestedClaim -> {
+                val documentType = getDocumentTypeForMdoc(mdocDocType = requestedClaim.docType)
+                    ?: getDocumentTypeForMdocNamespace(mdocNamespace = requestedClaim.namespaceName)
+                    ?: return null
+                val mdocDocumentType = documentType.mdocDocumentType!!
+                return mdocDocumentType
+                    .namespaces[requestedClaim.namespaceName]
+                    ?.dataElements[requestedClaim.dataElementName]
+                    ?.attribute
             }
         }
         return null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/Event.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/Event.kt
@@ -1,0 +1,38 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.annotation.CborSerializable
+import kotlin.time.Instant
+
+/**
+ * Base class for events recorded in the [EventLog].
+ *
+ * This sealed class ensures a restricted hierarchy of event types that can be securely
+ * serialized and persisted.
+ *
+ * Any data recorded needs to be able to work on other systems (e.g. forensic analysis)
+ * and in the future where the user might have deleted the document that they presented.
+ *
+ * As such, data should be copied into the event and use of identifiers to point to e.g.
+ * documents, credentials, or trust entries is only allowed if there it's optional or not
+ * the only source of truth.
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ */
+@CborSerializable
+sealed class Event(
+    open val identifier: String,
+    open val timestamp: Instant,
+) {
+    /**
+     * Creates a copy of this event with a new identifier and timestamp.
+     *
+     * This is used internally by [EventLog] to assign a storage-generated key
+     * and a concrete timestamp at the exact moment of persistence.
+     */
+    internal abstract fun copy(eventIdentifier: String, timestamp: Instant): Event
+
+    companion object
+}
+
+// TODO: Add events for provisioning, PII updates, MSO updates, etc

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/EventLog.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/EventLog.kt
@@ -1,0 +1,184 @@
+package org.multipaz.eventlog
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Cbor
+import org.multipaz.storage.Storage
+import org.multipaz.storage.StorageTable
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.util.UUID
+import kotlin.concurrent.Volatile
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+/**
+ * A persistent logger for recording and retrieving events.
+ *
+ * `EventLog` backs its data with a [Storage] implementation, serializing events
+ * into CBOR format. It also provides an observable flow ([eventFlow]) that emits
+ * whenever the underlying event data is modified, making it easy for UI or other
+ * observers to react to changes.
+ *
+ * @property storage The underlying persistent storage mechanism.
+ * @property partitionId A logical partition identifier to group events. Defaults to "default".
+ * @property expireAfter the amount of time to keep events, use [Duration.INFINITE] to never expire events.
+ * @property clock The time source used to timestamp events. Defaults to [Clock.System].
+ */
+class EventLog(
+    private val storage: Storage,
+    private val partitionId: String = "default",
+    private val expireAfter: Duration = 60.days,
+    private val clock: Clock = Clock.System
+) {
+    private lateinit var storageTable: StorageTable
+
+    private val _eventFlow = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /**
+     * A [SharedFlow] that emits a [Unit] whenever an event is added, deleted,
+     * or when all events are cleared. Observers can collect this flow to know
+     * when to refresh their data.
+     */
+    val eventFlow: SharedFlow<Unit>
+        get() = _eventFlow.asSharedFlow()
+
+    private val initializationLock = Mutex()
+
+    @Volatile
+    private var initializationComplete = false
+
+    /**
+     * Ensures that the underlying storage table is initialized and ready for operations.
+     *
+     * This method uses a double-checked locking mechanism to prevent unnecessary
+     * suspension once the initialization is complete. It is called automatically
+     * before any read or write operations.
+     */
+    private suspend fun ensureInitialized() {
+        if (initializationComplete) return
+
+        initializationLock.withLock {
+            if (initializationComplete) {
+                return
+            }
+            storageTable = storage.getTable(tableSpec)
+            initializationComplete = true
+        }
+    }
+
+    /**
+     * Adds a new event to the logger.
+     *
+     * This method generates a chronologically-sortable storage identifier and a current
+     * timestamp for the event before saving it. If successful, it triggers an emission
+     * to [eventFlow].
+     *
+     * @param event The [Event] to be recorded.
+     * @return A copy of the [Event] containing its assigned identifier and timestamp.
+     */
+    suspend fun addEvent(event: Event): Event {
+        ensureInitialized()
+        val now = clock.now()
+
+        // The ISO-8601 string representation of Instant sorts lexically in chronological order.
+        // Appending a UUID ensures uniqueness for events occurring at the exact same millisecond.
+        val key = "$now-${UUID.randomUUID()}"
+
+        val modifiedEvent = event.copy(
+            eventIdentifier = key,
+            timestamp = now
+        )
+
+        storageTable.insert(
+            key = key,
+            data = ByteString(Cbor.encode(modifiedEvent.toDataItem())),
+            partitionId = partitionId,
+            expiration = now + expireAfter
+        )
+
+        _eventFlow.tryEmit(Unit)
+
+        return modifiedEvent
+    }
+
+    /**
+     * Deletes a specific event from the logger.
+     *
+     * If the event is successfully deleted, it triggers an emission to [eventFlow].
+     *
+     * @param event The [Event] to delete. Must contain a valid identifier.
+     * @return `true` if the event was found and deleted, `false` otherwise.
+     */
+    suspend fun deleteEvent(event: Event): Boolean {
+        ensureInitialized()
+        return storageTable.delete(
+            key = event.identifier,
+            partitionId = partitionId,
+        ).also { deleted ->
+            if (deleted) {
+                _eventFlow.tryEmit(Unit)
+            }
+        }
+    }
+
+    /**
+     * Deletes all events within the current partition.
+     *
+     * Triggers an emission to [eventFlow] upon completion.
+     */
+    suspend fun deleteAllEvents() {
+        ensureInitialized()
+        storageTable.deletePartition(partitionId = partitionId)
+        _eventFlow.tryEmit(Unit)
+    }
+
+    /**
+     * Retrieves all events stored in the current partition.
+     *
+     * The returned list is sorted chronologically by the event's timestamp.
+     *
+     * To enumerate a large set of events completely in manageable chunks, specify the
+     * desired [limit] to repeated [getEvents] calls and pass the last event ID from from
+     * the previously returned list as [afterEventId].
+     *
+     * @param limit return at most this many events.
+     * @param afterEventId only return events after this event.
+     * @return A chronological list of [Event]s.
+     */
+    suspend fun getEvents(
+        limit: Int = Int.MAX_VALUE,
+        afterEventId: String? = null
+    ): List<Event> {
+        ensureInitialized()
+
+        return storageTable.enumerateWithData(
+            partitionId = partitionId,
+            afterKey = afterEventId,
+            limit = limit
+        )
+            .map { (_, encodedData) ->
+                Event.fromDataItem(Cbor.decode(encodedData.toByteArray()))
+            }
+    }
+
+    companion object {
+        /**
+         * The schema specification for the storage table used by this logger.
+         */
+        private val tableSpec = StorageTableSpec(
+            name = "EventLog",
+            supportPartitions = true,
+            supportExpiration = true,
+            schemaVersion = 0L
+        )
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventData.kt
@@ -1,0 +1,68 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.presentment.CredentialPresentmentSelection
+import org.multipaz.request.Requester
+import org.multipaz.trustmanagement.TrustMetadata
+
+/**
+ * High-level data involved in a presentment event.
+ *
+ * This data structure is designed to work for any credential type so the UI
+ * can show a simple overview. More detailed data is available in each of the [Event]-derived
+ * classes which include this data structure.
+ *
+ * @property requesterName the name of the requester, if available.
+ * @property requesterCertChain the certificate chain of the requester if available.
+ * @property trustMetadata a [TrustMetadata] or `null`.
+ * @property requestedDocuments list of requested documents and claims.
+ */
+@CborSerializable
+data class PresentmentEventData(
+    val requesterName: String?,
+    val requesterCertChain: X509CertChain?,
+    val trustMetadata: TrustMetadata?,
+    val requestedDocuments: List<PresentmentEventDocument>
+    // TODO: include high-level view of transaction data in this data structure.
+) {
+
+    companion object {
+        /**
+         * Creates a [PresentmentEventData] from a [CredentialPresentmentSelection].
+         *
+         * @param selection the [CredentialPresentmentSelection] to create the [PresentmentEventData] from.
+         * @param requester the requester of the data.
+         * @param trustMetadata a [TrustMetadata] or `null`.
+         * @return a [PresentmentEventData].
+         */
+        fun fromPresentmentSelection(
+            selection: CredentialPresentmentSelection,
+            requester: Requester,
+            trustMetadata: TrustMetadata?,
+        ): PresentmentEventData {
+            var requesterName: String? = null
+            if (trustMetadata != null) {
+                requesterName = trustMetadata.displayName
+            } else if (requester.isWebOrigin) {
+                requesterName = requester.origin
+            }
+
+            val requestedDocuments = mutableListOf<PresentmentEventDocument>()
+            selection.matches.forEach { match ->
+                requestedDocuments.add(PresentmentEventDocument(
+                    documentId = match.credential.document.identifier,
+                    documentName = match.credential.document.displayName,
+                    claims = match.claims
+                ))
+            }
+
+            return PresentmentEventData(
+                requesterName = requesterName,
+                requesterCertChain = requester.certChain,
+                trustMetadata = trustMetadata,
+                requestedDocuments = requestedDocuments
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDigitalCredentialsMdocApi.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDigitalCredentialsMdocApi.kt
@@ -1,0 +1,35 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.DataItem
+import kotlin.time.Instant
+
+/**
+ * An event representing an ISO/IEC 18013-7 Annex C presentment requested via Digital Credentials API.
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ * @property data Data about the presentment.
+ * @property appId the identifier of the application making the request, if known.
+ * @property origin the origin of the website making the request.
+ * @property protocol the W3C Digital Credentials API protocol identifier.
+ * @property requestJson the W3C Digital Credentials API request.
+ * @property responseJson the W3C Digital Credentials API response.
+ * @property deviceResponse The raw response data.
+ */
+data class PresentmentEventDigitalCredentialsMdocApi(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    val data: PresentmentEventData,
+    // The raw data from the presentment event.
+    val appId: String?,
+    val origin: String,
+    val protocol: String,
+    val requestJson: String,
+    val responseJson: String,
+    val deviceResponse: DataItem
+): Event(identifier, timestamp) {
+    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
+        identifier = eventIdentifier,
+        timestamp = timestamp
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDigitalCredentialsOpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDigitalCredentialsOpenID4VP.kt
@@ -1,0 +1,34 @@
+package org.multipaz.eventlog
+
+import kotlin.time.Instant
+
+/**
+ * An event representing an OpenID4VP presentment requested via Digital Credentials API.
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ * @property data Data about the presentment.
+ * @property appId the identifier of the application making the request, if known.
+ * @property origin the origin of the website making the request.
+ * @property protocol the W3C Digital Credentials API protocol identifier.
+ * @property requestJson the W3C Digital Credentials API request.
+ * @property responseJson the W3C Digital Credentials API response.
+ * @property vpToken the resulting vpToken.
+ */
+data class PresentmentEventDigitalCredentialsOpenID4VP(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    val data: PresentmentEventData,
+    // The raw data from the presentment event.
+    val appId: String?,
+    val origin: String,
+    val protocol: String,
+    val requestJson: String,
+    val responseJson: String,
+    val vpToken: String
+): Event(identifier, timestamp) {
+    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
+        identifier = eventIdentifier,
+        timestamp = timestamp
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventDocument.kt
@@ -1,0 +1,69 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializationImplemented
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborMap
+import org.multipaz.claim.Claim
+import org.multipaz.documenttype.DocumentAttribute
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.request.RequestedClaim
+
+/**
+ * A document requested in a presentment event.
+ *
+ * @property documentId the document identifier.
+ * @property documentName the name of the document or `null`.
+ * @property claims the requested claims.
+ */
+@CborSerializationImplemented(schemaId = "")
+data class PresentmentEventDocument(
+    val documentId: String,
+    val documentName: String?,
+    val claims: Map<RequestedClaim, Claim>,
+) {
+    /**
+     * Serializes [PresentmentEventDocument] to CBOR.
+     *
+     * Note that [DocumentAttribute] values in [claims] won't be serialized.
+     *
+     * @return a [DataItem].
+     */
+    fun toDataItem() = buildCborMap {
+        put("documentId", documentId)
+        documentName?.let {
+            put("documentName", documentName)
+        }
+        putCborMap("requestedClaims") {
+            claims.forEach { (requestedClaim, claim) ->
+                put(requestedClaim.toDataItem(), claim.toDataItem())
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Creates a [PresentmentEventDocument] previously serialized with [PresentmentEventDocument.toDataItem].
+         *
+         * @param dataItem a [DataItem].
+         * @param documentTypeRepository if not `null`, will be used to look up a [DocumentAttribute] for the claim.
+         * @return a new [PresentmentEventDocument].
+         */
+        fun fromDataItem(
+            dataItem: DataItem,
+            documentTypeRepository: DocumentTypeRepository? = null
+        ): PresentmentEventDocument {
+            val documentId = dataItem["documentId"].asTstr
+            val documentName = dataItem.getOrNull("documentName")?.asTstr
+            val claims = dataItem["requestedClaims"].asMap.entries.associate { (requestedClaimDataItem, claimDataItem) ->
+                RequestedClaim.fromDataItem(requestedClaimDataItem) to
+                        Claim.fromDataItem(claimDataItem, documentTypeRepository)
+            }
+            return PresentmentEventDocument(
+                documentId = documentId,
+                documentName = documentName,
+                claims = claims
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventIso18013AnnexA.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventIso18013AnnexA.kt
@@ -1,0 +1,37 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.DataItem
+import kotlin.time.Instant
+
+/**
+ * An event representing an ISO/IEC 18013-5 presentment according to 18013-7 Annex A.
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ * @property data Data about the presentment.
+ * @property uri the URI used to invoke the presentment.
+ * @property request The raw request data.
+ * @property response The raw response data.
+ * @property sessionTranscript The raw session transcript data.
+ * @property appId the identifier of the application making the request, if known.
+ * @property origin the origin of the website making the request, if known.
+ * @property readerEngagement The raw reader engagement data.
+ */
+data class PresentmentEventIso18013AnnexA(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    val data: PresentmentEventData,
+    // The raw data from the presentment event.
+    val uri: String,
+    val request: DataItem,
+    val response: DataItem,
+    val sessionTranscript: DataItem,
+    val appId: String?,
+    val origin: String?,
+    val readerEngagement: DataItem
+): Event(identifier, timestamp) {
+    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
+        identifier = eventIdentifier,
+        timestamp = timestamp
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventIso18013Proximity.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventIso18013Proximity.kt
@@ -1,0 +1,31 @@
+package org.multipaz.eventlog
+
+import org.multipaz.cbor.DataItem
+import kotlin.time.Instant
+
+/**
+ * An event representing an ISO/IEC 18013-5 presentment for proximity.
+ *
+ * TODO: include location (e.g. GPS coordinates)
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ * @property data Data about the presentment.
+ * @property request The raw request data.
+ * @property response The raw response data.
+ * @property sessionTranscript The raw session transcript data.
+ */
+data class PresentmentEventIso18013Proximity(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    val data: PresentmentEventData,
+    // The raw data from the presentment event.
+    val request: DataItem,
+    val response: DataItem,
+    val sessionTranscript: DataItem,
+): Event(identifier, timestamp) {
+    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
+        identifier = eventIdentifier,
+        timestamp = timestamp
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventUriSchemeOpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlog/PresentmentEventUriSchemeOpenID4VP.kt
@@ -1,0 +1,34 @@
+package org.multipaz.eventlog
+
+import kotlin.time.Instant
+
+/**
+ * An event representing an OpenID4VP presentment initiated via a URI scheme.
+ *
+ * @property identifier A unique identifier for the event.
+ * @property timestamp The timestamp when the event was recorded.
+ * @property data Data about the presentment.
+ * @property uri the URI used to invoke the presentment.
+ * @property appId the identifier of the application making the request, if known.
+ * @property origin the origin of the website making the request, if known.
+ * @property requestJwt the JWT containing the authorization request.
+ * @property vpToken the resulting vpToken.
+ * @property redirectUri the URI which was launched in the user's default browser.
+ */
+data class PresentmentEventUriSchemeOpenID4VP(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    val data: PresentmentEventData,
+    // The raw data from the presentment event.
+    val uri: String,
+    val appId: String?,
+    val origin: String?,
+    val requestJwt: String,
+    val vpToken: String,
+    val redirectUri: String
+): Event(identifier, timestamp) {
+    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
+        identifier = eventIdentifier,
+        timestamp = timestamp
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -251,6 +251,7 @@ class MdocCredential : SecureAreaBoundCredential {
                 val claim = MdocClaim(
                     displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
                     attribute = mdocAttr?.attribute,
+                    docType = docType,
                     namespaceName = namespaceName,
                     dataElementName = dataElementName,
                     value = issuerSignedItem.dataElementValue

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -627,6 +627,7 @@ data class DeviceRequest private constructor(
                 // Base Option (Index 0)
                 val baseClaim = MdocRequestedClaim(
                     id = null, // ID not strictly needed for internal logic
+                    docType = docRequest.docType,
                     namespaceName = namespace,
                     dataElementName = elementName,
                     intentToRetain = intentToRetain,
@@ -644,6 +645,7 @@ data class DeviceRequest private constructor(
                     val altOptionClaims = altSet.map { altElement ->
                         MdocRequestedClaim(
                             id = null,
+                            docType = docRequest.docType,
                             namespaceName = altElement.namespace,
                             dataElementName = altElement.dataElement,
                             intentToRetain = intentToRetain, // Inherit intent from base request

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -31,6 +31,7 @@ import org.multipaz.crypto.JsonWebEncryption
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
+import org.multipaz.eventlog.PresentmentEventData
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.response.DeviceResponse
@@ -264,6 +265,19 @@ object OpenID4VP {
     }
 
     /**
+     * Represents the response to an OpenID4VP request.
+     *
+     * @property response the response containing [vpToken], possibly encrypted.
+     * @property vpToken the VP Token.
+     * @property eventData a [PresentmentEventData] to be used for logging.
+     */
+    data class OpenID4VPResponse(
+        val response: JsonObject,
+        val vpToken: JsonObject,
+        val eventData: PresentmentEventData
+    )
+
+    /**
      * Generates an OpenID4VP response.
      *
      * @param version the version of OpenID4VP to generate a response for.
@@ -298,7 +312,7 @@ object OpenID4VP {
         request: JsonObject,
         requesterCertChain: X509CertChain?,
         onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
-    ): JsonObject {
+    ): OpenID4VPResponse {
         Logger.iJson(TAG, "request", request)
 
         val nonce = request["nonce"]!!.jsonPrimitive.content
@@ -424,10 +438,11 @@ object OpenID4VP {
         val transactionDataMap = request["transaction_data"]?.let {
             TransactionData.parse(it)
         }
-        // TODO: incorporate transaction data into the consent prompt
+        // TODO: incorporate transaction data into the consent prompt and event logging
+        val trustMetadata = source.resolveTrust(requester)
         val selection = source.showConsentPrompt(
             requester = requester,
-            trustMetadata = source.resolveTrust(requester),
+            trustMetadata = trustMetadata,
             credentialPresentmentData = dcqlResponse,
             preselectedDocuments = preselectedDocuments,
             onDocumentsInFocus = onDocumentsInFocus
@@ -437,6 +452,7 @@ object OpenID4VP {
         }
 
         var usingZk = false
+        val credentialsPresented = mutableSetOf<Credential>()
         selection.matches.forEach { match ->
             match.source as CredentialMatchSourceOpenID4VP
             val requestIsForZk = match.source.credentialQuery.format == "mso_mdoc_zk"
@@ -469,6 +485,7 @@ object OpenID4VP {
                 throw IllegalArgumentException("Expected ISO mdoc or IETF SD-JWT, got neither")
             }
             vpTokens.put(match.source.credentialQuery.id, credentialResponse)
+            credentialsPresented.add(match.credential)
         }
 
         val vpToken = when (version) {
@@ -501,7 +518,7 @@ object OpenID4VP {
         val compressionLevel = if (usingZk) 9 else null
 
         val walletGeneratedNonce = Random.nextBytes(16).toBase64Url()
-        return if (reReaderPublicKey != null) {
+        val response = if (reReaderPublicKey != null) {
             buildJsonObject {
                 put("response",
                     JsonWebEncryption.encrypt(
@@ -518,6 +535,16 @@ object OpenID4VP {
         } else {
             vpToken
         }
+
+        return OpenID4VPResponse(
+            response = response,
+            vpToken = vpToken,
+            eventData = PresentmentEventData.fromPresentmentSelection(
+                selection = selection,
+                requester = requester,
+                trustMetadata = trustMetadata
+            )
+        )
     }
 
     private suspend fun openID4VPMsoMdoc(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
@@ -388,6 +388,7 @@ data class DcqlQuery(
                         require(path.size == 2)
                         MdocRequestedClaim(
                             id = claimId,
+                            docType = mdocDocType,
                             namespaceName = path[0].jsonPrimitive.content,
                             dataElementName = path[1].jsonPrimitive.content,
                             intentToRetain = mdocIntentToRetain ?: false,
@@ -396,6 +397,7 @@ data class DcqlQuery(
                     } else {
                         JsonRequestedClaim(
                             id = claimId,
+                            vctValues = vctValues!!,
                             claimPath = path,
                             values = values
                         )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSelection.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSelection.kt
@@ -11,5 +11,5 @@ package org.multipaz.presentment
  * @property matches the list of credentials and claims to return to the relying party.
  */
 data class CredentialPresentmentSelection(
-    val matches: List<CredentialPresentmentSetOptionMemberMatch>
+    val matches: List<CredentialPresentmentSetOptionMemberMatch>,
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -11,6 +11,7 @@ import org.multipaz.cbor.buildCborArray
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.document.Document
+import org.multipaz.eventlog.PresentmentEventIso18013Proximity
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.sessionencryption.EReaderKey
@@ -136,7 +137,7 @@ suspend fun Iso18013Presentment(
             Logger.iCbor(TAG, "DeviceRequest", deviceRequestCbor)
             val deviceRequest = DeviceRequest.fromDataItem(deviceRequestCbor)
             deviceRequest.verifyReaderAuthentication(sessionTranscript)
-            val deviceResponse = mdocPresentment(
+            val responseObject = mdocPresentment(
                 deviceRequest = deviceRequest,
                 eReaderKey = eReaderKey.publicKey,
                 sessionTranscript = sessionTranscript,
@@ -150,11 +151,21 @@ suspend fun Iso18013Presentment(
             onSendingResponse()
             transport.sendMessage(
                 sessionEncryption.encryptMessage(
-                    messagePlaintext = Cbor.encode(deviceResponse.toDataItem()),
+                    messagePlaintext = Cbor.encode(responseObject.deviceResponse.toDataItem()),
                     statusCode = null
                 )
             )
             numRequestsServed += 1
+
+            source.eventLog?.addEvent(
+                PresentmentEventIso18013Proximity(
+                    data = responseObject.eventData,
+                    request = deviceRequest.toDataItem(),
+                    response = responseObject.deviceResponse.toDataItem(),
+                    sessionTranscript = sessionTranscript,
+                )
+            )
+
             Logger.i(TAG, "Response sent, keeping connection open")
         }
     } finally {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/MdocResponse.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/MdocResponse.kt
@@ -1,0 +1,15 @@
+package org.multipaz.presentment
+
+import org.multipaz.eventlog.PresentmentEventData
+import org.multipaz.mdoc.response.DeviceResponse
+
+/**
+ * The result of calling [mdocPresentment].
+ *
+ * @property deviceResponse a [org.multipaz.mdoc.response.DeviceResponse].
+ * @property eventData a [eventData] which can be used to log the presentment.
+ */
+data class MdocResponse(
+    val deviceResponse: DeviceResponse,
+    val eventData: PresentmentEventData
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
@@ -5,6 +5,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.eventlog.EventLog
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
@@ -25,12 +26,14 @@ import org.multipaz.trustmanagement.TrustMetadata
  * @property documentStore the [DocumentStore] which holds credentials that can be presented.
  * @property documentTypeRepository a [DocumentTypeRepository] which holds metadata for document types.
  * @property zkSystemRepository a [ZkSystemRepository] with ZKP systems or `null`.
+ * @property eventLog an [EventLog] for logging events or `null`.
  * @see SimplePresentmentSource for one concrete implementation tailored for ISO mdoc and IETF SD-JWT VC credentials.
  */
 abstract class PresentmentSource(
     open val documentStore: DocumentStore,
     open val documentTypeRepository: DocumentTypeRepository,
     open val zkSystemRepository: ZkSystemRepository? = null,
+    open val eventLog: EventLog? = null
 ) {
     /**
      * Determines if a requester is trusted.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -7,6 +7,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.eventlog.EventLog
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.prompt.ShowConsentPromptFn
 import org.multipaz.prompt.promptModelRequestConsent
@@ -32,6 +33,7 @@ private data class CredentialForPresentment(
  * @property documentStore the [DocumentStore] which holds credentials that can be presented.
  * @property documentTypeRepository a [DocumentTypeRepository] which holds metadata for document types.
  * @property zkSystemRepository the [ZkSystemRepository] to use or `null`.
+ * @property eventLog an [EventLog] for logging events or `null`.
  * @property resolveTrustFn a function which can be used to determine if a requester is trusted.
  * @property showConsentPrompt a [ShowConsentPromptFn] used show a consent prompt is required.
  * @property preferSignatureToKeyAgreement whether to use mdoc ECDSA authentication even if mdoc MAC authentication
@@ -45,6 +47,7 @@ class SimplePresentmentSource(
     override val documentStore: DocumentStore,
     override val documentTypeRepository: DocumentTypeRepository,
     override val zkSystemRepository: ZkSystemRepository? = null,
+    override val eventLog: EventLog? = null,
     private val resolveTrustFn: suspend (requester: Requester) -> TrustMetadata? = { requester -> null },
     private val showConsentPromptFn: ShowConsentPromptFn = ::promptModelRequestConsent,
     val preferSignatureToKeyAgreement: Boolean = true,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -17,6 +17,8 @@ import org.multipaz.crypto.Hpke
 import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.openid.OpenID4VP
 import org.multipaz.prompt.PromptDismissedException
@@ -176,7 +178,7 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
     } else {
         preReq
     }
-    val response = OpenID4VP.generateResponse(
+    val responseObject = OpenID4VP.generateResponse(
         version = version,
         preselectedDocuments = preselectedDocuments,
         source = source,
@@ -186,9 +188,22 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
         requesterCertChain = requesterCertChain,
         onDocumentsInFocus = onDocumentsInFocus
     )
+
+    source.eventLog?.addEvent(
+        PresentmentEventDigitalCredentialsOpenID4VP(
+            data = responseObject.eventData,
+            appId = appId,
+            origin = origin,
+            protocol = protocol,
+            requestJson = Json.encodeToString(data),
+            responseJson = Json.encodeToString(responseObject.response),
+            vpToken = Json.encodeToString(responseObject.vpToken)
+        )
+    )
+
     return buildJsonObject {
         put("protocol", protocol)
-        put("data", response)
+        put("data", responseObject.response)
     }
 }
 
@@ -232,7 +247,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
 
     val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(deviceRequestBase64.fromBase64Url()))
     deviceRequest.verifyReaderAuthentication(sessionTranscript)
-    val deviceResponse = mdocPresentment(
+    val responseObject = mdocPresentment(
         deviceRequest = deviceRequest,
         eReaderKey = null,
         sessionTranscript = sessionTranscript,
@@ -251,7 +266,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         info = Cbor.encode(sessionTranscript)
     )
     val ciphertext = encrypter.encrypt(
-        plaintext = Cbor.encode(deviceResponse.toDataItem()),
+        plaintext = Cbor.encode(responseObject.deviceResponse.toDataItem()),
         aad = ByteArray(0),
     )
     val encryptedResponse =
@@ -265,11 +280,24 @@ private suspend fun digitalCredentialsMdocApiProtocol(
             }
         )
 
-    val data = buildJsonObject {
+    val responseData = buildJsonObject {
         put("response", encryptedResponse.toBase64Url())
     }
+
+    source.eventLog?.addEvent(
+        PresentmentEventDigitalCredentialsMdocApi(
+            data = responseObject.eventData,
+            appId = appId,
+            origin = origin,
+            protocol = protocol,
+            requestJson = Json.encodeToString(data),
+            responseJson = Json.encodeToString(responseData),
+            deviceResponse = responseObject.deviceResponse.toDataItem()
+        )
+    )
+
     return buildJsonObject {
         put("protocol", protocol)
-        put("data", data)
+        put("data", responseData)
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -4,6 +4,7 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.document.Document
+import org.multipaz.eventlog.PresentmentEventData
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.devicesigned.buildDeviceNamespaces
 import org.multipaz.mdoc.request.DeviceRequest
@@ -37,7 +38,7 @@ private const val TAG = "mdocPresentment"
  * @param onWaitingForUserInput called when waiting for input from the user (consent or authentication)
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
  *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
- * @return a [DeviceResponse].
+ * @return a [MdocResponse] containing [DeviceResponse] and [PresentmentEventData].
  * @throws PresentmentCanceledException if the user canceled in a consent prompt.
  * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
@@ -60,8 +61,11 @@ suspend fun mdocPresentment(
     preselectedDocuments: List<Document> = emptyList(),
     onWaitingForUserInput: () -> Unit = {},
     onDocumentsInFocus: (documents: List<Document>) -> Unit
-): DeviceResponse {
-    return buildDeviceResponse(
+): MdocResponse {
+    val credentialsPresented = mutableSetOf<MdocCredential>()
+    lateinit var eventData: PresentmentEventData
+
+    val deviceResponse = buildDeviceResponse(
         sessionTranscript = sessionTranscript,
         status = DeviceResponse.STATUS_OK,
         eReaderKey = eReaderKey,
@@ -82,9 +86,10 @@ suspend fun mdocPresentment(
             origin = requesterOrigin,
         )
         onWaitingForUserInput()
+        val trustMetadata = source.resolveTrust(requester)
         val selection = source.showConsentPrompt(
             requester = requester,
-            trustMetadata = source.resolveTrust(requester),
+            trustMetadata = trustMetadata,
             credentialPresentmentData = presentmentData,
             preselectedDocuments = preselectedDocuments,
             onDocumentsInFocus = onDocumentsInFocus
@@ -145,6 +150,17 @@ suspend fun mdocPresentment(
                 addDocument(document)
             }
             match.credential.increaseUsageCount()
+            credentialsPresented.add(match.credential)
         }
+
+        eventData = PresentmentEventData.fromPresentmentSelection(
+            selection = selection,
+            requester = requester,
+            trustMetadata = trustMetadata
+        )
     }
+    return MdocResponse(
+        deviceResponse = deviceResponse,
+        eventData = eventData
+    )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -30,6 +30,8 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.document.Document
+import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
+import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.engagement.Capability
 import org.multipaz.mdoc.engagement.DeviceEngagement
@@ -38,7 +40,6 @@ import org.multipaz.mdoc.origininfo.OriginInfoDomain
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.sessionencryption.SessionEncryption
-import org.multipaz.mdoc.transport.MdocTransportClosedException
 import org.multipaz.openid.OpenID4VP
 import org.multipaz.util.Constants
 import org.multipaz.util.Logger
@@ -53,7 +54,8 @@ private const val TAG = "uriSchemePresentment"
  *
  * @param source the source of truth used for presentment.
  * @param uri the referrer.
- * @param origin the origin.
+ * @param appId the appId of the browser or app which invoked us, if known.
+ * @param origin the origin, if known.
  * @param httpClientEngineFactory a [HttpClientEngineFactory].
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
  *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
@@ -70,6 +72,7 @@ private const val TAG = "uriSchemePresentment"
 suspend fun uriSchemePresentment(
     source: PresentmentSource,
     uri: String,
+    appId: String?,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
     onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
@@ -78,6 +81,7 @@ suspend fun uriSchemePresentment(
         return mdocUriSchemePresentment(
             source = source,
             uri = uri,
+            appId = appId,
             origin = origin,
             httpClientEngineFactory = httpClientEngineFactory,
             onDocumentsInFocus = onDocumentsInFocus
@@ -116,16 +120,17 @@ suspend fun uriSchemePresentment(
 
     val responseUri = requestObject["response_uri"]?.jsonPrimitive?.content
         ?: throw IllegalArgumentException("response_uri not set in request")
-    val response = OpenID4VP.generateResponse(
+    val responseObject = OpenID4VP.generateResponse(
         version = OpenID4VP.Version.DRAFT_29,
         preselectedDocuments = listOf(),
         source = source,
-        appId = null, // TODO: maybe pass the browser's appId if we can
+        appId = appId,
         origin = origin ?: "",
         request = requestObject,
         requesterCertChain = requesterChain,
         onDocumentsInFocus = onDocumentsInFocus
     )
+    val response = responseObject.response
 
     val responseCs = when (requestObject["response_mode"]!!.jsonPrimitive.content) {
         "direct_post" -> {
@@ -155,12 +160,26 @@ suspend fun uriSchemePresentment(
     val bodyText = (postResponseResponse.body() as ByteArray).decodeToString()
     val postResponseBody = Json.decodeFromString<JsonObject>(bodyText)
     val redirectUri = postResponseBody["redirect_uri"]!!.jsonPrimitive.content
+
+    source.eventLog?.addEvent(
+        PresentmentEventUriSchemeOpenID4VP(
+            data = responseObject.eventData,
+            uri = uri,
+            appId = appId,
+            origin = origin,
+            requestJwt = reqJwt,
+            vpToken = Json.encodeToString(responseObject.vpToken),
+            redirectUri = redirectUri
+        )
+    )
+
     return redirectUri
 }
 
 private suspend fun mdocUriSchemePresentment(
     source: PresentmentSource,
     uri: String,
+    appId: String?,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
     onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
@@ -261,22 +280,37 @@ private suspend fun mdocUriSchemePresentment(
 
         val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(messageFromReader))
         deviceRequest.verifyReaderAuthentication(sessionTranscript)
-        val deviceResponse = mdocPresentment(
+        val responseObject = mdocPresentment(
             deviceRequest = deviceRequest,
             eReaderKey = eReaderKey,
             sessionTranscript = sessionTranscript,
             source = source,
             keyAgreementPossible = emptyList(), // TODO: support MacKeys
-            requesterAppId = null, // TODO: maybe pass the browser's appId if we can
+            requesterAppId = appId,
             requesterOrigin = origin ?: "",
             preselectedDocuments = emptyList(),
             onWaitingForUserInput = {},
             onDocumentsInFocus = onDocumentsInFocus
         )
         messageToPost = sessionEncryption.encryptMessage(
-            messagePlaintext = Cbor.encode(deviceResponse.toDataItem()),
+            messagePlaintext = Cbor.encode(responseObject.deviceResponse.toDataItem()),
             statusCode = null
         )
+
+        source.eventLog?.addEvent(
+            PresentmentEventIso18013AnnexA(
+                data = responseObject.eventData,
+                uri = uri,
+                request = deviceRequest.toDataItem(),
+                response = responseObject.deviceResponse.toDataItem(),
+                sessionTranscript = sessionTranscript,
+                appId = appId,
+                origin = origin,
+                readerEngagement = readerEngagement.toDataItem()
+            )
+        )
+
     } while (true)
+
     return null
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/JsonRequestedClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/JsonRequestedClaim.kt
@@ -6,10 +6,12 @@ import org.multipaz.documenttype.DocumentAttribute
 /**
  * A request for a claim in a JSON-based credential.
  *
+ * @property vctValues the Verifiable Credential Types that can satisfy the request.
  * @property claimPath the claims path pointer.
  */
 data class JsonRequestedClaim(
     override val id: String? = null,
+    val vctValues: List<String>,
     val claimPath: JsonArray,
     override val values: JsonArray? = null
 ): RequestedClaim(id = id, values = values) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/MdocRequestedClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/MdocRequestedClaim.kt
@@ -6,12 +6,14 @@ import org.multipaz.documenttype.DocumentAttribute
 /**
  * A request for a claim in an ISO mdoc credential.
  *
+ * @property docType the document type.
  * @property namespaceName the mdoc namespace.
  * @property dataElementName the data element name.
  * @property intentToRetain `true` if the requester intends to retain the value.
  */
 data class MdocRequestedClaim(
     override val id: String? = null,
+    val docType: String,
     val namespaceName: String,
     val dataElementName: String,
     val intentToRetain: Boolean,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/RequestedClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/RequestedClaim.kt
@@ -1,6 +1,13 @@
 package org.multipaz.request
 
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializationImplemented
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborArray
+import org.multipaz.claim.Claim
+import org.multipaz.documenttype.DocumentAttribute
 
 /**
  * Base class used for representing a request for a claim.
@@ -8,7 +15,77 @@ import kotlinx.serialization.json.JsonArray
  * @property id the identifier for the claim or `null`.
  * @property values A set of acceptable values or `null` to not match on value.
  */
+@CborSerializationImplemented(schemaId = "")
 sealed class RequestedClaim(
     open val id: String? = null,
     open val values: JsonArray? = null,
-)
+) {
+    /**
+     * Serializes [RequestedClaim] to CBOR.
+     *
+     * @return a [DataItem].
+     */
+    fun toDataItem() = buildCborMap {
+        id?.let {
+            put("id", it)
+        }
+        values?.let {
+            put("values", Json.encodeToString(it))
+        }
+        when (this@RequestedClaim) {
+            is JsonRequestedClaim -> {
+                put("type", TYPE_JSON_REQUESTED_CLAIM)
+                putCborArray("vctValues") {
+                    vctValues.forEach { add(it) }
+                }
+                put("claimPath", Json.encodeToString(claimPath))
+            }
+            is MdocRequestedClaim -> {
+                put("type", TYPE_MDOC_REQUESTED_CLAIM)
+                put("docType", docType)
+                put("namespaceName", namespaceName)
+                put("dataElementName", dataElementName)
+                put("intentToRetain", intentToRetain)
+            }
+        }
+    }
+
+    companion object {
+        private const val TYPE_JSON_REQUESTED_CLAIM = 0
+        private const val TYPE_MDOC_REQUESTED_CLAIM = 1
+
+        /**
+         * Creates a [RequestedClaim] previously serialized with [RequestedClaim.toDataItem].
+         *
+         * @param dataItem a [DataItem].
+         * @return a [RequestedClaim].
+         */
+        fun fromDataItem(dataItem: DataItem): RequestedClaim {
+            val id = dataItem.getOrNull("id")?.asTstr
+            val values = dataItem.getOrNull("values")?.let {
+                Json.decodeFromString<JsonArray>(it.asTstr)
+            }
+            when (dataItem["type"].asNumber.toInt()) {
+                TYPE_JSON_REQUESTED_CLAIM -> {
+                    return JsonRequestedClaim(
+                        id = id,
+                        values = values,
+                        vctValues = dataItem["vctValues"].asArray.map { it.asTstr },
+                        claimPath = Json.decodeFromString<JsonArray>(dataItem["claimPath"].asTstr)
+                    )
+                }
+                TYPE_MDOC_REQUESTED_CLAIM -> {
+                    return MdocRequestedClaim(
+                        id = id,
+                        values = values,
+                        docType = dataItem["docType"].asTstr,
+                        namespaceName = dataItem["namespaceName"].asTstr,
+                        dataElementName = dataItem["dataElementName"].asTstr,
+                        intentToRetain = dataItem["intentToRetain"].asBoolean
+                    )
+                }
+                else -> throw IllegalStateException("Unexpected type")
+            }
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/Requester.kt
@@ -18,4 +18,13 @@ data class Requester(
     val certChain: X509CertChain? = null,
     val appId: String? = null,
     val origin: String? = null,
-)
+) {
+
+    /**
+     * Set to `true` if [origin] is a web origin.
+     *
+     * This is true if [origin] is set and is either empty or starts with either `http://` or `https://`.
+     */
+    val isWebOrigin: Boolean
+        get() = origin != null && (origin.isEmpty() || origin.startsWith("http://") || origin.startsWith("https://"))
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/SdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/SdJwtVcCredential.kt
@@ -50,6 +50,7 @@ interface SdJwtVcCredential {
                 JsonClaim(
                     displayName = dt?.jsonDocumentType?.claims?.get(claimName)?.displayName ?: claimName,
                     attribute = attribute,
+                    vct = vct,
                     claimPath = buildJsonArray { add(claimName) },
                     value = claimValue
                 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -782,6 +782,7 @@ object VerificationUtil {
             claims.add(JsonClaim(
                 displayName = jsonAttr?.displayName ?: claimName,
                 attribute = jsonAttr,
+                vct = vct,
                 claimPath = JsonArray(listOf(JsonPrimitive(claimName))),
                 value = claimValue
             ))
@@ -794,6 +795,7 @@ object VerificationUtil {
                 claims.add(JsonClaim(
                     displayName = jsonAttr?.displayName ?: claimName + " (Device Signed)",
                     attribute = jsonAttr,
+                    vct = vct,
                     claimPath = JsonArray(listOf(JsonPrimitive(claimName))),
                     value = claimValue
                 ))
@@ -849,6 +851,7 @@ object VerificationUtil {
                         MdocClaim(
                             displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
                             attribute = mdocAttr?.attribute,
+                            docType = document.docType,
                             namespaceName = namespaceName,
                             dataElementName = dataElementName,
                             value = issuerSignedItem.dataElementValue
@@ -865,6 +868,7 @@ object VerificationUtil {
                         MdocClaim(
                             displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
                             attribute = mdocAttr?.attribute,
+                            docType = document.docType,
                             namespaceName = namespaceName,
                             dataElementName = dataElementName,
                             value = dataElementValue
@@ -911,6 +915,7 @@ object VerificationUtil {
                         MdocClaim(
                             displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
                             attribute = mdocAttr?.attribute,
+                            docType = zkDocument.documentData.docType,
                             namespaceName = namespaceName,
                             dataElementName = dataElementName,
                             value = value
@@ -927,6 +932,7 @@ object VerificationUtil {
                         MdocClaim(
                             displayName = mdocAttr?.attribute?.displayName ?: dataElementName,
                             attribute = mdocAttr?.attribute,
+                            docType = zkDocument.documentData.docType,
                             namespaceName = namespaceName,
                             dataElementName = dataElementName,
                             value = value

--- a/multipaz/src/commonTest/kotlin/org/multipaz/claim/ClaimTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/claim/ClaimTests.kt
@@ -1,0 +1,96 @@
+package org.multipaz.claim
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import org.multipaz.cbor.Simple
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+class ClaimTests {
+    @Test
+    fun testSerializationMdocClaim() {
+        val mdocClaim = MdocClaim(
+            displayName = "Age over 18?",
+            attribute = null,
+            docType = DrivingLicense.MDL_DOCTYPE,
+            namespaceName = DrivingLicense.MDL_NAMESPACE,
+            dataElementName = "age_over_18",
+            value = Simple.TRUE
+        )
+        assertEquals(
+            Claim.fromDataItem(mdocClaim.toDataItem()),
+            mdocClaim
+        )
+
+        val attribute = DrivingLicense.getDocumentType().mdocDocumentType!!
+            .namespaces[DrivingLicense.MDL_NAMESPACE]!!.dataElements["age_over_18"]!!.attribute
+        assertNotNull(attribute)
+
+        val mdocClaimWithAttribute = MdocClaim(
+            displayName = "Age over 18?",
+            attribute = attribute,
+            docType = DrivingLicense.MDL_DOCTYPE,
+            namespaceName = DrivingLicense.MDL_NAMESPACE,
+            dataElementName = "age_over_18",
+            value = Simple.TRUE
+        )
+
+        assertNotEquals(
+            Claim.fromDataItem(mdocClaim.toDataItem()),
+            mdocClaimWithAttribute
+        )
+
+        val docTypeRepo = DocumentTypeRepository().apply {
+            addDocumentType(DrivingLicense.getDocumentType())
+        }
+        assertEquals(
+            Claim.fromDataItem(mdocClaimWithAttribute.toDataItem(), docTypeRepo),
+            mdocClaimWithAttribute
+        )
+    }
+
+    @Test
+    fun testSerializationJsonClaim() {
+        val jsonClaim = JsonClaim(
+            displayName = "Given name",
+            attribute = null,
+            vct = EUPersonalID.EUPID_VCT,
+            claimPath = buildJsonArray { add("given_name") },
+            value = JsonPrimitive("Max")
+        )
+        assertEquals(
+            Claim.fromDataItem(jsonClaim.toDataItem()),
+            jsonClaim
+        )
+
+        val attribute = EUPersonalID.getDocumentType().jsonDocumentType!!.claims["given_name"]
+        assertNotNull(attribute)
+
+        val jsonClaimWithAttribute = JsonClaim(
+            displayName = "Given name",
+            attribute = attribute,
+            vct = EUPersonalID.EUPID_VCT,
+            claimPath = buildJsonArray { add("given_name") },
+            value = JsonPrimitive("Max")
+        )
+
+        assertNotEquals(
+            Claim.fromDataItem(jsonClaimWithAttribute.toDataItem()),
+            jsonClaimWithAttribute
+        )
+
+        val docTypeRepo = DocumentTypeRepository().apply {
+            addDocumentType(EUPersonalID.getDocumentType())
+        }
+        assertEquals(
+            Claim.fromDataItem(jsonClaimWithAttribute.toDataItem(), docTypeRepo),
+            jsonClaimWithAttribute
+        )
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/eventlog/EventLogTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/eventlog/EventLogTests.kt
@@ -1,0 +1,419 @@
+package org.multipaz.eventlog
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.toDataItem
+import org.multipaz.claim.MdocClaim
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.request.MdocRequestedClaim
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventLogTests {
+
+    @Test
+    fun testAddEventEmitsToFlowAndAssignsId() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val emissions = mutableListOf<Unit>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            logger.eventFlow.toList(emissions)
+        }
+
+        val event = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = mapOf(
+                            MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                intentToRetain = false,
+                            ) to MdocClaim(
+                                displayName = "Age over 18?",
+                                attribute = null,
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                value = true.toDataItem()
+                            )
+                        )
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val savedEvent = logger.addEvent(event)
+
+        // Verify the event was modified with a new ID and timestamp
+        assertTrue(savedEvent.identifier.isNotEmpty())
+        assertEquals(Instant.fromEpochMilliseconds(1000), savedEvent.timestamp)
+
+        // Verify flow emission
+        assertEquals(1, emissions.size)
+
+        // Verify storage state
+        val eventsInDb = logger.getEvents()
+        assertEquals(1, eventsInDb.size)
+        assertEquals(savedEvent.identifier, eventsInDb.first().identifier)
+
+        job.cancel()
+    }
+
+    @Test
+    fun testDeleteEventEmitsToFlowAndRemovesData() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val event = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = mapOf(
+                            MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                intentToRetain = false,
+                            ) to MdocClaim(
+                                displayName = "Age over 18?",
+                                attribute = null,
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                value = true.toDataItem()
+                            )
+                        )
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val savedEvent = logger.addEvent(event)
+
+        val emissions = mutableListOf<Unit>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            logger.eventFlow.toList(emissions)
+        }
+
+        val isDeleted = logger.deleteEvent(savedEvent)
+
+        assertTrue(isDeleted)
+        assertEquals(1, emissions.size)
+        assertTrue(logger.getEvents().isEmpty())
+
+        job.cancel()
+    }
+
+    @Test
+    fun testDeleteNonExistentEventDoesNotEmit() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val emissions = mutableListOf<Unit>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            logger.eventFlow.toList(emissions)
+        }
+
+        val dummyEvent = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = mapOf(
+                            MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                intentToRetain = false,
+                            ) to MdocClaim(
+                                displayName = "Age over 18?",
+                                attribute = null,
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                value = true.toDataItem()
+                            )
+                        )
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val isDeleted = logger.deleteEvent(dummyEvent)
+
+        assertFalse(isDeleted)
+        assertEquals(0, emissions.size)
+
+        job.cancel()
+    }
+
+    @Test
+    fun testDeleteAllEventsClearsPartitionAndEmits() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val event = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = mapOf(
+                            MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                intentToRetain = false,
+                            ) to MdocClaim(
+                                displayName = "Age over 18?",
+                                attribute = null,
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                value = true.toDataItem()
+                            )
+                        )
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+        logger.addEvent(event)
+        logger.addEvent(event)
+
+        val emissions = mutableListOf<Unit>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            logger.eventFlow.toList(emissions)
+        }
+
+        logger.deleteAllEvents()
+
+        assertEquals(1, emissions.size)
+        assertTrue(logger.getEvents().isEmpty())
+
+        job.cancel()
+    }
+
+    @Test
+    fun testGetEventsReturnsChronologicallySortedList() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(3000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val eventBase = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = mapOf(
+                            MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                intentToRetain = false,
+                            ) to MdocClaim(
+                                displayName = "Age over 18?",
+                                attribute = null,
+                                docType = DrivingLicense.MDL_DOCTYPE,
+                                namespaceName = DrivingLicense.MDL_NAMESPACE,
+                                dataElementName = "age_over_18",
+                                value = true.toDataItem()
+                            )
+                        )
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        // Add out of order chronologically by manipulating the clock
+        fakeClock.currentTime = Instant.fromEpochMilliseconds(3000)
+        val event3 = logger.addEvent(eventBase)
+
+        fakeClock.currentTime = Instant.fromEpochMilliseconds(1000)
+        val event1 = logger.addEvent(eventBase)
+
+        fakeClock.currentTime = Instant.fromEpochMilliseconds(2000)
+        val event2 = logger.addEvent(eventBase)
+
+        val sortedEvents = logger.getEvents()
+
+        assertEquals(3, sortedEvents.size)
+
+        // Assert that the items are sorted chronologically. Because our storage engine keys
+        // are now prefixed with the ISO-8601 timestamp, the database native retrieval matches
+        // our expected chronological order perfectly.
+        assertEquals(event1.identifier, sortedEvents[0].identifier)
+        assertEquals(event2.identifier, sortedEvents[1].identifier)
+        assertEquals(event3.identifier, sortedEvents[2].identifier)
+    }
+
+    @Test
+    fun testGetEventsPagination() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val eventBase = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = emptyMap()
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        // Insert 5 events, advancing the clock so they are chronologically staggered.
+        // Because the timestamp is the DB key prefix, native DB pagination will work.
+        val insertedEvents = mutableListOf<Event>()
+        for (i in 1..5) {
+            fakeClock.currentTime = Instant.fromEpochMilliseconds(1000L * i)
+            insertedEvents.add(logger.addEvent(eventBase))
+        }
+
+        // Fetch page 1 (limit 2)
+        val page1 = logger.getEvents(limit = 2)
+        assertEquals(2, page1.size)
+        assertEquals(insertedEvents[0].identifier, page1[0].identifier)
+        assertEquals(insertedEvents[1].identifier, page1[1].identifier)
+
+        // Fetch page 2 (limit 2, after event 2)
+        val page2 = logger.getEvents(limit = 2, afterEventId = page1.last().identifier)
+        assertEquals(2, page2.size)
+        assertEquals(insertedEvents[2].identifier, page2[0].identifier)
+        assertEquals(insertedEvents[3].identifier, page2[1].identifier)
+
+        // Fetch page 3 (limit 2, after event 4) -> Should only return 1 event
+        val page3 = logger.getEvents(limit = 2, afterEventId = page2.last().identifier)
+        assertEquals(1, page3.size)
+        assertEquals(insertedEvents[4].identifier, page3[0].identifier)
+    }
+
+    @Test
+    fun testEventExpiration() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = EventLog(
+            storage = ephemeralStorage,
+            partitionId = "test-partition",
+            expireAfter = 1.days,
+            clock = fakeClock
+        )
+
+        val eventBase = PresentmentEventIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            data = PresentmentEventData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    PresentmentEventDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = emptyMap()
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        logger.addEvent(eventBase)
+
+        // Ensure the event exists immediately after insertion
+        assertEquals(1, logger.getEvents().size)
+
+        // Fast forward time to just before the expiration (e.g., 23 hours later)
+        fakeClock.currentTime = fakeClock.currentTime.plus(23.hours)
+        assertEquals(1, logger.getEvents().size)
+
+        // Fast forward time past the expiration limit (e.g., another 2 hours)
+        fakeClock.currentTime = fakeClock.currentTime.plus(2.hours)
+
+        // Because EphemeralStorage relies on the injected clock to evaluate TTL,
+        // it should prune or filter out the expired event.
+        assertTrue(logger.getEvents().isEmpty(), "Expected event to be expired and removed")
+    }
+
+    // --- Fakes ---
+
+    class FakeClock(var currentTime: Instant = Instant.fromEpochMilliseconds(0)) : Clock {
+        override fun now(): Instant = currentTime
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
@@ -345,11 +345,13 @@ class DeviceResponseTest {
                 credential = mdlCredentialSignature,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "age_over_18",
                         intentToRetain = false
                     ),
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "given_name",
                         intentToRetain = false
@@ -485,6 +487,7 @@ class DeviceResponseTest {
                         credential = mdlCredentialMac,
                         requestedClaims = listOf(
                             MdocRequestedClaim(
+                                docType = DrivingLicense.MDL_DOCTYPE,
                                 namespaceName = DrivingLicense.MDL_NAMESPACE,
                                 dataElementName =  "age_over_18",
                                 intentToRetain = false
@@ -503,6 +506,7 @@ class DeviceResponseTest {
                 credential = mdlCredentialMac,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName =  "age_over_18",
                         intentToRetain = false
@@ -577,11 +581,13 @@ class DeviceResponseTest {
                 credential = mdlCredentialSignature,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "age_over_18",
                         intentToRetain = false
                     ),
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "given_name",
                         intentToRetain = false
@@ -624,11 +630,13 @@ class DeviceResponseTest {
                 credential = mdlCredentialSignature,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "age_over_18",
                         intentToRetain = false
                     ),
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "given_name",
                         intentToRetain = false
@@ -639,11 +647,13 @@ class DeviceResponseTest {
                 credential = photoIdCredential,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = PhotoID.ISO_23220_2_NAMESPACE,
                         dataElementName = "family_name",
                         intentToRetain = false
                     ),
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = PhotoID.ISO_23220_2_NAMESPACE,
                         dataElementName = "given_name",
                         intentToRetain = false
@@ -755,11 +765,13 @@ class DeviceResponseTest {
                 credential = mdlCredentialSignature,
                 requestedClaims = listOf(
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "age_over_18",
                         intentToRetain = false
                     ),
                     MdocRequestedClaim(
+                        docType = DrivingLicense.MDL_DOCTYPE,
                         namespaceName = DrivingLicense.MDL_NAMESPACE,
                         dataElementName = "given_name",
                         intentToRetain = false
@@ -907,11 +919,13 @@ class DeviceResponseTest {
                     credential = mdlCredentialSignature,
                     requestedClaims = listOf(
                         MdocRequestedClaim(
+                            docType = DrivingLicense.MDL_DOCTYPE,
                             namespaceName = DrivingLicense.MDL_NAMESPACE,
                             dataElementName = "age_over_18",
                             intentToRetain = false
                         ),
                         MdocRequestedClaim(
+                            docType = DrivingLicense.MDL_DOCTYPE,
                             namespaceName = DrivingLicense.MDL_NAMESPACE,
                             dataElementName = "given_name",
                             intentToRetain = false

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPathSelection.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPathSelection.kt
@@ -11,6 +11,7 @@ import org.multipaz.claim.JsonClaim
 import org.multipaz.claim.MdocClaim
 import org.multipaz.claim.findMatchingClaim
 import org.multipaz.document.Document
+import org.multipaz.documenttype.knowntypes.DrivingLicense
 import org.multipaz.documenttype.knowntypes.EUPersonalID
 import org.multipaz.presentment.DocumentStoreTestHarness
 import org.multipaz.request.JsonRequestedClaim
@@ -77,6 +78,7 @@ class TestPathSelection {
             "Erika",
             (mdlErikaClaims.findMatchingClaim(
                 requestedClaim = MdocRequestedClaim(
+                    docType = DrivingLicense.MDL_DOCTYPE,
                     namespaceName = "org.iso.18013.5.1",
                     dataElementName = "given_name",
                     intentToRetain = false,
@@ -89,7 +91,8 @@ class TestPathSelection {
             "Erika",
             (mdlErikaClaims.findMatchingClaim(
                 requestedClaim = MdocRequestedClaim(
-                    namespaceName = "org.iso.18013.5.1",
+                    docType = DrivingLicense.MDL_DOCTYPE,
+                    namespaceName = DrivingLicense.MDL_NAMESPACE,
                     dataElementName = "given_name",
                     intentToRetain = false,
                     values = buildJsonArray { add("Erika") }
@@ -100,7 +103,8 @@ class TestPathSelection {
         assertNull(
             mdlErikaClaims.findMatchingClaim(
                 requestedClaim = MdocRequestedClaim(
-                    namespaceName = "org.iso.18013.5.1",
+                    docType = DrivingLicense.MDL_DOCTYPE,
+                    namespaceName = DrivingLicense.MDL_NAMESPACE,
                     dataElementName = "given_name",
                     intentToRetain = false,
                     values = buildJsonArray { add("Max") }
@@ -120,6 +124,7 @@ class TestPathSelection {
             JsonPrimitive("Erika"),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("given_name") },
                 )
             )!! as JsonClaim).value
@@ -129,6 +134,7 @@ class TestPathSelection {
             null,
             pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("does-not-exist") },
                 )
             )
@@ -138,6 +144,7 @@ class TestPathSelection {
             JsonPrimitive("US"),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("address"); add("country") },
                 )
             )!! as JsonClaim).value
@@ -147,6 +154,7 @@ class TestPathSelection {
             JsonPrimitive("CA"),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("address"); add("state") },
                 )
             )!! as JsonClaim).value
@@ -156,6 +164,7 @@ class TestPathSelection {
             JsonPrimitive(123),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("address"); add("house_number") },
                 )
             )!! as JsonClaim).value
@@ -165,6 +174,7 @@ class TestPathSelection {
             null,
             pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("address"); add("does-not-exist") },
                 )
             )
@@ -180,6 +190,7 @@ class TestPathSelection {
             },
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("address") },
                 )
             )!! as JsonClaim).value
@@ -189,6 +200,7 @@ class TestPathSelection {
             JsonPrimitive("American"),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("nationalities"); add(1) },
                 )
             )!! as JsonClaim).value
@@ -201,6 +213,7 @@ class TestPathSelection {
             },
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("degrees"); add("type") },
                 )
             )!! as JsonClaim).value
@@ -210,6 +223,7 @@ class TestPathSelection {
             JsonPrimitive("Erika"),
             (pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("given_name") },
                     values = buildJsonArray { add("Erika") }
                 )
@@ -220,6 +234,7 @@ class TestPathSelection {
             null,
             pidErikaClaims.findMatchingClaim(
                 requestedClaim = JsonRequestedClaim(
+                    vctValues = listOf(EUPersonalID.EUPID_VCT),
                     claimPath = buildJsonArray { add("given_name") },
                     values = buildJsonArray { add("Max") }
                 )

--- a/multipaz/src/commonTest/kotlin/org/multipaz/request/RequestedClaimTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/request/RequestedClaimTests.kt
@@ -1,0 +1,39 @@
+package org.multipaz.request
+
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RequestedClaimTests {
+
+    @Test
+    fun testSerializationMdocRequestedClaim() {
+        val mdocRequestedClaim = MdocRequestedClaim(
+            docType = DrivingLicense.MDL_DOCTYPE,
+            namespaceName = DrivingLicense.MDL_NAMESPACE,
+            dataElementName = "age_over_18",
+            intentToRetain = true,
+            values = null
+        )
+        assertEquals(
+            RequestedClaim.fromDataItem(mdocRequestedClaim.toDataItem()),
+            mdocRequestedClaim
+        )
+    }
+
+    @Test
+    fun testSerializationJsonRequestedClaim() {
+        val jsonRequestedClaim = JsonRequestedClaim(
+            vctValues = listOf(EUPersonalID.EUPID_VCT),
+            claimPath = buildJsonArray { add("given_name") },
+            values = buildJsonArray { add("Max") }
+        )
+        assertEquals(
+            RequestedClaim.fromDataItem(jsonRequestedClaim.toDataItem()),
+            jsonRequestedClaim
+        )
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -90,6 +90,7 @@ import org.multipaz.documenttype.knowntypes.IDPass
 import org.multipaz.documenttype.knowntypes.Loyalty
 import org.multipaz.documenttype.knowntypes.PhotoID
 import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
+import org.multipaz.eventlog.EventLog
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.longfellow.LongfellowZkSystem
@@ -122,6 +123,8 @@ import org.multipaz.testapp.ui.DcRequestScreen
 import org.multipaz.testapp.ui.VerticalDocumentListScreen
 import org.multipaz.testapp.ui.DocumentStoreScreen
 import org.multipaz.testapp.ui.DocumentViewerScreen
+import org.multipaz.testapp.ui.EventLogScreen
+import org.multipaz.testapp.ui.EventViewerScreen
 import org.multipaz.testapp.ui.IsoMdocMultiDeviceTestingScreen
 import org.multipaz.testapp.ui.IsoMdocProximityReadingScreen
 import org.multipaz.testapp.ui.IsoMdocProximitySharingScreen
@@ -225,6 +228,7 @@ class App private constructor (val promptModel: PromptModel) {
             documentStore = documentStore,
             documentTypeRepository = documentTypeRepository,
             zkSystemRepository = zkSystemRepository,
+            eventLog = eventLog,
             showConsentPromptFn = if (settingsModel.presentmentShowConsentPrompt.value) {
                 ::promptModelRequestConsent
             } else {
@@ -303,6 +307,7 @@ class App private constructor (val promptModel: PromptModel) {
                 Pair(::zkSystemRepositoryInit, "zkSystemRepositoryInit"),
                 Pair(::observeModeInit, "observeModeInit"),
                 Pair(::digitalCredentialsInit, "digitalCredentialsInit"),
+                Pair(::eventLoggerInit, "eventLoggerInit"),
             )
 
             val begin = Clock.System.now()
@@ -767,6 +772,12 @@ class App private constructor (val promptModel: PromptModel) {
             }
         }
     }
+    
+    lateinit var eventLog: EventLog
+
+    private suspend fun eventLoggerInit() {
+        eventLog = EventLog(storage = TestAppConfiguration.storage)
+    }
 
     private suspend fun digitalCredentialsReregister() {
         try {
@@ -814,6 +825,7 @@ class App private constructor (val promptModel: PromptModel) {
                 val redirectUri = uriSchemePresentment(
                     source = getPresentmentSource(),
                     uri = requestUrl,
+                    appId = null,
                     origin = origin,
                     httpClientEngineFactory = TestAppConfiguration.httpClientEngineFactory,
                 )
@@ -1033,7 +1045,8 @@ class App private constructor (val promptModel: PromptModel) {
                                         showToast("Error launching QuickAccessWallet: ${e.message}")
                                     }
                                 }
-                            }
+                            },
+                            onClickEventLog = { navController.navigate(EventLogDestination) }
                         )
                     }
                 }
@@ -1578,6 +1591,41 @@ class App private constructor (val promptModel: PromptModel) {
                         onBackPressed = {
                             navController.navigateUp()
                         }
+                    )
+                }
+                composable<EventLogDestination> { backStackEntry ->
+                    // Note: EventLogScreen has its own AppBar
+                    EventLogScreen(
+                        eventLog = eventLog,
+                        imageLoader = imageLoader,
+                        documentModel = documentModel,
+                        onEventClicked = { event ->
+                            navController.navigate(EventViewerDestination(event.identifier))
+                        },
+                        onBack = { navController.navigateUp() },
+                        showToast = { message -> showToast(message) },
+                    )
+                }
+                composable<EventViewerDestination> { backStackEntry ->
+                    val destination = backStackEntry.toRoute<EventViewerDestination>()
+                    // Note: EventViewerScreen has its own AppBar
+                    EventViewerScreen(
+                        eventLog = eventLog,
+                        eventId = destination.eventId,
+                        documentTypeRepository = documentTypeRepository,
+                        documentModel = documentModel,
+                        imageLoader = imageLoader,
+                        onViewCertificateChain = { certChain ->
+                            val encodedCertificateData =
+                                Cbor.encode(certChain.toDataItem()).toBase64Url()
+                            navController.navigate(
+                                CertificateViewerDestination(
+                                    encodedCertificateData
+                                )
+                            )
+                        },
+                        onBack = { navController.navigateUp() },
+                        showToast = { message -> showToast(message) },
                     )
                 }
             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -146,3 +146,11 @@ data class NfcReaderDestination(
 
 @Serializable
 data object DocumentListDestination: Destination()
+
+@Serializable
+data object EventLogDestination: Destination()
+
+@Serializable
+data class EventViewerDestination(
+    val eventId: String,
+): Destination()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -290,6 +290,7 @@ private suspend fun doDcRequestFlow(
                         namespaceRequest.dataElementsToRequest.forEach { (mdocDataElement, intentToRetain) ->
                             claims.add(
                                 MdocRequestedClaim(
+                                    docType = request.mdocRequest!!.docType,
                                     namespaceName = namespaceRequest.namespace,
                                     dataElementName = mdocDataElement.attribute.identifier,
                                     intentToRetain = intentToRetain
@@ -326,6 +327,7 @@ private suspend fun doDcRequestFlow(
                         }
                         path.add(JsonPrimitive(documentAttribute.identifier))
                         JsonRequestedClaim(
+                            vctValues = listOf(request.jsonRequest!!.vct),
                             claimPath = JsonArray(path),
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLogScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLogScreen.kt
@@ -1,0 +1,239 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.multipaz.compose.document.DocumentModel
+import org.multipaz.compose.eventlog.EventLogModel
+import org.multipaz.compose.items.ItemList
+import org.multipaz.compose.items.ItemWithImageAndText
+import org.multipaz.datetime.formatLocalized
+import org.multipaz.eventlog.Event
+import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
+import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
+import org.multipaz.eventlog.PresentmentEventIso18013Proximity
+import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventLogScreen(
+    eventLog: EventLog,
+    imageLoader: ImageLoader,
+    documentModel: DocumentModel,
+    onEventClicked: (event: Event) -> Unit,
+    onBack: () -> Unit,
+    showToast: (message: String) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val model = EventLogModel(eventLog, coroutineScope)
+    val events by model.events.collectAsState()
+    var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirmationDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmationDialog = false },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteConfirmationDialog = false }
+                ) {
+                    Text(text = "Cancel")
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            showDeleteConfirmationDialog = false
+                            eventLog.deleteAllEvents()
+                        }
+                    }
+                ) {
+                    Text(text = "Delete all")
+                }
+            },
+            title = {
+                Text(text = "Delete all logged events?")
+            },
+            text = {
+                Text(text = "All logged events will be permanently deleted. This action cannot be undone")
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = "Event Log")
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ),
+                navigationIcon = {
+                    IconButton(onClick = {
+                        onBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { showDeleteConfirmationDialog = true }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null
+                        )
+                    }
+                }
+            )
+        },
+    ) { innerPadding ->
+
+        // TODO: with many events Column might be too slow, consider using LazyColumn instead.
+        //
+        val scrollState = rememberScrollState()
+        Column(modifier = Modifier
+            .verticalScroll(scrollState)
+            .fillMaxSize()
+            .padding(innerPadding)
+        ) {
+            val items = mutableListOf<@Composable () -> Unit>()
+
+            when (val currentEvents = events) {
+                null -> {
+                    items.add {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                emptyList<Event>() -> {
+                    items.add {
+                        Text(
+                            text = "No events recorded yet",
+                            color = MaterialTheme.colorScheme.secondary,
+                            fontStyle = FontStyle.Italic
+                        )
+                    }
+                }
+
+                else -> {
+                    currentEvents.forEach { event ->
+                        items.add {
+                            EventItem(
+                                modifier = Modifier
+                                    .clickable { onEventClicked(event) },
+                                event = event,
+                                imageLoader = imageLoader,
+                                documentModel = documentModel
+                            )
+                        }
+                    }
+                }
+            }
+            ItemList(
+                title = "Events",
+                items = items,
+            )
+        }
+    }
+}
+
+// TODO: Move to multipaz-compose when baked
+@Composable
+private fun EventItem(
+    event: Event,
+    imageLoader: ImageLoader,
+    documentModel: DocumentModel,
+    imageSize: Dp = 40.dp,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val (presentmentEventData, sharingType) = when (event) {
+        is PresentmentEventDigitalCredentialsMdocApi -> Pair(event.data, getSharingType(event.origin))
+        is PresentmentEventDigitalCredentialsOpenID4VP -> Pair(event.data, getSharingType(event.origin))
+        is PresentmentEventIso18013AnnexA -> Pair(event.data, getSharingType(event.origin))
+        is PresentmentEventIso18013Proximity -> Pair(event.data, "Shared in-person")
+        is PresentmentEventUriSchemeOpenID4VP -> Pair(event.data, getSharingType(event.origin))
+    }
+
+    val firstDoc = presentmentEventData.requestedDocuments.firstOrNull()
+    val firstDocInfo = firstDoc?.let { requestedDocument ->
+        documentModel.documentInfos.collectAsState().value.find {
+            it.document.identifier == requestedDocument.documentId
+        }
+    }
+
+    val eventDateTimeString = event.timestamp.toLocalDateTime(timeZone = timeZone).formatLocalized()
+    val text = "$eventDateTimeString • $sharingType"
+    ItemWithImageAndText(
+        modifier = modifier,
+        image = {
+            firstDocInfo?.cardArt?.let {
+                Image(
+                    modifier = modifier.size(imageSize),
+                    bitmap = it,
+                    contentDescription = null
+                )
+            } ?: Spacer(modifier = Modifier.size(imageSize))
+        },
+        heading = firstDocInfo?.document?.displayName ?: firstDoc?.documentName ?: "Unknown document",
+        text = text,
+    )
+}
+
+private fun getSharingType(
+    origin: String?,
+): String {
+    if (origin != null) {
+        if (origin.isNotEmpty() && (origin.startsWith("http://") || origin.startsWith("https://"))) {
+            return "Shared with website"
+        } else if (origin.isNotEmpty()) {
+            return "Shared with application"
+        } else {
+            return "Shared with website"
+        }
+    }
+    return "Shared with website"
+}
+

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -1,0 +1,469 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.multipaz.cbor.Simple
+import org.multipaz.compose.decodeImage
+import org.multipaz.compose.document.DocumentModel
+import org.multipaz.compose.eventlog.EventLogModel
+import org.multipaz.compose.getOutlinedImageVector
+import org.multipaz.compose.items.Item
+import org.multipaz.compose.items.ItemList
+import org.multipaz.compose.text.fromMarkdown
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.datetime.FormatStyle
+import org.multipaz.datetime.formatLocalized
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.documenttype.Icon
+import org.multipaz.eventlog.Event
+import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
+import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
+import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
+import org.multipaz.eventlog.PresentmentEventIso18013Proximity
+import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
+import org.multipaz.request.JsonRequestedClaim
+import org.multipaz.request.MdocRequestedClaim
+import org.multipaz.request.RequestedClaim
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventViewerScreen(
+    eventLog: EventLog,
+    eventId: String,
+    documentTypeRepository: DocumentTypeRepository,
+    documentModel: DocumentModel,
+    imageLoader: ImageLoader,
+    onViewCertificateChain: (certChain: X509CertChain) -> Unit,
+    onBack: () -> Unit,
+    showToast: (message: String) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val model = EventLogModel(eventLog, coroutineScope)
+    val events by model.events.collectAsState()
+    var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirmationDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmationDialog = false },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteConfirmationDialog = false }
+                ) {
+                    Text(text = "Cancel")
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            showDeleteConfirmationDialog = false
+                            eventLog.getEvents().find { it.identifier == eventId }?.let {
+                                eventLog.deleteEvent(it)
+                                onBack()
+                            }
+                        }
+                    }
+                ) {
+                    Text(text = "Delete")
+                }
+            },
+            title = {
+                Text(text = "Delete event?")
+            },
+            text = {
+                Text(text = "This event will be permanently deleted. This action cannot be undone")
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = "Event Viewer")
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                ),
+                navigationIcon = {
+                    IconButton(onClick = {
+                        onBack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { showDeleteConfirmationDialog = true }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null
+                        )
+                    }
+                }
+            )
+        },
+    ) { innerPadding ->
+
+        val scrollState = rememberScrollState()
+        Column(modifier = Modifier.fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(innerPadding)
+            .padding(8.dp)
+        ) {
+            val items = mutableListOf<@Composable () -> Unit>()
+
+            when (val currentEvents = events) {
+                null -> {
+                    items.add {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                else -> {
+                    val event = currentEvents.find { it.identifier == eventId }
+                    if (event != null) {
+                        EventViewer(
+                            event = event,
+                            documentTypeRepository = documentTypeRepository,
+                            documentModel = documentModel,
+                            imageLoader = imageLoader,
+                            onViewCertificateChain = onViewCertificateChain
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// TODO: Move to multipaz-compose when baked
+@Composable
+private fun EventViewer(
+    event: Event,
+    documentTypeRepository: DocumentTypeRepository,
+    documentModel: DocumentModel,
+    imageLoader: ImageLoader,
+    onViewCertificateChain: (certChain: X509CertChain) -> Unit,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val eventDateTime = event.timestamp.toLocalDateTime(timeZone = timeZone)
+    val eventDateTimeString = eventDateTime.formatLocalized(
+        dateStyle = FormatStyle.LONG,
+        timeStyle = FormatStyle.LONG
+    )
+
+    val presentmentEventData = when (event) {
+        is PresentmentEventDigitalCredentialsMdocApi -> event.data
+        is PresentmentEventDigitalCredentialsOpenID4VP -> event.data
+        is PresentmentEventIso18013AnnexA -> event.data
+        is PresentmentEventIso18013Proximity -> event.data
+        is PresentmentEventUriSchemeOpenID4VP -> event.data
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        val imageSize = 80.dp
+        presentmentEventData.trustMetadata?.displayIcon?.let {
+            val bitmap = remember { decodeImage(it.toByteArray()) }
+            Image(
+                modifier = Modifier.size(imageSize),
+                bitmap = bitmap,
+                contentDescription = null
+            )
+        } ?: presentmentEventData.trustMetadata?.displayIconUrl?.let {
+            AsyncImage(
+                modifier = Modifier.size(imageSize),
+                model = it,
+                imageLoader = imageLoader,
+                contentScale = ContentScale.Crop,
+                contentDescription = null
+            )
+        }
+
+        Text(
+            text = presentmentEventData.requesterName ?: "Unknown requester",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+
+        val items = mutableListOf<@Composable () -> Unit>()
+        items.add {
+            Item(
+                heading = "Date and time",
+                text = eventDateTimeString
+            )
+        }
+        when (event) {
+            is PresentmentEventDigitalCredentialsMdocApi -> {
+                addOriginAndAppId(items, event.origin, event.appId)
+            }
+            is PresentmentEventDigitalCredentialsOpenID4VP -> {
+                addOriginAndAppId(items, event.origin, event.appId)
+            }
+            is PresentmentEventIso18013AnnexA -> {
+                addOriginAndAppId(items, event.origin, event.appId)
+            }
+            is PresentmentEventUriSchemeOpenID4VP -> {
+                addOriginAndAppId(items, event.origin, event.appId)
+            }
+            is PresentmentEventIso18013Proximity -> {
+                val handover = event.sessionTranscript.asArray[2]
+                if (handover == Simple.NULL) {
+                    items.add {
+                        Item(
+                            heading = "Shared in-person",
+                            text = "Using QR code"
+                        )
+                    }
+                } else {
+                    items.add {
+                        Item(
+                            heading = "Shared in-person",
+                            text = "Using NFC"
+                        )
+                    }
+                }
+            }
+        }
+        items.add {
+            if (presentmentEventData.trustMetadata != null) {
+                Item(
+                    heading = "Requester trusted",
+                    text =  "Yes, in trust list"
+                )
+            } else {
+                Item(
+                    heading = "Requester trusted",
+                    text = buildAnnotatedString {
+                        withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                            append("No, not in a trust list")
+                        }
+                    }
+                )
+            }
+        }
+        presentmentEventData.requesterCertChain?.let {
+            items.add {
+                Item(
+                    heading = "Requester certificate",
+                    text = "Click to view",
+                    modifier = Modifier.clickable {
+                        onViewCertificateChain(it)
+                    }
+                )
+            }
+        } ?: {
+            items.add {
+                Item(
+                    heading = "Requester certificate",
+                    text = "Not available",
+                )
+            }
+        }
+        presentmentEventData.trustMetadata?.privacyPolicyUrl?.let {
+            items.add {
+                Item(
+                    heading = "Requester privacy policy",
+                    text = AnnotatedString.fromMarkdown(
+                        markdownString = "[$it]($it)"
+                    )
+                )
+            }
+        }
+        ItemList(
+            title = null,
+            items = items
+        )
+
+        presentmentEventData.requestedDocuments.forEach { requestedDocument ->
+            val info = documentModel.documentInfos.collectAsState().value.find {
+                it.document.identifier == requestedDocument.documentId
+            }
+            if (info != null) {
+                Image(
+                    modifier = Modifier.height(80.dp),
+                    bitmap = info.cardArt,
+                    contentDescription = null
+                )
+                Text(
+                    text = info.document.displayName ?: "Unknown document",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            val claimsShared = mutableListOf<@Composable () -> Unit>()
+            extractClaims(
+                requestedClaims = requestedDocument.claims.keys.filter { requestedClaim ->
+                    if (requestedClaim is MdocRequestedClaim) {
+                        !requestedClaim.intentToRetain
+                    } else {
+                        true
+                    }
+                },
+                items = claimsShared,
+                documentTypeRepository = documentTypeRepository
+            )
+            if (claimsShared.isNotEmpty()) {
+                ItemList(
+                    title = "This info was shared",
+                    items = claimsShared,
+                )
+            }
+
+            val claimsSharedAndStored = mutableListOf<@Composable () -> Unit>()
+            extractClaims(
+                requestedClaims = requestedDocument.claims.keys.filter { requestedClaim ->
+                    if (requestedClaim is MdocRequestedClaim) {
+                        requestedClaim.intentToRetain
+                    } else {
+                        false
+                    }
+                },
+                items = claimsSharedAndStored,
+                documentTypeRepository = documentTypeRepository
+            )
+            if (claimsSharedAndStored.isNotEmpty()) {
+                ItemList(
+                    title = "This info was shared and stored",
+                    items = claimsSharedAndStored,
+                )
+            }
+        }
+    }
+}
+
+private fun addOriginAndAppId(
+    items: MutableList<@Composable () -> Unit>,
+    origin: String?,
+    appId: String?,
+) {
+    if (origin != null && origin.isNotEmpty() && (origin.startsWith("http://") || origin.startsWith("https://"))) {
+        items.add {
+            Item(
+                heading = "Shared with website",
+                text = AnnotatedString.fromMarkdown("[$origin]($origin)")
+            )
+        }
+    } else if (origin != null && origin.isNotEmpty()) {
+        if (appId != null) {
+            items.add {
+                // TODO: look up details about the application
+                Item(
+                    heading = "Shared with application",
+                    text = appId
+                )
+            }
+        } else {
+            items.add {
+                Item(
+                    heading = "Shared with application",
+                    text = "Unknown application"
+                )
+            }
+        }
+    } else {
+        items.add {
+            Item(
+                heading = "Shared with website",
+                text = "Unknown website"
+            )
+        }
+    }
+}
+
+private fun extractClaims(
+    requestedClaims: List<RequestedClaim>,
+    items: MutableList<@Composable () -> Unit>,
+    documentTypeRepository: DocumentTypeRepository
+) {
+    requestedClaims.forEach { requestedClaim ->
+        val attribute = documentTypeRepository.getDocumentAttributeForRequestedClaim(requestedClaim)
+        val displayName = attribute?.displayName
+            ?: when (requestedClaim) {
+                is JsonRequestedClaim -> {
+                    requestedClaim.claimPath.toList().joinToString(".")
+                }
+
+                is MdocRequestedClaim -> {
+                    requestedClaim.dataElementName
+                }
+            }
+
+        items.add {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                val icon = attribute?.icon ?: Icon.PERSON
+                Icon(
+                    imageVector = icon.getOutlinedImageVector(),
+                    contentDescription = null
+                )
+                Text(
+                    text = displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -54,6 +54,7 @@ fun StartScreen(
     onClickNfcReadersScreen: () -> Unit = {},
     onClickDocumentListScreen: () -> Unit = {},
     onClickQuickAccessWallet: () -> Unit = {},
+    onClickEventLog: () -> Unit = {},
 ) {
     val blePermissionState = rememberBluetoothPermissionState()
     val coroutineScope = rememberCoroutineScope()
@@ -278,6 +279,12 @@ fun StartScreen(
                 item {
                     TextButton(onClick = onClickQuickAccessWallet) {
                         Text("QuickAccessWallet")
+                    }
+                }
+
+                item {
+                    TextButton(onClick = onClickEventLog) {
+                        Text("Event Log")
                     }
                 }
             }


### PR DESCRIPTION
This adds a new `EventLog` class for recording and retrieving events. Currently only events for presentment is added but in the future we'll add events for provisioning and retrieving credentials as well. Also add `EventLogModel` which can be used in the UI.

Also add UI in Compose TestApp to view and delete events. Once the UI bits are more baked it'll be moved to multipaz-compose so they can be used in both Multipaz Identity Reader and ComposeWallet.

Fixes #1594.

Test: Manually tested on TestApp and Swift TestApp.
