### PR TITLE
multipaz-compose: Add support for sharing files.

### DIFF
--- a/multipaz-compose/src/androidMain/AndroidManifest.xml
+++ b/multipaz-compose/src/androidMain/AndroidManifest.xml
@@ -39,6 +39,16 @@
             android:screenOrientation="portrait"
             tools:ignore="DiscouragedApi">
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.multipaz.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.android.kt
@@ -1,0 +1,33 @@
+package org.multipaz.compose.sharemanager
+
+import android.content.Intent
+import androidx.core.content.FileProvider
+import org.multipaz.context.AndroidUiContext
+import org.multipaz.context.applicationContext
+import java.io.File
+
+actual class ShareManager {
+    actual suspend fun shareDocument(content: ByteArray, filename: String, mimeType: String, title: String?) {
+        val context = AndroidUiContext.current()
+
+        val sharedFolder = File(context.cacheDir, "shared_docs").apply { mkdirs() }
+        val file = File(sharedFolder, filename)
+        file.writeBytes(content)
+
+        val authority = "${context.packageName}.multipaz.fileprovider"
+        val uri = FileProvider.getUriForFile(applicationContext, authority, file)
+
+        // 3. Create the share Intent
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            if (title != null) putExtra(Intent.EXTRA_TITLE, title)
+
+            // CRITICAL: Grant the target app permission to read this specific URI
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+        val chooserIntent = Intent.createChooser(sendIntent, title)
+        context.startActivity(chooserIntent)
+    }
+}

--- a/multipaz-compose/src/androidMain/res/xml/file_paths.xml
+++ b/multipaz-compose/src/androidMain/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="shared_documents" path="shared_docs/" />
+</paths>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.kt
@@ -1,0 +1,33 @@
+package org.multipaz.compose.sharemanager
+
+/**
+ * A platform-neutral interface for invoking system share sheets.
+ *
+ * This abstraction allows the shared Compose UI to export documents or media to other apps
+ * without leaking platform-specific contexts or file system implementations.
+ */
+expect class ShareManager() {
+    /**
+     * Presents the system share sheet for the given document payload.
+     *
+     * This will trigger external components for the user to interact with so make sure to launch
+     * this from a coroutine which is properly bound to the UI, see [org.multipaz.context.UiContext]
+     * for details.
+     *
+     * @param content The raw byte payload of the file to be shared.
+     * @param filename The name of the file, including its extension (e.g., "identity_doc.json").
+     * **Note:** iOS heavily relies on the file extension to determine the
+     * file's Uniform Type Identifier (UTI) and proper target apps.
+     * @param mimeType The MIME type of the content (e.g., "application/json").
+     * **Note:** This is required for Android to populate the share sheet
+     * with capable target apps. iOS ignores this parameter entirely.
+     * @param title An optional title to display on the share sheet UI, or to use as a
+     * subject line if the user selects an email client as the target app.
+     */
+    suspend fun shareDocument(
+        content: ByteArray,
+        filename: String,
+        mimeType: String,
+        title: String? = null
+    )
+}

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.ios.kt
@@ -1,0 +1,43 @@
+package org.multipaz.compose.sharemanager
+
+import platform.Foundation.*
+import platform.UIKit.*
+import kotlinx.cinterop.*
+
+actual class ShareManager {
+    @OptIn(ExperimentalForeignApi::class)
+    actual suspend fun shareDocument(content: ByteArray, filename: String, mimeType: String, title: String?) {
+        val nsData = content.usePinned { pinned ->
+            NSData.dataWithBytes(pinned.addressOf(0), content.size.toULong())
+        }
+
+        val tempDir = NSTemporaryDirectory()
+        val filePath = tempDir + filename
+        nsData.writeToFile(filePath, atomically = true)
+
+        val fileUrl = NSURL.fileURLWithPath(filePath)
+
+        val activityViewController = UIActivityViewController(
+            activityItems = listOf(fileUrl),
+            applicationActivities = null
+        )
+
+        val window = UIApplication.sharedApplication.windows.firstOrNull {
+            (it as UIWindow).isKeyWindow()
+        } as? UIWindow
+        val rootViewController = window?.rootViewController
+
+        val popoverController = activityViewController.popoverPresentationController
+        if (popoverController != null && rootViewController != null) {
+            popoverController.sourceView = rootViewController.view
+            popoverController.sourceRect = rootViewController.view.bounds
+            popoverController.permittedArrowDirections = 0UL
+        }
+
+        rootViewController?.presentViewController(
+            activityViewController,
+            animated = true,
+            completion = null
+        )
+    }
+}

--- a/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.web.kt
+++ b/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/sharemanager/ShareManager.web.kt
@@ -1,0 +1,7 @@
+package org.multipaz.compose.sharemanager
+
+actual class ShareManager {
+    actual suspend fun shareDocument(content: ByteArray, filename: String, mimeType: String, title: String?) {
+        throw NotImplementedError()
+    }
+}

--- a/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
@@ -29,7 +29,7 @@ func getPresentmentSource() async -> PresentmentSource {
     ).build()
     
     let ephemeralStorage = EphemeralStorage(clock: KotlinClockCompanion().getSystem())
-    let readerTrustManager = TrustManagerLocal(storage: ephemeralStorage, identifier: "default", partitionId: "default_default")
+    let readerTrustManager = TrustManager(storage: ephemeralStorage, identifier: "default", partitionId: "default_default")
     try! await readerTrustManager.addX509Cert(
         certificate: X509Cert.companion.fromPem(
             pemEncoding: """

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -141,6 +141,7 @@ import org.multipaz.testapp.ui.RichTextScreen
 import org.multipaz.testapp.ui.ScreenLockScreen
 import org.multipaz.testapp.ui.SecureEnclaveSecureAreaScreen
 import org.multipaz.testapp.ui.SettingsScreen
+import org.multipaz.testapp.ui.ShareSheetScreen
 import org.multipaz.testapp.ui.ShowResponseScreen
 import org.multipaz.testapp.ui.SoftwareSecureAreaScreen
 import org.multipaz.testapp.ui.StartScreen
@@ -1053,7 +1054,8 @@ class App private constructor (val promptModel: PromptModel) {
                                     }
                                 }
                             },
-                            onClickEventLog = { navController.navigate(EventLogDestination) }
+                            onClickEventLog = { navController.navigate(EventLogDestination) },
+                            onClickShareSheet = { navController.navigate(ShareSheetDestination) }
                         )
                     }
                 }
@@ -1627,8 +1629,18 @@ class App private constructor (val promptModel: PromptModel) {
                             )
                         },
                         onBack = { navController.navigateUp() },
+                        promptModel = promptModel,
                         showToast = { message -> showToast(message) },
                     )
+                }
+                composable<ShareSheetDestination> { backStackEntry ->
+                    WithAppBar(navController, "Share sheet") {
+                        ShareSheetScreen(
+                            onBack = { navController.navigateUp() },
+                            promptModel = promptModel,
+                            showToast = { message -> showToast(message) },
+                        )
+                    }
                 }
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -154,3 +154,7 @@ data object EventLogDestination: Destination()
 data class EventViewerDestination(
     val eventId: String,
 ): Destination()
+
+@Serializable
+data object ShareSheetDestination: Destination()
+

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,7 +46,14 @@ import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeComponents
+import kotlinx.datetime.format.FormatStringsInDatetimeFormats
+import kotlinx.datetime.format.byUnicodePattern
+import kotlinx.datetime.offsetAt
 import kotlinx.datetime.toLocalDateTime
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.Simple
 import org.multipaz.claim.Claim
 import org.multipaz.compose.decodeImage
@@ -54,6 +62,8 @@ import org.multipaz.compose.eventlog.EventLogModel
 import org.multipaz.compose.getOutlinedImageVector
 import org.multipaz.compose.items.FloatingItemHeadingAndText
 import org.multipaz.compose.items.FloatingItemList
+import org.multipaz.compose.rememberUiBoundCoroutineScope
+import org.multipaz.compose.sharemanager.ShareManager
 import org.multipaz.compose.text.fromMarkdown
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.datetime.FormatStyle
@@ -67,10 +77,13 @@ import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
 import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
 import org.multipaz.eventlog.PresentmentEventIso18013Proximity
 import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
+import org.multipaz.eventlog.toDataItem
+import org.multipaz.prompt.PromptModel
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
+import kotlin.time.Clock
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FormatStringsInDatetimeFormats::class)
 @Composable
 fun EventViewerScreen(
     eventLog: EventLog,
@@ -80,9 +93,10 @@ fun EventViewerScreen(
     imageLoader: ImageLoader,
     onViewCertificateChain: (certChain: X509CertChain) -> Unit,
     onBack: () -> Unit,
+    promptModel: PromptModel,
     showToast: (message: String) -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
+    val coroutineScope = rememberUiBoundCoroutineScope { promptModel }
     val model = EventLogModel(eventLog, coroutineScope)
     val events by model.events.collectAsState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
@@ -141,6 +155,39 @@ fun EventViewerScreen(
                     }
                 },
                 actions = {
+                    IconButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                val event = eventLog.getEvents().find { it.identifier == eventId }
+                                if (event != null) {
+                                    // For TestApp, just do a text file for now. In the future we might define
+                                    // a binary format and provide tools for offline analysis.
+                                    val format = DateTimeComponents.Format {
+                                        byUnicodePattern("yyyyMMdd-HHmmss")
+                                    }
+                                    val timeStampString = event.timestamp.format(
+                                        format = format,
+                                        offset = TimeZone.currentSystemDefault().offsetAt(Clock.System.now())
+                                    )
+                                    val shareManager = ShareManager()
+                                    shareManager.shareDocument(
+                                        content = Cbor.toDiagnostics(
+                                            item = event.toDataItem(),
+                                            options = setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR)
+                                        ).encodeToByteArray(),
+                                        filename = "mpztestapp-event-${timeStampString}.txt",
+                                        mimeType = "text/plain",
+                                        title = "Multipaz TestApp Event recorded ${event.timestamp}"
+                                    )
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Share,
+                            contentDescription = null
+                        )
+                    }
                     IconButton(
                         onClick = { showDeleteConfirmationDialog = true }
                     ) {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShareSheetScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShareSheetScreen.kt
@@ -1,0 +1,64 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import multipazproject.samples.testapp.generated.resources.Res
+import org.multipaz.compose.rememberUiBoundCoroutineScope
+import org.multipaz.compose.sharemanager.ShareManager
+import org.multipaz.prompt.PromptModel
+import kotlin.time.Clock
+
+@Composable
+fun ShareSheetScreen(
+    promptModel: PromptModel,
+    onBack: () -> Unit,
+    showToast: (message: String) -> Unit
+) {
+    val coroutineScope = rememberUiBoundCoroutineScope { promptModel }
+
+    LazyColumn(
+        modifier = Modifier.padding(8.dp)
+    ) {
+        item {
+            TextButton(
+                onClick = {
+                    coroutineScope.launch {
+                        val now = Clock.System.now()
+                        val shareManager = ShareManager()
+                        shareManager.shareDocument(
+                            content = "Hello World, this is a test, time is ${now.toString()}".encodeToByteArray(),
+                            filename = "test-share.txt",
+                            mimeType = "text/plain",
+                            title = "Test sharing of text/plain"
+                        )
+                    }
+                },
+                content = { Text("Share text (text/plain)") }
+            )
+        }
+
+        item {
+            TextButton(
+                onClick = {
+                    coroutineScope.launch {
+                        val now = Clock.System.now()
+                        val shareManager = ShareManager()
+                        shareManager.shareDocument(
+                            content = Res.readBytes("files/utopia-brewery.png"),
+                            filename = "test-image.png",
+                            mimeType = "image/png",
+                            title = "Test sharing of image/png"
+                        )
+                    }
+                },
+                content = { Text("Share Utopia Brewery image (image/png)") }
+            )
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -55,6 +55,7 @@ fun StartScreen(
     onClickDocumentListScreen: () -> Unit = {},
     onClickQuickAccessWallet: () -> Unit = {},
     onClickEventLog: () -> Unit = {},
+    onClickShareSheet: () -> Unit = {}
 ) {
     val blePermissionState = rememberBluetoothPermissionState()
     val coroutineScope = rememberCoroutineScope()
@@ -285,6 +286,12 @@ fun StartScreen(
                 item {
                     TextButton(onClick = onClickEventLog) {
                         Text("Event Log")
+                    }
+                }
+
+                item {
+                    TextButton(onClick = onClickShareSheet) {
+                        Text("Share sheet")
                     }
                 }
             }


### PR DESCRIPTION
This adds a `ShareManager` with a `shareDocument()` method which can be used to share files using the platform's native share sheet functionality. Add a "Share sheet" example usage in testapp and also use this in testapp to share log events.

Test: Manually tested.
