### PR TITLE
fix QR Proximity Reading not working on devices that do not support NFC in testapp

### DIFF
--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -251,7 +251,9 @@ fun IsoMdocProximityReadingScreen(
                             var transferProtocol = ""
                             doReaderFlow(
                                 app = app,
-                                nfcTagReader = readerSelected.value!!.getNfcTagReader(),
+                                nfcTagReader = readerSelected.value
+                                    .takeUnless { it is NfcReaderNoneAvailable }
+                                    ?.getNfcTagReader(),
                                 encodedDeviceEngagement = ByteString(data.substring(5).fromBase64Url()),
                                 existingTransport = null,
                                 handover = Simple.NULL,


### PR DESCRIPTION
Fixes https://github.com/openwallet-foundation/multipaz/issues/1648

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR

test: manually tested