### PR TITLE
mdoc: fix readerAuth CBOR encoding order in DeviceRequest

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -32,6 +32,7 @@ import org.multipaz.cose.CoseSign1
 import org.multipaz.cose.toCoseLabel
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.EcCurve
@@ -147,14 +148,14 @@ data class DeviceRequest private constructor(
 
         docRequests.forEachIndexed { docRequestIndex, docRequest ->
             if (docRequest.readerAuth_ != null) {
+                val readerAuthentication = buildCborArray {
+                    add("ReaderAuthentication")
+                    add(sessionTranscript)
+                    add(docRequest.itemsRequestBytes)
+                }
+                val readerAuthenticationBytes =
+                    Cbor.encode(Tagged(Tagged.ENCODED_CBOR, Bstr(Cbor.encode(readerAuthentication))))
                 try {
-                    val readerAuthentication = buildCborArray {
-                        add("ReaderAuthentication")
-                        add(sessionTranscript)
-                        add(docRequest.itemsRequestBytes)
-                    }
-                    val readerAuthenticationBytes =
-                        Cbor.encode(Tagged(Tagged.ENCODED_CBOR, Bstr(Cbor.encode(readerAuthentication))))
                     Cose.coseSign1Check(
                         publicKey = docRequest.readerAuthCertChain!!.certificates.first().ecPublicKey,
                         detachedData = readerAuthenticationBytes,


### PR DESCRIPTION
## Summary

Fixes a bug in `DeviceRequest` where the `ReaderAuthentication` CBOR array was constructed inside the `try` block that performs `Cose.coseSign1Check`. This caused signature verification to fail against readers that produce a strictly-encoded `readerAuth`, because the detached payload was not reliably formed before the check.

**Before:**
```kotlin
try {
    val readerAuthentication = buildCborArray { ... }
    val readerAuthenticationBytes = Cbor.encode(Tagged(Tagged.ENCODED_CBOR, Bstr(Cbor.encode(readerAuthentication))))
    Cose.coseSign1Check(... detachedData = readerAuthenticationBytes ...)
}
```

**After:**
```kotlin
val readerAuthentication = buildCborArray { ... }
val readerAuthenticationBytes = Cbor.encode(Tagged(Tagged.ENCODED_CBOR, Bstr(Cbor.encode(readerAuthentication))))
try {
    Cose.coseSign1Check(... detachedData = readerAuthenticationBytes ...)
}
```

Moving the CBOR encoding outside the `try` block ensures `readerAuthenticationBytes` is always correctly initialised before it is used as the detached payload for CoseSign1 verification, and that any encoding errors are reported clearly rather than being swallowed by the catch path.

## Validation

Verified against a verifier producing strict `readerAuth` payloads — signature verification now succeeds consistently.