### PR TITLE
Add transactional data support for DPC payment authorization (Phase 1B)

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -100,6 +100,12 @@ import org.multipaz.compose.text.fromMarkdown
 import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.Icon
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import org.multipaz.documenttype.TransactionDataType
+import org.multipaz.documenttype.TransactionDataTypeRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.multipaz_compose.generated.resources.Res
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_cancel
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_more
@@ -248,6 +254,8 @@ fun Consent(
     preselectedDocuments: List<Document>,
     imageLoader: ImageLoader?,
     onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>? = null,
+    transactionDataTypeRepository: TransactionDataTypeRepository? = null,
     onConfirm: (selection: CredentialPresentmentSelection) -> Unit,
     onCancel: () -> Unit = {},
 ) {
@@ -325,6 +333,8 @@ fun Consent(
                     imageLoader = imageLoader,
                     combinations = combinations,
                     matchSelectionLists = matchSelectionLists,
+                    transactionData = transactionData,
+                    transactionDataTypeRepository = transactionDataTypeRepository,
                     onShowRequesterInfo = {
                         navController.navigate("showRequesterInfo")
                     },
@@ -455,6 +465,8 @@ private fun ConsentPage(
     imageLoader: ImageLoader?,
     combinations: List<Combination>,
     matchSelectionLists: MutableState<List<List<Int>>>,
+    transactionData: Map<String, List<TransactionData>>? = null,
+    transactionDataTypeRepository: TransactionDataTypeRepository? = null,
     onShowRequesterInfo: () -> Unit,
     onConfirm: (selection: CredentialPresentmentSelection) -> Unit,
     onCancel: () -> Unit,
@@ -532,6 +544,8 @@ private fun ConsentPage(
                                         requesterDisplayData = requesterDisplayData,
                                         trustMetadata = trustMetadata,
                                         appInfo = appInfo,
+                                        transactionData = transactionData,
+                                        transactionDataTypeRepository = transactionDataTypeRepository,
                                         onChooseMatch = { _, elementNum ->
                                             activeElementIndex = elementNum
                                             isFlipped = true
@@ -754,6 +768,8 @@ private fun CredentialSetViewer(
     requesterDisplayData: RequesterDisplayData,
     trustMetadata: TrustMetadata?,
     appInfo: ApplicationInfo?,
+    transactionData: Map<String, List<TransactionData>>? = null,
+    transactionDataTypeRepository: TransactionDataTypeRepository? = null,
     onChooseMatch: (combinationNum: Int, elementNum: Int) -> Unit
 ) {
 
@@ -836,6 +852,67 @@ private fun CredentialSetViewer(
                 ClaimsGridView(claims = notStoredClaims, useColumns = true)
                 SharedStoredText(text = sharedWithAndStoredByText)
                 ClaimsGridView(claims = storedClaims, useColumns = true)
+            }
+        }
+    }
+
+    // Render transaction details if present
+    if (transactionData != null) {
+        val allTransactionItems = transactionData.values.flatten()
+        for (txnData in allTransactionItems) {
+            val txnType = txnData.typeDefinition
+                ?: transactionDataTypeRepository?.getType(txnData.type)
+            entries.add {
+                Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                    Text(
+                        text = txnType?.displayName ?: "Transaction Details",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                    if (txnType != null) {
+                        // Use registered field metadata for rendering
+                        for (field in txnType.fields) {
+                            if (!field.userVisible) continue
+                            val value = resolveJsonPath(txnData.data, field.path) ?: continue
+                            // Combine amount + currency on one line
+                            val displayValue = if (field.path == "amount") {
+                                val currency = resolveJsonPath(txnData.data, "currency")
+                                if (currency != null) "$value $currency" else value
+                            } else {
+                                value
+                            }
+                            TransactionDetailRow(
+                                icon = field.icon,
+                                label = field.displayName,
+                                value = displayValue
+                            )
+                        }
+                    } else {
+                        // Fallback: render primitive fields from the JSON
+                        for ((key, element) in txnData.data) {
+                            if (key == "type" || key == "credential_ids" || key == "transaction_data_hashes_alg") continue
+                            val value = (element as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull
+                            if (value != null) {
+                                TransactionDetailRow(
+                                    icon = Icon.NUMBERS,
+                                    label = key,
+                                    value = value
+                                )
+                            } else if (element is kotlinx.serialization.json.JsonObject) {
+                                // Render nested object fields with parent.child labels
+                                for ((nestedKey, nestedElement) in element) {
+                                    val nestedValue = (nestedElement as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull ?: continue
+                                    TransactionDetailRow(
+                                        icon = Icon.NUMBERS,
+                                        label = "$key.$nestedKey",
+                                        value = nestedValue
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -1027,6 +1104,50 @@ private fun RelyingPartyTrailer(
     }
 }
 
+
+/**
+ * Resolves a dot-separated JSON path (e.g., "payee.name") to a string value.
+ */
+private fun resolveJsonPath(json: kotlinx.serialization.json.JsonObject, path: String): String? {
+    val parts = path.split(".")
+    var current: kotlinx.serialization.json.JsonElement = json
+    for (part in parts.dropLast(1)) {
+        current = (current as? kotlinx.serialization.json.JsonObject)?.get(part) ?: return null
+    }
+    return (current as? kotlinx.serialization.json.JsonObject)
+        ?.get(parts.last())?.jsonPrimitive?.contentOrNull
+}
+
+@Composable
+private fun TransactionDetailRow(
+    icon: org.multipaz.documenttype.Icon,
+    label: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier.size(20.dp),
+            imageVector = icon.getOutlinedImageVector(),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "$label: ",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
 
 @Composable
 private fun EntryList(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/ConsentModalBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/ConsentModalBottomSheet.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import kotlinx.coroutines.launch
 import org.multipaz.document.Document
+import org.multipaz.documenttype.TransactionDataTypeRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.request.Requester
@@ -52,6 +54,8 @@ fun ConsentModalBottomSheet(
     imageLoader: ImageLoader?,
     maxHeight: Dp? = null,
     onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>? = null,
+    transactionDataTypeRepository: TransactionDataTypeRepository? = null,
     onConfirm: (selection: CredentialPresentmentSelection) -> Unit,
     onCancel: () -> Unit = {},
 ) {
@@ -71,6 +75,8 @@ fun ConsentModalBottomSheet(
             preselectedDocuments = preselectedDocuments,
             imageLoader = imageLoader,
             onDocumentsInFocus = onDocumentsInFocus,
+            transactionData = transactionData,
+            transactionDataTypeRepository = transactionDataTypeRepository,
             onConfirm = onConfirm,
             onCancel = {
                 coroutineScope.launch { sheetState.hide() }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/ConsentPromptDialog.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/ConsentPromptDialog.kt
@@ -39,6 +39,8 @@ fun ConsentPromptDialog(
             imageLoader = imageLoader,
             maxHeight = maxHeight,
             onDocumentsInFocus = dialogParameters.onDocumentsInFocus,
+            transactionData = dialogParameters.transactionData,
+            transactionDataTypeRepository = dialogParameters.transactionDataTypeRepository,
             onConfirm = { credentialPresentmentSelection ->
                 coroutineScope.launch {
                     dialogStateValue.resultChannel.send(credentialPresentmentSelection)

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransactionData.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransactionData.kt
@@ -1,0 +1,127 @@
+package org.multipaz.documenttype.knowntypes
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.multipaz.documenttype.Icon
+import org.multipaz.documenttype.TransactionDataType
+import org.multipaz.openid.TransactionData
+import org.multipaz.util.toBase64Url
+
+/**
+ * Payment transaction data type definition for DPC payment authorization flows.
+ *
+ * This defines the field metadata for the `org.multipaz.transaction_data.payment` type,
+ * enabling the consent UI to render payment transaction details generically.
+ */
+object PaymentTransactionData {
+    /** The transaction data type identifier for payment authorization. */
+    const val TYPE = "org.multipaz.transaction_data.payment"
+
+    private val transactionDataType = TransactionDataType.Builder(TYPE, "Payment Authorization")
+            .addField("payee.name", "Payee", Icon.ACCOUNT_BALANCE)
+            .addField("payee.id", "Payee ID", Icon.NUMBERS, userVisible = false)
+            .addField("amount", "Amount", Icon.NUMBERS)
+            .addField("currency", "Currency", Icon.LANGUAGE, userVisible = false)
+            .addField("transaction_id", "Reference", Icon.NUMBERS)
+            .addField("merchant_message", "Note", Icon.LANGUAGE)
+            .build()
+
+    init {
+        TransactionData.registerType(TYPE, transactionDataType)
+    }
+
+    /** Returns the [TransactionDataType] describing the fields of a payment transaction. */
+    fun getTransactionDataType(): TransactionDataType = transactionDataType
+
+    /**
+     * Builds a base64url-encoded payment transaction data item ready for
+     * [org.multipaz.openid.TransactionData.parse].
+     *
+     * @param credentialId the DCQL credential query ID this transaction applies to.
+     * @param transactionId a unique identifier for this payment event.
+     * @param payeeName the human-readable merchant/payee name.
+     * @param payeeId the machine-readable payee identifier.
+     * @param amount the payment amount as a decimal string (e.g., "90.00").
+     * @param currency the ISO 4217 currency code (e.g., "USD").
+     * @param merchantMessage optional explanatory text shown on the consent screen.
+     * @param hashAlgorithm the hash algorithm for transaction data binding (default: "sha-256").
+     * @return a base64url-encoded string suitable for passing to [org.multipaz.openid.TransactionData.parse].
+     */
+    fun encode(
+        credentialId: String,
+        transactionId: String,
+        payeeName: String,
+        payeeId: String,
+        amount: String,
+        currency: String,
+        merchantMessage: String? = null,
+        hashAlgorithm: String = "sha-256"
+    ): String {
+        require(amount.toDoubleOrNull() != null && amount.toDouble() > 0) {
+            "amount must be a positive decimal number, got: $amount"
+        }
+        val json = buildJsonObject {
+            put("type", TYPE)
+            putJsonArray("credential_ids") { add(JsonPrimitive(credentialId)) }
+            putJsonArray("transaction_data_hashes_alg") { add(JsonPrimitive(hashAlgorithm)) }
+            put("transaction_id", transactionId)
+            putJsonObject("payee") {
+                put("name", payeeName)
+                put("id", payeeId)
+            }
+            put("currency", currency)
+            put("amount", amount)
+            merchantMessage?.let { put("merchant_message", it) }
+        }
+        return json.toString().encodeToByteArray().toBase64Url()
+    }
+
+    /**
+     * Creates parsed payment transaction data ready for use in the consent flow.
+     *
+     * This is the recommended way to create payment transaction data — it handles
+     * encoding, parsing, and type registration in a single call.
+     *
+     * Example usage:
+     * ```
+     * val transactionData = PaymentTransactionData.create(
+     *     credentialId = "payment_cred",
+     *     transactionId = "txn-001",
+     *     payeeName = "Coffee Shop",
+     *     payeeId = "merchant-coffee-001",
+     *     amount = "4.50",
+     *     currency = "EUR",
+     *     merchantMessage = "Latte and croissant"
+     * )
+     * ```
+     *
+     * @return a map of credential ID to transaction data items, ready to pass to
+     *   [org.multipaz.prompt.PromptModel.requestConsent] or
+     *   [org.multipaz.presentment.PresentmentSource.showConsentPrompt].
+     */
+    suspend fun create(
+        credentialId: String,
+        transactionId: String,
+        payeeName: String,
+        payeeId: String,
+        amount: String,
+        currency: String,
+        merchantMessage: String? = null,
+        hashAlgorithm: String = "sha-256"
+    ): Map<String, List<TransactionData>> {
+        val encoded = encode(
+            credentialId = credentialId,
+            transactionId = transactionId,
+            payeeName = payeeName,
+            payeeId = payeeId,
+            amount = amount,
+            currency = currency,
+            merchantMessage = merchantMessage,
+            hashAlgorithm = hashAlgorithm
+        )
+        return TransactionData.parse(listOf(encoded))
+    }
+}

--- a/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
+++ b/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
@@ -33,6 +33,7 @@ extension SimplePresentmentSource.Companion {
             _ credentialPresentmentData: CredentialPresentmentData,
             _ preselectedDocuments: [Document],
             _ onDocumentsInFocus: @escaping @Sendable (_ documents: [Document]) -> Void,
+            _ transactionData: [String: [TransactionData]]?
         ) async -> CredentialPresentmentSelection?,
         preferSignatureToKeyAgreement: Bool = true,
         domainMdocSignature: String? = nil,
@@ -76,30 +77,33 @@ private class ResolveTrustHandler: KotlinSuspendFunction1 {
     }
 }
 
-private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
+private class ShowConsentPromptHandler: KotlinSuspendFunction6 {
     let f: @Sendable (
         _ requester: Requester,
         _ trustMetadata: TrustMetadata?,
         _ credentialPresentmentData: CredentialPresentmentData,
         _ preselectedDocuments: [Document],
         _ onDocumentsInFocus: @escaping @Sendable (_ documents: [Document]) -> Void,
+        _ transactionData: [String: [TransactionData]]?
     ) async -> CredentialPresentmentSelection?
-    
+
     init(f: @escaping @Sendable (
         _ requester: Requester,
         _ trustMetadata: TrustMetadata?,
         _ credentialPresentmentData: CredentialPresentmentData,
         _ preselectedDocuments: [Document],
         _ onDocumentsInFocus: @escaping @Sendable (_ documents: [Document]) -> Void,
+        _ transactionData: [String: [TransactionData]]?
     ) async -> CredentialPresentmentSelection?) {
         self.f = f
     }
 
-    func __invoke(p1: Any?, p2: Any?, p3: Any?, p4: Any?, p5: Any?, completionHandler: @escaping @Sendable (Any?, (any Error)?) -> Void) {
+    func __invoke(p1: Any?, p2: Any?, p3: Any?, p4: Any?, p5: Any?, p6: Any?, completionHandler: @escaping @Sendable (Any?, (any Error)?) -> Void) {
         let requester = p1 as! Requester
         let trustMetadata = p2 as! TrustMetadata?
         let credentialPresentmentData = p3 as! CredentialPresentmentData
         let preselectedDocuments = p4 as! [Document]
+        let transactionData = p6 as! [String: [TransactionData]]?
         let f = self.f
         Task {
             // TODO: The cast for onDocumentsInFocus fails at runtime, figure out how to make it work
@@ -108,7 +112,8 @@ private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
                 trustMetadata,
                 credentialPresentmentData,
                 preselectedDocuments,
-                { documents in }
+                { documents in },
+                transactionData
             )
             completionHandler(value, nil)
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionDataType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionDataType.kt
@@ -1,0 +1,80 @@
+package org.multipaz.documenttype
+
+/**
+ * Describes a type of transaction data, including metadata for rendering fields in a consent UI.
+ *
+ * This is the transaction data equivalent of [DocumentType] — it allows the consent UI to
+ * render transaction fields generically without hardcoding field names or display labels.
+ *
+ * @property type the transaction data type identifier (e.g., "org.multipaz.transaction_data.payment").
+ * @property displayName a human-readable name for this transaction type.
+ * @property fields the fields that this transaction data type contains.
+ */
+data class TransactionDataType(
+    val type: String,
+    val displayName: String,
+    val fields: List<TransactionDataField>
+) {
+    /**
+     * Looks up a field by its JSON path (e.g., "payee.name", "amount").
+     *
+     * @param path the dot-separated JSON path to the field.
+     * @return the [TransactionDataField] or null if not found.
+     */
+    fun getField(path: String): TransactionDataField? =
+        fields.find { it.path == path }
+
+    /**
+     * Builder for constructing [TransactionDataType] instances.
+     *
+     * @param type the transaction data type identifier.
+     * @param displayName a human-readable name for this transaction type.
+     */
+    class Builder(
+        private val type: String,
+        private val displayName: String
+    ) {
+        private val fields = mutableListOf<TransactionDataField>()
+
+        /**
+         * Adds a field definition to this transaction data type.
+         *
+         * @param path the dot-separated JSON path to the field.
+         * @param displayName a human-readable label for the field.
+         * @param icon the icon to display next to the field.
+         * @param userVisible whether the field should be shown in the consent UI.
+         * @return this builder for chaining.
+         */
+        fun addField(
+            path: String,
+            displayName: String,
+            icon: Icon,
+            userVisible: Boolean = true
+        ): Builder {
+            fields.add(TransactionDataField(path, displayName, icon, userVisible))
+            return this
+        }
+
+        /**
+         * Builds the [TransactionDataType] from the accumulated fields.
+         *
+         * @return the constructed [TransactionDataType].
+         */
+        fun build(): TransactionDataType = TransactionDataType(type, displayName, fields)
+    }
+}
+
+/**
+ * A field in a transaction data type.
+ *
+ * @property path the JSON path to this field (e.g., "payee.name", "amount").
+ * @property displayName a human-readable label for this field.
+ * @property icon the icon to display next to this field.
+ * @property userVisible whether this field should be shown to the user in the consent UI.
+ */
+data class TransactionDataField(
+    val path: String,
+    val displayName: String,
+    val icon: Icon,
+    val userVisible: Boolean = true
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionDataTypeRepository.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionDataTypeRepository.kt
@@ -1,0 +1,33 @@
+package org.multipaz.documenttype
+
+/**
+ * A registry of known transaction data types.
+ *
+ * This is the transaction data equivalent of [DocumentTypeRepository]. It allows the consent
+ * UI to look up field metadata (display names, icons) for any registered transaction data type.
+ */
+class TransactionDataTypeRepository {
+    private val _types: MutableList<TransactionDataType> = mutableListOf()
+
+    /** The list of registered transaction data types. */
+    val types: List<TransactionDataType>
+        get() = _types
+
+    /**
+     * Registers a transaction data type in the repository.
+     *
+     * @param type the [TransactionDataType] to add.
+     */
+    fun addType(type: TransactionDataType) {
+        _types.add(type)
+    }
+
+    /**
+     * Looks up a transaction data type by its identifier.
+     *
+     * @param typeIdentifier the type identifier string to search for.
+     * @return the matching [TransactionDataType], or null if not found.
+     */
+    fun getType(typeIdentifier: String): TransactionDataType? =
+        _types.find { it.type == typeIdentifier }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.putJsonObject
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.addCborArray
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.credential.Credential
@@ -34,6 +35,7 @@ import org.multipaz.document.Document
 import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.mdoc.devicesigned.buildDeviceNamespaces
 import org.multipaz.mdoc.response.DeviceResponse
 import org.multipaz.mdoc.response.MdocDocument
 import org.multipaz.mdoc.response.buildDeviceResponse
@@ -438,14 +440,14 @@ object OpenID4VP {
         val transactionDataMap = request["transaction_data"]?.let {
             TransactionData.parse(it)
         }
-        // TODO: incorporate transaction data into the consent prompt and event logging
         val trustMetadata = source.resolveTrust(requester)
         val selection = source.showConsentPrompt(
             requester = requester,
             trustMetadata = trustMetadata,
             credentialPresentmentData = dcqlResponse,
             preselectedDocuments = preselectedDocuments,
-            onDocumentsInFocus = onDocumentsInFocus
+            onDocumentsInFocus = onDocumentsInFocus,
+            transactionData = transactionDataMap
         )
         if (selection == null) {
             throw PresentmentCanceledException("User canceled at document selection time")
@@ -469,7 +471,8 @@ object OpenID4VP {
                     nonce = nonce,
                     reReaderPublicKey = reReaderPublicKey,
                     responseUri = responseUri,
-                    requestIsForZk = requestIsForZk
+                    requestIsForZk = requestIsForZk,
+                    transactionData = transactionDataMap?.get(match.source.credentialQuery.id)
                 )
             } else if (match.source.credentialQuery.vctValues != null) {
                 openID4VPSdJwt(
@@ -557,6 +560,7 @@ object OpenID4VP {
         reReaderPublicKey: EcPublicKey?,
         responseUri: String?,
         requestIsForZk: Boolean,
+        transactionData: List<TransactionData>? = null,
         onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
@@ -660,10 +664,34 @@ object OpenID4VP {
         Logger.iCbor(TAG, "encodedSessionTranscript", encodedSessionTranscript)
 
         val mdocCredential = match.credential as MdocCredential
+        val deviceNamespaces = buildDeviceNamespaces {
+            if (transactionData != null) {
+                addNamespace("org.multipaz.transaction_data") {
+                    addDataElement(
+                        "transaction_data_hashes",
+                        buildCborArray {
+                            transactionData.forEach { data ->
+                                add(Bstr(data.hash.toByteArray()))
+                            }
+                        }
+                    )
+                    transactionData.firstNotNullOfOrNull { it.hashAlgorithm }?.let { hashAlgorithm ->
+                        transactionData.forEach { data ->
+                            check(hashAlgorithm == (data.hashAlgorithm ?: Algorithm.SHA256))
+                        }
+                        addDataElement(
+                            "transaction_data_hashes_alg",
+                            Tstr(hashAlgorithm.hashAlgorithmName!!)
+                        )
+                    }
+                }
+            }
+        }
         val document = MdocDocument.fromPresentment(
             sessionTranscript = Cbor.decode(encodedSessionTranscript),
             credential = mdocCredential,
             requestedClaims = match.source.credentialQuery.claims as List<MdocRequestedClaim>,
+            deviceNamespaces = deviceNamespaces,
         )
         val deviceResponse = buildDeviceResponse(
             sessionTranscript = Cbor.decode(encodedSessionTranscript),

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/TransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/TransactionData.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
+import org.multipaz.documenttype.TransactionDataType
 import org.multipaz.util.fromBase64Url
 
 /**
@@ -24,14 +25,38 @@ import org.multipaz.util.fromBase64Url
  * @param hashAlgorithm algorithm, only if it was explicitly specified in transaction data
  * @param type type of the transaction data item
  * @param data JSON object that represents the transaction data item
+ * @param typeDefinition the [TransactionDataType] for this item, if registered. Used by the
+ *  consent UI to render field labels and icons without hardcoding.
  */
 class TransactionData(
     val hash: ByteString,
     val hashAlgorithm: Algorithm?,
     val type: String,
-    val data: JsonObject
+    val data: JsonObject,
+    val typeDefinition: TransactionDataType? = null
 ) {
     companion object {
+        private val supportedTypes = mutableSetOf(
+            "org.multipaz.transaction_data.test"
+        )
+        private val typeDefinitions = mutableMapOf<String, TransactionDataType>()
+
+        /**
+         * Registers a transaction data type so it is accepted by [parse].
+         *
+         * Built-in types (like `org.multipaz.transaction_data.test`) are always accepted.
+         * Call this for custom types before parsing transaction data that uses them.
+         *
+         * @param type the transaction data type identifier to register.
+         * @param definition optional [TransactionDataType] with field metadata for consent UI rendering.
+         */
+        fun registerType(type: String, definition: TransactionDataType? = null) {
+            supportedTypes.add(type)
+            if (definition != null) {
+                typeDefinitions[type] = definition
+            }
+        }
+
         /**
          * Parses encoded transaction data.
          *
@@ -64,7 +89,7 @@ class TransactionData(
                 val data = Json.parseToJsonElement(jsonText).jsonObject
                 val credentialIds = data["credential_ids"]!!.jsonArray
                 val type = data["type"]!!.jsonPrimitive.content
-                if (type != "org.multipaz.transaction_data.test") {
+                if (type !in supportedTypes) {
                     throw IllegalArgumentException("Unsupported transaction type: '$type'")
                 }
                 val hashAlgorithm = if (hashAlgorithmOverrides != null) {
@@ -85,7 +110,7 @@ class TransactionData(
                     }
                 }
                 val hash = Crypto.digest(hashAlgorithm ?: Algorithm.SHA256, encoded.encodeToByteArray())
-                val parsed = TransactionData(ByteString(hash), hashAlgorithm, type, data)
+                val parsed = TransactionData(ByteString(hash), hashAlgorithm, type, data, typeDefinitions[type])
                 for (id in credentialIds) {
                     map.getOrPut(id.jsonPrimitive.content) { mutableListOf() }.add(parsed)
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
@@ -234,8 +234,14 @@ data class DcqlQuery(
             //
             for ((_, response) in credentialQueryIdToResponse) {
                 if (response.matches.isEmpty()) {
+                    val query = response.credentialQuery
+                    val typeHint = query.mdocDocType
+                        ?: query.vctValues?.joinToString()
+                        ?: query.format
                     throw DcqlCredentialQueryException(
-                        "No matches for credential query with id ${response.credentialQuery.id}"
+                        "No matches for credential query with id '${query.id}'" +
+                            " (format=${query.format}, type=$typeHint)." +
+                            " Ensure a credential of this type is provisioned in the document store."
                     )
                 }
                 val matches = mutableListOf<CredentialPresentmentSetOptionMemberMatch>()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
@@ -7,6 +7,7 @@ import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.eventlogger.EventLogger
 import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
@@ -70,7 +71,8 @@ abstract class PresentmentSource(
         trustMetadata: TrustMetadata?,
         credentialPresentmentData: CredentialPresentmentData,
         preselectedDocuments: List<Document>,
-        onDocumentsInFocus: (documents: List<Document>) -> Unit
+        onDocumentsInFocus: (documents: List<Document>) -> Unit,
+        transactionData: Map<String, List<TransactionData>>? = null
     ): CredentialPresentmentSelection?
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -9,6 +9,7 @@ import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.mdoc.zkp.ZkSystemRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.prompt.ShowConsentPromptFn
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.request.JsonRequestedClaim
@@ -69,14 +70,16 @@ class SimplePresentmentSource(
         trustMetadata: TrustMetadata?,
         credentialPresentmentData: CredentialPresentmentData,
         preselectedDocuments: List<Document>,
-        onDocumentsInFocus: (documents: List<Document>) -> Unit
+        onDocumentsInFocus: (documents: List<Document>) -> Unit,
+        transactionData: Map<String, List<TransactionData>>?
     ): CredentialPresentmentSelection? {
         return showConsentPromptFn(
             requester,
             trustMetadata,
             credentialPresentmentData,
             preselectedDocuments,
-            onDocumentsInFocus
+            onDocumentsInFocus,
+            transactionData
         )
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/ConsentPromptDialogModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/ConsentPromptDialogModel.kt
@@ -3,6 +3,8 @@ package org.multipaz.prompt
 import org.multipaz.document.Document
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
+import org.multipaz.documenttype.TransactionDataTypeRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.trustmanagement.TrustPoint
@@ -19,6 +21,10 @@ class ConsentPromptDialogModel():
         val trustMetadata: TrustMetadata?,
         val credentialPresentmentData: CredentialPresentmentData,
         val preselectedDocuments: List<Document>,
-        val onDocumentsInFocus: (documents: List<Document>) -> Unit
+        val onDocumentsInFocus: (documents: List<Document>) -> Unit,
+        /** Transaction data to display in the consent prompt, keyed by credential query ID. */
+        val transactionData: Map<String, List<TransactionData>>? = null,
+        /** Repository for looking up transaction data field metadata (display names, icons). */
+        val transactionDataTypeRepository: TransactionDataTypeRepository? = null
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PromptModelExt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PromptModelExt.kt
@@ -1,6 +1,8 @@
 package org.multipaz.prompt
 
 import org.multipaz.document.Document
+import org.multipaz.documenttype.TransactionDataTypeRepository
+import org.multipaz.openid.TransactionData
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.prompt.PassphrasePromptDialogModel.PassphraseRequest
@@ -89,7 +91,9 @@ suspend fun PromptModel.requestConsent(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>? = null,
+    transactionDataTypeRepository: TransactionDataTypeRepository? = null
 ): CredentialPresentmentSelection {
     return getDialogModel(ConsentPromptDialogModel.DialogType).displayPrompt(
         parameters = ConsentPromptDialogModel.ConsentPromptRequest(
@@ -98,6 +102,8 @@ suspend fun PromptModel.requestConsent(
             credentialPresentmentData = credentialPresentmentData,
             preselectedDocuments = preselectedDocuments,
             onDocumentsInFocus = onDocumentsInFocus,
+            transactionData = transactionData,
+            transactionDataTypeRepository = transactionDataTypeRepository,
         )
     )
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/ShowConsentPrompt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/ShowConsentPrompt.kt
@@ -1,6 +1,7 @@
 package org.multipaz.prompt
 
 import org.multipaz.document.Document
+import org.multipaz.openid.TransactionData
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.request.Requester
@@ -23,7 +24,8 @@ typealias ShowConsentPromptFn = suspend (
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ) -> CredentialPresentmentSelection?
 
 /**
@@ -36,7 +38,8 @@ suspend fun promptModelSilentConsent(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection? {
     val ret = credentialPresentmentData.select(preselectedDocuments)
     onDocumentsInFocus(ret.matches.map { it.credential.document })
@@ -65,7 +68,8 @@ suspend fun promptModelRequestConsent(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection? {
     try {
         return PromptModel.get().requestConsent(
@@ -74,6 +78,7 @@ suspend fun promptModelRequestConsent(
             credentialPresentmentData = credentialPresentmentData,
             preselectedDocuments = preselectedDocuments,
             onDocumentsInFocus = onDocumentsInFocus,
+            transactionData = transactionData,
         )
     } catch (_: PromptDismissedException) {
         return null

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestMdlAndPid.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestMdlAndPid.kt
@@ -90,7 +90,7 @@ class TestMdlAndPid {
                 presentmentSource = harness.presentmentSource
             ).prettyPrint().trim()
         }
-        assertEquals("No matches for credential query with id my_mdl", e.message)
+        assertEquals("No matches for credential query with id 'my_mdl' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test
@@ -103,7 +103,7 @@ class TestMdlAndPid {
                 presentmentSource = harness.presentmentSource
             ).prettyPrint().trim()
         }
-        assertEquals("No matches for credential query with id my_pid", e.message)
+        assertEquals("No matches for credential query with id 'my_pid' (format=dc+sd-jwt, type=https://credentials.example.com/identity_credential). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test
@@ -116,7 +116,7 @@ class TestMdlAndPid {
                 presentmentSource = harness.presentmentSource
             ).prettyPrint().trim()
         }
-        assertEquals("No matches for credential query with id my_mdl", e.message)
+        assertEquals("No matches for credential query with id 'my_mdl' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPrivacyPreservingAgeRequest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPrivacyPreservingAgeRequest.kt
@@ -228,7 +228,7 @@ class TestPrivacyPreservingAgeRequest {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestSingleMdlQuery.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestSingleMdlQuery.kt
@@ -104,7 +104,7 @@ class TestSingleMdlQuery {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test
@@ -118,7 +118,7 @@ class TestSingleMdlQuery {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestSingleSdJwtVcQuery.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestSingleSdJwtVcQuery.kt
@@ -135,7 +135,7 @@ class TestSingleSdJwtVcQuery {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=dc+sd-jwt, type=${EUPersonalID.EUPID_VCT}). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test
@@ -149,7 +149,7 @@ class TestSingleSdJwtVcQuery {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=dc+sd-jwt, type=${EUPersonalID.EUPID_VCT}). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestValueMatchingClaimSet.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestValueMatchingClaimSet.kt
@@ -279,6 +279,6 @@ class TestValueMatchingClaimSet {
                 presentmentSource = harness.presentmentSource
             )
         }
-        assertEquals("No matches for credential query with id my_credential", e.message)
+        assertEquals("No matches for credential query with id 'my_credential' (format=mso_mdoc, type=org.iso.18013.5.1.mDL). Ensure a credential of this type is provisioned in the document store.", e.message)
     }
 }

--- a/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -77,13 +77,14 @@ func getPresentmentSource() async -> PresentmentSource {
             }
             return nil
         },
-        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus in
+        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus, transactionData in
             try! await promptModelSilentConsent(
                 requester: requester,
                 trustMetadata: trustMetadata,
                 credentialPresentmentData: credentialPresentmentData,
                 preselectedDocuments: preselectedDocuments,
-                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
+                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) },
+                transactionData: transactionData
             )
         },
         preferSignatureToKeyAgreement: false,

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -74,7 +74,8 @@ struct ConsentPromptScreen: View {
                                 trustMetadata: consentData.trustMetadata,
                                 credentialPresentmentData: consentData.presentmentData,
                                 preselectedDocuments: [],
-                                onDocumentsInFocus: { documents in }
+                                onDocumentsInFocus: { documents in },
+                                transactionData: nil
                             )
                             if selection != nil {
                                 print("Selection: \(selection!)")
@@ -572,13 +573,14 @@ private func calcConsentData(
         resolveTrustFn: { requester in
             return nil
         },
-        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus in
+        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus, transactionData in
             try! await promptModelSilentConsent(
                 requester: requester,
                 trustMetadata: trustMetadata,
                 credentialPresentmentData: credentialPresentmentData,
                 preselectedDocuments: preselectedDocuments,
-                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
+                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) },
+                transactionData: transactionData
             )
         },
         domainMdocSignature: "mdoc",

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -301,13 +301,14 @@ class ViewModel {
                 }
                 return nil
             },
-            showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus in
+            showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus, transactionData in
                 try! await promptModelRequestConsent(
                     requester: requester,
                     trustMetadata: trustMetadata,
                     credentialPresentmentData: credentialPresentmentData,
                     preselectedDocuments: preselectedDocuments,
-                    onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
+                    onDocumentsInFocus: { documents in onDocumentsInFocus(documents) },
+                    transactionData: transactionData
                 )
             },
             preferSignatureToKeyAgreement: false,

--- a/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
@@ -129,14 +129,15 @@ func getPresentmentSource() async -> PresentmentSource {
             }
             return nil
         },
-        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus in
-            try! await promptModelSilentConsent(
+        showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus, transactionData in
+            return try! await promptModelSilentConsent(
                 requester: requester,
                 trustMetadata: trustMetadata,
                 credentialPresentmentData: credentialPresentmentData,
                 preselectedDocuments: preselectedDocuments,
-                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
-            )
+                onDocumentsInFocus: { documents in onDocumentsInFocus(documents) },
+                transactionData: nil
+            ) as CredentialPresentmentSelection?
         },
         preferSignatureToKeyAgreement: false,
         domainMdocSignature: TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_USER_AUTH,

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
@@ -14,6 +14,7 @@ import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.showBiometricPrompt
+import org.multipaz.openid.TransactionData
 import org.multipaz.request.Requester
 import org.multipaz.securearea.UserAuthenticationType
 import org.multipaz.trustmanagement.TrustMetadata
@@ -27,7 +28,8 @@ actual suspend fun launchAndroidPresentmentActivity(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection? {
     PresentmentActivity.presentmentModel.reset(
         source = source,
@@ -50,6 +52,7 @@ actual suspend fun launchAndroidPresentmentActivity(
                     onDocumentsInFocus = { documents ->
                         PresentmentActivity.presentmentModel.setDocumentsSelected(selectedDocuments = documents)
                     },
+                    transactionData = transactionData,
                 )
                 if (selection == null) {
                     throw PresentmentCanceledException("Presentment cancelled because user dismissed consent prompt")

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -52,6 +52,9 @@ import org.multipaz.documenttype.knowntypes.DrivingLicense
 import org.multipaz.documenttype.knowntypes.PhotoID
 import org.multipaz.documenttype.knowntypes.UtopiaBoardingPass
 import org.multipaz.mdoc.util.MdocUtil
+import org.multipaz.documenttype.knowntypes.DigitalPaymentCredential
+import org.multipaz.documenttype.knowntypes.PaymentTransactionData
+import org.multipaz.openid.TransactionData
 import org.multipaz.openid.dcql.DcqlQuery
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
@@ -116,7 +119,8 @@ private enum class UseCase(
     PHOTO_ID_MANDATORY("PhotoID: Mandatory data elements (2 docs)"),
     OPENID4VP_COMPLEX_EXAMPLE("Complex example from OpenID4VP Appendix D"),
     BOARDING_PASS_AND_MDL_EXAMPLE("Boarding pass AND mDL"),
-    BOARDING_PASS_OR_MDL_EXAMPLE("Boarding pass OR mDL")
+    BOARDING_PASS_OR_MDL_EXAMPLE("Boarding pass OR mDL"),
+    PAYMENT_SCA_WITH_TRANSACTION("Payment SCA with transaction data")
 }
 
 private enum class PaDuration(
@@ -157,7 +161,8 @@ expect suspend fun launchAndroidPresentmentActivity(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection?
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -205,6 +210,7 @@ fun ConsentPromptScreen(
         documentTypeRepository.addDocumentType(DrivingLicense.getDocumentType())
         documentTypeRepository.addDocumentType(PhotoID.getDocumentType())
         documentTypeRepository.addDocumentType(UtopiaBoardingPass.getDocumentType())
+        documentTypeRepository.addDocumentType(DigitalPaymentCredential.getDocumentType())
         documentStore = buildDocumentStore(storage, secureAreaRepository) {}
         documentModel = DocumentModel.create(documentStore = documentStore!!, documentTypeRepository = documentTypeRepository)
 
@@ -307,6 +313,22 @@ fun ConsentPromptScreen(
             expectedUpdate = null,
             domain = "mdoc"
         )
+        val documentPayment = documentStore!!.createDocument(
+            displayName = "Erika's Payment Card",
+            typeDisplayName = "Payment Card Credential",
+            cardArt = ByteString(Res.readBytes("drawable/payment_card_art.png"))
+        )
+        DigitalPaymentCredential.getDocumentType().createMdocCredentialWithSampleData(
+            document = documentPayment,
+            secureArea = secureArea,
+            createKeySettings = CreateKeySettings(),
+            dsKey = dsKey,
+            signedAt = credsValidFrom,
+            validFrom = credsValidFrom,
+            validUntil = credsValidUntil,
+            expectedUpdate = null,
+            domain = "mdoc"
+        )
         addCredentialsForOpenID4VPComplexExample(
             documentStore = documentStore!!,
             secureArea = secureArea,
@@ -364,7 +386,8 @@ fun ConsentPromptScreen(
                 trustMetadata: TrustMetadata?,
                 credentialPresentmentData: CredentialPresentmentData,
                 preselectedDocuments: List<Document>,
-                onDocumentsInFocus: (documents: List<Document>) -> Unit
+                onDocumentsInFocus: (documents: List<Document>) -> Unit,
+                transactionData: Map<String, List<TransactionData>>?
             ) -> CredentialPresentmentSelection?,
                           paData: AndroidPresentmentActivityData,
         ) {
@@ -390,6 +413,7 @@ fun ConsentPromptScreen(
                         { documents ->
                             onDocumentsInFocus = documents
                         },
+                        queryResult.transactionData,
                     )
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
@@ -404,13 +428,14 @@ fun ConsentPromptScreen(
         item {
             Button(onClick = {
                 launchConsent(launcher = { source, paData,
-                                           requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus ->
+                                           requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus, transactionData ->
                         promptModel.requestConsent(
                             requester = requester,
                             trustMetadata = trustMetadata,
                             credentialPresentmentData = credentialPresentmentData,
                             preselectedDocuments = preselectedDocuments,
                             onDocumentsInFocus = onDocumentsInFocus,
+                            transactionData = transactionData,
                         )
                     },
                     paData = AndroidPresentmentActivityData()
@@ -540,7 +565,8 @@ fun ConsentPromptScreen(
 private data class QueryResult(
     val requester: Requester,
     val source: PresentmentSource,
-    val presentmentData: CredentialPresentmentData
+    val presentmentData: CredentialPresentmentData,
+    val transactionData: Map<String, List<TransactionData>>? = null
 )
 
 private suspend fun getQueryResult(
@@ -688,6 +714,8 @@ private suspend fun getQueryResult(
             }
             """.trimIndent()
         ).jsonObject
+        UseCase.PAYMENT_SCA_WITH_TRANSACTION ->
+            DigitalPaymentCredential.getDocumentType().cannedRequests.find { it.id == "payment_sca_minimal" }!!.mdocRequest!!.toDcql()
         UseCase.BOARDING_PASS_OR_MDL_EXAMPLE -> Json.parseToJsonElement(
                 """
             {
@@ -770,7 +798,28 @@ private suspend fun getQueryResult(
     )
     val dcqlQuery = DcqlQuery.fromJson(dcql = dcql)
     val dcqlResponse = dcqlQuery.execute(presentmentSource = source)
-    return QueryResult(requester, source, dcqlResponse)
+
+    val transactionDataMap = if (useCase == UseCase.PAYMENT_SCA_WITH_TRANSACTION) {
+        generateMockTransactionData(dcqlQuery)
+    } else {
+        null
+    }
+
+    return QueryResult(requester, source, dcqlResponse, transactionDataMap)
+}
+
+private suspend fun generateMockTransactionData(
+    dcqlQuery: DcqlQuery
+): Map<String, List<TransactionData>> {
+    return PaymentTransactionData.create(
+        credentialId = dcqlQuery.credentialQueries.first().id,
+        transactionId = "txn-mock-001",
+        payeeName = "Delta Airlines",
+        payeeId = "merchant-delta-001",
+        amount = "90.00",
+        currency = "USD",
+        merchantMessage = "Flight NYC-LAX, Mar 15"
+    )
 }
 
 private suspend fun calculateRequester(

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.ios.kt
@@ -4,6 +4,7 @@ import org.multipaz.document.Document
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.presentment.PresentmentSource
+import org.multipaz.openid.TransactionData
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
 
@@ -14,7 +15,8 @@ actual suspend fun launchAndroidPresentmentActivity(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection? {
     throw IllegalStateException("Not implemented on this OS")
 }

--- a/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.wasmJs.kt
+++ b/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.wasmJs.kt
@@ -4,6 +4,7 @@ import org.multipaz.document.Document
 import org.multipaz.presentment.CredentialPresentmentData
 import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.presentment.PresentmentSource
+import org.multipaz.openid.TransactionData
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
 
@@ -14,7 +15,8 @@ actual suspend fun launchAndroidPresentmentActivity(
     trustMetadata: TrustMetadata?,
     credentialPresentmentData: CredentialPresentmentData,
     preselectedDocuments: List<Document>,
-    onDocumentsInFocus: (documents: List<Document>) -> Unit
+    onDocumentsInFocus: (documents: List<Document>) -> Unit,
+    transactionData: Map<String, List<TransactionData>>?
 ): CredentialPresentmentSelection? {
     throw IllegalStateException("Not implemented on this OS")
 }


### PR DESCRIPTION
Add transaction data support to the Digital Payment Credential flow, enabling the wallet consent screen to display payment details (payee, amount, currency) alongside the stored payment credential, with cryptographic binding via transaction data hashes in the mdoc DeviceResponse's deviceSigned namespaces.

Demo: https://www.youtube.com/shorts/3DVbF3tffzY

Key changes:
- Payment transaction data type (org.multipaz.transaction_data.payment) with typed builder, validation, and self-registration
- Transaction-aware consent screen rendering with TransactionDataType registry for generic field metadata (labels, icons)
- Transaction data hash binding in mdoc DeviceResponse deviceNamespaces
- Pluggable type registry via TransactionData.registerType()
- PaymentTransactionData.create() one-call API for developers
- Improved DCQL error messages with doctype context
- Mock payment flow in test app ("Payment SCA with transaction data")
- Updated Swift bridge and all Swift callers for new parameter

Tested on Android. iOS pending fix for #1624.

Fixes #1625 