### PR TITLE
Expose Multipaz binary target as package product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     .iOS(.v26),
    ],
    products: [
-      .library(name: "Multipaz", targets: ["MultipazSwift"])
+      .library(name: "Multipaz", targets: ["MultipazSwift"]),
+      .library(name: "MultipazCore", targets: ["Multipaz"])
    ],
    targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ which includes an the `multipaz`, `multipaz-doctypes`, `multipaz-doctypes`,
 [SKIE](https://skie.touchlab.co/). Be careful relying on this as Swift/Kotlin
 interop technology might change in the near future.
 
+The Swift package exposes two products:
+
+- `Multipaz` includes the higher-level `multipaz-swift` wrapper APIs.
+- `MultipazCore` exposes the core binary target directly for applications that
+  build their own UI and only need the lower-level APIs. When using this
+  product, the module import remains `import Multipaz`.
+
 At this point both API interfaces and data stored on disk is subject to change
 but we expect to provide stability guarantees post 1.0. We only expect minor changes
 for example conversion from `ByteArray` to `ByteString` and similar things.
@@ -132,4 +139,3 @@ a number of samples for different platforms.
 ## Note
 
 This is not an official or supported Google product.
-


### PR DESCRIPTION
• Fixes #1619

  - [X] Tests pass
  - [X] Appropriate changes to README are included in PR

  This adds a second SwiftPM product exposing the existing `Multipaz` binary target directly, while keeping the current `Multipaz` product unchanged.

  ```diff
   products: [
  -    .library(name: "Multipaz", targets: ["MultipazSwift"])
  +    .library(name: "Multipaz", targets: ["MultipazSwift"]),
  +    .library(name: "MultipazCore", targets: ["Multipaz"])
   ]
```
  After this change:

  - Multipaz continues to point to MultipazSwift
  - MultipazCore points directly to the existing Multipaz binary target

  This is useful for downstream consumers that build their own UI and only need the lower-level core APIs, without depending on the higher-level Swift wrapper product.

  Validation:

  - swift package dump-package
  - ./gradlew :xcframework:assembleMultipazReleaseXCFramework

  I also verified that the existing iOS sample build still works with a companion fix for unrelated local Swift build issues:

  - xcodebuild build -project samples/SwiftTestApp/SwiftTestApp.xcodeproj -scheme SwiftTestApp -destination 'generic/platform=iOS' -derivedDataPath /tmp/MultipazSwiftTestAppDerivedData CODE_SIGNING_ALLOWED=NO
  - companion PR: #1621 

  That companion PR only fixes pre-existing local Swift sample build errors and is separate from this packaging change.