### PR TITLE
EventLog: Make it possible to add app-specific data or drop events.

### DIFF
--- a/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
+++ b/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
@@ -26,7 +26,6 @@ import org.multipaz.graphhash.Leaf
 import org.multipaz.graphhash.Node
 import org.multipaz.graphhash.UnassignedLoopException
 import java.security.MessageDigest
-import kotlin.collections.set
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.Base64.PaddingOption
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -496,14 +495,28 @@ class CborSymbolProcessor(
                             clazz
                         )
                     } else {
-                        // Annotated subclass
-                        allSealedSubclasses.getOrPut(superDeclaration) { mutableSetOf() }
-                            .add(clazz)
+                        // Annotated subclass - skip intermediates which are sealed
+                        if (!clazz.modifiers.contains(Modifier.SEALED)) {
+                            allSealedSubclasses.getOrPut(superDeclaration) { mutableSetOf() }
+                                .add(clazz)
+                        }
                         return@Declaration
                     }
                 }
                 if (clazz.modifiers.contains(Modifier.SEALED)) {
-                    val subclasses = clazz.getSealedSubclasses()
+                    // Note: getSealedSubclasses() only returns the immediate subclasses but we might have
+                    // a whole hierarchy for example
+                    //
+                    //  sealed class Event
+                    //  sealed class EventPresentment: Event
+                    //  sealed class EventPresentmentIso18013: EventPresentment
+                    //  sealed class EventPresentmentOpenID4VP: EventPresentment
+                    //
+                    // In this setup getSealedSubclasses() only returns EventPresentment but our
+                    // extension getAllSealedSubclasses() returns all of them.
+                    //
+                    val subclasses = clazz.getAllSealedSubclasses()
+                        .filterNot { it.modifiers.contains(Modifier.SEALED) }
                     for (subclass in subclasses) {
                         // if annotated, it will be processed in another branch
                         if (findAnnotation(subclass, ANNOTATION_SERIALIZABLE) == null) {
@@ -942,8 +955,8 @@ class CborSymbolProcessor(
         var extra: ByteString? = null
         if (clazz.modifiers.contains(Modifier.SEALED)) {
             // For sealed class, the schema is a union of subclasses
-            val annotation = findAnnotation(clazz, ANNOTATION_SERIALIZABLE)!!
-            extra = getTypeKey(annotation).encodeToByteString()
+            val annotation = findAnnotation(clazz, ANNOTATION_SERIALIZABLE)
+            extra = annotation?.let { getTypeKey(it).encodeToByteString() }
             for (subclass in clazz.getSealedSubclasses()) {
                 val subclassQualifiedName = subclass.qualifiedName!!.asString()
                 val subclassTypeInfo = schemaTypeInfoCache[qualifiedName] ?:
@@ -1161,3 +1174,14 @@ class CborSymbolProcessor(
     class ForceAddSerializableClass(val declaration: KSClassDeclaration): Exception()
 }
 
+private fun KSClassDeclaration.getAllSealedSubclasses(): Sequence<KSClassDeclaration> {
+    return this.getSealedSubclasses().flatMap { subclass ->
+        if (subclass.modifiers.contains(Modifier.SEALED)) {
+            // It's another sealed class, recurse!
+            sequenceOf(subclass) + subclass.getAllSealedSubclasses()
+        } else {
+            // It's a concrete class (or object), just return it
+            sequenceOf(subclass)
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/eventlogger/SimpleEventLoggerModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/eventlogger/SimpleEventLoggerModel.kt
@@ -1,4 +1,4 @@
-package org.multipaz.compose.eventlog
+package org.multipaz.compose.eventlogger
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -6,36 +6,36 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import org.multipaz.eventlog.Event
-import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlogger.Event
+import org.multipaz.eventlogger.SimpleEventLogger
 
 /**
- * A UI state holder for [EventLog] designed for Compose Multiplatform.
+ * A UI state holder for [SimpleEventLogger] designed for Compose Multiplatform.
  *
  * This model observes the underlying logger and exposes a reactive [StateFlow] of
- * events. The [eventLog] is exposed publicly to allow direct invocation of its
+ * events. The [eventLogger] is exposed publicly to allow direct invocation of its
  * suspending mutation functions (like `addEvent` or `deleteEvent`) from the UI's
  * coroutine scope.
  *
- * @property eventLog The underlying persistent event logger.
+ * @property eventLogger The underlying persistent event logger.
  * @property coroutineScope The scope used to run background queries for the state flow.
  */
-class EventLogModel(
-    val eventLog: EventLog,
+class SimpleEventLoggerModel(
+    val eventLogger: SimpleEventLogger,
     coroutineScope: CoroutineScope
 ) {
     /**
      * A reactive stream of the currently stored events.
      *
      * - The initial value is `null` while the first database read is in progress.
-     * - It automatically re-queries [EventLog.getEvents] whenever the logger
+     * - It automatically re-queries [SimpleEventLogger.getEvents] whenever the logger
      * emits a change notification.
      * - Uses [SharingStarted.WhileSubscribed] to pause database observations if
      * the UI is completely hidden, saving resources.
      */
-    val events: StateFlow<List<Event>?> = eventLog.eventFlow
+    val events: StateFlow<List<Event>?> = eventLogger.eventFlow
         .onStart { emit(Unit) } // Trigger the initial load
-        .map { eventLog.getEvents() }
+        .map { eventLogger.getEvents() }
         .stateIn(
             scope = coroutineScope,
             started = SharingStarted.WhileSubscribed(5000),

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/Event.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/Event.kt
@@ -1,16 +1,17 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
+import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.annotation.CborSerializable
 import kotlin.time.Instant
 
 /**
- * Base class for events recorded in the [EventLog].
+ * Base class for events recorded in the [EventLogger].
  *
  * This sealed class ensures a restricted hierarchy of event types that can be securely
- * serialized and persisted.
+ * serialized and persisted. New events may be added to this hierarchy in future versions.
  *
  * Any data recorded needs to be able to work on other systems (e.g. forensic analysis)
- * and in the future where the user might have deleted the document that they presented.
+ * and in the future where e.g. the user might have deleted the document that they presented.
  *
  * As such, data should be copied into the event and use of identifiers to point to e.g.
  * documents, credentials, or trust entries is only allowed if there it's optional or not
@@ -18,19 +19,21 @@ import kotlin.time.Instant
  *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
+ * @property appData Additional application-specific data.
  */
 @CborSerializable
 sealed class Event(
     open val identifier: String,
     open val timestamp: Instant,
+    open val appData: Map<String, DataItem>
 ) {
     /**
-     * Creates a copy of this event with a new identifier and timestamp.
+     * Creates a copy of this event with a new identifier, timestamp, and application-provided data.
      *
-     * This is used internally by [EventLog] to assign a storage-generated key
-     * and a concrete timestamp at the exact moment of persistence.
+     * This is used internally by [EventLogger] implementations to assign a storage-generated key,
+     * timestamp at the exact moment of persistence, and application-provided data.
      */
-    internal abstract fun copy(eventIdentifier: String, timestamp: Instant): Event
+    internal abstract fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event
 
     companion object
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventLogger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventLogger.kt
@@ -1,0 +1,42 @@
+package org.multipaz.eventlogger
+
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * An interface for a persistent logger for recording events.
+ *
+ * See [SimpleEventLogger] for an implementation backed by [org.multipaz.storage.Storage] and
+ * also includes an functionality for inspecting, filtering, amending, and deleting events
+ * as well as observing when events are added or removed.
+ */
+interface EventLogger {
+    /**
+     * Adds an event to the log.
+     *
+     * This method generates a chronologically-sortable storage identifier and a current
+     * timestamp for the event, runs application-provided code to check if the event
+     * should be dropped or if app-specific data should be amended, and then finally saves
+     * the event.
+     *
+     * Most code logging events will want to use [addEventAsync] since it runs in a separate
+     * coroutine and thus not slow down a time-sensitive code such as credential presentment
+     * where an external component is waiting for data to be returned.
+     *
+     * @param event The [Event] to be recorded, note that [Event.identifier], [Event.timestamp],
+     * and [Event.appData] will be overwritten.
+     * @return A copy of the [Event] with assigned id, timestamp, and appData. Returns `null` if
+     * the event was dropped.
+     */
+    suspend fun addEvent(event: Event): Event?
+
+    /**
+     * Asynchronously adds an event to the log.
+     *
+     * This calls [addEvent] in a [CoroutineScope] passed to [EventLogger] implementation
+     * at construction time. This is useful for time-sensitive code (e.g. presentment) which
+     * do not want to wait until the event has been processed or written to persistent storage.
+     *
+     * @param event The [Event] to be recorded.
+     */
+    fun addEventAsync(event: Event)
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentment.kt
@@ -1,0 +1,16 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import kotlin.time.Instant
+
+/**
+ * Base class for events recorded in the [EventLogger] related to credential presentment.
+ *
+ * @property presentmentData a [EventPresentmentData] with details about the presentment.
+ */
+sealed class EventPresentment(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    open val presentmentData: EventPresentmentData
+): Event(identifier, timestamp, appData)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentData.kt
@@ -1,4 +1,4 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.crypto.X509CertChain
@@ -19,28 +19,28 @@ import org.multipaz.trustmanagement.TrustMetadata
  * @property requestedDocuments list of requested documents and claims.
  */
 @CborSerializable
-data class PresentmentEventData(
+data class EventPresentmentData(
     val requesterName: String?,
     val requesterCertChain: X509CertChain?,
     val trustMetadata: TrustMetadata?,
-    val requestedDocuments: List<PresentmentEventDocument>
+    val requestedDocuments: List<EventPresentmentDataDocument>
     // TODO: include high-level view of transaction data in this data structure.
 ) {
 
     companion object {
         /**
-         * Creates a [PresentmentEventData] from a [CredentialPresentmentSelection].
+         * Creates a [EventPresentmentData] from a [CredentialPresentmentSelection].
          *
-         * @param selection the [CredentialPresentmentSelection] to create the [PresentmentEventData] from.
+         * @param selection the [CredentialPresentmentSelection] to create the [EventPresentmentData] from.
          * @param requester the requester of the data.
          * @param trustMetadata a [TrustMetadata] or `null`.
-         * @return a [PresentmentEventData].
+         * @return a [EventPresentmentData].
          */
         fun fromPresentmentSelection(
             selection: CredentialPresentmentSelection,
             requester: Requester,
             trustMetadata: TrustMetadata?,
-        ): PresentmentEventData {
+        ): EventPresentmentData {
             var requesterName: String? = null
             if (trustMetadata != null) {
                 requesterName = trustMetadata.displayName
@@ -48,16 +48,16 @@ data class PresentmentEventData(
                 requesterName = requester.origin
             }
 
-            val requestedDocuments = mutableListOf<PresentmentEventDocument>()
+            val requestedDocuments = mutableListOf<EventPresentmentDataDocument>()
             selection.matches.forEach { match ->
-                requestedDocuments.add(PresentmentEventDocument(
+                requestedDocuments.add(EventPresentmentDataDocument(
                     documentId = match.credential.document.identifier,
                     documentName = match.credential.document.displayName,
                     claims = match.claims
                 ))
             }
 
-            return PresentmentEventData(
+            return EventPresentmentData(
                 requesterName = requesterName,
                 requesterCertChain = requester.certChain,
                 trustMetadata = trustMetadata,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDataDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDataDocument.kt
@@ -1,4 +1,4 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.annotation.CborSerializationImplemented
@@ -17,13 +17,13 @@ import org.multipaz.request.RequestedClaim
  * @property claims the requested claims.
  */
 @CborSerializationImplemented(schemaId = "")
-data class PresentmentEventDocument(
+data class EventPresentmentDataDocument(
     val documentId: String,
     val documentName: String?,
     val claims: Map<RequestedClaim, Claim>,
 ) {
     /**
-     * Serializes [PresentmentEventDocument] to CBOR.
+     * Serializes [EventPresentmentDataDocument] to CBOR.
      *
      * Note that [DocumentAttribute] values in [claims] won't be serialized.
      *
@@ -43,23 +43,23 @@ data class PresentmentEventDocument(
 
     companion object {
         /**
-         * Creates a [PresentmentEventDocument] previously serialized with [PresentmentEventDocument.toDataItem].
+         * Creates a [EventPresentmentDataDocument] previously serialized with [EventPresentmentDataDocument.toDataItem].
          *
          * @param dataItem a [DataItem].
          * @param documentTypeRepository if not `null`, will be used to look up a [DocumentAttribute] for the claim.
-         * @return a new [PresentmentEventDocument].
+         * @return a new [EventPresentmentDataDocument].
          */
         fun fromDataItem(
             dataItem: DataItem,
             documentTypeRepository: DocumentTypeRepository? = null
-        ): PresentmentEventDocument {
+        ): EventPresentmentDataDocument {
             val documentId = dataItem["documentId"].asTstr
             val documentName = dataItem.getOrNull("documentName")?.asTstr
             val claims = dataItem["requestedClaims"].asMap.entries.associate { (requestedClaimDataItem, claimDataItem) ->
                 RequestedClaim.fromDataItem(requestedClaimDataItem) to
                         Claim.fromDataItem(claimDataItem, documentTypeRepository)
             }
-            return PresentmentEventDocument(
+            return EventPresentmentDataDocument(
                 documentId = documentId,
                 documentName = documentName,
                 claims = claims

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDigitalCredentialsMdocApi.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDigitalCredentialsMdocApi.kt
@@ -1,34 +1,38 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
+import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
 
 /**
- * An event representing an OpenID4VP presentment requested via Digital Credentials API.
+ * An event representing an ISO/IEC 18013-7 Annex C presentment requested via Digital Credentials API.
  *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
- * @property data Data about the presentment.
+ * @property presentmentData Data about the presentment.
  * @property appId the identifier of the application making the request, if known.
  * @property origin the origin of the website making the request.
  * @property protocol the W3C Digital Credentials API protocol identifier.
  * @property requestJson the W3C Digital Credentials API request.
  * @property responseJson the W3C Digital Credentials API response.
- * @property vpToken the resulting vpToken.
+ * @property deviceResponse The raw response data.
  */
-data class PresentmentEventDigitalCredentialsOpenID4VP(
+data class EventPresentmentDigitalCredentialsMdocApi(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
-    val data: PresentmentEventData,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentData: EventPresentmentData,
     // The raw data from the presentment event.
     val appId: String?,
     val origin: String,
     val protocol: String,
     val requestJson: String,
     val responseJson: String,
-    val vpToken: String
-): Event(identifier, timestamp) {
-    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
-        identifier = eventIdentifier,
-        timestamp = timestamp
+    val deviceResponse: DataItem
+): EventPresentment(identifier, timestamp, appData, presentmentData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentData = this.presentmentData
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDigitalCredentialsOpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentDigitalCredentialsOpenID4VP.kt
@@ -1,35 +1,38 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
 
 /**
- * An event representing an ISO/IEC 18013-7 Annex C presentment requested via Digital Credentials API.
+ * An event representing an OpenID4VP presentment requested via Digital Credentials API.
  *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
- * @property data Data about the presentment.
+ * @property presentmentData Data about the presentment.
  * @property appId the identifier of the application making the request, if known.
  * @property origin the origin of the website making the request.
  * @property protocol the W3C Digital Credentials API protocol identifier.
  * @property requestJson the W3C Digital Credentials API request.
  * @property responseJson the W3C Digital Credentials API response.
- * @property deviceResponse The raw response data.
+ * @property vpToken the resulting vpToken.
  */
-data class PresentmentEventDigitalCredentialsMdocApi(
+data class EventPresentmentDigitalCredentialsOpenID4VP(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
-    val data: PresentmentEventData,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentData: EventPresentmentData,
     // The raw data from the presentment event.
     val appId: String?,
     val origin: String,
     val protocol: String,
     val requestJson: String,
     val responseJson: String,
-    val deviceResponse: DataItem
-): Event(identifier, timestamp) {
-    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
-        identifier = eventIdentifier,
-        timestamp = timestamp
+    val vpToken: String
+): EventPresentment(identifier, timestamp, appData, presentmentData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentData = this.presentmentData
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentIso18013AnnexA.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentIso18013AnnexA.kt
@@ -1,4 +1,4 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
@@ -8,7 +8,7 @@ import kotlin.time.Instant
  *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
- * @property data Data about the presentment.
+ * @property presentmentData Data about the presentment.
  * @property uri the URI used to invoke the presentment.
  * @property request The raw request data.
  * @property response The raw response data.
@@ -17,10 +17,11 @@ import kotlin.time.Instant
  * @property origin the origin of the website making the request, if known.
  * @property readerEngagement The raw reader engagement data.
  */
-data class PresentmentEventIso18013AnnexA(
+data class EventPresentmentIso18013AnnexA(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
-    val data: PresentmentEventData,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentData: EventPresentmentData,
     // The raw data from the presentment event.
     val uri: String,
     val request: DataItem,
@@ -29,9 +30,11 @@ data class PresentmentEventIso18013AnnexA(
     val appId: String?,
     val origin: String?,
     val readerEngagement: DataItem
-): Event(identifier, timestamp) {
-    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
-        identifier = eventIdentifier,
-        timestamp = timestamp
+): EventPresentment(identifier, timestamp, appData, presentmentData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentData = this.presentmentData
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentIso18013Proximity.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentIso18013Proximity.kt
@@ -1,4 +1,4 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
@@ -6,26 +6,27 @@ import kotlin.time.Instant
 /**
  * An event representing an ISO/IEC 18013-5 presentment for proximity.
  *
- * TODO: include location (e.g. GPS coordinates)
- *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
- * @property data Data about the presentment.
+ * @property presentmentData Data about the presentment.
  * @property request The raw request data.
  * @property response The raw response data.
  * @property sessionTranscript The raw session transcript data.
  */
-data class PresentmentEventIso18013Proximity(
+data class EventPresentmentIso18013Proximity(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
-    val data: PresentmentEventData,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentData: EventPresentmentData,
     // The raw data from the presentment event.
     val request: DataItem,
     val response: DataItem,
     val sessionTranscript: DataItem,
-): Event(identifier, timestamp) {
-    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
-        identifier = eventIdentifier,
-        timestamp = timestamp
+): EventPresentment(identifier, timestamp, appData, presentmentData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentData = this.presentmentData
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentUriSchemeOpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentmentUriSchemeOpenID4VP.kt
@@ -1,5 +1,6 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
+import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
 
 /**
@@ -7,7 +8,7 @@ import kotlin.time.Instant
  *
  * @property identifier A unique identifier for the event.
  * @property timestamp The timestamp when the event was recorded.
- * @property data Data about the presentment.
+ * @property presentmentData Data about the presentment.
  * @property uri the URI used to invoke the presentment.
  * @property appId the identifier of the application making the request, if known.
  * @property origin the origin of the website making the request, if known.
@@ -15,10 +16,11 @@ import kotlin.time.Instant
  * @property vpToken the resulting vpToken.
  * @property redirectUri the URI which was launched in the user's default browser.
  */
-data class PresentmentEventUriSchemeOpenID4VP(
+data class EventPresentmentUriSchemeOpenID4VP(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
-    val data: PresentmentEventData,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentData: EventPresentmentData,
     // The raw data from the presentment event.
     val uri: String,
     val appId: String?,
@@ -26,9 +28,11 @@ data class PresentmentEventUriSchemeOpenID4VP(
     val requestJwt: String,
     val vpToken: String,
     val redirectUri: String
-): Event(identifier, timestamp) {
-    override fun copy(eventIdentifier: String, timestamp: Instant) = copy(
-        identifier = eventIdentifier,
-        timestamp = timestamp
+): EventPresentment(identifier, timestamp, appData, presentmentData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentData = this.presentmentData
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/SimpleEventLogger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/SimpleEventLogger.kt
@@ -1,13 +1,17 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
 import org.multipaz.storage.Storage
 import org.multipaz.storage.StorageTable
 import org.multipaz.storage.StorageTableSpec
@@ -17,25 +21,35 @@ import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
+private const val TAG = "SimpleEventLogger"
+
 /**
- * A persistent logger for recording and retrieving events.
+ * An implementation of [EventLogger] backed by a [Storage] implementation.
  *
- * `EventLog` backs its data with a [Storage] implementation, serializing events
- * into CBOR format. It also provides an observable flow ([eventFlow]) that emits
+ * This implementation also provides an observable flow ([eventFlow]) that emits
  * whenever the underlying event data is modified, making it easy for UI or other
  * observers to react to changes.
+ *
+ * Applications may use [onAddEvent] to determine if an event should be dropped
+ * or if additional application-specific data should be amended to the event. For
+ * example an application may have per-document setting on whether to log events
+ * or it may add a GPS-location for proximity presentment events.
  *
  * @property storage The underlying persistent storage mechanism.
  * @property partitionId A logical partition identifier to group events. Defaults to "default".
  * @property expireAfter the amount of time to keep events, use [Duration.INFINITE] to never expire events.
  * @property clock The time source used to timestamp events. Defaults to [Clock.System].
+ * @property onAddEvent Function to inject additional metadata or drop the event by returning `null`.
+ * @property scope a [CoroutineScope] used by [addEventAsync], to add events asynchronously.
  */
-class EventLog(
+class SimpleEventLogger(
     private val storage: Storage,
     private val partitionId: String = "default",
     private val expireAfter: Duration = 60.days,
-    private val clock: Clock = Clock.System
-) {
+    private val clock: Clock = Clock.System,
+    private val onAddEvent: suspend (event: Event) -> Map<String, DataItem>? = { _ -> emptyMap() },
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+): EventLogger {
     private lateinit var storageTable: StorageTable
 
     private val _eventFlow = MutableSharedFlow<Unit>(
@@ -79,13 +93,20 @@ class EventLog(
      * Adds a new event to the logger.
      *
      * This method generates a chronologically-sortable storage identifier and a current
-     * timestamp for the event before saving it. If successful, it triggers an emission
-     * to [eventFlow].
+     * timestamp for the event, runs application-provided [onAddEvent] to check if the event
+     * should be dropped or if app-specific data should be amended, and then finally saves
+     * the event.
+     *
+     * If successful, it triggers an emission to [eventFlow].
+     *
+     * Most code logging events will want to use [addEventAsync] since it runs in a separate
+     * coroutine and thus not slow down a time-sensitive where an external component is waiting
+     * for data to be returned.
      *
      * @param event The [Event] to be recorded.
-     * @return A copy of the [Event] containing its assigned identifier and timestamp.
+     * @return A copy of the [Event] with assigned id, timestamp, and appData. Returns `null` if the event was dropped.
      */
-    suspend fun addEvent(event: Event): Event {
+    override suspend fun addEvent(event: Event): Event? {
         ensureInitialized()
         val now = clock.now()
 
@@ -93,21 +114,49 @@ class EventLog(
         // Appending a UUID ensures uniqueness for events occurring at the exact same millisecond.
         val key = "$now-${UUID.randomUUID()}"
 
-        val modifiedEvent = event.copy(
-            eventIdentifier = key,
-            timestamp = now
+        val eventWithTimestamp = event.copy(
+            identifier = key,
+            timestamp = now,
+            appData = emptyMap()
+        )
+
+        val appData = onAddEvent(eventWithTimestamp)
+        if (appData == null) {
+            return null
+        }
+
+        val eventWithAppData = event.copy(
+            identifier = key,
+            timestamp = now,
+            appData = appData
         )
 
         storageTable.insert(
             key = key,
-            data = ByteString(Cbor.encode(modifiedEvent.toDataItem())),
+            data = ByteString(Cbor.encode(eventWithAppData.toDataItem())),
             partitionId = partitionId,
             expiration = now + expireAfter
         )
 
         _eventFlow.tryEmit(Unit)
 
-        return modifiedEvent
+        return eventWithAppData
+    }
+
+    /**
+     * Asynchronously adds an event to the event log.
+     *
+     * This calls [addEvent] in the [CoroutineScope] passed to [SimpleEventLogger] at construction time.
+     *
+     * This is useful for code emitting events which do not want to wait until the event has been processed or
+     * written to persistent storage.
+     *
+     * @param event The [Event] to be recorded.
+     */
+    override fun addEventAsync(event: Event) {
+        scope.launch {
+            addEvent(event)
+        }
     }
 
     /**
@@ -175,7 +224,7 @@ class EventLog(
          * The schema specification for the storage table used by this logger.
          */
         private val tableSpec = StorageTableSpec(
-            name = "EventLog",
+            name = "SimpleEventLogger",
             supportPartitions = true,
             supportExpiration = true,
             schemaVersion = 0L

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -31,7 +31,7 @@ import org.multipaz.crypto.JsonWebEncryption
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
-import org.multipaz.eventlog.PresentmentEventData
+import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.response.DeviceResponse
@@ -269,12 +269,12 @@ object OpenID4VP {
      *
      * @property response the response containing [vpToken], possibly encrypted.
      * @property vpToken the VP Token.
-     * @property eventData a [PresentmentEventData] to be used for logging.
+     * @property eventData a [EventPresentmentData] to be used for logging.
      */
     data class OpenID4VPResponse(
         val response: JsonObject,
         val vpToken: JsonObject,
-        val eventData: PresentmentEventData
+        val eventData: EventPresentmentData
     )
 
     /**
@@ -539,7 +539,7 @@ object OpenID4VP {
         return OpenID4VPResponse(
             response = response,
             vpToken = vpToken,
-            eventData = PresentmentEventData.fromPresentmentSelection(
+            eventData = EventPresentmentData.fromPresentmentSelection(
                 selection = selection,
                 requester = requester,
                 trustMetadata = trustMetadata

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -11,7 +11,7 @@ import org.multipaz.cbor.buildCborArray
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.document.Document
-import org.multipaz.eventlog.PresentmentEventIso18013Proximity
+import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.sessionencryption.EReaderKey
@@ -157,9 +157,9 @@ suspend fun Iso18013Presentment(
             )
             numRequestsServed += 1
 
-            source.eventLog?.addEvent(
-                PresentmentEventIso18013Proximity(
-                    data = responseObject.eventData,
+            source.eventLogger?.addEventAsync(
+                EventPresentmentIso18013Proximity(
+                    presentmentData = responseObject.eventData,
                     request = deviceRequest.toDataItem(),
                     response = responseObject.deviceResponse.toDataItem(),
                     sessionTranscript = sessionTranscript,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/MdocResponse.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/MdocResponse.kt
@@ -1,6 +1,6 @@
 package org.multipaz.presentment
 
-import org.multipaz.eventlog.PresentmentEventData
+import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.mdoc.response.DeviceResponse
 
 /**
@@ -11,5 +11,5 @@ import org.multipaz.mdoc.response.DeviceResponse
  */
 data class MdocResponse(
     val deviceResponse: DeviceResponse,
-    val eventData: PresentmentEventData
+    val eventData: EventPresentmentData
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
@@ -5,7 +5,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlogger.EventLogger
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
@@ -26,14 +26,14 @@ import org.multipaz.trustmanagement.TrustMetadata
  * @property documentStore the [DocumentStore] which holds credentials that can be presented.
  * @property documentTypeRepository a [DocumentTypeRepository] which holds metadata for document types.
  * @property zkSystemRepository a [ZkSystemRepository] with ZKP systems or `null`.
- * @property eventLog an [EventLog] for logging events or `null`.
+ * @property eventLogger an [EventLogger] for logging events or `null`.
  * @see SimplePresentmentSource for one concrete implementation tailored for ISO mdoc and IETF SD-JWT VC credentials.
  */
 abstract class PresentmentSource(
     open val documentStore: DocumentStore,
     open val documentTypeRepository: DocumentTypeRepository,
     open val zkSystemRepository: ZkSystemRepository? = null,
-    open val eventLog: EventLog? = null
+    open val eventLogger: EventLogger? = null
 ) {
     /**
      * Determines if a requester is trusted.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -7,7 +7,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.prompt.ShowConsentPromptFn
 import org.multipaz.prompt.promptModelRequestConsent
@@ -33,7 +33,7 @@ private data class CredentialForPresentment(
  * @property documentStore the [DocumentStore] which holds credentials that can be presented.
  * @property documentTypeRepository a [DocumentTypeRepository] which holds metadata for document types.
  * @property zkSystemRepository the [ZkSystemRepository] to use or `null`.
- * @property eventLog an [EventLog] for logging events or `null`.
+ * @property eventLogger an [SimpleEventLogger] for logging events or `null`.
  * @property resolveTrustFn a function which can be used to determine if a requester is trusted.
  * @property showConsentPrompt a [ShowConsentPromptFn] used show a consent prompt is required.
  * @property preferSignatureToKeyAgreement whether to use mdoc ECDSA authentication even if mdoc MAC authentication
@@ -47,7 +47,7 @@ class SimplePresentmentSource(
     override val documentStore: DocumentStore,
     override val documentTypeRepository: DocumentTypeRepository,
     override val zkSystemRepository: ZkSystemRepository? = null,
-    override val eventLog: EventLog? = null,
+    override val eventLogger: SimpleEventLogger? = null,
     private val resolveTrustFn: suspend (requester: Requester) -> TrustMetadata? = { requester -> null },
     private val showConsentPromptFn: ShowConsentPromptFn = ::promptModelRequestConsent,
     val preferSignatureToKeyAgreement: Boolean = true,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -17,8 +17,8 @@ import org.multipaz.crypto.Hpke
 import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsMdocApi
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
 import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.openid.OpenID4VP
 import org.multipaz.prompt.PromptDismissedException
@@ -187,9 +187,9 @@ private suspend fun digitalCredentialsOpenID4VPProtocol(
         onDocumentsInFocus = onDocumentsInFocus
     )
 
-    source.eventLog?.addEvent(
-        PresentmentEventDigitalCredentialsOpenID4VP(
-            data = responseObject.eventData,
+    source.eventLogger?.addEventAsync(
+        EventPresentmentDigitalCredentialsOpenID4VP(
+            presentmentData = responseObject.eventData,
             appId = appId,
             origin = origin,
             protocol = protocol,
@@ -282,9 +282,9 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         put("response", encryptedResponse.toBase64Url())
     }
 
-    source.eventLog?.addEvent(
-        PresentmentEventDigitalCredentialsMdocApi(
-            data = responseObject.eventData,
+    source.eventLogger?.addEventAsync(
+        EventPresentmentDigitalCredentialsMdocApi(
+            presentmentData = responseObject.eventData,
             appId = appId,
             origin = origin,
             protocol = protocol,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -4,7 +4,7 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.document.Document
-import org.multipaz.eventlog.PresentmentEventData
+import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.devicesigned.buildDeviceNamespaces
 import org.multipaz.mdoc.request.DeviceRequest
@@ -38,7 +38,7 @@ private const val TAG = "mdocPresentment"
  * @param onWaitingForUserInput called when waiting for input from the user (consent or authentication)
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
  *   first shown. If the user selects a different set of documents in the prompt, this will be called again.
- * @return a [MdocResponse] containing [DeviceResponse] and [PresentmentEventData].
+ * @return a [MdocResponse] containing [DeviceResponse] and [EventPresentmentData].
  * @throws PresentmentCanceledException if the user canceled in a consent prompt.
  * @throws PresentmentCannotSatisfyRequestException if it's not possible to satisfy the request.
  */
@@ -63,7 +63,7 @@ suspend fun mdocPresentment(
     onDocumentsInFocus: (documents: List<Document>) -> Unit
 ): MdocResponse {
     val credentialsPresented = mutableSetOf<MdocCredential>()
-    lateinit var eventData: PresentmentEventData
+    lateinit var eventData: EventPresentmentData
 
     val deviceResponse = buildDeviceResponse(
         sessionTranscript = sessionTranscript,
@@ -154,7 +154,7 @@ suspend fun mdocPresentment(
             credentialsPresented.add(match.credential)
         }
 
-        eventData = PresentmentEventData.fromPresentmentSelection(
+        eventData = EventPresentmentData.fromPresentmentSelection(
             selection = selection,
             requester = requester,
             trustMetadata = trustMetadata

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -30,8 +30,8 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.document.Document
-import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
-import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
+import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
+import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.mdoc.engagement.Capability
 import org.multipaz.mdoc.engagement.DeviceEngagement
@@ -161,9 +161,9 @@ suspend fun uriSchemePresentment(
     val postResponseBody = Json.decodeFromString<JsonObject>(bodyText)
     val redirectUri = postResponseBody["redirect_uri"]!!.jsonPrimitive.content
 
-    source.eventLog?.addEvent(
-        PresentmentEventUriSchemeOpenID4VP(
-            data = responseObject.eventData,
+    source.eventLogger?.addEventAsync(
+        EventPresentmentUriSchemeOpenID4VP(
+            presentmentData = responseObject.eventData,
             uri = uri,
             appId = appId,
             origin = origin,
@@ -297,9 +297,9 @@ private suspend fun mdocUriSchemePresentment(
             statusCode = null
         )
 
-        source.eventLog?.addEvent(
-            PresentmentEventIso18013AnnexA(
-                data = responseObject.eventData,
+        source.eventLogger?.addEventAsync(
+            EventPresentmentIso18013AnnexA(
+                presentmentData = responseObject.eventData,
                 uri = uri,
                 request = deviceRequest.toDataItem(),
                 response = responseObject.deviceResponse.toDataItem(),

--- a/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
@@ -1,4 +1,4 @@
-package org.multipaz.eventlog
+package org.multipaz.eventlogger
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -15,34 +15,36 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class EventLogTests {
+class SimpleEventLoggerTests {
 
     @Test
     fun testAddEventEmitsToFlowAndAssignsId() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
         val emissions = mutableListOf<Unit>()
         val job = launch(UnconfinedTestDispatcher(testScheduler)) {
             logger.eventFlow.toList(emissions)
         }
 
-        val event = PresentmentEventIso18013Proximity(
+        val event = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = mapOf(
@@ -71,6 +73,7 @@ class EventLogTests {
         val savedEvent = logger.addEvent(event)
 
         // Verify the event was modified with a new ID and timestamp
+        assertNotNull(savedEvent)
         assertTrue(savedEvent.identifier.isNotEmpty())
         assertEquals(Instant.fromEpochMilliseconds(1000), savedEvent.timestamp)
 
@@ -89,17 +92,17 @@ class EventLogTests {
     fun testDeleteEventEmitsToFlowAndRemovesData() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
-        val event = PresentmentEventIso18013Proximity(
+        val event = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = mapOf(
@@ -126,6 +129,7 @@ class EventLogTests {
         )
 
         val savedEvent = logger.addEvent(event)
+        assertNotNull(savedEvent)
 
         val emissions = mutableListOf<Unit>()
         val job = launch(UnconfinedTestDispatcher(testScheduler)) {
@@ -145,22 +149,22 @@ class EventLogTests {
     fun testDeleteNonExistentEventDoesNotEmit() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
         val emissions = mutableListOf<Unit>()
         val job = launch(UnconfinedTestDispatcher(testScheduler)) {
             logger.eventFlow.toList(emissions)
         }
 
-        val dummyEvent = PresentmentEventIso18013Proximity(
+        val dummyEvent = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = mapOf(
@@ -198,17 +202,17 @@ class EventLogTests {
     fun testDeleteAllEventsClearsPartitionAndEmits() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
-        val event = PresentmentEventIso18013Proximity(
+        val event = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = mapOf(
@@ -253,17 +257,17 @@ class EventLogTests {
     fun testGetEventsReturnsChronologicallySortedList() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(3000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
-        val eventBase = PresentmentEventIso18013Proximity(
+        val eventBase = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = mapOf(
@@ -306,26 +310,26 @@ class EventLogTests {
         // Assert that the items are sorted chronologically. Because our storage engine keys
         // are now prefixed with the ISO-8601 timestamp, the database native retrieval matches
         // our expected chronological order perfectly.
-        assertEquals(event1.identifier, sortedEvents[0].identifier)
-        assertEquals(event2.identifier, sortedEvents[1].identifier)
-        assertEquals(event3.identifier, sortedEvents[2].identifier)
+        assertEquals(event1?.identifier, sortedEvents[0].identifier)
+        assertEquals(event2?.identifier, sortedEvents[1].identifier)
+        assertEquals(event3?.identifier, sortedEvents[2].identifier)
     }
 
     @Test
     fun testGetEventsPagination() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
 
-        val eventBase = PresentmentEventIso18013Proximity(
+        val eventBase = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = emptyMap()
@@ -342,7 +346,7 @@ class EventLogTests {
         val insertedEvents = mutableListOf<Event>()
         for (i in 1..5) {
             fakeClock.currentTime = Instant.fromEpochMilliseconds(1000L * i)
-            insertedEvents.add(logger.addEvent(eventBase))
+            logger.addEvent(eventBase)?.let { insertedEvents.add(it) }
         }
 
         // Fetch page 1 (limit 2)
@@ -367,22 +371,22 @@ class EventLogTests {
     fun testEventExpiration() = runTest {
         val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
         val ephemeralStorage = EphemeralStorage(fakeClock)
-        val logger = EventLog(
+        val logger = SimpleEventLogger(
             storage = ephemeralStorage,
             partitionId = "test-partition",
             expireAfter = 1.days,
             clock = fakeClock
         )
 
-        val eventBase = PresentmentEventIso18013Proximity(
+        val eventBase = EventPresentmentIso18013Proximity(
             identifier = "",
             timestamp = Instant.DISTANT_PAST,
-            data = PresentmentEventData(
+            presentmentData = EventPresentmentData(
                 requesterName = "Test Requester",
                 requesterCertChain = null,
                 trustMetadata = null,
                 requestedDocuments = listOf(
-                    PresentmentEventDocument(
+                    EventPresentmentDataDocument(
                         documentId = "test-document-id",
                         documentName = "Test Document",
                         claims = emptyMap()
@@ -409,6 +413,102 @@ class EventLogTests {
         // Because EphemeralStorage relies on the injected clock to evaluate TTL,
         // it should prune or filter out the expired event.
         assertTrue(logger.getEvents().isEmpty(), "Expected event to be expired and removed")
+    }
+
+    @Test
+    fun testOnAddEventInjectsAppData() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val expectedAppData = mapOf("test_key" to "test_value".toDataItem())
+
+        val logger = SimpleEventLogger(
+            storage = ephemeralStorage,
+            partitionId = "test-partition",
+            clock = fakeClock,
+            onAddEvent = { _ -> expectedAppData }
+        )
+
+        val eventBase = EventPresentmentIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            presentmentData = EventPresentmentData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    EventPresentmentDataDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = emptyMap()
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val savedEvent = logger.addEvent(eventBase)
+
+        // Verify returned event contains the injected appData
+        assertNotNull(savedEvent)
+        assertEquals(expectedAppData, savedEvent.appData)
+
+        // Verify storage state contains the injected appData
+        val eventsInDb = logger.getEvents()
+        assertEquals(1, eventsInDb.size)
+        assertEquals(expectedAppData, eventsInDb.first().appData)
+    }
+
+    @Test
+    fun testOnAddEventDropsEvent() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+
+        val logger = SimpleEventLogger(
+            storage = ephemeralStorage,
+            partitionId = "test-partition",
+            clock = fakeClock,
+            onAddEvent = { _ -> null }
+        )
+
+        val emissions = mutableListOf<Unit>()
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            logger.eventFlow.toList(emissions)
+        }
+
+        val eventBase = EventPresentmentIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            presentmentData = EventPresentmentData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    EventPresentmentDataDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = emptyMap()
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val savedEvent = logger.addEvent(eventBase)
+
+        // Verify the event was dropped
+        assertNull(savedEvent)
+
+        // Verify no flow emission
+        assertEquals(0, emissions.size)
+
+        // Verify storage state is empty
+        assertTrue(logger.getEvents().isEmpty())
+
+        job.cancel()
     }
 
     // --- Fakes ---

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
@@ -128,6 +128,31 @@ data class SingleStringList(val a: List<String>) {
     companion object
 }
 
+// Check that intermediate classes can be sealed.
+@CborSerializable
+sealed class IscRoot(
+    open val stuff: String
+) {
+    companion object
+}
+
+sealed class IscIntermediate(
+    override val stuff: String,
+    open val moreStuff: Int
+): IscRoot(stuff)
+
+data class IscInheritsIntermediate(
+    override val stuff: String,
+    override val moreStuff: Int,
+    val leafStuff: Boolean
+): IscIntermediate(stuff, moreStuff)
+
+data class IscInheritsRoot(
+    override val stuff: String,
+    val foo: Boolean
+): IscRoot(stuff)
+
+
 class CborSerializationTest {
     @Test
     fun structuralEquivalency() {
@@ -258,6 +283,28 @@ class CborSerializationTest {
         assertEquals(
             ByteString("MfUotQQy34Na2r6Q-rDGrHog3hbbCpI0WTnTwsGTx8o".fromBase64Url()),
             SingleStringList.cborSchemaId
+        )
+    }
+
+    @Test
+    fun intermediateSealedClasses() {
+        val inheritsRoot = IscInheritsRoot(
+            stuff = "foo",
+            foo = true
+        )
+        assertEquals(
+            IscRoot.fromDataItem(inheritsRoot.toDataItem()),
+            inheritsRoot
+        )
+
+        val inheritsIntermediate = IscInheritsIntermediate(
+            stuff = "foo",
+            moreStuff = 5,
+            leafStuff = false
+        )
+        assertEquals(
+            IscRoot.fromDataItem(inheritsIntermediate.toDataItem()),
+            inheritsIntermediate
         )
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -91,7 +91,7 @@ import org.multipaz.documenttype.knowntypes.IDPass
 import org.multipaz.documenttype.knowntypes.Loyalty
 import org.multipaz.documenttype.knowntypes.PhotoID
 import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
-import org.multipaz.eventlog.EventLog
+import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.longfellow.LongfellowZkSystem
@@ -124,7 +124,7 @@ import org.multipaz.testapp.ui.DcRequestScreen
 import org.multipaz.testapp.ui.VerticalDocumentListScreen
 import org.multipaz.testapp.ui.DocumentStoreScreen
 import org.multipaz.testapp.ui.DocumentViewerScreen
-import org.multipaz.testapp.ui.EventLogScreen
+import org.multipaz.testapp.ui.EventLoggerScreen
 import org.multipaz.testapp.ui.EventViewerScreen
 import org.multipaz.testapp.ui.IsoMdocMultiDeviceTestingScreen
 import org.multipaz.testapp.ui.IsoMdocProximityReadingScreen
@@ -230,7 +230,7 @@ class App private constructor (val promptModel: PromptModel) {
             documentStore = documentStore,
             documentTypeRepository = documentTypeRepository,
             zkSystemRepository = zkSystemRepository,
-            eventLog = eventLog,
+            eventLogger = eventLogger,
             showConsentPromptFn = if (settingsModel.presentmentShowConsentPrompt.value) {
                 ::promptModelRequestConsent
             } else {
@@ -777,10 +777,15 @@ class App private constructor (val promptModel: PromptModel) {
         }
     }
     
-    lateinit var eventLog: EventLog
+    lateinit var eventLogger: SimpleEventLogger
 
     private suspend fun eventLoggerInit() {
-        eventLog = EventLog(storage = TestAppConfiguration.storage)
+        eventLogger = SimpleEventLogger(
+            storage = TestAppConfiguration.storage,
+            onAddEvent = { event ->
+                emptyMap()
+            }
+        )
     }
 
     private suspend fun digitalCredentialsReregister() {
@@ -1598,8 +1603,8 @@ class App private constructor (val promptModel: PromptModel) {
                 }
                 composable<EventLogDestination> { backStackEntry ->
                     // Note: EventLogScreen has its own AppBar
-                    EventLogScreen(
-                        eventLog = eventLog,
+                    EventLoggerScreen(
+                        eventLogger = eventLogger,
                         imageLoader = imageLoader,
                         documentModel = documentModel,
                         onEventClicked = { event ->
@@ -1613,7 +1618,7 @@ class App private constructor (val promptModel: PromptModel) {
                     val destination = backStackEntry.toRoute<EventViewerDestination>()
                     // Note: EventViewerScreen has its own AppBar
                     EventViewerScreen(
-                        eventLog = eventLog,
+                        eventLogger = eventLogger,
                         eventId = destination.eventId,
                         documentTypeRepository = documentTypeRepository,
                         documentModel = documentModel,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -38,23 +38,24 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.multipaz.compose.document.DocumentModel
-import org.multipaz.compose.eventlog.EventLogModel
+import org.multipaz.compose.eventlogger.SimpleEventLoggerModel
 import org.multipaz.compose.items.FloatingItemCenteredText
 import org.multipaz.compose.items.FloatingItemList
 import org.multipaz.compose.items.FloatingItemText
 import org.multipaz.datetime.formatLocalized
-import org.multipaz.eventlog.Event
-import org.multipaz.eventlog.EventLog
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
-import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
-import org.multipaz.eventlog.PresentmentEventIso18013Proximity
-import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
+import org.multipaz.eventlogger.Event
+import org.multipaz.eventlogger.EventPresentment
+import org.multipaz.eventlogger.SimpleEventLogger
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsMdocApi
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
+import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
+import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
+import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EventLogScreen(
-    eventLog: EventLog,
+fun EventLoggerScreen(
+    eventLogger: SimpleEventLogger,
     imageLoader: ImageLoader,
     documentModel: DocumentModel,
     onEventClicked: (event: Event) -> Unit,
@@ -62,7 +63,7 @@ fun EventLogScreen(
     showToast: (message: String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val model = EventLogModel(eventLog, coroutineScope)
+    val model = SimpleEventLoggerModel(eventLogger, coroutineScope)
     val events by model.events.collectAsState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
@@ -81,7 +82,7 @@ fun EventLogScreen(
                     onClick = {
                         coroutineScope.launch {
                             showDeleteConfirmationDialog = false
-                            eventLog.deleteAllEvents()
+                            eventLogger.deleteAllEvents()
                         }
                     }
                 ) {
@@ -178,15 +179,19 @@ private fun EventItem(
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
     modifier: Modifier = Modifier
 ) {
-    val (presentmentEventData, sharingType) = when (event) {
-        is PresentmentEventDigitalCredentialsMdocApi -> Pair(event.data, getSharingType(event.origin))
-        is PresentmentEventDigitalCredentialsOpenID4VP -> Pair(event.data, getSharingType(event.origin))
-        is PresentmentEventIso18013AnnexA -> Pair(event.data, getSharingType(event.origin))
-        is PresentmentEventIso18013Proximity -> Pair(event.data, "Shared in-person")
-        is PresentmentEventUriSchemeOpenID4VP -> Pair(event.data, getSharingType(event.origin))
+    // Right now the all events are presentment events. This will change in the future as we add
+    // support for logging other events
+    val presentmentData = (event as EventPresentment).presentmentData
+
+    val sharingType = when (event) {
+        is EventPresentmentDigitalCredentialsMdocApi -> getSharingType(event.origin)
+        is EventPresentmentDigitalCredentialsOpenID4VP -> getSharingType(event.origin)
+        is EventPresentmentIso18013AnnexA -> getSharingType(event.origin)
+        is EventPresentmentIso18013Proximity -> "Shared in-person"
+        is EventPresentmentUriSchemeOpenID4VP ->getSharingType(event.origin)
     }
 
-    val firstDoc = presentmentEventData.requestedDocuments.firstOrNull()
+    val firstDoc = presentmentData.requestedDocuments.firstOrNull()
     val firstDocInfo = firstDoc?.let { requestedDocument ->
         documentModel.documentInfos.collectAsState().value.find {
             it.document.identifier == requestedDocument.documentId
@@ -211,9 +216,7 @@ private fun EventItem(
     )
 }
 
-private fun getSharingType(
-    origin: String?,
-): String {
+private fun getSharingType(origin: String?): String {
     if (origin != null) {
         if (origin.isNotEmpty() && (origin.startsWith("http://") || origin.startsWith("https://"))) {
             return "Shared with website"

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,7 +57,7 @@ import org.multipaz.cbor.Simple
 import org.multipaz.claim.Claim
 import org.multipaz.compose.decodeImage
 import org.multipaz.compose.document.DocumentModel
-import org.multipaz.compose.eventlog.EventLogModel
+import org.multipaz.compose.eventlogger.SimpleEventLoggerModel
 import org.multipaz.compose.getOutlinedImageVector
 import org.multipaz.compose.items.FloatingItemHeadingAndText
 import org.multipaz.compose.items.FloatingItemList
@@ -70,14 +69,15 @@ import org.multipaz.datetime.FormatStyle
 import org.multipaz.datetime.formatLocalized
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.Icon
-import org.multipaz.eventlog.Event
-import org.multipaz.eventlog.EventLog
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsMdocApi
-import org.multipaz.eventlog.PresentmentEventDigitalCredentialsOpenID4VP
-import org.multipaz.eventlog.PresentmentEventIso18013AnnexA
-import org.multipaz.eventlog.PresentmentEventIso18013Proximity
-import org.multipaz.eventlog.PresentmentEventUriSchemeOpenID4VP
-import org.multipaz.eventlog.toDataItem
+import org.multipaz.eventlogger.Event
+import org.multipaz.eventlogger.EventPresentment
+import org.multipaz.eventlogger.SimpleEventLogger
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsMdocApi
+import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
+import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
+import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
+import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
+import org.multipaz.eventlogger.toDataItem
 import org.multipaz.prompt.PromptModel
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
@@ -86,7 +86,7 @@ import kotlin.time.Clock
 @OptIn(ExperimentalMaterial3Api::class, FormatStringsInDatetimeFormats::class)
 @Composable
 fun EventViewerScreen(
-    eventLog: EventLog,
+    eventLogger: SimpleEventLogger,
     eventId: String,
     documentTypeRepository: DocumentTypeRepository,
     documentModel: DocumentModel,
@@ -97,7 +97,7 @@ fun EventViewerScreen(
     showToast: (message: String) -> Unit
 ) {
     val coroutineScope = rememberUiBoundCoroutineScope { promptModel }
-    val model = EventLogModel(eventLog, coroutineScope)
+    val model = SimpleEventLoggerModel(eventLogger, coroutineScope)
     val events by model.events.collectAsState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
@@ -116,8 +116,8 @@ fun EventViewerScreen(
                     onClick = {
                         coroutineScope.launch {
                             showDeleteConfirmationDialog = false
-                            eventLog.getEvents().find { it.identifier == eventId }?.let {
-                                eventLog.deleteEvent(it)
+                            eventLogger.getEvents().find { it.identifier == eventId }?.let {
+                                eventLogger.deleteEvent(it)
                                 onBack()
                             }
                         }
@@ -158,7 +158,7 @@ fun EventViewerScreen(
                     IconButton(
                         onClick = {
                             coroutineScope.launch {
-                                val event = eventLog.getEvents().find { it.identifier == eventId }
+                                val event = eventLogger.getEvents().find { it.identifier == eventId }
                                 if (event != null) {
                                     // For TestApp, just do a text file for now. In the future we might define
                                     // a binary format and provide tools for offline analysis.
@@ -246,12 +246,16 @@ private fun EventViewer(
         timeStyle = FormatStyle.LONG
     )
 
-    val presentmentEventData = when (event) {
-        is PresentmentEventDigitalCredentialsMdocApi -> event.data
-        is PresentmentEventDigitalCredentialsOpenID4VP -> event.data
-        is PresentmentEventIso18013AnnexA -> event.data
-        is PresentmentEventIso18013Proximity -> event.data
-        is PresentmentEventUriSchemeOpenID4VP -> event.data
+    // Right now the all events are presentment events. This will change in the future as we add
+    // support for logging other events
+    val presentmentData = (event as EventPresentment).presentmentData
+
+    val protocol = when (event) {
+        is EventPresentmentDigitalCredentialsMdocApi -> "W3C DC API w/ ISO/IEC 18013-7:2025 Annex C"
+        is EventPresentmentDigitalCredentialsOpenID4VP -> "W3C DC API w/ OpenID4VP"
+        is EventPresentmentUriSchemeOpenID4VP -> "URI scheme w/ OpenID4VP"
+        is EventPresentmentIso18013AnnexA -> "URI scheme w/ ISO/IEC 18013-7:2025 Annex A"
+        is EventPresentmentIso18013Proximity -> "Proximity w/ ISO/IEC 18013-5:2021"
     }
 
     Column(
@@ -260,14 +264,14 @@ private fun EventViewer(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val imageSize = 80.dp
-        presentmentEventData.trustMetadata?.displayIcon?.let {
+        presentmentData.trustMetadata?.displayIcon?.let {
             val bitmap = remember { decodeImage(it.toByteArray()) }
             Image(
                 modifier = Modifier.size(imageSize),
                 bitmap = bitmap,
                 contentDescription = null
             )
-        } ?: presentmentEventData.trustMetadata?.displayIconUrl?.let {
+        } ?: presentmentData.trustMetadata?.displayIconUrl?.let {
             AsyncImage(
                 modifier = Modifier.size(imageSize),
                 model = it,
@@ -278,7 +282,7 @@ private fun EventViewer(
         }
 
         Text(
-            text = presentmentEventData.requesterName ?: "Unknown requester",
+            text = presentmentData.requesterName ?: "Unknown requester",
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
@@ -291,19 +295,19 @@ private fun EventViewer(
             )
 
             when (event) {
-                is PresentmentEventDigitalCredentialsMdocApi -> {
+                is EventPresentmentDigitalCredentialsMdocApi -> {
                     OriginAndAppIdItem(event.origin, event.appId)
                 }
-                is PresentmentEventDigitalCredentialsOpenID4VP -> {
+                is EventPresentmentDigitalCredentialsOpenID4VP -> {
                     OriginAndAppIdItem(event.origin, event.appId)
                 }
-                is PresentmentEventIso18013AnnexA -> {
+                is EventPresentmentIso18013AnnexA -> {
                     OriginAndAppIdItem(event.origin, event.appId)
                 }
-                is PresentmentEventUriSchemeOpenID4VP -> {
+                is EventPresentmentUriSchemeOpenID4VP -> {
                     OriginAndAppIdItem(event.origin, event.appId)
                 }
-                is PresentmentEventIso18013Proximity -> {
+                is EventPresentmentIso18013Proximity -> {
                     val handover = event.sessionTranscript.asArray[2]
                     if (handover == Simple.NULL) {
                         FloatingItemHeadingAndText(
@@ -319,7 +323,12 @@ private fun EventViewer(
                 }
             }
 
-            if (presentmentEventData.trustMetadata != null) {
+            FloatingItemHeadingAndText(
+                heading = "Presentment protocol",
+                text =  protocol
+            )
+
+            if (presentmentData.trustMetadata != null) {
                 FloatingItemHeadingAndText(
                     heading = "Requester trusted",
                     text =  "Yes, in trust list"
@@ -335,7 +344,7 @@ private fun EventViewer(
                 )
             }
 
-            presentmentEventData.requesterCertChain?.let {
+            presentmentData.requesterCertChain?.let {
                 FloatingItemHeadingAndText(
                     heading = "Requester certificate",
                     text = "Click to view",
@@ -350,7 +359,7 @@ private fun EventViewer(
                 )
             }
 
-            presentmentEventData.trustMetadata?.privacyPolicyUrl?.let {
+            presentmentData.trustMetadata?.privacyPolicyUrl?.let {
                 FloatingItemHeadingAndText(
                     heading = "Requester privacy policy",
                     text = AnnotatedString.fromMarkdown(
@@ -360,7 +369,7 @@ private fun EventViewer(
             }
         }
 
-        presentmentEventData.requestedDocuments.forEach { requestedDocument ->
+        presentmentData.requestedDocuments.forEach { requestedDocument ->
             val info = documentModel.documentInfos.collectAsState().value.find {
                 it.document.identifier == requestedDocument.documentId
             }


### PR DESCRIPTION
Also rename to SimpleEventLogger and introduce a new EventLogger interface with just the functionality to record events. The intent here is that this makes it easier for existing apps to hook into existing logging frameworks.

Additionally, rework the hierarchy for `Event` so there is an intermediate `EventPresentment` common for all presentment event classes. This is useful for applications as they then don't need to care about protocol-specifics like whether the presentment was done over Annex C or OpenID4VP. This requires extending our Cbor code generator to handle sealed hieararchies that are more than a single level so do this and all add unit tests for it.

Test: Unit tests.
