### PR TITLE
Fix incorrect exception handling.

### DIFF
--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -4,6 +4,54 @@ Our project follows the [standard Kotlin coding conventions](https://kotlinlang.
 with the following changes
 
 - We allow up to 120 characters per line, please use all of the available space.
+
 - Only capitalize the first letter of words/acronyms/abbreviations/initialisms when using
   CamelCasing for example it's `UiTest`, not `UITest`, `IsoMdocType`, not `ISOMDocType`,
   and so on.
+
+## Exception Handling
+
+- **Never catch `Throwable`:** `Throwable` is the root of the hierarchy and includes fatal
+  system errors (like `OutOfMemoryError`). Catching it prevents the environment from terminating
+  when it absolutely needs to, leading to corrupted state and unpredictable behavior.
+
+- **Avoid catching generic `Exception`:** Catching all exceptions acts as a black hole for
+  standard developer bugs (like `NullPointerException` or `IllegalArgumentException`). This
+  makes debugging extremely difficult because the application fails silently.
+
+- **Catch specific exceptions:** Scope your `try-catch` blocks tightly and only catch the exact
+  exceptions you anticipate and know how to recover from (e.g., `IOException` for network calls,
+  or `JsException` for JavaScript interop boundaries).
+
+- **Protect Coroutine Cancellation:** If you absolutely must catch a broad `Exception` (e.g., at a
+  top-level boundary to prevent a crash), you **must** explicitly rethrow `CancellationException`.
+  Failing to do so intercepts coroutine cancellation, breaking structured concurrency and causing
+  memory leaks.
+  ```kotlin
+  catch (e: Exception) {
+      if (e is CancellationException) throw e
+      // Handle other exceptions safely
+  }
+  ```
+
+* **Avoid standard `runCatching` with Coroutines:** Kotlin's built-in `runCatching {}` block
+  catches `Throwable` under the hood. Do not use it around suspending functions unless you are
+  using a custom wrapper that explicitly handles `CancellationException`.
+
+* **Wrap `suspend` calls in `finally` blocks:** When a coroutine is cancelled, it throws
+  a `CancellationException`. If you need to execute suspending cleanup code (like closing a
+  connection or releasing a lock) inside a `finally` block, the coroutine is already in a
+  cancelled state, and any standard `suspend` call will immediately fail. You must wrap the
+  cleanup code in `withContext(NonCancellable)`.
+  ```kotlin
+  finally {
+      withContext(NonCancellable) {
+          // Suspending cleanup code goes here
+      }
+  }
+  ```
+
+* **Document exceptions in KDoc:** Every function or method must explicitly document the
+  exceptions it throws using the `@throws` (or `@exception`) tag in its KDoc. This ensures that
+  contributors and consumers of the Multipaz library know exactly what edge cases they are
+  expected to handle.

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose
 
+import android.content.pm.PackageManager.NameNotFoundException
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
@@ -26,12 +27,16 @@ import kotlin.coroutines.CoroutineContext
 private const val TAG = "Util"
 
 actual fun getApplicationInfo(appId: String): ApplicationInfo {
-    val ai = applicationContext.packageManager.getApplicationInfo(appId, 0)
-    val icon = applicationContext.packageManager.getApplicationIcon(ai)
-    return ApplicationInfo(
-        name = applicationContext.packageManager.getApplicationLabel(ai).toString(),
-        icon = icon.toBitmap().asImageBitmap()
-    )
+    try {
+        val ai = applicationContext.packageManager.getApplicationInfo(appId, 0)
+        val icon = applicationContext.packageManager.getApplicationIcon(ai)
+        return ApplicationInfo(
+            name = applicationContext.packageManager.getApplicationLabel(ai).toString(),
+            icon = icon.toBitmap().asImageBitmap()
+        )
+    } catch (e: NameNotFoundException) {
+        throw IllegalArgumentException("Application not found", e)
+    }
 }
 
 actual fun decodeImage(encodedData: ByteArray): ImageBitmap {

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/camera/Camera.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/camera/Camera.android.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.camera
 
+import kotlinx.coroutines.CancellationException
 import android.util.Size
 import android.view.OrientationEventListener
 import android.view.Surface
@@ -147,6 +148,7 @@ actual fun Camera(
                     )
                 }
             } catch (exc: Exception) {
+                if (exc is CancellationException) throw exc
                 Logger.e(TAG, "Use case binding failed", exc)
             }
 

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.digitalcredentials
 
+import kotlinx.coroutines.CancellationException
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -173,7 +174,8 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
             PendingIntentHandler.setGetCredentialResponse(resultData, credentialManagerResponse)
             setResult(RESULT_OK, resultData)
             presentmentModel.setCompleted(error = null)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.i(TAG, "Error processing request", e)
             val resultData = Intent()
             val credentialManagerException = GetCredentialCustomException(

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
@@ -352,7 +352,7 @@ abstract class MdocNdefService: HostApduService() {
                 onSendingResponse = { settings.presentmentModel?.setSending() }
             )
             settings.presentmentModel?.setCompleted(null)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             Logger.w(TAG, "Caught error while performing 18013-5 transaction", e)
             if (e is CancellationException) {
                 settings.presentmentModel?.setCompleted(PresentmentCanceledException("Presentment was cancelled"))
@@ -400,7 +400,8 @@ abstract class MdocNdefService: HostApduService() {
                 val responseApdu = it.processApdu(commandApdu)
                 return responseApdu
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e(TAG, "Error processing APDU in MdocNfcEngagementHelper", e)
         }
         return null
@@ -410,7 +411,8 @@ abstract class MdocNdefService: HostApduService() {
     private suspend fun processDeactivated(reason: Int) {
         try {
             engagement?.processDeactivated(reason)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e(TAG, "Error processing deactivation event in MdocNfcEngagementHelper", e)
         }
     }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcDataTransferService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcDataTransferService.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.mdoc
 
+import kotlinx.coroutines.CancellationException
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import org.multipaz.mdoc.transport.NfcTransportMdoc
@@ -35,7 +36,8 @@ open class MdocNfcDataTransferService: HostApduService() {
                 commandApdu = commandApdu,
                 sendResponse = { responseApdu -> sendResponseApdu(responseApdu) }
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e(TAG, "processCommandApdu", e)
             e.printStackTrace()
         }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.android.kt
@@ -178,7 +178,7 @@ private fun MdocProximityQrPresentmentAndroid(
                                 onSendingResponse = { PresentmentActivity.presentmentModel.setSending() }
                             )
                             PresentmentActivity.presentmentModel.setCompleted(null)
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
                             if (e is CancellationException) {
                                 PresentmentActivity.presentmentModel.setCompleted(
                                     PresentmentCanceledException("Presentment was cancelled")

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/presentment/UriSchemePresentmentActivity.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.presentment
 
+import kotlinx.coroutines.CancellationException
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -169,7 +170,8 @@ abstract class UriSchemePresentmentActivity: FragmentActivity() {
                 }
             )
             presentmentModel.setCompleted(error = null)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.i(TAG, "Error processing request", e)
             presentmentModel.setCompleted(error = e)
         }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/BiometricPromptDialog.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/BiometricPromptDialog.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.prompt
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -39,7 +40,8 @@ internal fun BiometricPromptDialog(
                         requireConfirmation = dialogParameters.requireConfirmation
                     )
                     dialogStateValue.resultChannel.send(result)
-                } catch (err: Throwable) {
+                } catch (err: Exception) {
+                    if (err is CancellationException) throw err
                     dialogStateValue.resultChannel.send(false)
                 }
             }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ScanNfcTagPromptDialog.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ScanNfcTagPromptDialog.kt
@@ -132,7 +132,7 @@ private fun ScanNfcTagPromptDialogShown(
             dialogStateValue.resultChannel.close(PromptDismissedException())
             // coroutine cancellation should not be swallowed
             throw e
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             Logger.e(TAG, "Error scanning", e)
             icon.value = ScanNfcTagDialogIcon.ERROR
             message.value = e.message ?: e.toString()
@@ -206,7 +206,8 @@ class NfcReaderCallback<T>(
                         dialogMessage.value = initialMessage
                     }
                     Logger.w(TAG, "Tag lost", e)
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.e(TAG, "Error in interaction func", e)
                     continuation.resumeWithException(e)
                 }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/qrcode/QrCodeScanner.android.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.qrcode
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,7 +55,8 @@ actual fun QrCodeScanner(
                     onCodeScanned(result.text)
                     lastCodeScanned = result.text
                 }
-            } catch (_ : Throwable) {
+            } catch (e : Exception) {
+                if (e is CancellationException) throw e
                 // QR code not found in this frame
                 if (lastCodeScanned != null) {
                     onCodeScanned(null)

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/webview/WebViewRender.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/webview/WebViewRender.android.kt
@@ -176,7 +176,7 @@ internal class ClientImpl(
                                 output.write(bytes)
                             } catch (err: CancellationException) {
                                 throw err
-                            } catch (err: Throwable) {
+                            } catch (err: Exception) {
                                 Logger.e(TAG, "Error loading resource '$path'", err)
                             } finally {
                                 output.close()

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/certificateviewer/CertificateViewData.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/certificateviewer/CertificateViewData.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.certificateviewer
 
+import kotlinx.coroutines.CancellationException
 import kotlin.time.Instant
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Boolean
@@ -65,7 +66,7 @@ internal data class CertificateViewData(
 
             val issuer = cert.issuer.components.mapValues { it.value.value }
 
-            val pkAlgorithm: String = OID.Companion.lookupByOid(cert.signatureAlgorithmOid)?.description
+            val pkAlgorithm: String = OID.lookupByOid(cert.signatureAlgorithmOid)?.description
                     ?: "Unexpected algorithm OID ${cert.signatureAlgorithmOid}"
 
             val pkNamedCurve: String? = runCatching { cert.ecPublicKey.curve.name }.getOrNull()
@@ -110,7 +111,8 @@ internal data class CertificateViewData(
                                     sb.append("pathLenConstraint: ${(seq.elements[1] as ASN1Integer).toLong()}\n")
                                 }
                                 sb.toString()
-                            } catch (e: Throwable) {
+                            } catch (e: Exception) {
+                                if (e is CancellationException) throw e
                                 "Error decoding: $e"
                             }
                         }
@@ -135,13 +137,14 @@ internal data class CertificateViewData(
                                 // Most extensions are ASN.1 so we opportunistically try and decode
                                 // and if it works, pretty print that.
                                 ASN1.print(ASN1.decode(ext.data.toByteArray())!!)
-                            } catch (_: Throwable) {
+                            } catch (e: Exception) {
+                                if (e is CancellationException) throw e
                                 // If decoding fails, fall back to hex encoding.
                                 ext.data.toByteArray().toHex(byteDivider = " ", decodeAsString = true)
                             }
                         }
                     }
-                    val oidEntry = OID.Companion.lookupByOid(ext.oid)
+                    val oidEntry = OID.lookupByOid(ext.oid)
                     val oid = if (oidEntry != null) {
                         "${ext.oid} ${oidEntry.description}"
                     } else {

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/claim/RenderClaimValue.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/claim/RenderClaimValue.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.claim
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -50,6 +51,7 @@ fun RenderClaimValue(
                 }
                 decodeImage(bytes)
             } catch (err: Exception) {
+                if (err is CancellationException) throw err
                 Text(
                     text = "Image decoding: $err",
                     color = MaterialTheme.colorScheme.error,

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
@@ -1,6 +1,7 @@
 package org.multipaz.compose.document
 
 import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,7 +60,8 @@ private data class DocumentModelStorageData(
                         key.asTstr to value.asNumber.toInt()
                     }.toMap()
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error decoding sortingOrder", e)
             }
             return DocumentModelStorageData(sortingOrder)

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -85,6 +85,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -256,7 +257,8 @@ fun Consent(
         requester.appId?.let {
             try {
                 getApplicationInfo(it)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.w(TAG, "Error looking up information for appId $it")
                 null
             }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/MdocProximityQrPresentment.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.presentment
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -137,7 +138,8 @@ internal fun MdocProximityQrPresentmentDefault(
                                 keyAgreementPossible = listOf(eDeviceKeyCurve),
                             )
 
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             transactionError = e
                         } finally {
                             state = State.COMPLETED

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/Camera.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/Camera.ios.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.camera
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
@@ -481,7 +482,8 @@ private class CameraManager(
                 rotation = videoOrientation.toRotationAngle(),
                 previewTransformation = previewTransformation,
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e(TAG, "Error preparing frame data", e)
             isProcessingFrame.value = false // Release lock on error during prep.
             return
@@ -590,7 +592,8 @@ private fun CMSampleBufferRef.toUIImage(): UIImage? {
             return null
         }
         UIImage(cGImage = videoImage)
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         Logger.e(TAG, "Error during image creation", e)
         return null
     } finally {
@@ -599,7 +602,9 @@ private fun CMSampleBufferRef.toUIImage(): UIImage? {
                 CGImageRelease(it)
             }
         }
-        catch (_: Throwable) { }
+        catch (e: Exception) {
+            if (e is CancellationException) throw e
+        }
     }
     return finalUiImage
 }

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/webview/WebViewRender.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/webview/WebViewRender.ios.kt
@@ -192,7 +192,7 @@ class URLHandler(
                         startURLSchemeTask.didReceiveData(bytes.toNSData())
                     } catch (err: CancellationException) {
                         throw err
-                    } catch (err: Throwable) {
+                    } catch (err: Exception) {
                         Logger.e(TAG, "Error loading resource '$path'", err)
                     }
                     startURLSchemeTask.didFinish()

--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/CloudSecureAreaSettings.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/CloudSecureAreaSettings.kt
@@ -79,7 +79,7 @@ class CloudSecureAreaSettings(private val conf: Configuration) {
         }
         try {
             return value.toInt()
-        } catch (e: Throwable) {
+        } catch (_: NumberFormatException) {
             Logger.d(TAG, "getInt: Unexpected value '$value' with key $key, return default value $defaultValue")
         }
         return defaultValue

--- a/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
+++ b/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
@@ -1,5 +1,6 @@
 package org.multipaz.securearea.cloud
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.asn1.OID
 import org.multipaz.cbor.Cbor
@@ -184,7 +185,8 @@ class CloudSecureAreaServer(
                     androidRequiredKeyMintSecurityLevel = androidKeystoreSecurityLevel
                 )
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.w(TAG, "$remoteHost: RegisterRequest1: Device Attestation did not validate", e)
             e.printStackTrace()
             return Pair(403, e.message!!.toByteArray())
@@ -207,7 +209,8 @@ class CloudSecureAreaServer(
                 // Check that device created the key without user authentication.
                 val attestation = AndroidAttestationExtensionParser(request1.deviceBindingKeyAttestation!!.certificates[0])
                 check(attestation.getUserAuthenticationType() == 0L)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.w(TAG, "$remoteHost: RegisterRequest1: Android Keystore attestation did not validate", e)
                 return Pair(403, e.message!!.toByteArray())
             }
@@ -473,7 +476,8 @@ class CloudSecureAreaServer(
                 } else {
                     check(attestation.getUserAuthenticationType() == 0L)
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("doCreateKeyRequest1: Android Keystore attestation did not validate", e)
             }
         }
@@ -593,7 +597,8 @@ class CloudSecureAreaServer(
                     } else {
                         check(attestation.getUserAuthenticationType() == 0L)
                     }
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("doBatchCreateKeyRequest1: Android Keystore attestation did not validate", e)
                 }
             }
@@ -812,7 +817,8 @@ class CloudSecureAreaServer(
                 e2eeState.encrypt()
             )
             return Pair(200, encryptedResponse1.toCbor())
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
     }
@@ -955,7 +961,8 @@ class CloudSecureAreaServer(
                 e2eeState.encrypt()
             )
             return Pair(200, encryptedResponse1.toCbor())
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
     }

--- a/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
@@ -118,7 +118,7 @@ fun Application.installServerEnvironment(
                     }.toString(),
                     contentType = ContentType.Application.Json
                 )
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 Logger.e(TAG, "Error", err)
                 err.printStackTrace()
                 call.respondText(

--- a/multipaz-server/src/main/java/org/multipaz/server/request/rpc.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/request/rpc.kt
@@ -44,7 +44,7 @@ fun Routing.rpc(path: String, httpHandler: Deferred<HttpTransport>) {
         } catch (_: HttpTransport.TimeoutException) {
             Logger.e(TAG, "POST $path/$endpoint/$method status 500 (TimeoutException)")
             call.respond(HttpStatusCode.InternalServerError, "TimeoutException")
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             Logger.e(TAG, "POST $path/$endpoint/$method status 500", e)
             e.printStackTrace()
             call.respond(HttpStatusCode.InternalServerError, e.message ?: "")

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -1,5 +1,6 @@
 package org.multipaz.verifier.request
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
@@ -595,7 +596,8 @@ private suspend fun handleDcBegin(
             contentType = ContentType.Application.Json,
             text = json.encodeToString(beginResponse)
         )
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         val beginResponse = DCBeginResponse(
             sessionId = sessionId,
             dcRequestProtocol = "",
@@ -837,7 +839,8 @@ private suspend fun handleDcGetDataOpenID4VPForCredentialResponse(
     val isMdoc = try {
         val decodedCbor = Cbor.decode(credentialResponse.fromBase64Url())
         true
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         false
     }
     Logger.i(TAG, "isMdoc: $isMdoc")
@@ -1067,7 +1070,8 @@ private suspend fun handleOpenID4VPResponse(
     val isMdoc = try {
         val decodedCbor = Cbor.decode(vpTokenForCred.fromBase64Url())
         true
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         false
     }
     Logger.i(TAG, "isMdoc: $isMdoc")
@@ -1264,7 +1268,8 @@ private suspend fun handleGetDataMdoc(
                     "Verified"
                 )
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             lines.add(
                 ResultLine(
                     "Device Response",
@@ -1288,7 +1293,8 @@ private suspend fun handleGetDataMdoc(
                         lines.add(ResultLine("Issuer", "Not signed by issuer"))
                     }
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 lines.add(
                     ResultLine(
                         "Document",
@@ -1381,7 +1387,8 @@ private suspend fun handleGetDataMdoc(
                     }
                 }
                 // TODO: also iterate over DeviceSigned items
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 e.printStackTrace()
                 lines.add(
                     ResultLine(
@@ -1458,7 +1465,8 @@ private suspend fun handleGetDataSdJwt(
                     val claimValueStr = prettyJson.encodeToString(claimValue)
                     lines.add(ResultLine(claimName, claimValueStr))
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 lines.add(ResultLine("Key Binding", "Error validating: $e"))
             }
         } else if (issuerCert != null) {
@@ -1468,7 +1476,8 @@ private suspend fun handleGetDataSdJwt(
                     val claimValueStr = prettyJson.encodeToString(claimValue)
                     lines.add(ResultLine(claimName, claimValueStr))
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 lines.add(ResultLine("Error", "Error validating signature: $e"))
             }
         }

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
@@ -1,5 +1,6 @@
 package org.multipaz.verifier.request
 
+import kotlinx.coroutines.CancellationException
 import io.ktor.http.ContentType
 import io.ktor.http.Url
 import io.ktor.server.application.ApplicationCall
@@ -464,6 +465,7 @@ private suspend fun processMdocResponse(
     try {
         deviceResponse.verify(sessionTranscript = mdocSessionTranscript)
     } catch (err: Exception) {
+        if (err is CancellationException) throw err
         Logger.e(TAG, "Device response verification failed", err)
     }
     return deviceResponse.documents.zip(documentRequests).map { (document, request) ->
@@ -471,7 +473,8 @@ private suspend fun processMdocResponse(
             try {
                 val trustResult = trustManager.verify(document.issuerCertChain.certificates)
                 put("_trusted", trustResult.isTrusted)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Trust verification failed", e)
             }
 

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
@@ -839,7 +839,7 @@ class CloudSecureAreaTest {
             try {
                 body()
                 Assert.fail("Expected exception $clazz, no exception was thrown")
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 if (!clazz.isInstance(err)) {
                     throw err
                 }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
@@ -7,6 +7,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -97,8 +98,9 @@ object AppLinksCheck {
             } else {
                 response.readRawBytes().decodeToString()
             }
-        } catch (err: Exception) {
-            Logger.e(TAG, "Error connecting to $appLinkServer", err)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Logger.e(TAG, "Error connecting to $appLinkServer", e)
             // Assume we are offline, don't complain.
             return true
         }
@@ -130,8 +132,9 @@ object AppLinksCheck {
                     Logger.i(TAG, "Server app link setup is validated")
                     return true
                 }
-            } catch (err: Exception) {
-                Logger.e(TAG, "Parsing error", err)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.e(TAG, "Parsing error", e)
                 continue
             }
         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
@@ -154,13 +155,15 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             Logger.i(TAG, "Closing deferred L2CAP socket (via init)")
             try {
                 deferredCloseSocket?.close()
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error closing L2CAP socket (via init)", e)
             }
             deferredCloseSocket = null
             try {
                 deferredCloseJob?.cancel()
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error canceling deferred closing job (via init)", e)
             }
             deferredCloseJob = null
@@ -181,7 +184,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 } else {
                     Logger.w(TAG, "onScanResult but not waiting")
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onScanResult failed", error))
             }
         }
@@ -194,7 +198,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 } else {
                     Logger.w(TAG, "onScanFailed but not waiting")
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onScanFailed failed", error))
             }
         }
@@ -227,7 +232,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                         Logger.w(TAG, "onConnectionStateChange(): Unexpected newState $newState")
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onConnectionStateChange failed", error))
             }
         }
@@ -253,7 +259,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 } else {
                     Logger.w(TAG, "onMtuChanged but not waiting")
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onMtuChanged failed", error))
             }
         }
@@ -270,7 +277,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 } else {
                     Logger.w(TAG, "onServicesDiscovered but not waiting")
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onServicesDiscovered failed", error))
             }
         }
@@ -327,7 +335,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                         Logger.w(TAG, "onCharacteristicRead for ident but not waiting")
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onCharacteristicRead failed", error))
             }
         }
@@ -397,7 +406,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                         Logger.w(TAG, "Ignoring unexpected write to state characteristic")
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
                 onError(Error("onCharacteristicChanged failed", error))
             }
         }
@@ -705,7 +715,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 Logger.i(TAG, "Closing deferred L2CAP socket (via delay)")
                 try {
                     deferredCloseSocket?.close()
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.e(TAG, "Error closing L2CAP socket (via delay)", e)
                 }
                 deferredCloseSocket = null
@@ -753,7 +764,8 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 val message = inputStream.readNOctets(length)
                 incomingMessages.send(message)
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             onError(Error("Reading from L2CAP socket failed", e))
         }
     }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCharacteristic
@@ -161,13 +162,15 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
             Logger.i(TAG, "Closing deferred L2CAP socket (via init)")
             try {
                 deferredCloseSocket?.close()
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error closing L2CAP socket (via init)", e)
             }
             deferredCloseSocket = null
             try {
                 deferredCloseJob?.cancel()
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error canceling deferred closing job (via init)", e)
             }
             deferredCloseJob = null
@@ -288,7 +291,8 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
             } else if (characteristic.uuid == client2ServerCharacteristicUuid.toJavaUuid()) {
                 try {
                     handleIncomingData(value)
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     onError(Error("Error processing incoming data", e))
                 }
             }
@@ -580,7 +584,8 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                 Logger.i(TAG, "Closing deferred L2CAP socket (via delay)")
                 try {
                     deferredCloseSocket?.close()
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.e(TAG, "Error closing L2CAP socket (via delay)", e)
                 }
                 deferredCloseSocket = null
@@ -631,7 +636,8 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                 val message = inputStream.readNOctets(inputStream.readNOctets(4U).getUInt32(0))
                 incomingMessages.send(message)
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             if (l2capNotUsed) {
                 Logger.d(TAG, "Ignoring error since l2capNotUsed is true", e)
             } else {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
@@ -1,5 +1,6 @@
 package org.multipaz.nfc
 
+import kotlinx.coroutines.CancellationException
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import kotlinx.coroutines.CoroutineScope
@@ -83,7 +84,8 @@ internal class NfcTagReaderUsb(
                                     // This is to properly handle emulated tags - such as on Android - which may be showing
                                     // disambiguation UI if multiple applications have registered for the same AID.
                                     Logger.w(TAG, "Tag lost", e)
-                                } catch (e: Throwable) {
+                                } catch (e: Exception) {
+                                    if (e is CancellationException) throw e
                                     continuation.resumeWithException(e)
                                 }
                                 readJob = null
@@ -103,7 +105,8 @@ internal class NfcTagReaderUsb(
             }
             driver.disconnect()
             return result
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             driver.disconnect()
             throw e
         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
@@ -1,5 +1,6 @@
 package org.multipaz.securearea
 
+import kotlinx.coroutines.CancellationException
 import androidx.biometric.BiometricPrompt
 import org.multipaz.crypto.Algorithm
 import org.multipaz.securearea.KeyUnlockData
@@ -67,6 +68,7 @@ class AndroidKeystoreKeyUnlockData(
             cryptoObjectForSigning = BiometricPrompt.CryptoObject(signature!!)
             return cryptoObjectForSigning
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
     }
@@ -114,6 +116,7 @@ class AndroidKeystoreKeyUnlockData(
                 //  b/282058146 and b/400115331 for details.
                 throw IllegalStateException("ECDH for keys with timeout 0 is not currently supported")
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException(e)
             }
         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.securearea
 
+import kotlinx.coroutines.CancellationException
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.pm.FeatureInfo
@@ -53,6 +54,7 @@ import org.multipaz.prompt.Reason
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import org.multipaz.util.validateAndroidKeyAttestation
 import java.io.IOException
+import java.security.GeneralSecurityException
 import java.security.InvalidAlgorithmParameterException
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
@@ -298,17 +300,13 @@ class AndroidKeystoreSecureArea private constructor(
                 builder.setKeyValidityEnd(notAfter)
                 builder.setCertificateNotAfter(notAfter)
             }
-            try {
-                kpg.initialize(builder.build())
-            } catch (e: InvalidAlgorithmParameterException) {
-                throw IllegalStateException(e)
-            }
+            kpg.initialize(builder.build())
             kpg.generateKeyPair()
-        } catch (e: NoSuchAlgorithmException) {
-            throw IllegalStateException("Error creating key", e)
-        } catch (e: NoSuchProviderException) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException("Error creating key", e)
         }
+
         val attestationCerts = mutableListOf<X509Cert>()
         try {
             val ks = KeyStore.getInstance("AndroidKeyStore")
@@ -319,6 +317,7 @@ class AndroidKeystoreSecureArea private constructor(
                 attestationCerts.add(X509Cert(ByteString(certificate.encoded)))
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
         //Logger.d(TAG, "EC key with alias '$alias' created")
@@ -351,26 +350,13 @@ class AndroidKeystoreSecureArea private constructor(
         val entry = ks.getEntry(existingAlias, null)
             ?: throw IllegalArgumentException("A key with this alias doesn't exist")
 
-        val keyInfo: KeyInfo = try {
+        val keyInfo = try {
             val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
             val factory = KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
-            try {
-                factory.getKeySpec(privateKey, KeyInfo::class.java)
-            } catch (e: InvalidKeySpecException) {
-                throw IllegalStateException("Given key is not an Android Keystore key", e)
-            }
-        } catch (e: UnrecoverableEntryException) {
-            throw IllegalStateException(e.message, e)
-        } catch (e: CertificateException) {
-            throw IllegalStateException(e.message, e)
-        } catch (e: KeyStoreException) {
-            throw IllegalStateException(e.message, e)
-        } catch (e: IOException) {
-            throw IllegalStateException(e.message, e)
-        } catch (e: NoSuchAlgorithmException) {
-            throw IllegalStateException(e.message, e)
-        } catch (e: NoSuchProviderException) {
-            throw IllegalStateException(e.message, e)
+            factory.getKeySpec(privateKey, KeyInfo::class.java)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw IllegalStateException("Given key is not an Android Keystore key", e)
         }
 
         // Need to generate the data which getKeyInfo() reads from disk.
@@ -388,6 +374,7 @@ class AndroidKeystoreSecureArea private constructor(
                 attestationCerts.add(X509Cert(ByteString(certificate.encoded)))
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
 
@@ -443,14 +430,9 @@ class AndroidKeystoreSecureArea private constructor(
             }
             ks.deleteEntry(alias)
             storageTable.delete(alias, partitionId)
-        } catch (e: CertificateException) {
-            throw IllegalStateException("Error loading keystore", e)
-        } catch (e: IOException) {
-            throw IllegalStateException("Error loading keystore", e)
-        } catch (e: NoSuchAlgorithmException) {
-            throw IllegalStateException("Error loading keystore", e)
-        } catch (e: KeyStoreException) {
-            throw IllegalStateException("Error loading keystore", e)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw IllegalStateException( e)
         }
         Logger.d(TAG, "EC key with alias '$alias' deleted")
     }
@@ -512,6 +494,7 @@ class AndroidKeystoreSecureArea private constructor(
             }
             throw IllegalStateException(e.message, e)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalArgumentException(e)
         }
     }
@@ -556,6 +539,7 @@ class AndroidKeystoreSecureArea private constructor(
             }
             throw IllegalArgumentException(e)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalArgumentException(e)
         }
     }
@@ -596,7 +580,7 @@ class AndroidKeystoreSecureArea private constructor(
     override suspend fun getKeyInvalidated(alias: String): Boolean {
         try {
             loadKey(alias)
-        } catch (e: KeyInvalidatedException) {
+        } catch (_: KeyInvalidatedException) {
             return true
         }
         return false
@@ -662,6 +646,7 @@ class AndroidKeystoreSecureArea private constructor(
                 validUntil
             )
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(e)
         }
     }
@@ -821,7 +806,8 @@ class AndroidKeystoreSecureArea private constructor(
                             setUseStrongBox(useStrongBox)
                         }
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("Error creating key: ${e.message}", e)
                 }
                 keyAliasToCleanUp = keyInfo.alias
@@ -849,7 +835,8 @@ class AndroidKeystoreSecureArea private constructor(
                         requireAppSignatureCertificateDigests = signatureCertificateDigests,
                         requireAppPackages = setOf(pkg.packageName)
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("Error validating attestation: ${e.message}", e)
                 }
 
@@ -861,7 +848,8 @@ class AndroidKeystoreSecureArea private constructor(
                             dataToSign = message,
                             unlockReason = Reason.Unspecified
                         )
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         throw IllegalStateException("Error signing message of $messageLen bytes", e)
                     }
                     try {
@@ -871,11 +859,13 @@ class AndroidKeystoreSecureArea private constructor(
                             algorithm = Algorithm.ESP256,
                             signature = signature
                         )
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         throw IllegalStateException("Error verifying signature for message of $messageLen bytes", e)
                     }
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Test failed: ${e.message}", e)
             } finally {
                 if (keyAliasToCleanUp != null) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1.kt
@@ -1,5 +1,6 @@
 package org.multipaz.asn1
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.util.toHex
 import kotlinx.io.bytestring.ByteStringBuilder
@@ -171,7 +172,8 @@ object ASN1 {
     fun decode(derEncoded: ByteArray): ASN1Object? {
         val (newOffset, obj) = try {
             decode(derEncoded, 0)
-        } catch(e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalArgumentException("Unexpected error decoding", e)
         }
         if (newOffset != derEncoded.size) {
@@ -323,7 +325,8 @@ object ASN1 {
                 try {
                     val decodedObject = ASN1.decode(obj.content)
                     print(sb, indent + 2, decodedObject!!)
-                } catch (_: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     for (n in IntRange(1, indent + 2)) {
                         sb.append(" ")
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/OID.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/OID.kt
@@ -1,5 +1,7 @@
 package org.multipaz.asn1
 
+import kotlinx.coroutines.CancellationException
+
 /**
  * Registry of known OIDs.
  *
@@ -81,7 +83,8 @@ enum class OID(
             for (component in components) {
                 try {
                     component.toLong(10)
-                } catch (_: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     return false
                 }
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Cbor.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Cbor.kt
@@ -1,5 +1,6 @@
 package org.multipaz.cbor
 
+import kotlinx.coroutines.CancellationException
 import kotlin.math.pow
 import kotlinx.io.bytestring.ByteStringBuilder
 import org.multipaz.util.appendUInt16
@@ -190,7 +191,8 @@ object Cbor {
             return Pair(newOffset, item)
         } catch (e: IndexOutOfBoundsException) {
             throw IllegalArgumentException("Out of bounds decoding data", e)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalArgumentException("Error occurred when decoding CBOR", e)
         }
     }
@@ -303,6 +305,7 @@ object Cbor {
                                 val embeddedItem = decode(item.value)
                                 toDiagnostics(sb, indent, embeddedItem, null, options)
                             } catch (e: Exception) {
+                                if (e is CancellationException) throw e
                                 // Never throw an exception
                                 sb.append("Error Decoding CBOR")
                             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/JsonClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/JsonClaim.kt
@@ -1,5 +1,6 @@
 package org.multipaz.claim
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.datetime.formatLocalized
 import org.multipaz.documenttype.DocumentAttribute
 import org.multipaz.documenttype.DocumentAttributeType
@@ -90,7 +91,8 @@ data class JsonClaim(
                 }
 
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             val fallback = value.toString()
             "$fallback (fallback, error occurred during rendering: ${e.message})"
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/MdocClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/MdocClaim.kt
@@ -1,5 +1,6 @@
 package org.multipaz.claim
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
@@ -142,7 +143,8 @@ data class MdocClaim(
                 }
 
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             val fallback = Cbor.toDiagnostics(value, setOf(DiagnosticOption.BSTR_PRINT_LENGTH))
             "$fallback (fallback, error occurred during rendering: ${e.message})"
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
@@ -105,7 +105,7 @@ expect object Crypto {
      * @param algorithm the signature algorithm to use.
      * @param signature the signature.
      * @throws SignatureVerificationException if the signature check fails.
-     * @throws IllegalStateException if an error occurred during the check, for example if data is malformed.
+     * @throws IllegalArgumentException if an error occurred during the check, for example if data is malformed.
      */
     suspend fun checkSignature(
         publicKey: EcPublicKey,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebSignature.kt
@@ -1,5 +1,6 @@
 package org.multipaz.crypto
 
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -99,26 +100,30 @@ object JsonWebSignature {
      *
      * @param jws the compact serialization of the JWS.
      * @param publicKey the key to use for verification
-     * @throws Throwable if verification fails.
+     * @throws IllegalArgumentException if the JWS is malformed.
+     * @throws SignatureVerificationException if the signature check fails.
      */
     suspend fun verify(
         jws: String,
         publicKey: EcPublicKey
     ) {
-        val splits = jws.split(".")
-        require(splits.size == 3) { "Malformed JWS" }
-        val (headerStr, bodyStr, signatureStr) = splits
-        val headerObj = Json.decodeFromString(JsonObject.serializer(), headerStr.fromBase64Url().decodeToString())
-
-        val toBeVerified = "$headerStr.$bodyStr".encodeToByteArray()
-        val signature = EcSignature.fromCoseEncoded(signatureStr.fromBase64Url())
-        val algorithm = Algorithm.fromJoseAlgorithmIdentifier(headerObj["alg"]!!.jsonPrimitive.content)
-        Crypto.checkSignature(
-            publicKey = publicKey,
-            message = toBeVerified,
-            algorithm = algorithm,
-            signature = signature
-        )
+        try {
+            val splits = jws.split(".")
+            require(splits.size == 3) { "Malformed JWS" }
+            val (headerStr, bodyStr, signatureStr) = splits
+            val headerObj = Json.decodeFromString(JsonObject.serializer(), headerStr.fromBase64Url().decodeToString())
+            val toBeVerified = "$headerStr.$bodyStr".encodeToByteArray()
+            val signature = EcSignature.fromCoseEncoded(signatureStr.fromBase64Url())
+            val algorithm = Algorithm.fromJoseAlgorithmIdentifier(headerObj["alg"]!!.jsonPrimitive.content)
+            Crypto.checkSignature(
+                publicKey = publicKey,
+                message = toBeVerified,
+                algorithm = algorithm,
+                signature = signature
+            )
+        } catch (e: SerializationException) {
+            throw IllegalArgumentException("Malformed JWS", e)
+        }
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationAndroid.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationAndroid.kt
@@ -1,5 +1,6 @@
 package org.multipaz.device
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcSignature
@@ -25,8 +26,9 @@ data class DeviceAttestationAndroid(
                 requireAppSignatureCertificateDigests = validationData.androidAppSignatureCertificateDigests,
                 requireAppPackages = validationData.androidAppPackageNames
             )
-        } catch (err: Exception) {
-            throw DeviceAttestationException("Failed Android device attestation", err)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw DeviceAttestationException("Failed Android device attestation", e)
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationIos.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationIos.kt
@@ -1,5 +1,6 @@
 package org.multipaz.device
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1OctetString
 import org.multipaz.asn1.ASN1Sequence
@@ -54,7 +55,8 @@ data class DeviceAttestationIos(
             if (!X509CertChain(x5c).validate()) {
                 throw DeviceAttestationException("Invalid certificate chain")
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw DeviceAttestationException("Error validating certificate chain", e)
         }
         try {
@@ -170,7 +172,7 @@ data class DeviceAttestationIos(
         val hash = Crypto.digest(Algorithm.SHA256, composite.toByteArray())
         try {
             Crypto.checkSignature(publicKey, hash, Algorithm.ES256, signature)
-        } catch (e: Throwable) {
+        } catch (e: SignatureVerificationException) {
             throw DeviceAssertionException("Error validating signature", e)
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.document
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -495,9 +496,15 @@ class Document internal constructor(
     companion object {
         private const val TAG = "Document"
 
+        /**
+         * Migration function to update to 0.97.0.
+         */
         var customSchema0_97_0_MigrationFn:
                 ((documentId: String, data: ByteString) -> ByteString)? = null
 
+        /**
+         * The default [StorageTableSpec] to use for [Document].
+         */
         val defaultTableSpec = object: StorageTableSpec(
             name = "Documents",
             supportPartitions = false,
@@ -562,6 +569,7 @@ class Document internal constructor(
                                     metadata = existing.other
                                 )
                             } catch (err: Exception) {
+                                if (err is CancellationException) throw err
                                 Logger.e(TAG, "Error parsing document '$documentId'", err)
                                 // keep the document as not provisioned; this will have to be handled by
                                 // the app (e.g. consult credentials, delete document,
@@ -572,6 +580,7 @@ class Document internal constructor(
                         try {
                             table.update(documentId, ByteString(newData.toCbor()))
                         } catch (err: Exception) {
+                            if (err is CancellationException) throw err
                             Logger.e(TAG, "Error writing document '$documentId'", err)
                             table.delete(documentId)
                         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDataElement.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDataElement.kt
@@ -16,6 +16,7 @@
 
 package org.multipaz.documenttype
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
@@ -145,7 +146,8 @@ data class MdocDataElement(
                     option?.displayName ?: value.asTstr
                 }
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             val diagnosticsString = Cbor.toDiagnostics(value, diagnosticsOptions)
             Logger.w(TAG, "Error decoding value $diagnosticsString for data element " +
                     "${attribute.identifier}, falling back to diagnostics", e)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodBle.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodBle.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.connectionmethod
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.nfc.NdefRecord
 import org.multipaz.nfc.Nfc
 import org.multipaz.util.Logger
@@ -250,7 +251,8 @@ data class MdocConnectionMethodBle(
                         try {
                             val mdocBleServiceData = Cbor.decode(encodedMdocBleServiceData.toByteArray())
                             psm = mdocBleServiceData.getOrNull(0)?.asNumber?.toInt()
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.w(TAG, "Error decoding BleServiceData CBOR", e)
                         }
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/DeviceEngagement.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/DeviceEngagement.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.engagement
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
@@ -121,7 +122,8 @@ data class DeviceEngagement private constructor(
                         if (originInfo != null) {
                             originInfos.add(originInfo)
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         Logger.w(TAG, "OriginInfo is incorrectly formatted", e)
                     }
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementParser.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.mdoc.engagement
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.DataItem
@@ -111,6 +112,7 @@ class EngagementParser(private val encodedEngagement: ByteArray) {
                                 ois.add(originInfo)
                             }
                         } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.w(TAG, "OriginInfo is incorrectly formatted.", e)
                         }
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObject.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObject.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.mso
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.DataItem
@@ -173,7 +174,8 @@ data class MobileSecurityObject(
             val revocationStatus = if (dataItem.hasKey("status")) {
                 try {
                     RevocationStatus.fromDataItem(dataItem["status"])
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.w(TAG, "Ignoring malformed status field in MSO", e)
                     Logger.iCbor(TAG, "The malformed status field is", dataItem["status"])
                     null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.nfc
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Simple
 import org.multipaz.crypto.EcPublicKey
@@ -351,7 +352,8 @@ class MdocNfcEngagementHelper(
             bsb.append(responseNdefMessagePayload)
             selectedFilePayload = bsb.toByteString()
             return ResponseApdu(Nfc.RESPONSE_STATUS_SUCCESS)
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
             raiseError(error.message!!, error)
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
         }
@@ -439,7 +441,8 @@ class MdocNfcEngagementHelper(
             }
             raiseError("Command APDU $command not supported, returning 6d00")
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
             raiseError("Error processing APDU: ${error.message}", error)
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -135,7 +135,8 @@ data class DeviceRequest private constructor(
                         signature = readerAuthAllSignature,
                         signatureAlgorithm = alg
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
                     throw SignatureVerificationException(
                         message = "Error verifying ReaderAuthAll at index $readerAuthAllIndex",
                         cause = e
@@ -161,7 +162,8 @@ data class DeviceRequest private constructor(
                         signature = docRequest.readerAuth_,
                         signatureAlgorithm = docRequest.readerAuthAlgorithm!!
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw SignatureVerificationException(
                         message = "Error verifying reader authentication for DocRequest at index $docRequestIndex",
                         cause = e

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestParser.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.mdoc.request
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
@@ -23,6 +24,7 @@ import org.multipaz.cbor.buildCborArray
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.mdoc.zkp.ZkSystemSpec
 
@@ -154,7 +156,8 @@ class DeviceRequestParser(
                                 signatureAlgorithm
                             )
                             true
-                        } catch (_: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             false
                         }
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.response
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborMap
@@ -85,7 +86,8 @@ data class DeviceResponse internal constructor(
         documents_.forEachIndexed { index, document ->
             try {
                 document.verify(sessionTranscript, eReaderKey, atTime)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Error verifying document $index in DeviceResponse", e)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.mdoc.response
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
@@ -156,9 +157,10 @@ class DeviceResponseParser(
                         signatureAlgorithm
                     )
                     true
-                } catch (_: Throwable) {
-                    false
-                }
+                 } catch (e: Exception) {
+                     if (e is CancellationException) throw e
+                     false
+                 }
             } else {
                 false
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/EncryptedDocuments.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/EncryptedDocuments.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.response
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
@@ -80,7 +81,8 @@ data class EncryptedDocuments internal constructor(
         encDocsPt.documents.forEachIndexed { index, document ->
             try {
                 document.verify(encSessionTranscript, null, atTime)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Error verifying document $index in decrypted DeviceResponse", e)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -121,7 +121,7 @@ internal class BleTransportCentralMdoc(
                         _state.value = State.CONNECTED
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 error.unwrapCancellationException().let {
                     failTransport(it)
                     throw it.wrapUnlessCancellationException("Failed while opening transport")
@@ -140,7 +140,7 @@ internal class BleTransportCentralMdoc(
             return centralManager.incomingMessages.receive()
         } catch (error: CancellationException) {
             throw error
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {
@@ -168,7 +168,7 @@ internal class BleTransportCentralMdoc(
                         }
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while sending message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -92,7 +92,7 @@ internal class BleTransportCentralMdocReader(
                         _state.value = State.ADVERTISING
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while advertising")
@@ -128,7 +128,7 @@ internal class BleTransportCentralMdocReader(
                         _state.value = State.CONNECTED
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while opening transport")
@@ -147,7 +147,7 @@ internal class BleTransportCentralMdocReader(
             return peripheralManager.incomingMessages.receive()
         } catch (error: CancellationException) {
             throw error
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {
@@ -175,7 +175,7 @@ internal class BleTransportCentralMdocReader(
                         }
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while sending message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -93,7 +93,7 @@ internal class BleTransportPeripheralMdoc(
                         _state.value = State.ADVERTISING
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while advertising")
@@ -129,7 +129,7 @@ internal class BleTransportPeripheralMdoc(
                         _state.value = State.CONNECTED
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while opening transport")
@@ -148,7 +148,7 @@ internal class BleTransportPeripheralMdoc(
             return peripheralManager.incomingMessages.receive()
         } catch (error: CancellationException) {
             throw error
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {
@@ -176,7 +176,7 @@ internal class BleTransportPeripheralMdoc(
                         }
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while sending message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -120,7 +120,7 @@ internal class BleTransportPeripheralMdocReader(
                         _state.value = State.CONNECTED
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while opening transport")
@@ -139,7 +139,7 @@ internal class BleTransportPeripheralMdocReader(
             return centralManager.incomingMessages.receive()
         } catch (error: CancellationException) {
             throw error
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {
@@ -167,7 +167,7 @@ internal class BleTransportPeripheralMdocReader(
                         }
                     }
                 }
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 throw error.unwrapCancellationException().let {
                     failTransport(it)
                     it.wrapUnlessCancellationException("Failed while sending message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.multipaz.crypto.EcPublicKey
@@ -317,7 +318,7 @@ class NfcTransportMdoc(
             }
             failTransport(Error("Command APDU $command not supported, returning 6d00"))
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             error.printStackTrace()
             failTransport(Error("Error processing APDU: ${error.message}", error))
             val status = if (error is NfcError) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
@@ -91,7 +91,7 @@ class NfcTransportMdocReader(
                 _state.value = State.CONNECTING
                 tag.selectApplication(Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID)
                 _state.value = State.CONNECTED
-            } catch (error: Throwable) {
+            } catch (error: Exception) {
                 failTransport(error)
                 throw error.wrapUnlessCancellationException("Failed while opening transport")
             }
@@ -104,7 +104,7 @@ class NfcTransportMdocReader(
                     val responseMessage = nfcTransceive(messageToSend)
                     incomingMessages.send(responseMessage)
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
                 Logger.i(TAG, "Error while waiting for message to send", e)
                 e.printStackTrace()
                 mutex.withLock {
@@ -228,7 +228,7 @@ class NfcTransportMdocReader(
             return incomingMessages.receive().toByteArray()
         } catch (error: CancellationException) {
             throw error
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
@@ -83,7 +84,8 @@ suspend fun List<MdocTransport>.waitForConnection(
                 try {
                     Logger.i(TAG, "opening connection ${transport.connectionMethod}")
                     transport.open(eSenderKey)
-                } catch (error: Throwable) {
+                } catch (error: Exception) {
+                    if (error is CancellationException) throw error
                     Logger.e(TAG, "Caught exception while opening connection ${transport.connectionMethod}", error)
                 }
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NdefMessage.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NdefMessage.kt
@@ -32,6 +32,7 @@ data class NdefMessage(
          *
          * @param encoded the encoded messages.
          * @return the decoded message
+         * @throws IllegalArgumentException if the message is invalid.
          */
         fun fromEncoded(encoded: ByteArray): NdefMessage {
             return NdefMessage(NdefRecord.fromEncoded(encoded))

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NdefRecord.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NdefRecord.kt
@@ -1,5 +1,6 @@
 package org.multipaz.nfc
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.util.ByteDataReader
 import org.multipaz.util.appendByteString
 import org.multipaz.util.appendUInt32
@@ -132,7 +133,8 @@ data class NdefRecord(
                                 }
                             }
                             return null
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             return null
                         }
                     }
@@ -175,6 +177,7 @@ data class NdefRecord(
          *
          * @param encoded the encoded NDEF message
          * @return a list of records.
+         * @throws IllegalArgumentException if the message is invalid.
          */
         internal fun fromEncoded(encoded: ByteArray): List<NdefRecord> {
             try {
@@ -195,7 +198,7 @@ data class NdefRecord(
                     var tnf = Tnf.entries[flags.and(0x07)]
 
                     if (records.size == 0 && chunkBsb == null) {
-                        check(isMessageBegin)
+                        require(isMessageBegin) { "First record must be message begin" }
                     }
 
                     val typeLength = reader.getUInt8().toInt()
@@ -217,7 +220,7 @@ data class NdefRecord(
                     var payload = reader.getByteString(payloadLength)
 
                     if (reader.exhausted()) {
-                        check(isMessageEnd)
+                        require(isMessageEnd) { "Last record must be message end" }
                     }
 
                     if (tnf == Tnf.EMPTY && id.size != 0) {
@@ -262,7 +265,8 @@ data class NdefRecord(
                     throw IllegalArgumentException("No records in message")
                 }
                 return records
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalArgumentException("Parsing NdefMessage failed", e)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -175,7 +175,8 @@ suspend fun Iso18013Presentment(
                 transport.sendMessage(
                     SessionEncryption.encodeStatus(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.w(TAG, "Caught error while sending session-termination", e)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -77,7 +77,8 @@ suspend fun mdocPresentment(
             )
         } catch (e: Iso18015ResponseException) {
             throw PresentmentCannotSatisfyRequestException("Error satisfying the request", e)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException("Error satisfying request", e)
         }
         val requester = Requester(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -137,7 +137,7 @@ class ProvisioningModel(
             } catch(err: CancellationException) {
                 mutableState.emit(Idle)
                 throw err
-            } catch(err: Throwable) {
+            } catch (err: Exception) {
                 Logger.e(TAG, "Error provisioning", err)
                 mutableState.emit(Error(err))
                 throw err
@@ -289,8 +289,8 @@ class ProvisioningModel(
                     documentAuthorizationData = provisioningClient.getAuthorizationData()
                 )
             }
-        } catch (err: Throwable) {
-            // Clean-up after failed provisioning
+        } catch (err: Exception) {
+            // Clean-up after failed provisioning and then rethrow - so we also handle CancellationException here
             if (targetDocument == null) {
                 // Initial provisioning: failed
                 documentProvisioningHandler.cleanupDocumentOnError(document, err)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -1,5 +1,6 @@
 package org.multipaz.provisioning.openid4vci
 
+import kotlinx.coroutines.CancellationException
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.headers
@@ -707,6 +708,7 @@ internal class OpenID4VCIProvisioningClient(
                     keys.forEach { secureArea.deleteKey(it) }
                 }
             } catch (err: Exception) {
+                if (err is CancellationException) throw err
                 Logger.e(TAG, "Failed to clean up authorization data", err)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherLocal.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherLocal.kt
@@ -155,7 +155,7 @@ class RpcDispatcherLocal private constructor(
                     )
                 } catch (err: CancellationException) {
                     throw err
-                } catch (err: Throwable) {
+                } catch (err: Exception) {
                     val newStateBlob = stateDataItem(cipher, argList[0], decryptedState, state)
                     return owner.exceptionMap.exceptionReturn(newStateBlob, err)
                 }
@@ -178,7 +178,7 @@ class RpcDispatcherLocal private constructor(
                     )
                 } catch (err: CancellationException) {
                     throw err
-                } catch (err: Throwable) {
+                } catch (err: Exception) {
                     val newStateBlob = stateDataItem(cipher, argList[0], decryptedState, state)
                     return owner.exceptionMap.exceptionReturn(
                         newStateBlob, err, nextNonce)
@@ -197,7 +197,7 @@ class RpcDispatcherLocal private constructor(
                         RpcReturnCode.RESULT.ordinal.toDataItem(), result)
                 } catch (err: CancellationException) {
                     throw err
-                } catch (err: Throwable) {
+                } catch (err: Exception) {
                     val newStateBlob = stateDataItem(cipher, argList[0], decryptedState, state)
                     return owner.exceptionMap.exceptionReturn(newStateBlob, err)
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcNotifierPoll.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcNotifierPoll.kt
@@ -56,7 +56,7 @@ class RpcNotifierPoll(private val poll: RpcPoll) : RpcNotifier {
                     // important to rethrow this one
                     Logger.w(TAG, "Polling cancelled", e)
                     throw e
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
                     Logger.w(TAG, "Error polling, retrying in 5s...", e)
                     delay(5.seconds)
                     continue

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/transport/KtorHttpTransport.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/transport/KtorHttpTransport.kt
@@ -71,7 +71,7 @@ class KtorHttpTransport: HttpTransport {
             throw HttpTransport.TimeoutException("Timed out", e)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             throw HttpTransport.ConnectionException("Error", e)
         }
         HttpTransport.processStatus(url, response.status.value, response.status.description)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -1,5 +1,6 @@
 package org.multipaz.sdjwt
 
+import kotlinx.coroutines.CancellationException
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlinx.serialization.json.Json
@@ -148,7 +149,8 @@ class SdJwt private constructor(
         // TODO: make sure we perform all checks in Section 7.1
         try {
             JsonWebSignature.verify("$header.$body.$signature", issuerKey)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw SignatureVerificationException("Error validating issuer signature", e)
         }
         return processObject(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
@@ -1,5 +1,6 @@
 package org.multipaz.sdjwt
 
+import kotlinx.coroutines.CancellationException
 import kotlin.time.Instant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -64,7 +65,8 @@ class SdJwtKb private constructor(
     ): JsonObject {
         try {
             JsonWebSignature.verify("$kbHeader.$kbBody.$kbSignature", sdJwt.kbKey!!)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw SignatureVerificationException("Error validating KB signature", e)
         }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -1,5 +1,6 @@
 package org.multipaz.securearea.cloud
 
+import kotlinx.coroutines.CancellationException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngineFactory
@@ -183,6 +184,7 @@ open class CloudSecureArea protected constructor(
             val responseBody: ByteArray = httpResponse.body()
             return Pair(responseStatus, responseBody)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw CloudException("Error communicating with Cloud Secure Area", e)
         }
     }
@@ -306,7 +308,8 @@ open class CloudSecureArea protected constructor(
                 partitionId = identifier,
                 data = ByteString(passphraseConstraints.toCbor())
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw CloudException(e)
         }
     }
@@ -443,6 +446,7 @@ open class CloudSecureArea protected constructor(
             encryptedCounter = 1
             decryptedCounter = 1
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw CloudException(e)
         }
     }
@@ -579,6 +583,7 @@ open class CloudSecureArea protected constructor(
             saveKeyMetadata(newKeyAlias, cSettings, response1.remoteKeyAttestation)
             return getKeyInfo(newKeyAlias)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw CloudException(e)
         }
     }
@@ -672,6 +677,7 @@ open class CloudSecureArea protected constructor(
                 openid4vciKeyAttestationJws = response1.openid4vciKeyAttestationCompactSerialization
             )
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw CloudException(e)
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.securearea.software
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
@@ -132,7 +133,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             )
             return getKeyInfo(newAlias)
         } catch (e: Exception) {
-            // such as NoSuchAlgorithmException, CertificateException, InvalidAlgorithmParameterException, OperatorCreationException, IOException, NoSuchProviderException
+            if (e is CancellationException) throw e
             throw IllegalStateException("Unexpected exception", e)
         }
     }
@@ -183,6 +184,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             val encodedPrivateKey = try {
                 Crypto.decrypt(Algorithm.A128GCM, secretKey, iv, encryptedPrivateKey)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw KeyLockedException("Error decrypting private key - wrong passphrase?", e)
             }
             EcPrivateKey.fromDataItem(Cbor.decode(encodedPrivateKey))
@@ -315,7 +317,8 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
                         try {
                             secureArea.loadKey(alias, SoftwareKeyUnlockData(enteredPassphrase))
                             PassphraseEvaluation.OK
-                        } catch (_: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             // TODO: translations
                             PassphraseEvaluation.TryAgain
                         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/storage/GenericStorageEngine.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/storage/GenericStorageEngine.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.storage
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborMap
 import org.multipaz.util.Logger
@@ -67,14 +68,16 @@ open class GenericStorageEngine(
                     for ((key, value) in map) {
                         data!!.put(key.asTstr, value.asBstr)
                     }
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.w(TAG, "Error decoding data at $path - treating as zeroed data", e)
                 }
             }
-        } catch (e: FileNotFoundException) {
+        } catch (_: FileNotFoundException) {
             // No problem, we all start from zero at some point...
             data = mutableMapOf()
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException("Error loading data", e)
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManagerUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManagerUtil.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.trustmanagement
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509KeyUsage
 import kotlin.time.Instant
@@ -88,9 +89,11 @@ internal object TrustManagerUtil {
     suspend fun verifySignature(certificate: X509Cert, caCertificate: X509Cert) =
         try {
             certificate.verify(caCertificate.ecPublicKey)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException(
-                "Certificate '${certificate.subject}' could not be verified with the public key of CA certificate '${caCertificate.subject}'"
+                "Certificate '${certificate.subject}' could not be verified with the public key of CA certificate '${caCertificate.subject}'",
+                e
             )
         }
 
@@ -110,7 +113,8 @@ internal object TrustManagerUtil {
                     trustPoints = trustPoints,
                     trustChain = X509CertChain(completeChain)
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 // there are validation errors, but the trust chain could be built.
                 return TrustResult(
                     isTrusted = false,
@@ -119,7 +123,8 @@ internal object TrustManagerUtil {
                     error = e
                 )
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             // No CA certificate found for the passed in chain.
             //
             // However, handle the case where the passed in chain _is_ a trust point. This won't

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/AndroidAttestationExtensionParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/AndroidAttestationExtensionParser.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.util
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Boolean
 import org.multipaz.asn1.ASN1Integer
@@ -336,7 +337,8 @@ class AndroidAttestationExtensionParser(cert: X509Cert) {
             } else {
                 return "  $tag: ${ASN1.print(value).trim()}\n"
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             return "  $tag: Error rendering: ${e.message}"
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -15,6 +15,7 @@
  */
 package org.multipaz.util
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
 import kotlin.time.Clock
@@ -140,7 +141,8 @@ object Logger {
             try {
                 fileWriter!!.write((logLine + "\n").encodeToByteArray())
                 fileWriter!!.flush()
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 printer.print(Level.ERROR, tag, "Error writing log message to file", e)
                 e.printStackTrace()
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/validateAndroidKeyAttestation.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/validateAndroidKeyAttestation.kt
@@ -1,5 +1,6 @@
 package org.multipaz.util
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import kotlinx.io.bytestring.ByteString
@@ -37,7 +38,8 @@ suspend fun validateAndroidKeyAttestation(
     // Check the Attestation Extension...
     val parser = try {
         AndroidAttestationExtensionParser(chain.certificates.first())
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         throw IllegalArgumentException("Error parsing Android Attestation Extension", e)
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/prompt/PromptModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/prompt/PromptModelTest.kt
@@ -39,7 +39,7 @@ class PromptModelTest {
         val exception = try {
             PromptModel.get()
             null
-        } catch (err: Throwable) {
+        } catch (err: Exception) {
             err
         }
         assertTrue(exception is PromptModelNotAvailableException)
@@ -55,7 +55,7 @@ class PromptModelTest {
                 passphraseEvaluator = null
             )
             null
-        } catch (err: Throwable) {
+        } catch (err: Exception) {
             err
         }
         assertTrue(exception is PromptUiNotAvailableException)
@@ -162,7 +162,7 @@ class PromptModelTest {
                     passphraseEvaluator = null
                 )
                 null
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 err
             }
         }
@@ -244,7 +244,7 @@ class PromptModelTest {
             } catch (err: CancellationException) {
                 pendingResultChannel?.close(PromptDismissedException())
                 throw err
-            } catch (err: Throwable) {
+            } catch (err: Exception) {
                 fail("Unexpected error", err)
             }
         }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/util/ByteStringUtilTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/util/ByteStringUtilTest.kt
@@ -786,7 +786,7 @@ class ByteStringBuilderExtensionsTest {
 private fun assertDoesNotThrow(block: () -> Unit) {
     try {
         block()
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
         kotlin.test.fail("Expected no exception, but got: $e")
     }
 }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
@@ -195,7 +196,8 @@ internal class BleCentralManagerIos : BleCentralManager {
             if (characteristic == readCharacteristic) {
                 try {
                     handleIncomingData(characteristic.value!!.toByteArray())
-                } catch (error: Throwable) {
+                } catch (error: Exception) {
+                    if (error is CancellationException) throw error
                     onError(error)
                 }
             } else {
@@ -476,7 +478,8 @@ internal class BleCentralManagerIos : BleCentralManager {
                 val value = l2capCharacteristic!!.value!!.toByteArray()
                 _l2capPsm = value.getUInt32(0).toInt()
                 Logger.i(TAG, "L2CAP PSM is $_l2capPsm")
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.i(TAG, "L2CAP not available on peripheral", e)
             }
         }
@@ -629,7 +632,8 @@ internal class BleCentralManagerIos : BleCentralManager {
                 val message = l2capSource!!.readByteArray(length)
                 incomingMessages.send(message)
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             onError(Error("Reading from L2CAP channel failed", e))
         }
     }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tagged
@@ -220,7 +221,8 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
                     val data = attRequest.value?.toByteArray() ?: byteArrayOf()
                     try {
                         handleIncomingData(data)
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         onError(Error("Error processing incoming data", e))
                     }
                 } else {
@@ -493,7 +495,8 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
                 val message = l2capSource!!.readByteArray(length)
                 incomingMessages.send(message)
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             onError(Error("Reading from L2CAP channel failed", e))
         }
     }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/nfc/NfcTagReader.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/nfc/NfcTagReader.ios.kt
@@ -72,7 +72,8 @@ private class IosTagReader<T>(
                             } else {
                                 session.restartPolling()
                             }
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             continuation?.resumeWithException(e)
                             continuation = null
                         }
@@ -116,7 +117,7 @@ private class IosTagReader<T>(
         } catch (e: CancellationException) {
             session.invalidateSessionWithErrorMessage("Dialog was canceled")
             throw e
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             e.message?.let { session.invalidateSessionWithErrorMessage(it) } ?: session.invalidateSession()
             throw e
         }

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
@@ -1,10 +1,12 @@
 package org.multipaz.crypto
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.asn1.ASN1ObjectIdentifier
 import org.multipaz.asn1.ASN1OctetString
 import org.multipaz.asn1.ASN1Sequence
+import java.security.GeneralSecurityException
 import java.security.KeyPairGenerator
 import java.security.MessageDigest
 import java.security.Security
@@ -201,6 +203,7 @@ actual object Crypto {
                 doFinal(messageCiphertext)
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException("Error decrypting", e)
         }
     }
@@ -253,8 +256,9 @@ actual object Crypto {
                 update(message)
                 verify(rawSignature)
             }
-        } catch (e: Throwable) {
-            throw IllegalStateException("Error occurred verifying signature", e)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw IllegalArgumentException("Error occurred verifying signature", e)
         }
         if (!verified) {
             throw SignatureVerificationException("Signature verification failed")
@@ -381,7 +385,8 @@ actual object Crypto {
                     sign()
                 }
                 EcSignature.fromDerEncoded(key.curve.bitSize, derEncodedSignature)
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Unexpected Exception", e)
             }
         }
@@ -398,7 +403,8 @@ actual object Crypto {
                     rawSignature.sliceArray(IntRange(0, rawSignature.size/2 - 1)),
                     rawSignature.sliceArray(IntRange(rawSignature.size/2, rawSignature.size - 1))
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Unexpected Exception", e)
             }
         }
@@ -415,7 +421,8 @@ actual object Crypto {
                     rawSignature.sliceArray(IntRange(0, rawSignature.size/2 - 1)),
                     rawSignature.sliceArray(IntRange(rawSignature.size/2, rawSignature.size - 1))
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Unexpected Exception", e)
             }
         }
@@ -450,7 +457,8 @@ actual object Crypto {
                     ka.init(key.javaPrivateKey)
                     ka.doPhase(otherKey.javaPublicKey, true)
                     ka.generateSecret()
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("Unexpected Exception", e)
                 }
             }
@@ -467,7 +475,8 @@ actual object Crypto {
                     ka.init(key.javaPrivateKey)
                     ka.doPhase(otherKey.javaPublicKey, true)
                     ka.generateSecret()
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("Unexpected Exception", e)
                 }
             }
@@ -479,7 +488,8 @@ actual object Crypto {
                     ka.init(key.javaPrivateKey)
                     ka.doPhase(otherKey.javaPublicKey, true)
                     ka.generateSecret()
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     throw IllegalStateException("Unexpected Exception", e)
                 }
             }
@@ -493,7 +503,8 @@ actual object Crypto {
                 val certSignedBy = javaCerts[n + 1]
                 try {
                     cert.verify(certSignedBy.publicKey)
-                } catch (_: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     return false
                 }
             }

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/EcPublicKeyJvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/EcPublicKeyJvm.kt
@@ -1,5 +1,6 @@
 package org.multipaz.crypto
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.bytestring.ByteStringBuilder
 import java.math.BigInteger
 import java.security.AlgorithmParameters
@@ -111,6 +112,7 @@ val EcPublicKey.javaPublicKey: PublicKey
                 val kf = KeyFactory.getInstance("EC")
                 kf.generatePublic(keySpec)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 throw IllegalStateException("Unexpected error", e)
             }
         }
@@ -149,6 +151,7 @@ val EcPublicKey.javaPublicKey: PublicKey
                 bsb.append(x)
                 kf.generatePublic(X509EncodedKeySpec(bsb.toByteString().toByteArray()))
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 // any exception, such as NoSuchAlgorithmException, InvalidKeySpecException, IOException, NoSuchProviderException
                 throw IllegalStateException("Unexpected error", e)
             }

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/util/Compression.jvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/util/Compression.jvm.kt
@@ -1,5 +1,6 @@
 package org.multipaz.util
 
+import kotlinx.coroutines.CancellationException
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.util.zip.Deflater
@@ -36,7 +37,8 @@ actual suspend fun ByteArray.inflate(): ByteArray {
             }
         } while (length > 0)
         iis.close();
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         throw IllegalArgumentException("Error decompressing data", e)
     }
     return baos.toByteArray()

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/storage/jdbc/JdbcStorage.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/storage/jdbc/JdbcStorage.kt
@@ -1,5 +1,6 @@
 package org.multipaz.storage.jdbc
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.storage.base.BaseStorage
 import org.multipaz.storage.base.BaseStorageTable
 import org.multipaz.storage.StorageTableSpec
@@ -87,7 +88,8 @@ class JdbcStorage(
                             )
                         )
                     }
-                } catch (error: Throwable) {
+                } catch (error: Exception) {
+                    if (error is CancellationException) throw error
                     continuation.resumeWithException(error)
                     // Close after exceptions instead of returning to the pool
                     connection.close()
@@ -95,7 +97,8 @@ class JdbcStorage(
                 for (staleConnection in staleConnections) {
                     try {
                         staleConnection.close()
-                    } catch (err: Throwable) {
+                    } catch (err: Exception) {
+                        if (err is CancellationException) throw err
                         // ignore all errors
                     }
                 }

--- a/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
@@ -4,6 +4,7 @@ import js.array.jsArrayOf
 import js.buffer.toByteArray
 import js.objects.unsafeJso
 import kotlinx.browser.window
+import kotlinx.coroutines.CancellationException
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1BitString
 import org.multipaz.asn1.ASN1ObjectIdentifier
@@ -38,6 +39,7 @@ import web.crypto.sign
 import web.crypto.spki
 import web.crypto.verify
 import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsException
 import kotlin.js.toJsString
 import kotlin.js.unsafeCast
 
@@ -189,6 +191,7 @@ actual object Crypto {
         ).toByteArray()
     }
 
+    @OptIn(ExperimentalWasmJsInterop::class)
     actual suspend fun decrypt(
         algorithm: Algorithm,
         key: ByteArray,
@@ -215,7 +218,10 @@ actual object Crypto {
                 key = key,
                 data = messageCiphertext.toBufferSource()
             ).toByteArray()
-        } catch (e : Throwable) {
+        } catch (e : JsException) {
+            throw IllegalStateException("Error decrypting", e)
+        } catch (e : Exception) {
+            if (e is CancellationException) throw e
             throw IllegalStateException("Error decrypting", e)
         }
     }

--- a/multipaz/src/webMain/kotlin/org/multipaz/tools/Tools.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/tools/Tools.kt
@@ -2,6 +2,7 @@
 
 package org.multipaz.tools
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.util.fromHex
@@ -16,6 +17,7 @@ fun cborToDiagnostic(text: String): String {
         return Cbor.toDiagnostics(dataItem,
         setOf(DiagnosticOption.EMBEDDED_CBOR, DiagnosticOption.PRETTY_PRINT))
     } catch (e: Exception) {
+        if (e is CancellationException) throw e
         return "Error decoding: ${e.message}"
     }
 }

--- a/multipaz/src/webMain/kotlin/org/multipaz/util/Compression.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/util/Compression.web.kt
@@ -1,5 +1,6 @@
 package org.multipaz.util
 
+import kotlinx.coroutines.CancellationException
 import js.array.jsArrayOf
 import js.buffer.ArrayBuffer
 import js.typedarrays.Int8Array
@@ -15,6 +16,8 @@ import web.http.BodyInit
 import web.http.Response
 import web.http.arrayBuffer
 import web.streams.ReadableWritablePair
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsException
 import kotlin.js.unsafeCast
 
 actual suspend fun ByteArray.deflate(compressionLevel: Int): ByteArray {
@@ -31,6 +34,7 @@ actual suspend fun ByteArray.deflate(compressionLevel: Int): ByteArray {
     return Int8Array(compressedBuffer).toByteArray()
 }
 
+@OptIn(ExperimentalWasmJsInterop::class)
 actual suspend fun ByteArray.inflate(): ByteArray {
     val jsData = this.toUint8Array()
     val blob = Blob(jsArrayOf(jsData))
@@ -41,7 +45,10 @@ actual suspend fun ByteArray.inflate(): ByteArray {
         val outputStream = inputStream.pipeThrough(transform)
         val decompressedBuffer = Response(outputStream as BodyInit?).arrayBuffer()
         return Int8Array(decompressedBuffer).toByteArray()
-    } catch (e: Throwable) {
+    } catch (e: JsException) {
+        throw IllegalArgumentException("Error decompressing data", e)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         throw IllegalArgumentException("Error decompressing data", e)
     }
 }

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
@@ -99,7 +99,7 @@ actual object TestAppConfiguration {
                 if (!inetAddress.isLoopbackAddress) {
                     val address = inetAddress.hostAddress
                     if (address != null && address.indexOf(':') < 0) {
-                        address
+                        return@lazy address
                     }
                 }
             }

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.FeatureInfo
@@ -134,7 +135,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
                                 androidKeystoreCapabilities.testKeyAttestationsAndEcdsaSigning(useStrongBox)
                                 val durationMsec = (Clock.System.now() - t0).inWholeMilliseconds
                                 showToast("Sanity check passed ($durationMsec msec)")
-                            } catch (e: Throwable) {
+                            } catch (e: Exception) {
+                                if (e is CancellationException) throw e
                                 val durationMsec = (Clock.System.now() - t0).inWholeMilliseconds
                                 e.printStackTrace()
                                 showToast("Sanity check failed ($durationMsec msec): ${e.message}")
@@ -160,7 +162,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
                         withContext(Dispatchers.Main) {
                             onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace();
                         showToast("${e.message}")
                     }
@@ -183,7 +186,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
                         withContext(Dispatchers.Main) {
                             onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace();
                         showToast("${e.message}")
                     }
@@ -208,7 +212,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
                                 Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url()
                             )
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace();
                         showToast("${e.message}")
                     }
@@ -233,7 +238,8 @@ actual fun AndroidKeystoreSecureAreaScreen(
                                 Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url()
                             )
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace();
                         showToast("${e.message}")
                     }
@@ -604,7 +610,8 @@ private suspend fun aksTest(
     try {
         aksTestUnguarded(algorithm, authRequired, authTimeout, userAuthType,
             biometricConfirmationRequired, strongBox, showToast)
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         e.printStackTrace();
         showToast("${e.message}")
     }

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
@@ -75,7 +75,8 @@ actual suspend fun launchAndroidPresentmentActivity(
             PresentmentActivity.presentmentModel.setSending()
             delay(paData.sendResponseDuration)
             PresentmentActivity.presentmentModel.setCompleted(null)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             if (e is CancellationException) {
                 PresentmentActivity.presentmentModel.setCompleted(PresentmentCanceledException("Presentment was cancelled"))
             } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -731,7 +732,8 @@ class App private constructor (val promptModel: PromptModel) {
                     documentTypeRepository = documentTypeRepository,
                     selectedProtocols = settingsModel.dcApiProtocols.value
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.w(TAG, "Error registering with W3C DC API", e)
             }
 
@@ -746,7 +748,8 @@ class App private constructor (val promptModel: PromptModel) {
                                 documentTypeRepository = documentTypeRepository,
                                 selectedProtocols = settingsModel.dcApiProtocols.value
                             )
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.w(TAG, "Error registering with W3C DC API", e)
                         }
                     }
@@ -765,7 +768,8 @@ class App private constructor (val promptModel: PromptModel) {
                                 documentTypeRepository = documentTypeRepository,
                                 selectedProtocols = settingsModel.dcApiProtocols.value
                             )
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.w(TAG, "Error registering with W3C DC API", e)
                         }
                     }
@@ -786,7 +790,8 @@ class App private constructor (val promptModel: PromptModel) {
                 documentTypeRepository = documentTypeRepository,
                 selectedProtocols = settingsModel.dcApiProtocols.value
             )
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.w(TAG, "Error registering with W3C DC API", e)
         }
     }
@@ -833,7 +838,8 @@ class App private constructor (val promptModel: PromptModel) {
                 if (redirectUri != null) {
                     urlsToOpen.send(redirectUri)
                 }
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.i(TAG, "Error processing request", e)
             }
         }
@@ -1041,7 +1047,8 @@ class App private constructor (val promptModel: PromptModel) {
                                             source = getPresentmentSource(),
                                             initiallySelectedDocumentId = settingsModel.currentlyFocusedDocumentId.value
                                         )
-                                    } catch (e: Throwable) {
+                                    } catch (e: Exception) {
+                                        if (e is CancellationException) throw e
                                         showToast("Error launching QuickAccessWallet: ${e.message}")
                                     }
                                 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
@@ -14,6 +14,7 @@ import io.ktor.network.sockets.openReadChannel
 import io.ktor.network.sockets.openWriteChannel
 import io.ktor.utils.io.readUTF8Line
 import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
@@ -174,7 +175,8 @@ class MultiDeviceTestsClient(
                     }
                 } catch (e: TimeoutCancellationException) {
                     sendChannel.writeStringUtf8("TestPresentationTimeout\n")
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.w(TAG, "Iteration failed", e)
                     e.printStackTrace()
                     sendChannel.writeStringUtf8("TestPresentationFailed\n")

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -275,7 +275,7 @@ class MultiDeviceTestsServer(
         } catch (e: TimeoutCancellationException) {
             Logger.w(TAG, "Iteration timeout")
             numHolderTimeouts += 1
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             Logger.w(TAG, "Iteration failed", e)
             e.printStackTrace()
             numHolderErrors += 1

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/AppUpdateCard.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,7 +55,8 @@ fun AppUpdateCard() {
                 Logger.i(TAG, "Latest available version from $updateWebsiteUrl is ${latestVersionString.value} " +
                         "and our version is $currentVersion")
             }
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Logger.e(TAG, "Error checking latest version from $updateWebsiteUrl", e)
         }
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CloudSecureAreaScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.secure_area_test_app.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -114,7 +115,8 @@ fun CloudSecureAreaScreen(
                         connectText =
                             "Connected to ${cloudSecureArea!!.serverUrl}"
                         connectColor = Color.Blue
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         cloudSecureArea = null
                         showToast("${e.message}")
@@ -160,7 +162,8 @@ fun CloudSecureAreaScreen(
                                 onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
                             }
                         }
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         showToast("${e.message}")
                     }
@@ -430,7 +433,8 @@ private suspend fun csaTest(
         csaTestUnguarded(
             algorithm, authRequired, authTypes, passphraseRequired, showToast
         )
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         showToast("${e.message}")
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -390,7 +391,8 @@ fun ConsentPromptScreen(
                             onDocumentsInFocus = documents
                         },
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     e.printStackTrace()
                     showToast("Error evaluating query: $e")
                 } finally {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -228,7 +229,8 @@ fun DcRequestScreen(
                                 zkSystemRepository = app.zkSystemRepository,
                                 showResponse = showResponse
                             )
-                        } catch (error: Throwable) {
+                        } catch (error: Exception) {
+                            if (error is CancellationException) throw error
                             Logger.e(TAG, "Error requesting credentials", error)
                             showToast("Error: ${error.message}")
                         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -196,7 +197,8 @@ fun DocumentStoreScreen(
                             numCredentialsPerDomain = numCredentialsPerDomain.value,
                             showDocumentCreationDialog = showDocumentCreationDialog,
                         )
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         showToast("${e.message}")
                     }
@@ -576,7 +578,8 @@ private suspend fun provisionTestDocuments(
             }
         }
         showProvisioningResult.value = provisioningResult
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         e.printStackTrace()
         showToast("Error provisioning documents: $e")
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocMultiDeviceTestingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocMultiDeviceTestingScreen.kt
@@ -29,6 +29,7 @@ import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.InetSocketAddress
 import io.ktor.network.sockets.Socket
 import io.ktor.network.sockets.aSocket
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
@@ -97,8 +98,9 @@ fun IsoMdocMultiDeviceTestingScreen(
                                     multiDeviceTestClient,
                                     showToast
                                 )
-                            } catch (error: Throwable) {
-                                showToast("Error: ${error.message}")
+                            } catch (e: Exception) {
+                                if (e is CancellationException) throw e
+                                showToast("Error: ${e.message}")
                             }
                         }
                     }
@@ -135,8 +137,9 @@ fun IsoMdocMultiDeviceTestingScreen(
                         multiDeviceTestResults,
                         showToast
                     )
-                } catch (error: Throwable) {
-                    showToast("Error: ${error.message}")
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    showToast("Error: ${e.message}")
                 }
             }
         }
@@ -293,10 +296,11 @@ private suspend fun runMultiDeviceTestsServer(
     multiDeviceTestsServer.value = server
     try {
         server.run()
-    } catch (error: Throwable) {
-        Logger.i(TAG, "Multi-Device Tests failed", error)
-        error.printStackTrace()
-        showToast("Multi-Device-Tests failed: ${error.message}")
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Logger.i(TAG, "Multi-Device Tests failed", e)
+        e.printStackTrace()
+        showToast("Multi-Device-Tests failed: ${e.message}")
     }
     // Keep multiDeviceTestServer around so user has a chance to review the results...
     // multiDeviceTestsServer.value = null
@@ -314,10 +318,11 @@ private suspend fun runMultiDeviceTestsClient(
     multiDeviceTestsClient.value = client
     try {
         client.run()
-    } catch (error: Throwable) {
-        Logger.i(TAG, "Multi-Device Tests failed", error)
-        error.printStackTrace()
-        showToast("Multi-Device-Tests failed: ${error.message}")
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Logger.i(TAG, "Multi-Device Tests failed", e)
+        e.printStackTrace()
+        showToast("Multi-Device-Tests failed: ${e.message}")
     }
     multiDeviceTestsClient.value = null
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -301,7 +302,8 @@ fun IsoMdocProximityReadingScreen(
                                     )
                                 )
                             }
-                        } catch (error: Throwable) {
+                        } catch (error: Exception) {
+                            if (error is CancellationException) throw error
                             Logger.e(TAG, "Caught exception", error)
                             showToast("Error: ${error.message}")
                         }
@@ -392,7 +394,8 @@ fun IsoMdocProximityReadingScreen(
                                             statusCode = null
                                         )
                                     )
-                                } catch (error: Throwable) {
+                                } catch (error: Exception) {
+                                    if (error is CancellationException) throw error
                                     Logger.e(TAG, "Caught exception", error)
                                     showToast("Error: ${error.message}")
                                 }
@@ -410,7 +413,8 @@ fun IsoMdocProximityReadingScreen(
                                         SessionEncryption.encodeStatus(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)
                                     )
                                     readerTransport.value!!.close()
-                                } catch (error: Throwable) {
+                                } catch (error: Exception) {
+                                    if (error is CancellationException) throw error
                                     Logger.e(TAG, "Caught exception", error)
                                     showToast("Error: ${error.message}")
                                 }
@@ -426,7 +430,8 @@ fun IsoMdocProximityReadingScreen(
                                 try {
                                     readerTransport.value!!.sendMessage(byteArrayOf())
                                     readerTransport.value!!.close()
-                                } catch (error: Throwable) {
+                                } catch (error: Exception) {
+                                    if (error is CancellationException) throw error
                                     Logger.e(TAG, "Caught exception", error)
                                     showToast("Error: ${error.message}")
                                 }
@@ -441,7 +446,8 @@ fun IsoMdocProximityReadingScreen(
                             coroutineScope.launch {
                                 try {
                                     readerTransport.value!!.close()
-                                } catch (error: Throwable) {
+                                } catch (error: Exception) {
+                                    if (error is CancellationException) throw error
                                     Logger.e(TAG, "Caught exception", error)
                                     showToast("Error: ${error.message}")
                                 }
@@ -645,7 +651,8 @@ fun IsoMdocProximityReadingScreen(
                                         // when cancelled/dismissed
                                         readerJob = null
                                     }
-                                } catch (e: Throwable) {
+                                } catch (e: Exception) {
+                                    if (e is CancellationException) throw e
                                     Logger.e(TAG, "NFC engagement failed", e)
                                     showToast("NFC engagement failed with $e")
                                     readerJob = null

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -71,7 +72,8 @@ fun NfcReaderScreen(
                             if (!reader.requestPermission()) {
                                 showToast("User did not grant permission")
                             }
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             showToast("Error requesting permission: ${e.message}")
                         }
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -174,7 +175,8 @@ fun NfcScreen(
                             showToast("NDEF CC file: ${ccFile.toHex()}")
                         } catch (e: PromptDismissedException) {
                             showToast("Dialog dismissed by user")
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.e(TAG, "Fail", e)
                             e.printStackTrace()
                             showToast("Fail: ${e.message}")
@@ -212,7 +214,8 @@ fun NfcScreen(
                             showToast("NDEF CC file: ${ccFile.toHex()}")
                         } catch (e: PromptDismissedException) {
                             showToast("Dialog dismissed by user")
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.e(TAG, "Fail", e)
                             e.printStackTrace()
                             showToast("Fail: ${e.message}")
@@ -253,7 +256,8 @@ fun NfcScreen(
                             showToast("NDEF CC file: ${ccFile.toHex()}")
                         } catch (e: PromptDismissedException) {
                             showToast("Dialog dismissed by user")
-                        } catch (e: Throwable) {
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
                             Logger.e(TAG, "Fail", e)
                             e.printStackTrace()
                             showToast("Fail: ${e.message}")

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -141,6 +142,7 @@ private fun StatusListCheckSection(
                                 else -> "Unexpected status $code"
                             }
                         } catch (err: Exception) {
+                            if (err is CancellationException) throw err
                             Logger.e(TAG, "Failed to parse status list", err)
                             statusText.value = "Failed to parse status list"
                         }
@@ -199,6 +201,7 @@ fun IdentifierListCheckSection(
                                 "Valid"
                             }
                         } catch (err: Exception) {
+                            if (err is CancellationException) throw err
                             Logger.e(TAG, "Failed to parse identifier list", err)
                             statusText.value = "Failed to parse identifier list"
                         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -61,7 +62,8 @@ fun SettingsScreen(
                     app.settingsModel.cryptoPreferBouncyCastle.value = it
                     try {
                         TestAppConfiguration.restartApp()
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         showToast("An error occurred: $e")
                     }
                 },

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -135,7 +136,8 @@ fun ShowResponse(
                     issuerTrustManager = issuerTrustManager,
                     onViewCertChain = onViewCertChain
                 )
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Logger.e(TAG, "Error parsing response", e)
                 verificationError.value = e
             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SoftwareSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SoftwareSecureAreaScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
@@ -96,7 +97,8 @@ private suspend fun swTest(
     )
     try {
         swTestUnguarded(softwareSecureArea, algorithm, passphrase, passphraseConstraints, showToast)
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
         e.printStackTrace();
         showToast("${e.message}")
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -178,7 +179,8 @@ fun TrustManagerScreen(
                         )
                     } catch (_: TrustEntryAlreadyExistsException) {
                         showImportErrorDialog.value = "A certificate with this Subject Key Identifier already exists"
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         showImportErrorDialog.value = "Importing certificate failed: $e"
                     }
@@ -213,7 +215,8 @@ fun TrustManagerScreen(
                         onTrustEntryAdded(
                             updatedInfos.find { it.entry.identifier == entry.identifier }!!
                         )
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         showImportErrorDialog.value = "Importing VICAL failed: $e"
                     }
@@ -248,7 +251,8 @@ fun TrustManagerScreen(
                         onTrustEntryAdded(
                             updatedInfos.find { it.entry.identifier == entry.identifier }!!
                         )
-                    } catch (e: Throwable) {
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                         e.printStackTrace()
                         showImportErrorDialog.value = "Importing RICAL failed: $e"
                     }

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
@@ -120,7 +120,7 @@ actual object TestAppConfiguration {
 
         for (address in addresses) {
             if (address.startsWith("192.168") || address.startsWith("10.") || address.startsWith("172.")) {
-                address
+                return@lazy address
             }
         }
         throw IllegalStateException("Unable to determine local address")

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp.ui
 
+import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -123,7 +124,8 @@ private fun seTest(
     coroutineScope.launch {
         try {
             seTestUnguarded(algorithm, userAuthTypes, showToast)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             e.printStackTrace();
             showToast("${e.message}")
         }


### PR DESCRIPTION
We've been doing exceptions wrong. First, update CODING-STYLE.md with how it should be done. Second, go through the entire codebase so it at least doesn't try to catch `Throwable` and when we do catch `Exception`, do the right thing for `CancellationException`.

We still catch `Exception` at a lot of sites and this could probably be tightened up to just catch what we except. Future PRs can address this.

This intentionally doesn't touch `multipaz-android-legacy` at all.

Test: ./gradlew check
Test: Manually tested with Test App including multi-device tests.
