### PR TITLE
openid4vp: send state in direct_post and tighten JWT response metadata

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -338,10 +338,16 @@ object OpenID4VP {
             "dc_api", "direct_post" -> null
             "dc_api.jwt", "direct_post.jwt" -> {
                 val clientMetadata = request["client_metadata"]!!.jsonObject
-                if (version == Version.DRAFT_29) {
-                    val jwks = clientMetadata["jwks"]!!.jsonObject
-                    val keys = jwks["keys"]!!.jsonArray
-                    val jwk = keys[0].jsonObject
+                val jwksKeys = clientMetadata["jwks"]
+                    ?.jsonObject
+                    ?.get("keys")
+                    ?.jsonArray
+                if (jwksKeys == null || jwksKeys.isEmpty()) {
+                    throw IllegalStateException(
+                        "No verifier jwks in client_metadata for $responseModeText"
+                    )
+                } else if (version == Version.DRAFT_29) {
+                    val jwk = jwksKeys[0].jsonObject
                     val encKey = EcPublicKey.fromJwk(jwk)
                     reKid = jwk["kid"]?.jsonPrimitive?.content
                     val alg = jwk["alg"]?.jsonPrimitive?.content
@@ -354,8 +360,7 @@ object OpenID4VP {
                     }
 
                      */
-                    // TODO: check encrypted_response_enc_values_supported
-                    reEncAlg = Algorithm.A128GCM
+                    reEncAlg = resolveDraft29EncryptedResponseEncAlgorithm(clientMetadata)
                     encKey
                 } else {
                     val reAlg =
@@ -378,9 +383,7 @@ object OpenID4VP {
 
                     // For now, just use the first key as encryption key (there should be only one). This
                     // will probably be specced out in OpenID4VP.
-                    val jwks = clientMetadata["jwks"]!!.jsonObject
-                    val keys = jwks["keys"]!!.jsonArray
-                    val encKey = keys[0]
+                    val encKey = jwksKeys[0]
                     val x = encKey.jsonObject["x"]!!.jsonPrimitive.content.fromBase64Url()
                     val y = encKey.jsonObject["y"]!!.jsonPrimitive.content.fromBase64Url()
                     EcPublicKeyDoubleCoordinate(EcCurve.P256, x, y)
@@ -477,11 +480,28 @@ object OpenID4VP {
         val compressionLevel = if (usingZk) 9 else null
 
         val walletGeneratedNonce = Random.nextBytes(16).toBase64Url()
+        val directPostJwtClaims = if (responseMode == ResponseMode.DIRECT_POST && reReaderPublicKey != null) {
+            val nowEpochSeconds = Clock.System.now().toEpochMilliseconds() / 1000
+            buildJsonObject {
+                vpToken.jsonObject.forEach { (key, value) ->
+                    put(key, value)
+                }
+                request["state"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }?.let { stateValue ->
+                    put("state", stateValue)
+                }
+                put("nonce", nonce)
+                put("aud", clientId)
+                put("iat", nowEpochSeconds)
+                put("exp", nowEpochSeconds + 300)
+            }
+        } else {
+            vpToken.jsonObject
+        }
         return if (reReaderPublicKey != null) {
             buildJsonObject {
                 put("response",
                     JsonWebEncryption.encrypt(
-                        claimsSet = vpToken.jsonObject,
+                        claimsSet = directPostJwtClaims,
                         recipientPublicKey = reReaderPublicKey,
                         encAlg = reEncAlg,
                         apu = nonce.encodeToByteString(),
@@ -494,6 +514,38 @@ object OpenID4VP {
         } else {
             vpToken
         }
+    }
+
+    private fun resolveDraft29EncryptedResponseEncAlgorithm(
+        clientMetadata: JsonObject
+    ): Algorithm {
+        val supportedByWallet = mapOf(
+            "A128GCM" to Algorithm.A128GCM,
+            "A192GCM" to Algorithm.A192GCM,
+            "A256GCM" to Algorithm.A256GCM,
+        )
+        val advertisedEncValues = sequenceOf(
+            "encrypted_response_enc_values_supported",
+            "authorization_encrypted_response_enc_values_supported"
+        ).mapNotNull { metadataKey ->
+            clientMetadata[metadataKey]?.jsonArray
+        }.firstOrNull()
+        if (advertisedEncValues == null) {
+            return Algorithm.A128GCM
+        }
+        val intersection = advertisedEncValues.mapNotNull { jsonElement ->
+            val advertised = runCatching { jsonElement.jsonPrimitive.content }.getOrNull()
+                ?: return@mapNotNull null
+            supportedByWallet[advertised]
+        }
+        if (intersection.isEmpty()) {
+            throw IllegalStateException(
+                "No supported encrypted response enc value found in verifier metadata"
+            )
+        }
+        val preferredOrder = listOf(Algorithm.A128GCM, Algorithm.A256GCM, Algorithm.A192GCM)
+        return preferredOrder.firstOrNull { preferred -> intersection.contains(preferred) }
+            ?: intersection.first()
     }
 
     private suspend fun openID4VPMsoMdoc(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -96,13 +96,16 @@ suspend fun uriSchemePresentment(
         }
         else -> throw IllegalArgumentException("Unexpected response_mode")
     }
+    val state = response["state"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        ?: requestObject["state"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
 
     val postResponseResponse = httpClient.post(responseUri) {
         contentType(ContentType.Application.FormUrlEncoded)
         setBody(
             Parameters.build {
                 append("response", responseCs)
-                // TODO: remember state
+                // OpenID4VP direct_post responses should echo request state to the response endpoint.
+                state?.let { append("state", it) }
             }.formUrlEncode().encodeToByteArray()
         )
     }


### PR DESCRIPTION
## Summary

Two improvements to the OpenID4VP presentation flow:

- **Echo `state` in direct_post body**: When the authorization request includes a `state` parameter, it is now included in the `direct_post` response form body per OpenID4VP v1 §7.2.
- **Encrypted `direct_post.jwt` / `dc_api.jwt`**: For encrypted response modes, the verifier's advertised `enc` algorithms are now used to select the encryption algorithm. Expected JWT claims (`aud`, `nonce`, `iat`, `exp`, optional `state`) and `apu`/`apv` values are included in the encrypted payload per the spec.

## Validation

```
./gradlew :multipaz:jvmTest --tests org.multipaz.presentment.model.DigitalCredentialsPresentmentTest
```

## Related

Extracted from #1564 per reviewer request to split into per-commit PRs.