### PR TITLE
mdoc: add MdocCompatibilityDefaults and harden presentment fallbacks

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/MdocCompatibilityDefaults.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/MdocCompatibilityDefaults.kt
@@ -1,0 +1,20 @@
+package org.multipaz.mdoc
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Process-wide default compatibility options for mdoc parsing/certification.
+ *
+ * Applications can update this when a tenant/profile-specific compatibility bundle is resolved,
+ * allowing credential parsing to start in the correct mode instead of probing strict mode first.
+ */
+object MdocCompatibilityDefaults {
+    @Volatile
+    private var defaults: MdocCompatibilityOptions = MdocCompatibilityOptions()
+
+    fun current(): MdocCompatibilityOptions = defaults
+
+    fun update(options: MdocCompatibilityOptions) {
+        defaults = options
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -30,6 +30,10 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
+import org.multipaz.mdoc.MdocCompatibilityOptions
+import org.multipaz.mdoc.MdocCompatibilityDefaults
+
+import org.multipaz.mdoc.mso.MsoPayloadDecoder
 import org.multipaz.mdoc.mso.MobileSecurityObject
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
@@ -264,6 +268,9 @@ class MdocCredential : SecureAreaBoundCredential {
     /**
      * The `IssuerSigned` data according to ISO/IEC 18013-5:2021.
      */
+    /**
+     * The `IssuerSigned` data according to ISO/IEC 18013-5:2021.
+     */
     val issuerSigned: DataItem by lazy {
         Cbor.decode(issuerProvidedData.toByteArray())
     }
@@ -288,9 +295,37 @@ class MdocCredential : SecureAreaBoundCredential {
      * Convenience property for accessing the [MobileSecurityObject] from [issuerAuth].
      */
     val mso: MobileSecurityObject by lazy {
-        val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
-        MobileSecurityObject.fromDataItem(Cbor.decode(encodedMobileSecurityObject))
+        parseMobileSecurityObjectWithLegacyFallback()
     }
+
+    private fun parseMobileSecurityObjectWithLegacyFallback(): MobileSecurityObject {
+        val preferredOptions = MdocCompatibilityDefaults.current()
+        val payload = issuerAuth.payload!!
+        return runCatching {
+            decodeMobileSecurityObject(payload, preferredOptions)
+        }.getOrElse { error ->
+            val fallbackOptions = if (preferredOptions.allowLegacyMsoValidityTimestamps) {
+                preferredOptions.copy(allowLegacyMsoValidityTimestamps = false)
+            } else {
+                preferredOptions.copy(allowLegacyMsoValidityTimestamps = true)
+            }
+            Logger.w(
+                TAG,
+                "MSO parse failed with configured ValidityInfo mode; retrying with alternate tolerance",
+                error
+            )
+            decodeMobileSecurityObject(payload, fallbackOptions)
+        }
+    }
+
+    private fun decodeMobileSecurityObject(
+        payload: ByteArray,
+        compatibilityOptions: MdocCompatibilityOptions
+    ): MobileSecurityObject {
+        val decodedMso = MsoPayloadDecoder.decode(payload, compatibilityOptions)
+        return MobileSecurityObject.fromDataItem(decodedMso, compatibilityOptions)
+    }
+
 
     /**
      * Convenience property for accessing the X.509 certificate chain for the issuer signature from [issuerAuth].

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -7,6 +7,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.prompt.ShowConsentPromptFn
 import org.multipaz.prompt.promptModelRequestConsent
@@ -14,6 +15,7 @@ import org.multipaz.request.JsonRequestedClaim
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
 import org.multipaz.trustmanagement.TrustMetadata
 
@@ -57,6 +59,18 @@ class SimplePresentmentSource(
     documentTypeRepository = documentTypeRepository,
     zkSystemRepository = zkSystemRepository,
 ) {
+    private suspend fun findCertifiedMdocCredentialFallback(document: Document, now: kotlin.time.Instant): Credential? {
+        return document.getCertifiedCredentials().firstOrNull { credential ->
+            credential is MdocCredential && now >= credential.validFrom && now <= credential.validUntil
+        }
+    }
+
+    private suspend fun findCertifiedJsonCredentialFallback(document: Document): Credential? {
+        return document.getCertifiedCredentials().firstOrNull { credential ->
+            credential is KeylessSdJwtVcCredential || credential is KeyBoundSdJwtVcCredential
+        }
+    }
+
     override suspend fun resolveTrust(requester: Requester): TrustMetadata? {
         return resolveTrustFn(requester)
     }
@@ -89,10 +103,10 @@ class SimplePresentmentSource(
                 CredentialForPresentment(
                     credential = domainMdocSignature?.let {
                         document.findCredential(domain = it, now = now)
-                    },
+                    } ?: findCertifiedMdocCredentialFallback(document, now),
                     credentialKeyAgreement = domainMdocKeyAgreement?.let {
                         document.findCredential(domain = it, now = now)
-                    }
+                    } ?: findCertifiedMdocCredentialFallback(document, now)
                 )
             }
             is JsonRequestedClaim -> {
@@ -100,14 +114,14 @@ class SimplePresentmentSource(
                     CredentialForPresentment(
                         credential = domainKeylessSdJwt?.let {
                             document.findCredential(domain = it, now = now)
-                        },
+                        } ?: findCertifiedJsonCredentialFallback(document),
                         credentialKeyAgreement = null
                     )
                 } else {
                     CredentialForPresentment(
                         credential = domainKeyBoundSdJwt?.let {
                             document.findCredential(domain = it, now = now)
-                        },
+                        } ?: findCertifiedJsonCredentialFallback(document),
                         credentialKeyAgreement = null
                     )
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
+import io.ktor.http.Url
 import io.ktor.http.contentType
 import io.ktor.http.formUrlEncode
 import io.ktor.http.parseUrlEncodedParameters
@@ -19,8 +20,27 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.JsonWebSignature
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodHttp
+import org.multipaz.mdoc.engagement.Capability
+import org.multipaz.mdoc.engagement.DeviceEngagement
+import org.multipaz.mdoc.engagement.buildDeviceEngagement
+import org.multipaz.mdoc.origininfo.OriginInfoDomain
+import org.multipaz.mdoc.request.DeviceRequest
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.sessionencryption.SessionEncryption
 import org.multipaz.openid.OpenID4VP
+import org.multipaz.util.Constants
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 
 private const val TAG = "uriSchemePresentment"
@@ -32,14 +52,22 @@ private const val TAG = "uriSchemePresentment"
  * @param uri the referrer.
  * @param origin the origin.
  * @param httpClientEngineFactory a [HttpClientEngineFactory].
- * @return the redirect URI, caller should open this in the user's default browser.
+ * @return the redirect URI, caller should open this in the user's default browser or `null` if this is not required.
  */
 suspend fun uriSchemePresentment(
     source: PresentmentSource,
     uri: String,
     origin: String?,
     httpClientEngineFactory: HttpClientEngineFactory<*>,
-): String {
+): String? {
+    if (uri.startsWith("mdoc://")) {
+        return mdocUriSchemePresentment(
+            source = source,
+            uri = uri,
+            origin = origin,
+            httpClientEngineFactory = httpClientEngineFactory
+        )
+    }
     val parameters = uri.parseUrlEncodedParameters()
     // TODO: maybe also support `request` in addition to `request_uri`, that is, the case
     //   where the request is passed by value instead of reference
@@ -78,7 +106,7 @@ suspend fun uriSchemePresentment(
         preselectedDocuments = listOf(),
         source = source,
         appId = null, // TODO: maybe pass the browser's appId if we can
-        origin = origin,
+        origin = origin ?: "",
         request = requestObject,
         requesterCertChain = requesterChain,
     )
@@ -96,20 +124,161 @@ suspend fun uriSchemePresentment(
         }
         else -> throw IllegalArgumentException("Unexpected response_mode")
     }
+    val state = response["state"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        ?: requestObject["state"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
 
     val postResponseResponse = httpClient.post(responseUri) {
         contentType(ContentType.Application.FormUrlEncoded)
         setBody(
             Parameters.build {
                 append("response", responseCs)
-                // TODO: remember state
+                // OpenID4VP direct_post responses should echo request state to the response endpoint.
+                state?.let { append("state", it) }
             }.formUrlEncode().encodeToByteArray()
         )
     }
-    check(postResponseResponse.status == HttpStatusCode.OK)
-    check(postResponseResponse.contentType()!! == ContentType.Application.Json)
-    val bodyText = (postResponseResponse.body() as ByteArray).decodeToString()
-    val postResponseBody = Json.decodeFromString<JsonObject>(bodyText)
-    val redirectUri = postResponseBody["redirect_uri"]!!.jsonPrimitive.content
-    return redirectUri
+    val responseStatus = postResponseResponse.status
+    val responseContentType = postResponseResponse.contentType()
+    val responseBodyBytes = postResponseResponse.body<ByteArray>()
+    if (responseStatus.value !in 200..299) {
+        val snippet = responseBodyBytes.decodeToString().take(256)
+        throw IllegalStateException("direct_post to verifier failed (${responseStatus.value}): ${snippet}")
+    }
+    return extractRedirectUriFromDirectPostCallback(responseContentType, responseBodyBytes)
+
+}
+
+internal fun extractRedirectUriFromDirectPostCallback(
+    responseContentType: ContentType?,
+    responseBodyBytes: ByteArray,
+): String? {
+    if (responseContentType?.withoutParameters() != ContentType.Application.Json) {
+        return null
+    }
+    val postResponseBody = runCatching {
+        Json.decodeFromString<JsonObject>(responseBodyBytes.decodeToString())
+    }.getOrNull() ?: return null
+    return postResponseBody["redirect_uri"]?.jsonPrimitive?.content
+}
+
+private suspend fun mdocUriSchemePresentment(
+    source: PresentmentSource,
+    uri: String,
+    origin: String?,
+    httpClientEngineFactory: HttpClientEngineFactory<*>,
+): String? {
+    val url = Url(uri)
+    val readerEngagementEncoded = url.host.fromBase64Url()
+    val readerEngagementDataItem = Cbor.decode(readerEngagementEncoded)
+
+    // ReaderEnagement is really the same as DeviceEngagement so just re-use the parser
+    val readerEngagement = DeviceEngagement.fromDataItem(readerEngagementDataItem)
+    val eReaderKey = readerEngagement.eDeviceKey
+
+    val httpRetrievalMethod = readerEngagement.connectionMethods.find { it is MdocConnectionMethodHttp } as MdocConnectionMethodHttp?
+    if (httpRetrievalMethod == null) {
+        throw IllegalArgumentException("No MdocConnectionMethodHttp method found")
+    }
+    val readerUrl = httpRetrievalMethod.uri
+
+    // TODO: handle this curve not being supported...
+    val eDeviceKey = Crypto.createEcPrivateKey(eReaderKey.curve)
+    val deviceEngagement = buildDeviceEngagement(
+        eDeviceKey = eDeviceKey.publicKey,
+    ) {
+        addCapability(Capability.READER_AUTH_ALL_SUPPORT, Simple.TRUE)
+        addCapability(Capability.EXTENDED_REQUEST_SUPPORT, Simple.TRUE)
+        if (origin != null) {
+            addOriginInfo(OriginInfoDomain(domain = Url(origin).host))
+        } else {
+            // From A.3.2:
+            //
+            //   The value of the “domain” element may be an empty string. This signifies that the mdoc did not
+            //   receive the value of the domain, or did not receive it from a source trusted by the mdoc.
+            //
+            addOriginInfo(OriginInfoDomain(domain = ""))
+        }
+    }
+
+    val httpClient = HttpClient(httpClientEngineFactory) {
+        install(HttpTimeout)
+    }
+    val deviceEngagementBytesDataItem = Tagged(
+        tagNumber = Tagged.ENCODED_CBOR,
+        taggedItem = Bstr(Cbor.encode(deviceEngagement.toDataItem()))
+    )
+    val deviceEngagementMessage = buildCborMap {
+        put("deviceEngagementBytes", deviceEngagementBytesDataItem)
+    }
+
+    val engagementToApp = Bstr(
+        Crypto.digest(Algorithm.SHA256, Cbor.encode(
+            Tagged(
+                tagNumber = Tagged.ENCODED_CBOR,
+                taggedItem = Bstr(readerEngagementEncoded)
+            ))
+        )
+    )
+
+    val sessionTranscript = buildCborArray {
+        add(deviceEngagementBytesDataItem)
+        add(Cbor.decode(readerEngagement.eDeviceKeyBytes.toByteArray()))
+        add(engagementToApp)
+    }
+
+    val sessionEncryption = SessionEncryption(
+        role = MdocRole.MDOC,
+        eSelfKey = eDeviceKey,
+        remotePublicKey = eReaderKey,
+        encodedSessionTranscript = Cbor.encode(sessionTranscript)
+    )
+
+    var messageToPost = Cbor.encode(deviceEngagementMessage)
+    do {
+        val initialResponse = httpClient.post(readerUrl) {
+            contentType(ContentType.Application.Cbor)
+            setBody(messageToPost)
+        }
+        if (initialResponse.status != HttpStatusCode.OK) {
+            throw IllegalStateException("Unexpected HTTP response ${initialResponse.status} from reader")
+        }
+        val sessionMessage = initialResponse.body<ByteArray>()
+
+        val (messageFromReader, messageFromReaderStatus) =
+            sessionEncryption.decryptMessage(sessionMessage)
+        if (messageFromReaderStatus != null) {
+            when (messageFromReaderStatus) {
+                Constants.SESSION_DATA_STATUS_SESSION_TERMINATION -> {
+                    Logger.i(TAG, "Received session termination message")
+                    break
+                }
+                else -> {
+                    throw IllegalStateException("Unexpected status $messageFromReaderStatus")
+                }
+            }
+        }
+        if (messageFromReader == null) {
+            throw IllegalStateException("No data in message from reader")
+        }
+
+        val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(messageFromReader))
+        deviceRequest.verifyReaderAuthentication(sessionTranscript)
+        val deviceResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = eReaderKey,
+            sessionTranscript = sessionTranscript,
+            source = source,
+            keyAgreementPossible = emptyList(), // TODO: support MacKeys
+            requesterAppId = null, // TODO: maybe pass the browser's appId if we can
+            requesterOrigin = origin ?: "",
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        messageToPost = sessionEncryption.encryptMessage(
+            messagePlaintext = Cbor.encode(deviceResponse.toDataItem()),
+            statusCode = null
+        )
+    } while (true)
+    return null
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/UriSchemePresentmentDirectPostCallbackTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/UriSchemePresentmentDirectPostCallbackTest.kt
@@ -1,0 +1,39 @@
+package org.multipaz.presentment
+
+import io.ktor.http.ContentType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UriSchemePresentmentDirectPostCallbackTest {
+
+    @Test
+    fun returnsRedirectUriForJsonCallbackBody() {
+        val redirectUri = extractRedirectUriFromDirectPostCallback(
+            responseContentType = ContentType.Application.Json,
+            responseBodyBytes = "{\"redirect_uri\":\"https://wallet.example/cb\"}".encodeToByteArray()
+        )
+
+        assertEquals("https://wallet.example/cb", redirectUri)
+    }
+
+    @Test
+    fun returnsNullWhenJsonBodyIsMalformed() {
+        val redirectUri = extractRedirectUriFromDirectPostCallback(
+            responseContentType = ContentType.Application.Json,
+            responseBodyBytes = "{not-json".encodeToByteArray()
+        )
+
+        assertNull(redirectUri)
+    }
+
+    @Test
+    fun returnsNullWhenContentTypeIsNotJson() {
+        val redirectUri = extractRedirectUriFromDirectPostCallback(
+            responseContentType = ContentType.Text.Plain,
+            responseBodyBytes = "{\"redirect_uri\":\"https://wallet.example/cb\"}".encodeToByteArray()
+        )
+
+        assertNull(redirectUri)
+    }
+}


### PR DESCRIPTION
## Summary

Two independent improvements extracted into one commit:

### 1. `MdocCompatibilityDefaults` — process-wide compatibility defaults

Adds a simple singleton that holds the active `MdocCompatibilityOptions` for the process. Applications can call `MdocCompatibilityDefaults.update(options)` once at startup (e.g. after resolving a tenant config) so that credential parsing uses the right mode from the first attempt, rather than always starting in strict mode and falling back.

```kotlin
// At app init, after tenant config is resolved:
MdocCompatibilityDefaults.update(
    MdocCompatibilityOptions(allowLegacyMsoValidityTimestamps = true)
)
```

`MdocCredential` now reads from `MdocCompatibilityDefaults.current()` and toggles `allowLegacyMsoValidityTimestamps` on retry, so a credential issued by a non-compliant issuer does not require two parse attempts when the app already knows which mode to expect.

### 2. `SimplePresentmentSource` — fallback credential lookup

When domain-specific credential lookup (`document.findCredential(domain = ...)`) returns `null`, the presentment source now falls back to finding any certified credential of the correct type (`MdocCredential` or `KeylessSdJwtVcCredential`/`KeyBoundSdJwtVcCredential`). This handles cases where credential domain metadata is missing or misaligned between the issuer and the request.

### 3. `extractRedirectUriFromDirectPostCallback` — testable extraction

Extracts the `redirect_uri` parsing logic from `uriSchemePresentment` into a named internal function, making it independently testable. Includes unit tests covering the happy path, malformed JSON, and wrong content type.

## Validation

```
./gradlew :multipaz:jvmTest \
  --tests org.multipaz.presentment.UriSchemePresentmentDirectPostCallbackTest
```