### PR TITLE
Provisioning UI improvements

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -92,6 +92,10 @@
     </plurals>
     <string name="passphrase_prompt_too_many_attempts">Too many wrong passphrases attempted, try again later</string>
 
+    <!-- ProvisioningBottomSheet when selecting issuer -->
+    <string name="issuer_loading">Loading issuer metadata...</string>
+    <string name="issuer_loading_failed">Loading issuer metadata failed</string>
+
     <!-- ProvisioningBottomSheet -->
     <string name="provisioning_title">Provisioning</string>
     <string name="provisioning_authorization_failed">Authorization failed</string>
@@ -104,6 +108,8 @@
     <string name="provisioning_browser">Launching browser, continue there</string>
     <string name="provisioning_retry">Please retry</string>
     <string name="provisioning_error">Error provisioning (error code: %1$s)</string>
+    <string name="provisioning_select_credential">Select credential to provision:</string>
+    <string name="provisioning_cancel_button">Cancel provisioning</string>
 
     <!-- durationFromNowText -->
     <string name="duration_just_now">just now</string>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
@@ -1,11 +1,24 @@
 package org.multipaz.compose.provisioning
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -13,22 +26,32 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.PassphraseEntryField
+import org.multipaz.compose.decodeImage
+import org.multipaz.document.Document
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.issuer_loading
+import org.multipaz.multipaz_compose.generated.resources.issuer_loading_failed
 import org.multipaz.multipaz_compose.generated.resources.provisioning_authorization_failed
 import org.multipaz.multipaz_compose.generated.resources.provisioning_authorized
 import org.multipaz.multipaz_compose.generated.resources.provisioning_browser
+import org.multipaz.multipaz_compose.generated.resources.provisioning_cancel_button
 import org.multipaz.multipaz_compose.generated.resources.provisioning_connected
 import org.multipaz.multipaz_compose.generated.resources.provisioning_credentials_issued
 import org.multipaz.multipaz_compose.generated.resources.provisioning_error
@@ -37,10 +60,17 @@ import org.multipaz.multipaz_compose.generated.resources.provisioning_initial
 import org.multipaz.multipaz_compose.generated.resources.provisioning_processing_authorization
 import org.multipaz.multipaz_compose.generated.resources.provisioning_requestion_credentials
 import org.multipaz.multipaz_compose.generated.resources.provisioning_retry
+import org.multipaz.multipaz_compose.generated.resources.provisioning_select_credential
 import org.multipaz.provisioning.AuthorizationChallenge
 import org.multipaz.provisioning.AuthorizationException
 import org.multipaz.provisioning.AuthorizationResponse
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialMetadata
+import org.multipaz.provisioning.ProvisioningMetadata
+import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
+import org.multipaz.provisioning.openid4vci.OpenID4VCIClientPreferences
 import org.multipaz.securearea.PassphraseConstraints
+import org.multipaz.util.Logger
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -63,114 +93,295 @@ import kotlin.time.Duration.Companion.seconds
  * @param modifier Compose [Modifier] for this UI control
  * @param provisioningModel model that manages credential provisioning
  * @param waitForRedirectLinkInvocation wait for redirect url with the given state parameter
- *     being navigated to in the browser.
+ *  being navigated to in the browser.
+ * @param onFinishedProvisioning called when the document is provisioned (or it fails provisioning)
+ * @param issuerUrl if given, starts provisioning from the metadata exposed by the given issuer,
+ *  credential offer is not needed in this case
+ * @param clientPreferences preferences for OpenID4VCI protocol, must be given if [issuerUrl] is given
+ * @param backend OpenID4VCI protocol support object, must be given if [issuerUrl] is given
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProvisioningBottomSheet(
     modifier: Modifier = Modifier,
     provisioningModel: ProvisioningModel,
-    waitForRedirectLinkInvocation: suspend (state: String) -> String
+    waitForRedirectLinkInvocation: suspend (state: String) -> String,
+    onFinishedProvisioning: (document: Document?, isNewlyIssued: Boolean) -> Unit = { _, _ -> },
+    issuerUrl: String? = null,
+    clientPreferences: OpenID4VCIClientPreferences? = null,
+    backend: OpenID4VCIBackend? = null,
 ) {
     val provisioningState = provisioningModel.state.collectAsState().value
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    if (provisioningState !== ProvisioningModel.Idle) {
-        ModalBottomSheet(
-            modifier = modifier,
-            onDismissRequest = { provisioningModel.cancel() },
-            sheetState = sheetState,
-            dragHandle = {},
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp).fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Text(
-                    text = stringResource(Res.string.provisioning_title),
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.headlineMedium,
+    val issuerMetadata = remember { mutableStateOf<ProvisioningMetadata?>(null) }
+    val issuerError = remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(issuerUrl) {
+        issuerMetadata.value = try {
+            issuerUrl?.let {
+                provisioningModel.getOpenID4VCIIssuerMetadata(
+                    issuerUrl = issuerUrl,
+                    clientPreferences = clientPreferences!!,
                 )
+            }?.also {
+                sheetState.expand()
+            }
+        } catch (err: CancellationException) {
+            issuerError.value = "Cancelled"  // for completeness, should never show up in UI
+            throw err
+        } catch (err: Exception) {
+            issuerError.value = err.message
+            Logger.e(TAG, "Could not load metadata", err)
+            null
+        }
+    }
 
+    if (provisioningState !== ProvisioningModel.Idle || issuerUrl != null) {
+        ModalBottomSheet(
+            onDismissRequest = {
+                onFinishedProvisioning.invoke(null, false)
+                provisioningModel.cancel()
+            },
+            sheetState = sheetState,
+            dragHandle = null,
+            containerColor = MaterialTheme.colorScheme.surfaceBright,
+        ) {
+            val metadata = provisioningModel.metadata.collectAsState().value
+            ProvisioningHeader(
+                provisioningMetadata = metadata,
+                issuerMetadata = issuerMetadata.value,
+                onClose = {
+                    onFinishedProvisioning.invoke(null, false)
+                    provisioningModel.cancel()
+                }
+            )
+            val errorText = issuerError.value
+            if (errorText != null) {
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp, 4.dp),
+                    text = stringResource(Res.string.issuer_loading_failed)
+                )
+                Text(
+                    modifier = Modifier.padding(16.dp, 4.dp),
+                    text = errorText
+                )
+            } else if (provisioningState == ProvisioningModel.Idle
+                    && issuerMetadata.value == null) {
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp, 4.dp),
+                    text = stringResource(Res.string.issuer_loading)
+                )
+            } else {
+                ProvisioningBottomSheetContent(
+                    provisioningModel = provisioningModel,
+                    provisioningMetadata = metadata,
+                    provisioningState = provisioningState,
+                    waitForRedirectLinkInvocation = waitForRedirectLinkInvocation,
+                    onFinishedProvisioning = onFinishedProvisioning,
+                    issuerUrl = issuerUrl,
+                    issuerMetadata = issuerMetadata.value,
+                    clientPreferences = clientPreferences,
+                    backend = backend,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProvisioningHeader(
+    onClose: () -> Unit,
+    provisioningMetadata: ProvisioningMetadata?,
+    issuerMetadata: ProvisioningMetadata?
+) {
+    val issuerDisplay = (provisioningMetadata ?: issuerMetadata)?.display
+    Row(
+        modifier = Modifier
+            .padding(24.dp, 8.dp, 24.dp, 0.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (issuerDisplay != null) {
+            RenderImage(
+                modifier = Modifier.height(32.dp),
+                bytes = issuerDisplay.logo
+            )
+            Text(
+                modifier = Modifier.padding(8.dp),
+                text = issuerDisplay.text,
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        } else {
+            Text(
+                modifier = Modifier.padding(24.dp, 8.dp),
+                text = stringResource(Res.string.provisioning_title),
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        }
+        IconButton(
+            modifier = Modifier.size(32.dp),
+            onClick = onClose
+        ) {
+            Icon(
+                Icons.Filled.Close,
+                contentDescription = stringResource(Res.string.provisioning_cancel_button),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProvisioningBottomSheetContent(
+    provisioningModel: ProvisioningModel,
+    provisioningMetadata: ProvisioningMetadata?,
+    provisioningState: ProvisioningModel.State,
+    waitForRedirectLinkInvocation: suspend (state: String) -> String,
+    onFinishedProvisioning: (document: Document?, isNewlyIssued: Boolean) -> Unit,
+    issuerUrl: String?,
+    issuerMetadata: ProvisioningMetadata?,
+    clientPreferences: OpenID4VCIClientPreferences?,
+    backend: OpenID4VCIBackend?,
+) {
+    val credentialIdState = remember { mutableStateOf<String?>(null) }
+    val credentialMap = if (provisioningState == ProvisioningModel.Idle) {
+        // Selecting the credential
+        Text(
+            modifier = Modifier
+                .padding(16.dp, 4.dp),
+            text = stringResource(Res.string.provisioning_select_credential)
+        )
+        issuerMetadata!!.credentials
+    } else {
+        // Just displaying the selected credential
+        provisioningMetadata?.credentials
+            ?: issuerMetadata?.let { metadata ->
+                credentialIdState.value?.let { credentialId ->
+                    mapOf(credentialId to metadata.credentials[credentialId]!!)
+                }
+            }
+    }
+
+    if (credentialMap != null) {
+        val scrollState = rememberScrollState()
+        DisplayCredentialMetadata(
+            modifier = Modifier
+                .padding(16.dp, 8.dp)
+                .fillMaxWidth()
+                .let {
+                    if (provisioningState == ProvisioningModel.Idle) {
+                        it
+                            .heightIn(max = 192.dp)
+                            .background(MaterialTheme.colorScheme.background)
+                            .verticalScroll(scrollState)
+                    } else {
+                        it
+                    }
+                },
+            credentialMap = credentialMap,
+            onCredentialSelected = if (provisioningState == ProvisioningModel.Idle) {
+                // Selecting a credential
+                { credentialId ->
+                    credentialIdState.value = credentialId
+                    provisioningModel.launchOpenID4VCIProvisioning(
+                        issuerUrl = issuerUrl!!,
+                        credentialId = credentialId,
+                        clientPreferences = clientPreferences!!,
+                        backend = backend!!
+                    )
+                }
+            } else {
+                // Just displaying selected credential
+                null
+            }
+        )
+    }
+
+    when (provisioningState) {
+        ProvisioningModel.Idle -> {}
+        is ProvisioningModel.Authorizing -> {
+            Authorize(
+                provisioningModel = provisioningModel,
+                waitForRedirectLinkInvocation = waitForRedirectLinkInvocation,
+                challenges = provisioningState.authorizationChallenges
+            )
+        }
+
+        is ProvisioningModel.Error -> {
+            if (provisioningState.err is AuthorizationException) {
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp, 4.dp),
+                    text = stringResource(Res.string.provisioning_authorization_failed)
+                )
+                val err = provisioningState.err as AuthorizationException
+                Text(
+                    modifier = Modifier.padding(16.dp, 4.dp),
+                    text = stringResource(
+                        Res.string.provisioning_error,
+                        err.code
+                    )
+                )
+                err.description?.let {
+                    Text(
+                        modifier = Modifier.padding(16.dp, 4.dp),
+                        text = it
+                    )
+                }
+            } else {
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp, 4.dp),
+                    text = stringResource(
+                        Res.string.provisioning_error,
+                        provisioningState.err.message ?: "unknown"
+                    )
+                )
+            }
+            LaunchedEffect(true) {
+                delay(3.seconds)
+                provisioningModel.cancel()  // resets to Idle
+                onFinishedProvisioning(null, false)
+            }
+        }
+
+        else -> {
+            val text = stringResource(
                 when (provisioningState) {
-                    is ProvisioningModel.Authorizing -> {
-                        Authorize(
-                            provisioningModel = provisioningModel,
-                            waitForRedirectLinkInvocation = waitForRedirectLinkInvocation,
-                            challenges = provisioningState.authorizationChallenges
-                        )
-                    }
-
-                    is ProvisioningModel.Error -> {
-                        if (provisioningState.err is AuthorizationException) {
-                            Text(
-                                modifier = Modifier
-                                    .align(Alignment.CenterHorizontally)
-                                    .padding(8.dp),
-                                text = stringResource(Res.string.provisioning_authorization_failed)
-                            )
-                            val err = provisioningState.err as AuthorizationException
-                            Text(
-                                modifier = Modifier.padding(4.dp),
-                                text = stringResource(
-                                    Res.string.provisioning_error,
-                                    err.code
-                                )
-                            )
-                            err.description?.let {
-                                Text(
-                                    modifier = Modifier.padding(4.dp),
-                                    text = it
-                                )
-                            }
-                        } else {
-                            Text(
-                                modifier = Modifier
-                                    .align(Alignment.CenterHorizontally)
-                                    .padding(8.dp),
-                                text = stringResource(
-                                    Res.string.provisioning_error,
-                                    provisioningState.err.message ?: "unknown"
-                                )
-                            )
-                        }
-                        LaunchedEffect(true) {
-                            delay(3.seconds)
-                            provisioningModel.cancel()  // resets to Idle
-                        }
-                    }
-
-                    else -> {
-                        val text = stringResource(
-                            when (provisioningState) {
-                                ProvisioningModel.Idle -> throw IllegalStateException()
-                                ProvisioningModel.Initial -> Res.string.provisioning_initial
-                                ProvisioningModel.Connected -> Res.string.provisioning_connected
-                                ProvisioningModel.ProcessingAuthorization -> Res.string.provisioning_processing_authorization
-                                ProvisioningModel.Authorized -> Res.string.provisioning_authorized
-                                ProvisioningModel.RequestingCredentials -> Res.string.provisioning_requestion_credentials
-                                ProvisioningModel.CredentialsIssued -> Res.string.provisioning_credentials_issued
-                                is ProvisioningModel.Error -> throw IllegalStateException()
-                                is ProvisioningModel.Authorizing -> throw IllegalStateException()
-                            }
-                        )
-                        Text(
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(8.dp),
-                            text = text
-                        )
-                        if (provisioningState == ProvisioningModel.CredentialsIssued) {
-                            LaunchedEffect(true) {
-                                delay(3.seconds)
-                                provisioningModel.cancel()  // resets to Idle
-                            }
-                        }
-                    }
+                    ProvisioningModel.Idle -> throw IllegalStateException()
+                    ProvisioningModel.Initial -> Res.string.provisioning_initial
+                    ProvisioningModel.Connected -> Res.string.provisioning_connected
+                    ProvisioningModel.ProcessingAuthorization -> Res.string.provisioning_processing_authorization
+                    ProvisioningModel.Authorized -> Res.string.provisioning_authorized
+                    ProvisioningModel.RequestingCredentials -> Res.string.provisioning_requestion_credentials
+                    is ProvisioningModel.CredentialsIssued -> Res.string.provisioning_credentials_issued
+                    is ProvisioningModel.Error -> throw IllegalStateException()
+                    is ProvisioningModel.Authorizing -> throw IllegalStateException()
+                }
+            )
+            Text(
+                modifier = Modifier
+                    .padding(16.dp, 4.dp),
+                text = text
+            )
+            if (provisioningState is ProvisioningModel.CredentialsIssued) {
+                LaunchedEffect(true) {
+                    onFinishedProvisioning(
+                        provisioningState.document,
+                        provisioningState.isNewlyIssued
+                    )
+                    delay(3.seconds)
+                    provisioningModel.cancel()  // resets to Idle
                 }
             }
         }
     }
+
+    Spacer(modifier = Modifier.height(24.dp))
 }
 
 @Composable
@@ -216,12 +427,11 @@ private fun EvidenceRequestWebView(
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
         ) {
             Text(
                 text = stringResource(Res.string.provisioning_browser),
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(8.dp)
+                modifier = Modifier.padding(16.dp, 8.dp)
             )
         }
     }
@@ -243,14 +453,14 @@ private fun EvidenceRequestSecretText(
         Text(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
-                .padding(8.dp),
+                .padding(16.dp, 8.dp),
             text = passphraseRequest.description
         )
         if (challenge.retry) {
             Text(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .padding(8.dp),
+                    .padding(0.dp, 8.dp),
                 text = stringResource(Res.string.provisioning_retry)
             )
         }
@@ -271,3 +481,65 @@ private fun EvidenceRequestSecretText(
         }
     }
 }
+
+@Composable
+private fun DisplayCredentialMetadata(
+    credentialMap: Map<String, CredentialMetadata>,
+    modifier: Modifier = Modifier,
+    onCredentialSelected: ((credentialId: String) -> Unit)?,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        for ((id, credential) in credentialMap) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RenderImage(
+                    modifier = Modifier.height(32.dp).padding(4.dp),
+                    bytes = credential.display.logo
+                )
+                val format = when (credential.format) {
+                    is CredentialFormat.Mdoc -> "mDoc"
+                    is CredentialFormat.SdJwt -> "SD-JWT"
+                }
+                Text(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .let {
+                            if (onCredentialSelected == null) {
+                                it
+                            } else {
+                                it.clickable {
+                                    onCredentialSelected.invoke(id)
+                                }
+                            }
+                        },
+                    text = "${credential.display.text} ($format)",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RenderImage(
+    bytes: ByteString?,
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier
+) {
+    val image = remember { mutableStateOf<ImageBitmap?>(null)}
+    LaunchedEffect(bytes) {
+        image.value = bytes?.let { decodeImage(it.toByteArray()) }
+    }
+    image.value?.let { bitmap ->
+        Image(
+            bitmap = bitmap,
+            contentDescription = contentDescription,
+            modifier = modifier
+        )
+    }
+}
+
+private const val TAG = "ProvisioningBottomSheet"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -6,12 +6,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.buildJsonObject
@@ -57,9 +59,13 @@ class ProvisioningModel(
     private val authorizationSecureArea: SecureArea
 ) {
     private var mutableState = MutableStateFlow<State>(Idle)
+    private var mutableMetadata = MutableStateFlow<ProvisioningMetadata?>(null)
 
     /** State of the model */
     val state: StateFlow<State> get() = mutableState.asStateFlow()
+
+    /** Issuer and credential metadata for the credential being provisioned (if any) */
+    val metadata: StateFlow<ProvisioningMetadata?> get() = mutableMetadata.asStateFlow()
 
     private val authorizationResponseChannel = Channel<AuthorizationResponse>()
 
@@ -86,6 +92,27 @@ class ProvisioningModel(
         launch(createCoroutineContext(clientPreferences, backend)) {
             targetDocument = null
             OpenID4VCI.createClientFromOffer(offerUri, clientPreferences)
+        }
+
+    /**
+     * Launch provisioning session to provision credentials to a new [Document] using
+     * OpenID4VCI protocol.
+     *
+     * @param issuerUrl issuer server URL
+     * @param credentialId credential configuration id
+     * @param clientPreferences configuration parameters for OpenID4VCI client
+     * @param backend interface to the wallet back-end service
+     * @return deferred [Document] value
+     */
+    fun launchOpenID4VCIProvisioning(
+        issuerUrl: String,
+        credentialId: String,
+        clientPreferences: OpenID4VCIClientPreferences,
+        backend: OpenID4VCIBackend,
+    ): Deferred<Document> =
+        launch(createCoroutineContext(clientPreferences, backend)) {
+            targetDocument = null
+            OpenID4VCI.createClientCredentialId(issuerUrl, credentialId, clientPreferences)
         }
 
     /**
@@ -133,19 +160,39 @@ class ProvisioningModel(
                 mutableState.emit(Initial)
                 targetDocument = document
                 val provisioningClient = provisioningClientFactory.invoke()
+                mutableMetadata.emit(provisioningClient.getMetadata())
                 runProvisioning(provisioningClient)
             } catch(err: CancellationException) {
-                mutableState.emit(Idle)
+                launch(NonCancellable) {
+                    mutableState.emit(Idle)
+                    mutableMetadata.emit(null)
+                }
                 throw err
             } catch (err: Exception) {
                 Logger.e(TAG, "Error provisioning", err)
                 mutableState.emit(Error(err))
+                mutableMetadata.emit(null)
                 throw err
             }
         }
         this.job = deferred
         return deferred
     }
+
+    /**
+     * Gets metadata for the given issuer.
+     *
+     * @param issuerUrl issuer identifier (server URL)
+     * @param clientPreferences OpenID4VCI client parameters
+     * @returns metadata that includes all supported credential configurations
+     */
+    suspend fun getOpenID4VCIIssuerMetadata(
+        issuerUrl: String,
+        clientPreferences: OpenID4VCIClientPreferences,
+    ): ProvisioningMetadata =
+        OpenID4VCI.getMetadata(issuerUrl, httpClient, clientPreferences)
+
+
 
     /**
      * Cancel currently-running provisioning session (if any) and sets the state to [Idle].
@@ -159,6 +206,7 @@ class ProvisioningModel(
                 it.cancel()
             } else {
                 CoroutineScope(Dispatchers.Default).launch {
+                    mutableMetadata.emit(null)
                     mutableState.emit(Idle)
                 }
             }
@@ -300,7 +348,7 @@ class ProvisioningModel(
             }
             throw err
         }
-        mutableState.emit(CredentialsIssued)
+        mutableState.emit(CredentialsIssued(document, targetDocument == null))
         return document
     }
 
@@ -339,8 +387,16 @@ class ProvisioningModel(
     /** Credentials are being requested from the provisioning server */
     data object RequestingCredentials: State()
 
-    /** Credentials are issued, provisioning has stopped */
-    data object CredentialsIssued: State()
+    /**
+     * Credentials are issued, provisioning has stopped
+     *
+     * @param document [Document] to which new credentials belong
+     * @param isNewlyIssued if this is a newly issued document (as opposed to refreshed credentials)
+     */
+    data class CredentialsIssued(
+        val document: Document,
+        val isNewlyIssued: Boolean
+    ): State()
 
     /** Error occurred when provisioning, provisioning has stopped */
     data class Error(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -69,9 +69,7 @@ internal sealed class CredentialOffer {
                 var credentialOfferString = params["credential_offer"]
                 if (credentialOfferString == null) {
                     val url = params["credential_offer_uri"]
-                    if (url == null) {
-                        throw IllegalStateException("Neither 'credential_offer' nor 'credential_offer_uri' are given")
-                    }
+                        ?: throw IllegalStateException("Neither 'credential_offer' nor 'credential_offer_uri' are given")
                     val response = HttpClient().get(url) {}
                     if (response.status != HttpStatusCode.OK) {
                         throw IllegalStateException("Error retrieving '$url'")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
@@ -4,22 +4,22 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
-import kotlinx.io.bytestring.ByteString
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.openid.wellKnown
 import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.provisioning.CredentialMetadata
-import org.multipaz.provisioning.Display
 import org.multipaz.provisioning.KeyBindingType
 import org.multipaz.provisioning.ProvisioningMetadata
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.util.Logger
 
 internal data class IssuerConfiguration(
+    val url: String,
     val nonceEndpoint: String?,
     val credentialEndpoint: String,
     val provisioningMetadata: ProvisioningMetadata,
@@ -28,9 +28,23 @@ internal data class IssuerConfiguration(
 ) {
     companion object: JsonParsing("Issuer metadata") {
         private const val TAG = "IssuerConfiguration"
+        private val cacheLock = Mutex()
+        private var cachedIssuerConfiguration: IssuerConfiguration? = null
+        private var cachedClientPreferences: OpenID4VCIClientPreferences? = null
 
-        suspend fun get(url: String, clientPreferences: OpenID4VCIClientPreferences): IssuerConfiguration {
-            val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+        suspend fun get(
+            url: String,
+            httpClient: HttpClient,
+            clientPreferences: OpenID4VCIClientPreferences
+        ): IssuerConfiguration {
+            cacheLock.withLock {
+                if (cachedClientPreferences === clientPreferences) {
+                    val issuerConfiguration = cachedIssuerConfiguration
+                    if (issuerConfiguration?.url == url) {
+                        return issuerConfiguration
+                    }
+                }
+            }
 
             // Fetch issuer metadata
             val issuerMetadataUrl = wellKnown(url, "openid-credential-issuer")
@@ -79,6 +93,7 @@ internal data class IssuerConfiguration(
                 credentials[id] = CredentialMetadata(
                     display = extractDisplay(
                         element = config.objOrNull("credential_metadata") ?: config,
+                        httpClient = httpClient,
                         clientPreferences = clientPreferences
                     ),
                     format = format,
@@ -89,16 +104,22 @@ internal data class IssuerConfiguration(
 
 
             val provisioningMetadata = ProvisioningMetadata(
-                display = extractDisplay(credentialMetadata, clientPreferences),
+                display = extractDisplay(credentialMetadata, httpClient, clientPreferences),
                 credentials = credentials.toMap()
             )
             return IssuerConfiguration(
+                url = url,
                 nonceEndpoint = nonceEndpoint,
                 credentialEndpoint = credentialEndpoint,
                 provisioningMetadata = provisioningMetadata,
                 authorizationServerUrls = authorizationServerUrls,
                 credentialConfigurations = credentialConfigurations.toMap()
-            )
+            ).also {
+                cacheLock.withLock {
+                    cachedClientPreferences = clientPreferences
+                    cachedIssuerConfiguration = it
+                }
+            }
         }
 
         private fun extractFormat(config: JsonObject): CredentialFormat =

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/JsonParsing.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/JsonParsing.kt
@@ -69,7 +69,7 @@ internal open class JsonParsing(val source: String) {
         throw IllegalStateException("$source: $name must be an integer")
     }
 
-    fun JsonObject.integerOrNull(name: String): Int {
+    fun JsonObject.integerOrNull(name: String): Int? {
         val value = this[name]
         if (value is JsonPrimitive && !value.isString) {
             val intValue = value.intOrNull
@@ -77,7 +77,7 @@ internal open class JsonParsing(val source: String) {
                 return intValue
             }
         }
-        throw IllegalStateException("$source: $name must be an integer")
+        return null
     }
 
     fun JsonObject.obj(name: String): JsonObject {
@@ -114,6 +114,7 @@ internal open class JsonParsing(val source: String) {
 
     suspend fun extractDisplay(
         element: JsonObject?,
+        httpClient: HttpClient,
         clientPreferences: OpenID4VCIClientPreferences
     ): Display {
         val displayJson = element?.arrayOrNull("display")
@@ -155,7 +156,6 @@ internal open class JsonParsing(val source: String) {
                         logo = ByteString(uri.substring(start + 1).fromBase64())
                     }
                 } else {
-                    val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
                     val response = httpClient.get(uri)
                     if (response.status == HttpStatusCode.OK) {
                         logo = ByteString(response.readRawBytes())

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCI.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCI.kt
@@ -1,7 +1,12 @@
 package org.multipaz.provisioning.openid4vci
 
+import io.ktor.client.HttpClient
 import org.multipaz.provisioning.ProvisioningClient
+import org.multipaz.provisioning.ProvisioningMetadata
 
+/**
+ * Utilities for provisioning through OpenID4VCI protocol.
+ */
 object OpenID4VCI {
     /**
      * Creates [ProvisioningClient] for Openid4Vci from a credential offer.
@@ -10,4 +15,34 @@ object OpenID4VCI {
         offerUri: String,
         clientPreferences: OpenID4VCIClientPreferences
     ): ProvisioningClient = OpenID4VCIProvisioningClient.createFromOffer(offerUri, clientPreferences)
+
+    /**
+     * Creates [ProvisioningClient] for Openid4Vci from the issuer configuration.
+     *
+     * @param issuerUrl issuer identifier (server URL)
+     * @param credentialId credential configuration id
+     * @param clientPreferences OpenID4VCI client parameters
+     * @return new [ProvisioningClient]
+     */
+    suspend fun createClientCredentialId(
+        issuerUrl: String,
+        credentialId: String,
+        clientPreferences: OpenID4VCIClientPreferences
+    ): ProvisioningClient = OpenID4VCIProvisioningClient.createFromCredentialId(
+        issuerUrl, credentialId, clientPreferences)
+
+    /**
+     * Fetches metadata from the server for the given issuer.
+     *
+     * @param issuerUrl issuer identifier (server URL)
+     * @param httpClient HTTP client
+     * @param clientPreferences OpenID4VCI client parameters
+     * @returns metadata that includes all supported credential configurations
+     */
+    suspend fun getMetadata(
+        issuerUrl: String,
+        httpClient: HttpClient,
+        clientPreferences: OpenID4VCIClientPreferences
+    ): ProvisioningMetadata =
+        OpenID4VCIProvisioningClient.getMetadata(issuerUrl, httpClient, clientPreferences)
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -225,7 +225,7 @@ internal class OpenID4VCIProvisioningClient(
             }
         }
         val display = if (response.containsKey("display")) {
-            JsonParsing("Credentials").extractDisplay(response, clientPreferences)
+            JsonParsing("Credentials").extractDisplay(response, httpClient, clientPreferences)
         } else {
             null
         }
@@ -272,7 +272,7 @@ internal class OpenID4VCIProvisioningClient(
     private suspend fun performPushedAuthorizationRequest(): String {
         maybeObtainClientAttestationChallenge()
 
-        pkceCodeVerifier = Random.Default.nextBytes(32).toBase64Url()
+        pkceCodeVerifier = Random.nextBytes(32).toBase64Url()
         val codeChallenge = Crypto.digest(
             Algorithm.SHA256,
             pkceCodeVerifier!!.encodeToByteArray()
@@ -636,7 +636,7 @@ internal class OpenID4VCIProvisioningClient(
 
         private suspend fun createUniqueStateValue(): String {
             while (true) {
-                val state = Random.Default.nextBytes(15).toBase64Url()
+                val state = Random.nextBytes(15).toBase64Url()
                 stateLock.withLock {
                     if (states.add(state)) {
                         return state
@@ -651,11 +651,47 @@ internal class OpenID4VCIProvisioningClient(
             }
         }
 
+        suspend fun getMetadata(
+            issuerUrl: String,
+            httpClient: HttpClient,
+            clientPreferences: OpenID4VCIClientPreferences
+        ): ProvisioningMetadata =
+            IssuerConfiguration.get(
+                url = issuerUrl,
+                httpClient = httpClient,
+                clientPreferences = clientPreferences
+            ).provisioningMetadata
+
         suspend fun createFromOffer(
             offerUri: String,
             clientPreferences: OpenID4VCIClientPreferences,
         ): OpenID4VCIProvisioningClient {
             val credentialOffer = CredentialOffer.parseCredentialOffer(offerUri)
+            val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
+            return create(
+                secureArea = secureArea,
+                credentialOffer = credentialOffer,
+                clientPreferences = clientPreferences,
+                authorizationData = OpenID4VCIAuthorizationData(
+                    issuerUri = credentialOffer.issuerUri,
+                    configurationId = credentialOffer.configurationId,
+                    authorizationServer = credentialOffer.authorizationServer,
+                    secureAreaId = secureArea.identifier
+                )
+            )
+        }
+
+        suspend fun createFromCredentialId(
+            issuerUrl: String,
+            credentialId: String,
+            clientPreferences: OpenID4VCIClientPreferences,
+        ): OpenID4VCIProvisioningClient {
+            val credentialOffer = CredentialOffer.AuthorizationCode(
+                issuerUri = issuerUrl,
+                configurationId = credentialId,
+                authorizationServer = null,
+                issuerState = null
+            )
             val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
             return create(
                 secureArea = secureArea,
@@ -722,6 +758,7 @@ internal class OpenID4VCIProvisioningClient(
             require(authorizationData.secureAreaId == secureArea.identifier)
             val issuerConfig = IssuerConfiguration.get(
                 url = credentialOffer.issuerUri,
+                httpClient = BackendEnvironment.getInterface(HttpClient::class)!!,
                 clientPreferences = clientPreferences
             )
             val authorizationServerUrl = credentialOffer.authorizationServer

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -945,6 +945,7 @@ class App private constructor (val promptModel: PromptModel) {
 
         snackbarHostState = remember { SnackbarHostState() }
 
+        val provisioningIssuerUrl = remember { mutableStateOf<String?>(null) }
         val currentBranding = Branding.Current.collectAsState().value
         currentBranding.theme {
             PromptDialogs(
@@ -955,7 +956,16 @@ class App private constructor (val promptModel: PromptModel) {
                 provisioningModel = provisioningModel,
                 waitForRedirectLinkInvocation = { state ->
                     provisioningSupport.waitForAppLinkInvocation(state)
-                }
+                },
+                onFinishedProvisioning = { document, isNewlyIssued ->
+                    provisioningIssuerUrl.value = null
+                    if (document != null && isNewlyIssued) {
+                        navController.navigate(DocumentViewerDestination(document.identifier))
+                    }
+                },
+                issuerUrl = provisioningIssuerUrl.value,
+                clientPreferences = provisioningSupport.getOpenID4VCIClientPreferences(),
+                backend = provisioningSupport.getOpenID4VCIBackend()
             )
             NavHost(
                 navController = navController,
@@ -1061,7 +1071,7 @@ class App private constructor (val promptModel: PromptModel) {
                                 }
                             },
                             onClickEventLog = { navController.navigate(EventLogDestination) },
-                            onClickShareSheet = { navController.navigate(ShareSheetDestination) }
+                            onClickShareSheet = { navController.navigate(ShareSheetDestination) },
                         )
                     }
                 }
@@ -1089,6 +1099,9 @@ class App private constructor (val promptModel: PromptModel) {
                             showToast = { message: String -> showToast(message) },
                             onViewDocument = { documentId ->
                                 navController.navigate(DocumentViewerDestination(documentId))
+                            },
+                            onIssuerSelected = { issuerUrl ->
+                                provisioningIssuerUrl.value = issuerUrl
                             }
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -84,6 +85,8 @@ private val userAuthenticationTimeoutValues = mapOf(
     "No auth" to null
 )
 
+private const val INITIAL_ISSUER_URL = "https://issuer.multipaz.org/issuer"
+
 @Composable
 fun DocumentStoreScreen(
     documentStore: DocumentStore,
@@ -93,6 +96,7 @@ fun DocumentStoreScreen(
     iacaKey: AsymmetricKey.X509Certified,
     showToast: (message: String) -> Unit,
     onViewDocument: (documentId: String) -> Unit,
+    onIssuerSelected: (issuerUrl: String) -> Unit
 ) {
     // TODO: Use the same coroutine scope as what the storage layer uses to make it faster.
     val coroutineScope = rememberCoroutineScope()
@@ -121,6 +125,34 @@ fun DocumentStoreScreen(
         )
     }
 
+    val showIssuanceDialog = remember { mutableStateOf(false) }
+    if (showIssuanceDialog.value) {
+        val issuingServerUrl = remember { mutableStateOf(INITIAL_ISSUER_URL) }
+        AlertDialog(
+            onDismissRequest = { showIssuanceDialog.value = false },
+            title = { Text("Select Issuer") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showIssuanceDialog.value = false
+                        onIssuerSelected(issuingServerUrl.value)
+                    }) {
+                    Text("Start")
+                }
+            },
+            text = {
+                TextField(
+                    modifier = Modifier.padding(4.dp),
+                    value = issuingServerUrl.value,
+                    onValueChange = { issuingServerUrl.value = it },
+                    label = {
+                        Text("Issuer server URL")
+                    }
+                )
+            }
+        )
+    }
+
     showProvisioningResult.value?.let {
         val scrollState = rememberScrollState()
         AlertDialog(
@@ -141,7 +173,10 @@ fun DocumentStoreScreen(
             },
             confirmButton = {
                 Button(
-                    onClick = { showProvisioningResult.value = null }) {
+                    onClick = {
+                        showProvisioningResult.value = null
+                    }
+                ) {
                     Text("Close")
                 }
             }
@@ -269,6 +304,13 @@ fun DocumentStoreScreen(
                 }
             }) {
                 Text(text = "Delete all Documents")
+            }
+        }
+        item {
+            TextButton(onClick = {
+                showIssuanceDialog.value = true
+            }) {
+                Text(text = "Provision a Document from an Issuer")
             }
         }
         item {


### PR DESCRIPTION
Added functionality to provision credentials from OpenID4VCI issuer URL without credential offers (by examining issuer metadata). Display issuer/credential logo and title in the UI. Added ability to initiate issuance from within the Test App (from Document Store page). Navigate to the document page once initial provisioning completes.

Fixes #1645

Test: manual tested in testapp
