### PR TITLE
Fix eventLogger parameter in SimplePresentmentSource.

### DIFF
--- a/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
+++ b/multipaz-swift/Sources/MultipazSwift/SimplePresentmentSourceExt.swift
@@ -11,7 +11,7 @@ extension SimplePresentmentSource.Companion {
     ///   - documetStore: the [DocumentStore] which holds credentials that can be presented.
     ///   - documentTypeRepository: a [DocumentTypeRepository] which holds metadata for document types.
     ///   - zkSystemRepository: the [ZkSystemRepository] to use or `nil`.
-    ///   - eventLog: an [EventLog] for logging events or `nil`.
+    ///   - eventLogger: an [EventLogger] for logging events or `nil`.
     ///   - resolveTrustFn: a function which can be used to determine if a requester is trusted.
     ///   - showConsentPromptFn: a [ShowConsentPromptFn] used show a consent prompt is required.
     ///   - preferSignatureToKeyAgreement: whether to use mdoc ECDSA authentication even if mdoc MAC authentication is possible (ISO mdoc only).
@@ -23,7 +23,7 @@ extension SimplePresentmentSource.Companion {
         documentStore: DocumentStore,
         documentTypeRepository: DocumentTypeRepository,
         zkSystemRepository: ZkSystemRepository? = nil,
-        eventLog: EventLog? = nil,
+        eventLogger: EventLogger? = nil,
         resolveTrustFn: @escaping @Sendable (
             _ requester: Requester
         ) async -> TrustMetadata?,
@@ -44,7 +44,7 @@ extension SimplePresentmentSource.Companion {
             documentStore: documentStore,
             documentTypeRepository: documentTypeRepository,
             zkSystemRepository: zkSystemRepository,
-            eventLog: eventLog,
+            eventLogger: eventLogger,
             resolveTrustFn: ResolveTrustHandler(f: resolveTrustFn),
             showConsentPromptFn: ShowConsentPromptHandler(f: showConsentPromptFn),
             preferSignatureToKeyAgreement: preferSignatureToKeyAgreement,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -1,13 +1,12 @@
 package org.multipaz.presentment
 
-import kotlin.time.Clock
 import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.eventlogger.SimpleEventLogger
+import org.multipaz.eventlogger.EventLogger
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.prompt.ShowConsentPromptFn
 import org.multipaz.prompt.promptModelRequestConsent
@@ -17,6 +16,7 @@ import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
 import org.multipaz.trustmanagement.TrustMetadata
+import kotlin.time.Clock
 
 
 private data class CredentialForPresentment(
@@ -33,7 +33,7 @@ private data class CredentialForPresentment(
  * @property documentStore the [DocumentStore] which holds credentials that can be presented.
  * @property documentTypeRepository a [DocumentTypeRepository] which holds metadata for document types.
  * @property zkSystemRepository the [ZkSystemRepository] to use or `null`.
- * @property eventLogger an [SimpleEventLogger] for logging events or `null`.
+ * @property eventLogger an [EventLogger] for logging events or `null`.
  * @property resolveTrustFn a function which can be used to determine if a requester is trusted.
  * @property showConsentPrompt a [ShowConsentPromptFn] used show a consent prompt is required.
  * @property preferSignatureToKeyAgreement whether to use mdoc ECDSA authentication even if mdoc MAC authentication
@@ -47,7 +47,7 @@ class SimplePresentmentSource(
     override val documentStore: DocumentStore,
     override val documentTypeRepository: DocumentTypeRepository,
     override val zkSystemRepository: ZkSystemRepository? = null,
-    override val eventLogger: SimpleEventLogger? = null,
+    override val eventLogger: EventLogger? = null,
     private val resolveTrustFn: suspend (requester: Requester) -> TrustMetadata? = { requester -> null },
     private val showConsentPromptFn: ShowConsentPromptFn = ::promptModelRequestConsent,
     val preferSignatureToKeyAgreement: Boolean = true,
@@ -59,6 +59,7 @@ class SimplePresentmentSource(
     documentStore = documentStore,
     documentTypeRepository = documentTypeRepository,
     zkSystemRepository = zkSystemRepository,
+    eventLogger = eventLogger
 ) {
     override suspend fun resolveTrust(requester: Requester): TrustMetadata? {
         return resolveTrustFn(requester)


### PR DESCRIPTION
This should take an `EventLogger` instance, not a
`SimpleEventLogger`. Also fix up the Swift-specific extensions.

Test: Both TestApp and Swift TestApp compiles and runs.
