### PR TITLE
Fix Swift sample build errors

### DIFF
--- a/multipaz-swift/Sources/MultipazSwift/Consent.swift
+++ b/multipaz-swift/Sources/MultipazSwift/Consent.swift
@@ -33,7 +33,7 @@ func getIconName(claim: Claim) -> String {
         case .globe: return "globe"
         case .phone: return "phone"
         case .badge: return "person.crop.circle"
-        case .email return "envelope"
+        case .email: return "envelope"
         case .none: return "gear"
         }
     }

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -539,6 +539,7 @@ private func calcConsentData(
         ),
         readerKey: readerKey.publicKey,
         subject: X500Name.companion.fromName(name: "CN=Test Reader Key"),
+        dnsName: nil,
         serial: ASN1Integer.companion.fromRandom(numBits: 128, random: KotlinRandom.companion),
         validFrom: validFrom.toKotlinInstant().truncateToWholeSeconds(),
         validUntil: validUntil.toKotlinInstant().truncateToWholeSeconds(),


### PR DESCRIPTION
Fixes #1620

  > It's a good idea to open an issue first for discussion.

  - [X] Tests pass
  - [ ] Appropriate changes to README are included in PR

  This fixes two Swift build issues in the local package/sample path:

  - fix a missing `:` in `multipaz-swift/Sources/MultipazSwift/Consent.swift`
  - update `samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift` for the current `generateReaderCertificate(...)` signature by passing `dnsName: nil`

  Validation:
  - `./gradlew :xcframework:assembleMultipazReleaseXCFramework`
  - `xcodebuild build -project samples/SwiftTestApp/SwiftTestApp.xcodeproj -scheme SwiftTestApp -destination 'generic/platform=iOS' -derivedDataPath /tmp/MultipazSwiftTestAppDerivedData CODE_SIGNING_ALLOWED=NO`