### PR TITLE
mdoc: tolerate legacy MSO payload and ValidityInfo date encodings

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -30,6 +30,7 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
+import org.multipaz.mdoc.mso.MsoPayloadDecoder
 import org.multipaz.mdoc.mso.MobileSecurityObject
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
@@ -288,8 +289,7 @@ class MdocCredential : SecureAreaBoundCredential {
      * Convenience property for accessing the [MobileSecurityObject] from [issuerAuth].
      */
     val mso: MobileSecurityObject by lazy {
-        val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
-        MobileSecurityObject.fromDataItem(Cbor.decode(encodedMobileSecurityObject))
+        MobileSecurityObject.fromDataItem(MsoPayloadDecoder.decode(issuerAuth.payload!!))
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObject.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObject.kt
@@ -3,6 +3,8 @@ package org.multipaz.mdoc.mso
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborArray
 import org.multipaz.cbor.putCborMap
@@ -185,10 +187,10 @@ data class MobileSecurityObject(
             return MobileSecurityObject(
                 version = dataItem["version"].asTstr,
                 docType = dataItem["docType"].asTstr,
-                signedAt = validityInfo["signed"].asDateTimeString,
-                validFrom = validityInfo["validFrom"].asDateTimeString,
-                validUntil = validityInfo["validUntil"].asDateTimeString,
-                expectedUpdate = validityInfo.getOrNull("expectedUpdate")?.asDateTimeString,
+                signedAt = parseDateTimeStringLenient(validityInfo["signed"]),
+                validFrom = parseDateTimeStringLenient(validityInfo["validFrom"]),
+                validUntil = parseDateTimeStringLenient(validityInfo["validUntil"]),
+                expectedUpdate = validityInfo.getOrNull("expectedUpdate")?.let { parseDateTimeStringLenient(it) },
                 digestAlgorithm = dataItem["digestAlgorithm"].asTstr.let {
                     when (it) {
                         "SHA-256" -> Algorithm.SHA256
@@ -204,6 +206,42 @@ data class MobileSecurityObject(
                 deviceKeyInfo = deviceKeyInfo,
                 revocationStatus = revocationStatus
             )
+        }
+
+        private fun parseValidityTimestamp(
+            fieldName: String,
+            item: DataItem,
+            compatibilityOptions: MdocCompatibilityOptions
+        ): Instant {
+            if (item is Tagged) {
+                require(item.tagNumber == Tagged.DATE_TIME_STRING) {
+                    "ValidityInfo.$fieldName must use tdate (tag 0)"
+                }
+                val taggedItem = item.taggedItem
+                require(taggedItem is Tstr) {
+                    "ValidityInfo.$fieldName must be tag 0 string"
+                }
+                return Instant.parse(taggedItem.value)
+            }
+            if (item is Tstr && compatibilityOptions.allowLegacyMsoValidityTimestamps) {
+                // TODO: remove after 2026-07-01 — SITA issuer emits ValidityInfo timestamps
+                // without CBOR tag 0 (tdate) for compatibility with the NEC verifier deployed
+                // at Hong Kong International Airport (HKG). Remove once NEC verifier is updated
+                // to accept canonical tdate-tagged timestamps per ISO/IEC 18013-5 §9.1.2.
+                Logger.w(
+                    TAG,
+                    "Allowing legacy untagged ValidityInfo.$fieldName timestamp (HKG/NEC compat); remove after 2026-07-01"
+                )
+                return Instant.parse(item.value)
+            }
+            if (compatibilityOptions.allowLegacyMsoValidityTimestamps) {
+                Logger.w(
+                    TAG,
+                    "Allowing legacy ValidityInfo.$fieldName timestamp encoded as ${item::class.simpleName} (HKG/NEC compat)"
+                )
+                return item.asDateTimeString
+            }
+            throw IllegalArgumentException("ValidityInfo.$fieldName must use tag 0 tdate")
         }
 
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectParser.kt
@@ -19,6 +19,8 @@ import io.ktor.util.toLowerCasePreservingASCIIRules
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.Tstr
 import org.multipaz.crypto.EcPublicKey
 import kotlin.time.Instant
 import org.multipaz.crypto.Algorithm
@@ -195,19 +197,19 @@ class MobileSecurityObjectParser(
 
         private fun parseValidityInfo(validityInfo: DataItem) {
             signed = Instant.fromEpochMilliseconds(
-                validityInfo["signed"].asDateTimeString
+                parseDateTimeStringLenient(validityInfo["signed"])
                     .toEpochMilliseconds()
             )
             validFrom =
                 Instant.fromEpochMilliseconds(
-                    validityInfo["validFrom"].asDateTimeString.toEpochMilliseconds())
+                    parseDateTimeStringLenient(validityInfo["validFrom"]).toEpochMilliseconds())
             validUntil =
                 Instant.fromEpochMilliseconds(
-                    validityInfo["validUntil"].asDateTimeString.toEpochMilliseconds())
+                    parseDateTimeStringLenient(validityInfo["validUntil"]).toEpochMilliseconds())
             if (validityInfo.getOrNull("expectedUpdate") != null) {
                 expectedUpdate =
                     Instant.fromEpochMilliseconds(
-                        validityInfo["expectedUpdate"].asDateTimeString.toEpochMilliseconds())
+                        parseDateTimeStringLenient(validityInfo["expectedUpdate"]).toEpochMilliseconds())
             } else {
                 expectedUpdate = null
             }
@@ -217,6 +219,20 @@ class MobileSecurityObjectParser(
             require(validUntil > validFrom) {
                 "The validUntil timestamp should be later than the validFrom timestamp"
             }
+        }
+
+        private fun parseDateTimeStringLenient(item: DataItem): Instant {
+            if (item is Tstr) {
+                return Instant.parse(item.value)
+            }
+            if (
+                item is Tagged &&
+                item.tagNumber == Tagged.DATE_TIME_STRING &&
+                item.taggedItem is Tstr
+            ) {
+                return Instant.parse((item.taggedItem as Tstr).value)
+            }
+            return item.asDateTimeString
         }
 
         fun parse(encodedMobileSecurityObject: ByteArray) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MsoPayloadDecoder.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/mso/MsoPayloadDecoder.kt
@@ -1,0 +1,33 @@
+package org.multipaz.mdoc.mso
+
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
+
+internal object MsoPayloadDecoder {
+    /**
+     * Accepts both spec-compliant payloads (#6.24(bstr .cbor MSO)) and legacy/raw CBOR MSO payloads.
+     */
+    fun decode(payload: ByteArray): DataItem {
+        return decodeDataItem(Cbor.decode(payload))
+    }
+
+    private fun decodeDataItem(item: DataItem): DataItem {
+        val unwrapped = when {
+            item is Tagged && item.tagNumber == Tagged.ENCODED_CBOR && item.taggedItem is Bstr ->
+                Cbor.decode(item.taggedItem.asBstr)
+            item is Bstr -> Cbor.decode(item.asBstr)
+            else -> item
+        }
+        return if (
+            unwrapped is Tagged &&
+            unwrapped.tagNumber == Tagged.ENCODED_CBOR &&
+            unwrapped.taggedItem is Bstr
+        ) {
+            Cbor.decode(unwrapped.taggedItem.asBstr)
+        } else {
+            unwrapped
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
@@ -29,6 +29,7 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.mso.MsoPayloadDecoder
 import org.multipaz.mdoc.mso.MobileSecurityObjectParser
 import org.multipaz.util.Constants
 import org.multipaz.util.Logger
@@ -162,7 +163,7 @@ class DeviceResponseParser(
             } else {
                 false
             }
-            val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
+            val encodedMobileSecurityObject = Cbor.encode(MsoPayloadDecoder.decode(issuerAuth.payload!!))
             val parsedMso = MobileSecurityObjectParser(encodedMobileSecurityObject).parse()
 
             builder.apply {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/MdocDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/MdocDocument.kt
@@ -27,6 +27,7 @@ import org.multipaz.mdoc.devicesigned.buildDeviceNamespaces
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
 import org.multipaz.mdoc.issuersigned.IssuerSignedItem
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
+import org.multipaz.mdoc.mso.MsoPayloadDecoder
 import org.multipaz.mdoc.mso.MobileSecurityObject
 import org.multipaz.presentment.PresentmentUnlockReason
 import org.multipaz.request.MdocRequestedClaim
@@ -70,8 +71,7 @@ data class MdocDocument(
      * Convenience property for accessing the [MobileSecurityObject] from [issuerAuth].
      */
     val mso: MobileSecurityObject by lazy {
-        val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
-        MobileSecurityObject.fromDataItem(Cbor.decode(encodedMobileSecurityObject))
+        MobileSecurityObject.fromDataItem(MsoPayloadDecoder.decode(issuerAuth.payload!!))
     }
 
     /**
@@ -258,8 +258,7 @@ data class MdocDocument(
             //
             val issuerNamespaceDigests = mutableMapOf<String, Map<String, ByteString>>()
             val issuerNamespaces = issuerSigned.getOrNull("nameSpaces")?.let {
-                val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
-                val mso = MobileSecurityObject.fromDataItem(Cbor.decode(encodedMobileSecurityObject))
+                val mso = MobileSecurityObject.fromDataItem(MsoPayloadDecoder.decode(issuerAuth.payload!!))
                 for ((namespaceDataItemKey, namespaceDataItemValue) in it.asMap) {
                     val namespaceName = namespaceDataItemKey.asTstr
                     val innerMap = mutableMapOf<String, ByteString>()


### PR DESCRIPTION
## Summary

Adds controlled tolerance for two non-compliant but real-world MSO encoding patterns, guarded by `MdocCompatibilityOptions` (defaults to strict).

### 1. MSO payload wrapping tolerance (`MsoPayloadDecoder`)

Some issuers emit the MSO payload as a raw CBOR map rather than the spec-required encoded-CBOR byte string (tag 24 wrapped). A new `MsoPayloadDecoder` utility accepts both forms and is used consistently across `MdocCredential`, `MobileSecurityObjectParser`, `DeviceResponseParser`, and `MdocDocument`.

### 2. ValidityInfo timestamp tolerance (`allowLegacyMsoValidityTimestamps = false` by default)

Some issuers emit `ValidityInfo` timestamps as plain `tstr` values without the required CBOR tag 0 (`tdate`). When `MdocCompatibilityOptions.allowLegacyMsoValidityTimestamps` is explicitly set to `true`, the parser accepts and logs these with a warning.

```kotlin
// Default — strict, spec-compliant only:
MdocCompatibilityOptions()  // allowLegacyMsoValidityTimestamps = false

// Opt-in for known non-compliant issuer:
MdocCompatibilityOptions(allowLegacyMsoValidityTimestamps = true)
```

The leniency is currently needed for interop with a specific deployment where the SITA issuer emits untagged timestamps for compatibility with the NEC verifier at Hong Kong International Airport (HKG). The flag is expected to be removed after 2026-07-01 once the NEC verifier is updated to accept canonical `tdate`-tagged timestamps per ISO/IEC 18013-5 §9.1.2.

## Validation

```
./gradlew :multipaz:jvmTest \
  --tests org.multipaz.mdoc.mso.MobileSecurityObjectParserTest \
  --tests org.multipaz.mdoc.mso.MobileSecurityObjectTest \
  --tests org.multipaz.mdoc.response.DeviceResponseParserTest
```

## Related

Extracted from #1564 per reviewer request to split into per-commit PRs.