### PR TITLE
Fix for exception in extractCredentialIds on JWT

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -262,9 +262,14 @@ internal class OpenID4VCIProvisioningClient(
         when (keyInfo) {
             KeyBindingInfo.Keyless -> listOf("")
             is KeyBindingInfo.OpenidProofOfPossession -> keyInfo.jwtList.map { jwt ->
-                val header = Json.parseToJsonElement(jwt.take(jwt.indexOf('.') - 1))
-                // 'kid' must be present and corresponds to the credential id
-                header.jsonObject["kid"]!!.jsonPrimitive.content
+                val headerB64 = jwt.substringBefore('.')
+                val header = Json.parseToJsonElement(
+                    headerB64.fromBase64Url().decodeToString()
+                )
+                val headerObj = header.jsonObject
+                headerObj["kid"]?.jsonPrimitive?.content
+                    ?: headerObj["jwk"]?.jsonObject?.get("kid")?.jsonPrimitive?.content
+                    ?: ""
             }
             is KeyBindingInfo.Attestation -> keyInfo.attestations.map { it.credentialId }
         }


### PR DESCRIPTION
Fixes #1559

Fixed an issue where OpenId4VciProvisioningClient would handle posession JWTs incorrectly when calling extractCredentialIds.

Full credit to https://github.com/michaeljfazio for the solution, I just wanted to get this PR going since the fix works for my use case and it would be great to have this in sooner than later.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR