### PR TITLE
multipaz-android-legacy: Expose ProofOfProvisioning SHA-256.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
@@ -112,7 +112,7 @@ class CredentialData {
     private String mDocType = "";
     private String mCredentialKeyAlias = "";
     private Collection<X509Certificate> mCertificateChain = null;
-    private byte[] mProofOfProvisioningSha256 = null;
+    byte[] mProofOfProvisioningSha256 = null;
     private AbstractList<AccessControlProfile> mAccessControlProfiles = new ArrayList<>();
     private AbstractMap<Integer, AccessControlProfile> mProfileIdToAcpMap = new HashMap<>();
     private AbstractList<PersonalizationData.NamespaceData> mNamespaceDatas = new ArrayList<>();

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
@@ -775,6 +775,10 @@ public class KeystoreIdentityCredential extends IdentityCredential {
         mData.storeStaticAuthenticationData(authenticationKey, expirationDate, staticAuthData);
     }
 
+    public @Nullable byte[] getProofOfProvisioningSha256() {
+        return mData.mProofOfProvisioningSha256;
+    }
+
     @Override
     public @NonNull
     int[] getAuthenticationDataUsageCount() {


### PR DESCRIPTION
This is needed by an upstream for migrating to DocumentStore.

Test: Tested upstream.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR