### PR TITLE
Add Digital Payment Credential support to verifier light UI.

### DIFF
--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -15,6 +15,7 @@ import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
 import org.multipaz.crypto.JsonWebEncryption
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.knowntypes.Aadhaar
+import org.multipaz.documenttype.knowntypes.DigitalPaymentCredential
 import org.multipaz.documenttype.knowntypes.DrivingLicense
 import org.multipaz.documenttype.knowntypes.EUCertificateOfResidence
 import org.multipaz.documenttype.knowntypes.EUPersonalID
@@ -346,6 +347,7 @@ private val documentTypeRepo: DocumentTypeRepository by lazy {
     repo.addDocumentType(AgeVerification.getDocumentType())
     repo.addDocumentType(Loyalty.getDocumentType())
     repo.addDocumentType(Aadhaar.getDocumentType())
+    repo.addDocumentType(DigitalPaymentCredential.getDocumentType())
     repo
 }
 

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifyCredentials.kt
@@ -34,6 +34,7 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Nint
 import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.Uint
 import org.multipaz.cbor.addCborArray
@@ -493,6 +494,11 @@ private suspend fun processMdocResponse(
                     Simple.TRUE -> JsonPrimitive(true)
                     Simple.FALSE -> JsonPrimitive(false)
                     Simple.NULL -> JsonPrimitive(null as String?)
+                    is Tagged -> when (item.tagNumber) {
+                        Tagged.DATE_TIME_STRING,
+                        Tagged.FULL_DATE_STRING -> JsonPrimitive((item.taggedItem as Tstr).asTstr)
+                        else -> JsonPrimitive("<unsupported>")
+                    }
                     else -> JsonPrimitive("<unsupported>")
                 }
                 val id = claim.id ?: claim.path.last().asTstr

--- a/multipaz-verifier-server/src/main/resources/resources/www/light.js
+++ b/multipaz-verifier-server/src/main/resources/resources/www/light.js
@@ -30,6 +30,96 @@ const examples = {
            ]
         }
     },
+    "Payment SCA (minimal)": {
+        "dcql": {
+            "credentials": [
+                {
+                    "id": "payment",
+                    "format": "mso_mdoc",
+                    "meta": {
+                        "doctype_value": "org.multipaz.payment.sca.1"
+                    },
+                    "claims": [
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "issuer_name"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "masked_account_reference"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "holder_name"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "expiry_date"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "Payment SCA (full)": {
+        "dcql": {
+            "credentials": [
+                {
+                    "id": "payment",
+                    "format": "mso_mdoc",
+                    "meta": {
+                        "doctype_value": "org.multipaz.payment.sca.1"
+                    },
+                    "claims": [
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "issuer_name"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "payment_instrument_id"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "masked_account_reference"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "holder_name"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "issue_date"
+                            ]
+                        },
+                        {
+                            "path": [
+                                "org.multipaz.payment.sca.1",
+                                "expiry_date"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
     "Movie ticket + EU PID age": {
         "dcql": {
           "credentials": [


### PR DESCRIPTION
Register DigitalPaymentCredential in the verifier document type repo, add Payment SCA examples (minimal and full) to light.js, and handle CBOR tagged date types in mdoc response processing so issue_date and expiry_date render correctly.

Submitted as a standalone PR ahead of DPC Transaction Data support, per agreement with Peter to land the light.html changes first.

Demo: https://www.youtube.com/shorts/lW_nzQeqApY