### PR TITLE
multipaz-compose: Only use compose for strings, not Android resources.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/biometrics/showBiometricPrompt.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/biometrics/showBiometricPrompt.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.multipaz.compose.R
+import org.jetbrains.compose.resources.getString
+import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.biometric_prompt_negative_btn_lskf
+import org.multipaz.multipaz_compose.generated.resources.biometric_prompt_negative_btn_no_lskf
 import kotlin.coroutines.resumeWithException
 
 /**
@@ -36,6 +39,8 @@ suspend fun showBiometricPrompt(
     userAuthenticationTypes: Set<UserAuthenticationType>,
     requireConfirmation: Boolean
 ): Boolean {
+    val negativeButtonText = getString(Res.string.biometric_prompt_negative_btn_lskf)
+    val negativeButtonTextNoLskf = getString(Res.string.biometric_prompt_negative_btn_no_lskf)
     // BiometricPrompt must be called from the UI thread.
     return withContext(Dispatchers.Main) {
         suspendCancellableCoroutine { continuation ->
@@ -44,6 +49,8 @@ suspend fun showBiometricPrompt(
                 activity = activity,
                 title = title,
                 subtitle = subtitle,
+                negativeButtonText = negativeButtonText,
+                negativeButtonTextNoLskf = negativeButtonTextNoLskf,
                 userAuthenticationTypes = userAuthenticationTypes,
                 requireConfirmation = requireConfirmation,
                 onSuccess = { continuation.resume(true, null) },
@@ -58,6 +65,8 @@ private fun showBiometricPromptAsync(
     activity: FragmentActivity,
     title: String,
     subtitle: String,
+    negativeButtonText: String,
+    negativeButtonTextNoLskf: String,
     cryptoObject: CryptoObject?,
     userAuthenticationTypes: Set<UserAuthenticationType>,
     requireConfirmation: Boolean,
@@ -76,6 +85,8 @@ private fun showBiometricPromptAsync(
         activity = activity,
         title = title,
         subtitle = subtitle,
+        negativeButtonText = negativeButtonText,
+        negativeButtonTextNoLskf = negativeButtonTextNoLskf,
         cryptoObject = cryptoObject,
         userAuthenticationTypes = userAuthenticationTypes,
         requireConfirmation = requireConfirmation,
@@ -89,6 +100,8 @@ private class ShowBiometricPrompt(
     private val activity: FragmentActivity,
     private val title: String,
     private val subtitle: String,
+    private val negativeButtonText: String,
+    private val negativeButtonTextNoLskf: String,
     private val cryptoObject: CryptoObject?,
     private val userAuthenticationTypes: Set<UserAuthenticationType>,
     private val requireConfirmation: Boolean,
@@ -149,10 +162,9 @@ private class ShowBiometricPrompt(
     private fun authenticateBiometric() {
         val negativeTxt =
             if (lskfOnNegativeBtn) {
-                activity.applicationContext.resources.getString(R.string.biometric_prompt_negative_btn_lskf)
-            }
-            else {
-                activity.applicationContext.resources.getString(R.string.biometric_prompt_negative_btn_no_lskf)
+                negativeButtonText
+            } else {
+                negativeButtonTextNoLskf
             }
 
         val biometricPromptInfo = BiometricPrompt.PromptInfo.Builder()

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/nfc/NfcTagReaderModalBottomSheet.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/nfc/NfcTagReaderModalBottomSheet.kt
@@ -16,11 +16,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import org.multipaz.compose.R
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.nfc_tag_reader_modal_bottom_sheet_cancel
+import org.multipaz.multipaz_compose.generated.resources.nfc_tag_reader_modal_bottom_sheet_ready_to_scan
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,7 +45,7 @@ fun NfcTagReaderModalBottomSheet(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = stringResource(R.string.nfc_tag_reader_modal_bottom_sheet_ready_to_scan),
+                text = stringResource(Res.string.nfc_tag_reader_modal_bottom_sheet_ready_to_scan),
                 fontWeight = FontWeight.Bold,
                 style = MaterialTheme.typography.headlineLarge,
             )
@@ -60,7 +62,7 @@ fun NfcTagReaderModalBottomSheet(
             FilledTonalButton(
                 onClick = { onDismissed() }
             ) {
-                Text(text = stringResource(R.string.nfc_tag_reader_modal_bottom_sheet_cancel))
+                Text(text = stringResource(Res.string.nfc_tag_reader_modal_bottom_sheet_cancel))
             }
         }
     }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -72,7 +72,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
-import org.multipaz.compose.R
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.branding.Branding
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.document.VerticalDocumentList
@@ -81,6 +81,15 @@ import org.multipaz.context.applicationContext
 import org.multipaz.context.initializeApplication
 import org.multipaz.document.Document
 import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_app_name_default
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_canceled
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_cannot_satisfy_request
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_connecting_to_reader
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_hold_to_reader
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_info_was_shared
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_no_documents_available
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_open_wallet
+import org.multipaz.multipaz_compose.generated.resources.presentment_activity_something_went_wrong
 import org.multipaz.presentment.DocumentChooserData
 import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentCannotSatisfyRequestException
@@ -444,9 +453,9 @@ internal fun PresentmentActivityContent(
                                         ) {
                                             Text(
                                                 modifier = Modifier.padding(vertical = 8.dp),
-                                                text = applicationContext.getString(
-                                                    R.string.presentment_activity_open_wallet,
-                                                    currentBranding.appName ?: R.string.presentment_activity_app_name_default
+                                                text = stringResource(
+                                                    Res.string.presentment_activity_open_wallet,
+                                                    currentBranding.appName ?: Res.string.presentment_activity_app_name_default
                                                 ),
                                                 style = MaterialTheme.typography.titleMedium
                                             )
@@ -484,21 +493,21 @@ internal fun PresentmentActivityContent(
                                             when (state.error!!) {
                                                 is PresentmentCanceledException -> {
                                                     if (state.error!!.message != null) {
-                                                        ShowFailure(applicationContext.getString(
-                                                            R.string.presentment_activity_canceled
+                                                        ShowFailure(stringResource(
+                                                            Res.string.presentment_activity_canceled
                                                         ))
                                                     } else {
                                                         startFadeOut = true
                                                     }
                                                 }
                                                 is PresentmentCannotSatisfyRequestException -> {
-                                                    ShowFailure(applicationContext.getString(
-                                                        R.string.presentment_activity_cannot_satisfy_request
+                                                    ShowFailure(stringResource(
+                                                        Res.string.presentment_activity_cannot_satisfy_request
                                                     ))
                                                 }
                                                 else -> {
-                                                    ShowFailure(applicationContext.getString(
-                                                        R.string.presentment_activity_something_went_wrong
+                                                    ShowFailure(stringResource(
+                                                        Res.string.presentment_activity_something_went_wrong
                                                     ))
                                                 }
                                             }
@@ -578,8 +587,8 @@ private fun ShowCardChooser(
         cardMaxHeight = maxCardHeight,
         showDocumentInfo = { documentInfo -> contentBelow() },
         emptyDocumentContent = {
-            Text(applicationContext.getString(
-                R.string.presentment_activity_no_documents_available
+            Text(stringResource(
+                Res.string.presentment_activity_no_documents_available
             ))
         },
         onDocumentFocused = { documentInfo ->
@@ -600,7 +609,7 @@ private fun ShowCardChooser(
 @Composable
 private fun ShowShared() {
     ShowLottieAnimation(
-        message = applicationContext.getString(R.string.presentment_activity_info_was_shared),
+        message = stringResource(Res.string.presentment_activity_info_was_shared),
         animationPath = "files/success_animation.json",
         repeat = false
     )
@@ -628,7 +637,7 @@ private fun ShowWaiting() {
 private fun ShowHoldToReader() {
     val isDarkTheme = isSystemInDarkTheme()
     ShowLottieAnimation(
-        message = applicationContext.getString(R.string.presentment_activity_hold_to_reader),
+        message = stringResource(Res.string.presentment_activity_hold_to_reader),
         animationPath = if (isDarkTheme) {
             "files/nfc_animation_dark.json"
         } else {
@@ -642,7 +651,7 @@ private fun ShowHoldToReader() {
 private fun ShowConnectingToReader() {
     val isDarkTheme = isSystemInDarkTheme()
     ShowLottieAnimation(
-        message = applicationContext.getString(R.string.presentment_activity_connecting_to_reader),
+        message = stringResource(Res.string.presentment_activity_connecting_to_reader),
         animationPath = if (isDarkTheme) {
             "files/nfc_animation_dark.json"
         } else {

--- a/multipaz-compose/src/androidMain/res/values/strings.xml
+++ b/multipaz-compose/src/androidMain/res/values/strings.xml
@@ -1,22 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- showBiometricPrompt.kt -->
-    <string name="biometric_prompt_negative_btn_lskf">Use PIN</string>
-    <string name="biometric_prompt_negative_btn_no_lskf">Cancel</string>
-
-    <!-- NfcTagReaderModalBottomSheet -->
-    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Ready to Scan</string>
-    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Cancel</string>
-
-    <!-- PresentmentActivity -->
-    <string name="presentment_activity_hold_to_reader">Hold to reader</string>
-    <string name="presentment_activity_connecting_to_reader">Connecting to reader</string>
-    <string name="presentment_activity_info_was_shared">The info was shared</string>
-    <string name="presentment_activity_something_went_wrong">Something went wrong</string>
-    <string name="presentment_activity_canceled">Cancelled</string>
-    <string name="presentment_activity_cannot_satisfy_request">Cannot satisfy request</string>
-    <string name="presentment_activity_open_wallet">Open %1$s</string>
-    <string name="presentment_activity_app_name_default">Wallet</string>
-    <string name="presentment_activity_no_documents_available">No documents available</string>
-
+    <!-- DO NOT USE - use Compose Multiplatform resources instead since those are translated -->
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ar/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ar/strings.xml
@@ -212,4 +212,24 @@
         <item quantity="few">RICAL يتضمن %1$d شهادات</item>
         <item quantity="many">RICAL يتضمن %1$d شهادات</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">استخدام رمز PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">إلغاء</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">جاهز للمسح الضوئي</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">إلغاء</string>
+    <string name="presentment_activity_hold_to_reader">امسك بالقارئ</string>
+    <string name="presentment_activity_connecting_to_reader">جارٍ الاتصال بالقارئ</string>
+    <string name="presentment_activity_info_was_shared">تمت مشاركة المعلومات</string>
+    <string name="presentment_activity_something_went_wrong">حدث خطأ ما</string>
+    <string name="presentment_activity_canceled">تم الإلغاء</string>
+    <string name="presentment_activity_cannot_satisfy_request">تعذر تلبية الطلب</string>
+    <string name="presentment_activity_open_wallet">فتح %1$s</string>
+    <string name="presentment_activity_app_name_default">المحفظة</string>
+    <string name="presentment_activity_no_documents_available">لا توجد مستندات متاحة</string>
+    <string name="trust_entry_extensions">الإضافات</string>
+    <string name="trust_entry_vical_details_valid_until">صالح حتى</string>
+    <string name="trust_entry_vical_details_update_url">رابط التحديث</string>
+    <string name="trust_entry_rical_entry_title">إدخال RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">مرسى الثقة</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">نعم</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">لا</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-cs/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-cs/strings.xml
@@ -180,4 +180,24 @@
         <item quantity="one">RICAL obsahující %1$d certifikát</item>
         <item quantity="other">RICAL obsahující %1$d certifikátů</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Použít PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Zrušit</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Připraveno ke skenování</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Zrušit</string>
+    <string name="presentment_activity_hold_to_reader">Přiložte ke čtečce</string>
+    <string name="presentment_activity_connecting_to_reader">Připojování ke čtečce</string>
+    <string name="presentment_activity_info_was_shared">Informace byly sdíleny</string>
+    <string name="presentment_activity_something_went_wrong">Něco se pokazilo</string>
+    <string name="presentment_activity_canceled">Zrušeno</string>
+    <string name="presentment_activity_cannot_satisfy_request">Nelze vyhovět požadavku</string>
+    <string name="presentment_activity_open_wallet">Otevřít %1$s</string>
+    <string name="presentment_activity_app_name_default">Peněženka</string>
+    <string name="presentment_activity_no_documents_available">Žádné dokumenty nejsou k dispozici</string>
+    <string name="trust_entry_extensions">Rozšíření</string>
+    <string name="trust_entry_vical_details_valid_until">Platné do</string>
+    <string name="trust_entry_vical_details_update_url">Adresa URL pro aktualizaci</string>
+    <string name="trust_entry_rical_entry_title">Položka RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Důvěryhodná kotva</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ano</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Ne</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-da/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-da/strings.xml
@@ -170,4 +170,24 @@
         <item quantity="one">RICAL indeholdende %1$d certifikat</item>
         <item quantity="other">RICAL indeholdende %1$d certifikater</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Brug pinkode</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Annuller</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Klar til scanning</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Annuller</string>
+    <string name="presentment_activity_hold_to_reader">Hold mod læser</string>
+    <string name="presentment_activity_connecting_to_reader">Opretter forbindelse til læser</string>
+    <string name="presentment_activity_info_was_shared">Oplysningerne blev delt</string>
+    <string name="presentment_activity_something_went_wrong">Noget gik galt</string>
+    <string name="presentment_activity_canceled">Annulleret</string>
+    <string name="presentment_activity_cannot_satisfy_request">Kan ikke imødekomme anmodning</string>
+    <string name="presentment_activity_open_wallet">Åbn %1$s</string>
+    <string name="presentment_activity_app_name_default">Pung</string>
+    <string name="presentment_activity_no_documents_available">Ingen dokumenter tilgængelige</string>
+    <string name="trust_entry_extensions">Udvidelser</string>
+    <string name="trust_entry_vical_details_valid_until">Gyldig til</string>
+    <string name="trust_entry_vical_details_update_url">Opdaterings-URL</string>
+    <string name="trust_entry_rical_entry_title">RICAL-post</string>
+    <string name="trust_entry_rical_is_trust_anchor">Tillidsanker</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ja</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Nej</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-de/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-de/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL enthält %1$d Zertifikat</item>
         <item quantity="other">RICAL enthält %1$d Zertifikate</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">PIN verwenden</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Abbrechen</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Bereit zum Scannen</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Abbrechen</string>
+    <string name="presentment_activity_hold_to_reader">An Lesegerät halten</string>
+    <string name="presentment_activity_connecting_to_reader">Verbindung zum Lesegerät wird hergestellt</string>
+    <string name="presentment_activity_info_was_shared">Die Infos wurden geteilt</string>
+    <string name="presentment_activity_something_went_wrong">Etwas ist schiefgelaufen</string>
+    <string name="presentment_activity_canceled">Abgebrochen</string>
+    <string name="presentment_activity_cannot_satisfy_request">Anfrage kann nicht erfüllt werden</string>
+    <string name="presentment_activity_open_wallet">Öffnen Sie %1$s</string>
+    <string name="presentment_activity_app_name_default">Wallet</string>
+    <string name="presentment_activity_no_documents_available">Keine Dokumente verfügbar</string>
+    <string name="trust_entry_extensions">Erweiterungen</string>
+    <string name="trust_entry_vical_details_valid_until">Gültig bis</string>
+    <string name="trust_entry_vical_details_update_url">Update-URL</string>
+    <string name="trust_entry_rical_entry_title">RICAL-Eintrag</string>
+    <string name="trust_entry_rical_is_trust_anchor">Vertrauensanker</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ja</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Nein</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-el/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-el/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL που περιέχει %1$d πιστοποιητικό</item>
         <item quantity="other">RICAL που περιέχει %1$d πιστοποιητικά</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Χρήση PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Ακύρωση</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Έτοιμο για σάρωση</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Ακύρωση</string>
+    <string name="presentment_activity_hold_to_reader">Κρατήστε στον αναγνώστη</string>
+    <string name="presentment_activity_connecting_to_reader">Σύνδεση με αναγνώστη</string>
+    <string name="presentment_activity_info_was_shared">Οι πληροφορίες κοινοποιήθηκαν</string>
+    <string name="presentment_activity_something_went_wrong">Κάτι πήγε στραβά</string>
+    <string name="presentment_activity_canceled">Ακυρώθηκε</string>
+    <string name="presentment_activity_cannot_satisfy_request">Δεν είναι δυνατή η ικανοποίηση του αιτήματος</string>
+    <string name="presentment_activity_open_wallet">Άνοιγμα %1$s</string>
+    <string name="presentment_activity_app_name_default">Πορτοφόλι</string>
+    <string name="presentment_activity_no_documents_available">Δεν υπάρχουν διαθέσιμα έγγραφα</string>
+    <string name="trust_entry_extensions">Επεκτάσεις</string>
+    <string name="trust_entry_vical_details_valid_until">Ισχύει έως</string>
+    <string name="trust_entry_vical_details_update_url">URL ενημέρωσης</string>
+    <string name="trust_entry_rical_entry_title">Καταχώριση RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Άγκυρα εμπιστοσύνης</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ναι</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Όχι</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-es/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-es/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL que contiene %1$d certificado</item>
         <item quantity="other">RICAL que contiene %1$d certificados</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Usar PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Cancelar</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Listo para escanear</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Cancelar</string>
+    <string name="presentment_activity_hold_to_reader">Acerca al lector</string>
+    <string name="presentment_activity_connecting_to_reader">Conectando al lector</string>
+    <string name="presentment_activity_info_was_shared">Se compartió la información</string>
+    <string name="presentment_activity_something_went_wrong">Algo salió mal</string>
+    <string name="presentment_activity_canceled">Cancelado</string>
+    <string name="presentment_activity_cannot_satisfy_request">No se puede satisfacer la solicitud</string>
+    <string name="presentment_activity_open_wallet">Abrir %1$s</string>
+    <string name="presentment_activity_app_name_default">Billetera</string>
+    <string name="presentment_activity_no_documents_available">No hay documentos disponibles</string>
+    <string name="trust_entry_extensions">Extensiones</string>
+    <string name="trust_entry_vical_details_valid_until">Válido hasta</string>
+    <string name="trust_entry_vical_details_update_url">URL de actualización</string>
+    <string name="trust_entry_rical_entry_title">Entrada RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Ancla de confianza</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Sí</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">No</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-fr/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-fr/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL contenant %1$d certificat</item>
         <item quantity="other">RICAL contenant %1$d certificats</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Utiliser le code PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Annuler</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Prêt à scanner</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Annuler</string>
+    <string name="presentment_activity_hold_to_reader">Approcher du lecteur</string>
+    <string name="presentment_activity_connecting_to_reader">Connexion au lecteur</string>
+    <string name="presentment_activity_info_was_shared">Les informations ont été partagées</string>
+    <string name="presentment_activity_something_went_wrong">Une erreur est survenue</string>
+    <string name="presentment_activity_canceled">Annulé</string>
+    <string name="presentment_activity_cannot_satisfy_request">Impossible de satisfaire la demande</string>
+    <string name="presentment_activity_open_wallet">Ouvrir %1$s</string>
+    <string name="presentment_activity_app_name_default">Portefeuille</string>
+    <string name="presentment_activity_no_documents_available">Aucun document disponible</string>
+    <string name="trust_entry_extensions">Extensions</string>
+    <string name="trust_entry_vical_details_valid_until">Valide jusqu'au</string>
+    <string name="trust_entry_vical_details_update_url">URL de mise à jour</string>
+    <string name="trust_entry_rical_entry_title">Entrée RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Ancre de confiance</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Oui</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Non</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-he/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-he/strings.xml
@@ -188,4 +188,24 @@
         <item quantity="one">RICAL מכיל %1$d תעודה</item>
         <item quantity="other">RICAL מכיל %1$d תעודות</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">השתמש ב-PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">ביטול</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">מוכן לסריקה</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">ביטול</string>
+    <string name="presentment_activity_hold_to_reader">החזק ליד הקורא</string>
+    <string name="presentment_activity_connecting_to_reader">מתחבר לקורא</string>
+    <string name="presentment_activity_info_was_shared">המידע שותף</string>
+    <string name="presentment_activity_something_went_wrong">משהו השתבש</string>
+    <string name="presentment_activity_canceled">בוטל</string>
+    <string name="presentment_activity_cannot_satisfy_request">לא ניתן למלא את הבקשה</string>
+    <string name="presentment_activity_open_wallet">לפתוח את %1$s</string>
+    <string name="presentment_activity_app_name_default">ארנק</string>
+    <string name="presentment_activity_no_documents_available">אין מסמכים זמינים</string>
+    <string name="trust_entry_extensions">הרחבות</string>
+    <string name="trust_entry_vical_details_valid_until">תקף עד</string>
+    <string name="trust_entry_vical_details_update_url">כתובת אתר עדכון</string>
+    <string name="trust_entry_rical_entry_title">רשומת RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">עוגן אמון</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">כן</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">לא</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-hi/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-hi/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL में %1$d प्रमाणपत्र</item>
         <item quantity="other">RICAL में %1$d प्रमाणपत्र</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">पिन का उपयोग करें</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">रद्द करें</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">स्कैन करने के लिए तैयार</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">रद्द करें</string>
+    <string name="presentment_activity_hold_to_reader">रीडर के पास रखें</string>
+    <string name="presentment_activity_connecting_to_reader">रीडर से कनेक्ट हो रहा है</string>
+    <string name="presentment_activity_info_was_shared">जानकारी साझा की गई</string>
+    <string name="presentment_activity_something_went_wrong">कुछ गड़बड़ हो गई</string>
+    <string name="presentment_activity_canceled">रद्द किया गया</string>
+    <string name="presentment_activity_cannot_satisfy_request">अनुरोध पूरा नहीं किया जा सकता</string>
+    <string name="presentment_activity_open_wallet">खोलें %1$s</string>
+    <string name="presentment_activity_app_name_default">वॉलेट</string>
+    <string name="presentment_activity_no_documents_available">कोई दस्तावेज़ उपलब्ध नहीं</string>
+    <string name="trust_entry_extensions">एक्सटेंशन</string>
+    <string name="trust_entry_vical_details_valid_until">तक वैध</string>
+    <string name="trust_entry_vical_details_update_url">अपडेट यूआरएल</string>
+    <string name="trust_entry_rical_entry_title">रिकल एंट्री</string>
+    <string name="trust_entry_rical_is_trust_anchor">ट्रस्ट एंकर</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">हाँ</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">नहीं</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-id/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-id/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL berisi %1$d sertifikat</item>
         <item quantity="other">RICAL berisi %1$d sertifikat</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Gunakan PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Batal</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Siap Memindai</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Batal</string>
+    <string name="presentment_activity_hold_to_reader">Dekatkan ke pembaca</string>
+    <string name="presentment_activity_connecting_to_reader">Menghubungkan ke pembaca</string>
+    <string name="presentment_activity_info_was_shared">Informasi berhasil dibagikan</string>
+    <string name="presentment_activity_something_went_wrong">Terjadi kesalahan</string>
+    <string name="presentment_activity_canceled">Dibatalkan</string>
+    <string name="presentment_activity_cannot_satisfy_request">Tidak dapat memenuhi permintaan</string>
+    <string name="presentment_activity_open_wallet">Buka %1$s</string>
+    <string name="presentment_activity_app_name_default">Dompet</string>
+    <string name="presentment_activity_no_documents_available">Tidak ada dokumen yang tersedia</string>
+    <string name="trust_entry_extensions">Ekstensi</string>
+    <string name="trust_entry_vical_details_valid_until">Berlaku hingga</string>
+    <string name="trust_entry_vical_details_update_url">URL Pembaruan</string>
+    <string name="trust_entry_rical_entry_title">Entri RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Jangkar kepercayaan</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ya</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Tidak</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-it/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-it/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL contenente %1$d certificato</item>
         <item quantity="other">RICAL contenente %1$d certificati</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Usa PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Annulla</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Pronto per la scansione</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Annulla</string>
+    <string name="presentment_activity_hold_to_reader">Avvicina al lettore</string>
+    <string name="presentment_activity_connecting_to_reader">Connessione al lettore</string>
+    <string name="presentment_activity_info_was_shared">Le informazioni sono state condivise</string>
+    <string name="presentment_activity_something_went_wrong">Qualcosa è andato storto</string>
+    <string name="presentment_activity_canceled">Annullato</string>
+    <string name="presentment_activity_cannot_satisfy_request">Impossibile soddisfare la richiesta</string>
+    <string name="presentment_activity_open_wallet">Apri %1$s</string>
+    <string name="presentment_activity_app_name_default">Wallet</string>
+    <string name="presentment_activity_no_documents_available">Nessun documento disponibile</string>
+    <string name="trust_entry_extensions">Estensioni</string>
+    <string name="trust_entry_vical_details_valid_until">Valido fino a</string>
+    <string name="trust_entry_vical_details_update_url">Aggiorna URL</string>
+    <string name="trust_entry_rical_entry_title">Voce RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Ancora di fiducia</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Sì</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">No</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ja/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ja/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL containing %1$d certificate</item>
         <item quantity="other">RICAL: %1$d 個の証明書を格納</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">PINを使用</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">キャンセル</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">スキャン準備完了</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">キャンセル</string>
+    <string name="presentment_activity_hold_to_reader">リーダーにかざしてください</string>
+    <string name="presentment_activity_connecting_to_reader">リーダーに接続中</string>
+    <string name="presentment_activity_info_was_shared">情報が共有されました</string>
+    <string name="presentment_activity_something_went_wrong">問題が発生しました</string>
+    <string name="presentment_activity_canceled">キャンセルされました</string>
+    <string name="presentment_activity_cannot_satisfy_request">リクエストに応じられません</string>
+    <string name="presentment_activity_open_wallet">%1$sを開く</string>
+    <string name="presentment_activity_app_name_default">ウォレット</string>
+    <string name="presentment_activity_no_documents_available">利用可能な書類はありません</string>
+    <string name="trust_entry_extensions">拡張機能</string>
+    <string name="trust_entry_vical_details_valid_until">有効期限</string>
+    <string name="trust_entry_vical_details_update_url">更新URL</string>
+    <string name="trust_entry_rical_entry_title">RICALエントリ</string>
+    <string name="trust_entry_rical_is_trust_anchor">トラストアンカー</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">はい</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">いいえ</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ko/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ko/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL containing %1$d certificate</item>
         <item quantity="other">RICAL에 인증서 %1$d개 포함</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">PIN 사용</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">취소</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">스캔 준비 완료</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">취소</string>
+    <string name="presentment_activity_hold_to_reader">리더기에 대세요</string>
+    <string name="presentment_activity_connecting_to_reader">리더기에 연결 중</string>
+    <string name="presentment_activity_info_was_shared">정보가 공유되었습니다</string>
+    <string name="presentment_activity_something_went_wrong">문제가 발생했습니다</string>
+    <string name="presentment_activity_canceled">취소됨</string>
+    <string name="presentment_activity_cannot_satisfy_request">요청을 처리할 수 없습니다</string>
+    <string name="presentment_activity_open_wallet">%1$s 열기</string>
+    <string name="presentment_activity_app_name_default">지갑</string>
+    <string name="presentment_activity_no_documents_available">사용 가능한 문서 없음</string>
+    <string name="trust_entry_extensions">확장 기능</string>
+    <string name="trust_entry_vical_details_valid_until">유효 기한</string>
+    <string name="trust_entry_vical_details_update_url">업데이트 URL</string>
+    <string name="trust_entry_rical_entry_title">RICAL 항목</string>
+    <string name="trust_entry_rical_is_trust_anchor">신뢰 앵커</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">예</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">아니요</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-nl/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-nl/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL bevat %1$d certificaat</item>
         <item quantity="other">RICAL bevat %1$d certificaten</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">PIN gebruiken</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Annuleren</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Klaar om te scannen</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Annuleren</string>
+    <string name="presentment_activity_hold_to_reader">Houd bij de lezer</string>
+    <string name="presentment_activity_connecting_to_reader">Verbinden met lezer</string>
+    <string name="presentment_activity_info_was_shared">De info is gedeeld</string>
+    <string name="presentment_activity_something_went_wrong">Er is iets misgegaan</string>
+    <string name="presentment_activity_canceled">Geannuleerd</string>
+    <string name="presentment_activity_cannot_satisfy_request">Kan verzoek niet voltooien</string>
+    <string name="presentment_activity_open_wallet">Open %1$s</string>
+    <string name="presentment_activity_app_name_default">Portemonnee</string>
+    <string name="presentment_activity_no_documents_available">Geen documenten beschikbaar</string>
+    <string name="trust_entry_extensions">Extensies</string>
+    <string name="trust_entry_vical_details_valid_until">Geldig tot</string>
+    <string name="trust_entry_vical_details_update_url">Update-URL</string>
+    <string name="trust_entry_rical_entry_title">RICAL-item</string>
+    <string name="trust_entry_rical_is_trust_anchor">Vertrouwensanker</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Ja</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Nee</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-pl/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-pl/strings.xml
@@ -192,4 +192,24 @@
         <item quantity="few">RICAL zawierający %1$d certyfikaty</item>
         <item quantity="many">RICAL zawierający %1$d certyfikatów</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Użyj kodu PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Anuluj</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Gotowe do skanowania</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Anuluj</string>
+    <string name="presentment_activity_hold_to_reader">Przytrzymaj przy czytniku</string>
+    <string name="presentment_activity_connecting_to_reader">Łączę z czytnikiem</string>
+    <string name="presentment_activity_info_was_shared">Informacje zostały udostępnione</string>
+    <string name="presentment_activity_something_went_wrong">Coś poszło nie tak</string>
+    <string name="presentment_activity_canceled">Anulowano</string>
+    <string name="presentment_activity_cannot_satisfy_request">Nie można zrealizować żądania</string>
+    <string name="presentment_activity_open_wallet">Otwórz %1$s</string>
+    <string name="presentment_activity_app_name_default">Portfel</string>
+    <string name="presentment_activity_no_documents_available">Brak dostępnych dokumentów</string>
+    <string name="trust_entry_extensions">Rozszerzenia</string>
+    <string name="trust_entry_vical_details_valid_until">Ważne do</string>
+    <string name="trust_entry_vical_details_update_url">Adres URL aktualizacji</string>
+    <string name="trust_entry_rical_entry_title">Wpis RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Kotwica zaufania</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Tak</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Nie</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-pt/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-pt/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL contendo %1$d certificado</item>
         <item quantity="other">RICAL contendo %1$d certificados</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Usar PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Cancelar</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Pronto para Ler</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Cancelar</string>
+    <string name="presentment_activity_hold_to_reader">Aproxime do leitor</string>
+    <string name="presentment_activity_connecting_to_reader">Conectando ao leitor</string>
+    <string name="presentment_activity_info_was_shared">As informações foram compartilhadas</string>
+    <string name="presentment_activity_something_went_wrong">Algo deu errado</string>
+    <string name="presentment_activity_canceled">Cancelado</string>
+    <string name="presentment_activity_cannot_satisfy_request">Não foi possível atender à solicitação</string>
+    <string name="presentment_activity_open_wallet">Abrir %1$s</string>
+    <string name="presentment_activity_app_name_default">Carteira</string>
+    <string name="presentment_activity_no_documents_available">Nenhum documento disponível</string>
+    <string name="trust_entry_extensions">Extensões</string>
+    <string name="trust_entry_vical_details_valid_until">Válido até</string>
+    <string name="trust_entry_vical_details_update_url">URL de atualização</string>
+    <string name="trust_entry_rical_entry_title">Entrada RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Âncora de confiança</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Sim</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Não</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ru/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ru/strings.xml
@@ -192,4 +192,24 @@
         <item quantity="few">RICAL, содержащий %1$d сертификата</item>
         <item quantity="many">RICAL, содержащий %1$d сертификатов</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Использовать PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Отмена</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Готово к сканированию</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Отмена</string>
+    <string name="presentment_activity_hold_to_reader">Приложите к считывателю</string>
+    <string name="presentment_activity_connecting_to_reader">Подключение к считывателю</string>
+    <string name="presentment_activity_info_was_shared">Информация была передана</string>
+    <string name="presentment_activity_something_went_wrong">Что-то пошло не так</string>
+    <string name="presentment_activity_canceled">Отменено</string>
+    <string name="presentment_activity_cannot_satisfy_request">Не удалось выполнить запрос</string>
+    <string name="presentment_activity_open_wallet">Открыть %1$s</string>
+    <string name="presentment_activity_app_name_default">Кошелек</string>
+    <string name="presentment_activity_no_documents_available">Документы недоступны</string>
+    <string name="trust_entry_extensions">Расширения</string>
+    <string name="trust_entry_vical_details_valid_until">Действительно до</string>
+    <string name="trust_entry_vical_details_update_url">URL-адрес обновления</string>
+    <string name="trust_entry_rical_entry_title">Запись RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Якорь доверия</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Да</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Нет</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-th/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-th/strings.xml
@@ -164,4 +164,24 @@
         <item quantity="one">RICAL containing %1$d certificate</item>
         <item quantity="other">RICAL บรรจุใบรับรอง %1$d ใบ</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">ใช้ PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">ยกเลิก</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">พร้อมสแกน</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">ยกเลิก</string>
+    <string name="presentment_activity_hold_to_reader">แตะกับเครื่องอ่าน</string>
+    <string name="presentment_activity_connecting_to_reader">กำลังเชื่อมต่อกับเครื่องอ่าน</string>
+    <string name="presentment_activity_info_was_shared">แชร์ข้อมูลแล้ว</string>
+    <string name="presentment_activity_something_went_wrong">เกิดข้อผิดพลาด</string>
+    <string name="presentment_activity_canceled">ยกเลิกแล้ว</string>
+    <string name="presentment_activity_cannot_satisfy_request">ไม่สามารถดำเนินการตามคำขอได้</string>
+    <string name="presentment_activity_open_wallet">เปิด %1$s</string>
+    <string name="presentment_activity_app_name_default">กระเป๋าสตางค์</string>
+    <string name="presentment_activity_no_documents_available">ไม่มีเอกสารให้ใช้งาน</string>
+    <string name="trust_entry_extensions">ส่วนขยาย</string>
+    <string name="trust_entry_vical_details_valid_until">ใช้ได้ถึง</string>
+    <string name="trust_entry_vical_details_update_url">อัปเดต URL</string>
+    <string name="trust_entry_rical_entry_title">รายการ RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">จุดยึดความน่าเชื่อถือ</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">ใช่</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">ไม่</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-tr/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-tr/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL, %1$d sertifika içeren</item>
         <item quantity="other">RICAL, %1$d sertifika içeren</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">PIN kullan</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">İptal</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Taramaya Hazır</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">İptal</string>
+    <string name="presentment_activity_hold_to_reader">Okuyucuya Yaklaştırın</string>
+    <string name="presentment_activity_connecting_to_reader">Okuyucuya Bağlanılıyor</string>
+    <string name="presentment_activity_info_was_shared">Bilgiler paylaşıldı</string>
+    <string name="presentment_activity_something_went_wrong">Bir şeyler yanlış gitti</string>
+    <string name="presentment_activity_canceled">İptal Edildi</string>
+    <string name="presentment_activity_cannot_satisfy_request">İstek karşılanamıyor</string>
+    <string name="presentment_activity_open_wallet">%1$s'i Aç</string>
+    <string name="presentment_activity_app_name_default">Cüzdan</string>
+    <string name="presentment_activity_no_documents_available">Belge yok</string>
+    <string name="trust_entry_extensions">Uzantılar</string>
+    <string name="trust_entry_vical_details_valid_until">Şu tarihe kadar geçerli</string>
+    <string name="trust_entry_vical_details_update_url">Güncelleme URL'si</string>
+    <string name="trust_entry_rical_entry_title">RICAL girişi</string>
+    <string name="trust_entry_rical_is_trust_anchor">Güven çapası</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Evet</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Hayır</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-uk/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-uk/strings.xml
@@ -192,4 +192,24 @@
         <item quantity="few">RICAL, що містить %1$d сертифікати</item>
         <item quantity="many">RICAL, що містить %1$d сертифікатів</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Використати PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Скасувати</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Готово до сканування</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Скасувати</string>
+    <string name="presentment_activity_hold_to_reader">Піднесіть до зчитувача</string>
+    <string name="presentment_activity_connecting_to_reader">Підключення до зчитувача</string>
+    <string name="presentment_activity_info_was_shared">Інформацію було передано</string>
+    <string name="presentment_activity_something_went_wrong">Щось пішло не так</string>
+    <string name="presentment_activity_canceled">Скасовано</string>
+    <string name="presentment_activity_cannot_satisfy_request">Не вдається виконати запит</string>
+    <string name="presentment_activity_open_wallet">Відкрити %1$s</string>
+    <string name="presentment_activity_app_name_default">Гаманець</string>
+    <string name="presentment_activity_no_documents_available">Немає доступних документів</string>
+    <string name="trust_entry_extensions">Розширення</string>
+    <string name="trust_entry_vical_details_valid_until">Дійсний до</string>
+    <string name="trust_entry_vical_details_update_url">URL оновлення</string>
+    <string name="trust_entry_rical_entry_title">Запис RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Якір довіри</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Так</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Ні</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-vi/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-vi/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL containing %1$d certificate</item>
         <item quantity="other">RICAL chứa %1$d chứng chỉ</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">Dùng mã PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Hủy</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Sẵn sàng quét</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Hủy</string>
+    <string name="presentment_activity_hold_to_reader">Giữ gần đầu đọc</string>
+    <string name="presentment_activity_connecting_to_reader">Đang kết nối với đầu đọc</string>
+    <string name="presentment_activity_info_was_shared">Thông tin đã được chia sẻ</string>
+    <string name="presentment_activity_something_went_wrong">Đã xảy ra lỗi</string>
+    <string name="presentment_activity_canceled">Đã hủy</string>
+    <string name="presentment_activity_cannot_satisfy_request">Không thể xử lý yêu cầu</string>
+    <string name="presentment_activity_open_wallet">Mở %1$s</string>
+    <string name="presentment_activity_app_name_default">Ví</string>
+    <string name="presentment_activity_no_documents_available">Không có tài liệu nào</string>
+    <string name="trust_entry_extensions">Phần mở rộng</string>
+    <string name="trust_entry_vical_details_valid_until">Có hiệu lực đến</string>
+    <string name="trust_entry_vical_details_update_url">URL cập nhật</string>
+    <string name="trust_entry_rical_entry_title">Mục RICAL</string>
+    <string name="trust_entry_rical_is_trust_anchor">Neo tin cậy</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">Có</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">Không</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -172,4 +172,24 @@
         <item quantity="one">RICAL containing %1$d certificate</item>
         <item quantity="other">RICAL 包含 %1$d 个证书</item>
     </plurals>
+    <string name="biometric_prompt_negative_btn_lskf">使用 PIN 码</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">取消</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">准备扫描</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">取消</string>
+    <string name="presentment_activity_hold_to_reader">靠近读卡器</string>
+    <string name="presentment_activity_connecting_to_reader">正在连接读卡器</string>
+    <string name="presentment_activity_info_was_shared">信息已共享</string>
+    <string name="presentment_activity_something_went_wrong">出错了</string>
+    <string name="presentment_activity_canceled">已取消</string>
+    <string name="presentment_activity_cannot_satisfy_request">无法满足请求</string>
+    <string name="presentment_activity_open_wallet">打开%1$s</string>
+    <string name="presentment_activity_app_name_default">钱包</string>
+    <string name="presentment_activity_no_documents_available">无可用文件</string>
+    <string name="trust_entry_extensions">扩展</string>
+    <string name="trust_entry_vical_details_valid_until">有效期至</string>
+    <string name="trust_entry_vical_details_update_url">更新网址</string>
+    <string name="trust_entry_rical_entry_title">RICAL 条目</string>
+    <string name="trust_entry_rical_is_trust_anchor">信任锚点</string>
+    <string name="trust_entry_rical_is_trust_anchor_true">是</string>
+    <string name="trust_entry_rical_is_trust_anchor_false">否</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -1,4 +1,23 @@
 <resources>
+    <!-- showBiometricPrompt.kt -->
+    <string name="biometric_prompt_negative_btn_lskf">Use PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Cancel</string>
+
+    <!-- NfcTagReaderModalBottomSheet -->
+    <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Ready to Scan</string>
+    <string name="nfc_tag_reader_modal_bottom_sheet_cancel">Cancel</string>
+
+    <!-- PresentmentActivity -->
+    <string name="presentment_activity_hold_to_reader">Hold to reader</string>
+    <string name="presentment_activity_connecting_to_reader">Connecting to reader</string>
+    <string name="presentment_activity_info_was_shared">The info was shared</string>
+    <string name="presentment_activity_something_went_wrong">Something went wrong</string>
+    <string name="presentment_activity_canceled">Cancelled</string>
+    <string name="presentment_activity_cannot_satisfy_request">Cannot satisfy request</string>
+    <string name="presentment_activity_open_wallet">Open %1$s</string>
+    <string name="presentment_activity_app_name_default">Wallet</string>
+    <string name="presentment_activity_no_documents_available">No documents available</string>
+
     <!-- PassphraseEntryField.kt -->
     <string name="passphrase_entry_field_pin_is_weak">PIN is weak, please choose another</string>
     <string name="passphrase_entry_field_passphrase_is_weak">Passphrase is weak, please choose another</string>


### PR DESCRIPTION
This way translations will work everywhere. Also update all translations using `./gradlew :multipaz-compose:lokalizeFix`.

Manually tested using `da` locale. `PresentmentActivity` is now fully translated except for multipaz-doctypes strings which is being worked on elsewhere.

Test: Manually tested.
