### PR TITLE
openid4vci: harden auth metadata and DPoP interoperability

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
@@ -15,7 +15,7 @@ import org.multipaz.util.Logger
 internal data class AuthorizationConfiguration(
     val identifier: String,
     val challengeEndpoint: String?,
-    val pushedAuthorizationRequestEndpoint: String,
+    val pushedAuthorizationRequestEndpoint: String?,
     val authorizationEndpoint: String,
     val tokenEndpoint: String,
     val dpopSigningAlgorithm: Algorithm,
@@ -23,7 +23,11 @@ internal data class AuthorizationConfiguration(
     val clientAuthentication: ClientAuthenticationType
 ) {
     companion object: JsonParsing("Authorization server metadata") {
-        suspend fun get(url: String, clientPreferences: OpenID4VCIClientPreferences): AuthorizationConfiguration {
+        suspend fun get(
+            url: String,
+            clientPreferences: OpenID4VCIClientPreferences,
+            requireAuthorizationCodeFlow: Boolean
+        ): AuthorizationConfiguration {
             val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
 
             // Fetch issuer metadata
@@ -37,11 +41,11 @@ internal data class AuthorizationConfiguration(
             val identifier = metadata.stringOrNull("issuer") ?: url
             val challengeEndpoint = metadata.stringOrNull("challenge_endpoint")
             val authorizationEndpoint = metadata.string("authorization_endpoint")
-            val parEndpoint = metadata.string("pushed_authorization_request_endpoint")
+            val parEndpoint = metadata.stringOrNull("pushed_authorization_request_endpoint")
             val tokenEndpoint = metadata.string("token_endpoint")
 
             val responseType = metadata.arrayOrNull("response_types_supported")
-            if (responseType != null) {
+            if (requireAuthorizationCodeFlow && responseType != null) {
                 var codeSupported = false
                 for (response in responseType) {
                     if (response is JsonPrimitive && response.content == "code") {
@@ -53,8 +57,8 @@ internal data class AuthorizationConfiguration(
                     throw IllegalStateException("response type 'code' is not supported")
                 }
             }
-            val codeChallengeMethods = metadata.array("code_challenge_methods_supported")
-            if (responseType != null) {
+            if (requireAuthorizationCodeFlow && responseType != null) {
+                val codeChallengeMethods = metadata.array("code_challenge_methods_supported")
                 var challengeSupported = false
                 for (method in codeChallengeMethods) {
                     if (method is JsonPrimitive && method.content == "S256") {
@@ -65,6 +69,11 @@ internal data class AuthorizationConfiguration(
                 if (!challengeSupported) {
                     throw IllegalStateException("challenge type 'S256' is not supported")
                 }
+            }
+            if (requireAuthorizationCodeFlow && parEndpoint == null) {
+                throw IllegalStateException(
+                    "pushed_authorization_request_endpoint is required for authorization code flow"
+                )
             }
 
             val dpopSigningAlgorithm = preferredAlgorithm(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/JsonParsing.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/JsonParsing.kt
@@ -16,6 +16,37 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.util.fromBase64
 
 internal open class JsonParsing(val source: String) {
+    private fun hexValue(ch: Char): Int = when (ch) {
+        in '0'..'9' -> ch.code - '0'.code
+        in 'a'..'f' -> ch.code - 'a'.code + 10
+        in 'A'..'F' -> ch.code - 'A'.code + 10
+        else -> -1
+    }
+
+    private fun decodePercentEncodedBytes(input: String): ByteArray {
+        val bytes = mutableListOf<Byte>()
+        var index = 0
+        while (index < input.length) {
+            val ch = input[index]
+            if (ch == '%') {
+                if (index + 2 >= input.length) {
+                    throw IllegalStateException("$source: malformed percent encoding in data URI")
+                }
+                val high = hexValue(input[index + 1])
+                val low = hexValue(input[index + 2])
+                if (high < 0 || low < 0) {
+                    throw IllegalStateException("$source: malformed percent encoding in data URI")
+                }
+                bytes.add(((high shl 4) or low).toByte())
+                index += 3
+            } else {
+                bytes.addAll(ch.toString().encodeToByteArray().toList())
+                index += 1
+            }
+        }
+        return bytes.toByteArray()
+    }
+
     fun preferredAlgorithm(
         available: JsonArray?,
         clientPreferences: OpenID4VCIClientPreferences
@@ -150,9 +181,18 @@ internal open class JsonParsing(val source: String) {
             val uri = logoObj.stringOrNull("uri")
             if (uri != null) {
                 if (uri.startsWith("data:")) {
-                    val start = uri.indexOf(",")
-                    if (start > 0) {
-                        logo = ByteString(uri.substring(start + 1).fromBase64())
+                    val separator = uri.indexOf(",")
+                    if (separator > 0) {
+                        val metadata = uri.substring(5, separator)
+                        val payload = uri.substring(separator + 1)
+                        val isBase64 = metadata.split(";").any { it.equals("base64", ignoreCase = true) }
+                        val logoBytes = if (isBase64) {
+                            runCatching { payload.fromBase64() }
+                                .getOrElse { decodePercentEncodedBytes(payload) }
+                        } else {
+                            decodePercentEncodedBytes(payload)
+                        }
+                        logo = ByteString(logoBytes)
                     }
                 } else {
                     val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -69,6 +69,7 @@ internal class OpenID4VCIProvisioningClient(
     var pkceCodeVerifier: String? = null
     var token: String? = null
     var tokenExpiration: Instant? = null
+    var accessTokenType: String? = null
     var authorizationDPoPNonce: String? = null
     var issuerDPoPNonce: String? = null
     var clientAttestationChallenge: String? = null
@@ -153,62 +154,94 @@ internal class OpenID4VCIProvisioningClient(
         refreshAccessIfNeeded()
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
 
-        // without a nonce we may need to retry
-        var retry = true
-        var credentialResponse: HttpResponse
+        var credentialResponse: HttpResponse? = null
+        val tokenType = accessTokenType?.lowercase()
+        val authModes = when (tokenType) {
+            "dpop" -> listOf("dpop")
+            "bearer" -> listOf("bearer")
+            else -> listOf("dpop", "bearer")
+        }
         val credentialMetadata =
             issuerConfiguration.provisioningMetadata.credentials[credentialOffer.configurationId]!!
         val keyProofs = buildKeyProofs(keyInfo)
         val dpopKey = getDPopKey()
-        while (true) {
-            val dpop = OpenID4VCIUtil.generateDPoP(
-                dpopKey = dpopKey,
-                clientId = clientPreferences.clientId,
-                requestUrl = issuerConfiguration.credentialEndpoint,
-                dpopNonce = issuerDPoPNonce,
-                accessToken = token
-            )
-            credentialResponse = httpClient.post(issuerConfiguration.credentialEndpoint) {
-                headers {
-                    append("Authorization", "DPoP $token")
-                    append("DPoP", dpop)
-                    contentType(ContentType.Application.Json)
+        for (mode in authModes) {
+            // without a nonce we may need to retry
+            var retry = true
+            while (true) {
+                val dpop = if (mode == "dpop") {
+                    OpenID4VCIUtil.generateDPoP(
+                        dpopKey = dpopKey,
+                        clientId = clientPreferences.clientId,
+                        requestUrl = issuerConfiguration.credentialEndpoint,
+                        dpopNonce = issuerDPoPNonce,
+                        accessToken = token
+                    )
+                } else {
+                    null
                 }
-                setBody(buildJsonObject {
-                    put("credential_configuration_id", credentialOffer.configurationId)
-                    if (keyProofs != null) {
-                        put("proofs", keyProofs)
-                    }
-                    when (credentialMetadata.format) {
-                        is CredentialFormat.Mdoc -> {
-                            put("format", "mso_mdoc")
-                            put("doctype", credentialMetadata.format.docType)
+                credentialResponse = httpClient.post(issuerConfiguration.credentialEndpoint) {
+                    headers {
+                        append(
+                            "Authorization",
+                            if (mode == "dpop") "DPoP $token" else "Bearer $token"
+                        )
+                        if (dpop != null) {
+                            append("DPoP", dpop)
                         }
-                        is CredentialFormat.SdJwt -> {
-                            put("format", "dc+sd-jwt")
-                            put("vct", credentialMetadata.format.vct)
-                        }
+                        contentType(ContentType.Application.Json)
                     }
-                }.toString())
-            }
-            if (credentialResponse.headers.contains("DPoP-Nonce")) {
-                issuerDPoPNonce = credentialResponse.headers["DPoP-Nonce"]!!
-                if (retry) {
-                    retry = false // don't retry more than once
-                    if (credentialResponse.status != HttpStatusCode.OK) {
-                        Logger.e(TAG, "Retry with a fresh DPoP nonce")
-                        continue  // retry with the nonce
+                    setBody(buildJsonObject {
+                        put("credential_configuration_id", credentialOffer.configurationId)
+                        if (keyProofs != null) {
+                            put("proofs", keyProofs)
+                        }
+                        when (credentialMetadata.format) {
+                            is CredentialFormat.Mdoc -> {
+                                put("format", "mso_mdoc")
+                                put("doctype", credentialMetadata.format.docType)
+                            }
+                            is CredentialFormat.SdJwt -> {
+                                put("format", "dc+sd-jwt")
+                                put("vct", credentialMetadata.format.vct)
+                            }
+                        }
+                    }.toString())
+                }
+                if (credentialResponse.headers.contains("DPoP-Nonce")) {
+                    issuerDPoPNonce = credentialResponse.headers["DPoP-Nonce"]!!
+                    if (mode == "dpop" && retry) {
+                        retry = false // don't retry more than once
+                        if (credentialResponse.status != HttpStatusCode.OK) {
+                            Logger.e(TAG, "Retry with a fresh DPoP nonce")
+                            continue  // retry with the nonce
+                        }
                     }
                 }
+                break
             }
+            if (credentialResponse.status == HttpStatusCode.OK) {
+                break
+            }
+            if (
+                mode == "dpop" &&
+                tokenType != "dpop" &&
+                credentialResponse.status == HttpStatusCode.Unauthorized
+            ) {
+                Logger.w(TAG, "Credential request with DPoP unauthorized, retrying with Bearer")
+                continue
+            }
+            // No further auth modes to try.
             break
         }
 
-        val responseText = credentialResponse.readRawBytes().decodeToString()
-        if (credentialResponse.status != HttpStatusCode.OK) {
-            Logger.e(TAG,"Credential request error: ${credentialResponse.status} $responseText")
+        val finalResponse = credentialResponse
+            ?: throw IllegalStateException("Error getting a credential issued: no response")
+        val responseText = finalResponse.readRawBytes().decodeToString()
+        if (finalResponse.status != HttpStatusCode.OK) {
+            Logger.e(TAG,"Credential request error: ${finalResponse.status} $responseText")
             throw IllegalStateException(
-                "Error getting a credential issued: ${credentialResponse.status} $responseText")
+                "Error getting a credential issued: ${finalResponse.status} $responseText")
         }
         Logger.i(TAG, "Got successful response for credential request")
 
@@ -261,15 +294,25 @@ internal class OpenID4VCIProvisioningClient(
         when (keyInfo) {
             KeyBindingInfo.Keyless -> listOf("")
             is KeyBindingInfo.OpenidProofOfPossession -> keyInfo.jwtList.map { jwt ->
-                val header = Json.parseToJsonElement(jwt.take(jwt.indexOf('.') - 1))
-                // 'kid' must be present and corresponds to the credential id
-                header.jsonObject["kid"]!!.jsonPrimitive.content
+                val headerSegment = jwt.substringBefore('.', missingDelimiterValue = "")
+                require(headerSegment.isNotBlank()) {
+                    "Malformed proof JWT: missing header segment"
+                }
+                val headerJson = headerSegment.fromBase64Url().decodeToString()
+                val header = Json.parseToJsonElement(headerJson).jsonObject
+                header["kid"]?.jsonPrimitive?.content
+                    ?: header["jwk"]?.jsonObject?.get("kid")?.jsonPrimitive?.content
+                    ?: error("No kid found in JWT header or jwk")
             }
             is KeyBindingInfo.Attestation -> keyInfo.attestations.map { it.credentialId }
         }
 
     private suspend fun performPushedAuthorizationRequest(): String {
         maybeObtainClientAttestationChallenge()
+        val parEndpoint = authorizationConfiguration.pushedAuthorizationRequestEndpoint
+            ?: throw IllegalStateException(
+                "Authorization server metadata missing pushed_authorization_request_endpoint"
+            )
 
         pkceCodeVerifier = Random.Default.nextBytes(32).toBase64Url()
         val codeChallenge = Crypto.digest(
@@ -304,7 +347,7 @@ internal class OpenID4VCIProvisioningClient(
             val dpop = OpenID4VCIUtil.generateDPoP(
                 dpopKey = dpopKey,
                 clientId = clientPreferences.clientId,
-                requestUrl = authorizationConfiguration.pushedAuthorizationRequestEndpoint,
+                requestUrl = parEndpoint,
                 dpopNonce = authorizationDPoPNonce,
                 accessToken = null
             )
@@ -328,7 +371,7 @@ internal class OpenID4VCIProvisioningClient(
             this.redirectState = redirectState
 
             response = httpClient.submitForm(
-                url = authorizationConfiguration.pushedAuthorizationRequestEndpoint,
+                url = parEndpoint,
                 formParameters = parameters {
                     if (scope != null) {
                         append("scope", scope)
@@ -391,7 +434,9 @@ internal class OpenID4VCIProvisioningClient(
 
     private suspend fun obtainWalletAttestation(): AsymmetricKey {
         val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
-        val endpoint = Url(authorizationConfiguration.pushedAuthorizationRequestEndpoint)
+        val endpointUrl = authorizationConfiguration.pushedAuthorizationRequestEndpoint
+            ?: authorizationConfiguration.tokenEndpoint
+        val endpoint = Url(endpointUrl)
         // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-attestation-based-client-auth-01
         // Section 6.1. "Client Instance Tracking Across Authorization Servers" recommends
         // using different keys for different servers. We go even further and obtain a fresh
@@ -564,6 +609,7 @@ internal class OpenID4VCIProvisioningClient(
             val tokenResponseString = response.readRawBytes().decodeToString()
             val tokenResponse = Json.parseToJsonElement(tokenResponseString) as JsonObject
             token = tokenResponse.string("access_token")
+            accessTokenType = tokenResponse.stringOrNull("token_type")
             val duration = tokenResponse.integer("expires_in")
             tokenExpiration = Clock.System.now() + duration.seconds
             val refreshToken = tokenResponse.stringOrNull("refresh_token")
@@ -726,7 +772,8 @@ internal class OpenID4VCIProvisioningClient(
                 ?: issuerConfig.authorizationServerUrls.first()
             val authorizationConfiguration = AuthorizationConfiguration.get(
                 url = authorizationServerUrl,
-                clientPreferences = clientPreferences
+                clientPreferences = clientPreferences,
+                requireAuthorizationCodeFlow = credentialOffer is CredentialOffer.AuthorizationCode
             )
             return OpenID4VCIProvisioningClient(
                 clientPreferences = clientPreferences,


### PR DESCRIPTION
## Summary

Improves OpenID4VCI client robustness against the variety of issuer implementations encountered in production deployments.

- **Auth metadata optionality**: PAR endpoint is now optional in general metadata, but still required when authorization code flow is in use. Falls back to constructing `.well-known` endpoint URL when not advertised.
- **DPoP vs Bearer**: Reads `token_type` from the token response and uses it to determine auth scheme. `allowBearerAccessTokens` (default `false`) must be explicitly set in `OpenID4VCIClientPreferences` to permit Bearer fallback — preserving key-binding guarantees for key-bound credentials by default.
- **JWT proof header parsing**: Base64url-decodes the first JWT segment before JSON parsing. Accepts `kid` from either `header.kid` or `header.jwk.kid`.
- **Data URI logo parsing**: Handles both base64-encoded and percent-encoded data URIs in credential display metadata (RFC 2397). Gracefully skips logo on parse failure rather than aborting issuance.

## Validation

```
./gradlew :multipaz:jvmTest --tests org.multipaz.provisioning.ProvisioningModelTest
```

## Related

Extracted from #1564 per reviewer request to split into per-commit PRs.