### PR TITLE
Refactor `PromptModel` to use semantic `Reason` objects instead of ra…

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/BiometricPromptDialog.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/BiometricPromptDialog.kt
@@ -11,13 +11,15 @@ import org.multipaz.context.getActivity
 import org.multipaz.prompt.PromptDialogModel
 import androidx.lifecycle.compose.currentStateAsState
 import org.multipaz.prompt.BiometricPromptDialogModel
+import org.multipaz.prompt.Reason
 
 /**
  * Displays biometric prompt dialog in Composable UI environment.
  */
 @Composable
 internal fun BiometricPromptDialog(
-    model: PromptDialogModel<BiometricPromptDialogModel.BiometricPromptState, Boolean>
+    model: PromptDialogModel<BiometricPromptDialogModel.BiometricPromptState, Boolean>,
+    toHumanReadable: suspend (Reason) -> Reason.HumanReadable
 ) {
     val activity = LocalContext.current.getActivity() as FragmentActivity
     val dialogState = model.dialogState.collectAsState(PromptDialogModel.NoDialogState())
@@ -31,11 +33,12 @@ internal fun BiometricPromptDialog(
             is PromptDialogModel.DialogShownState -> {
                 val dialogParameters = dialogStateValue.parameters
                 try {
+                    val humanReadable = toHumanReadable(dialogParameters.reason)
                     val result = org.multipaz.compose.biometrics.showBiometricPrompt(
                         activity = activity,
                         cryptoObject = dialogParameters.cryptoObject,
-                        title = dialogParameters.title,
-                        subtitle = dialogParameters.subtitle,
+                        title = humanReadable.title,
+                        subtitle = humanReadable.subtitle,
                         userAuthenticationTypes = dialogParameters.userAuthenticationTypes,
                         requireConfirmation = dialogParameters.requireConfirmation
                     )

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.android.kt
@@ -3,10 +3,10 @@ package org.multipaz.compose.prompt
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import coil3.ImageLoader
-import org.multipaz.compose.branding.Branding
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.BiometricPromptDialogModel
 import org.multipaz.prompt.ConsentPromptDialogModel
+import org.multipaz.prompt.ConvertToHumanReadableFn
 import org.multipaz.prompt.PassphrasePromptDialogModel
 import org.multipaz.prompt.PromptDialogModel
 import org.multipaz.prompt.PromptModel
@@ -17,7 +17,8 @@ actual fun PromptDialogs(
     promptModel: PromptModel,
     imageLoader: ImageLoader?,
     maxHeight: Dp?,
-    excludeTypes: List<PromptDialogModel.DialogType<*>>
+    excludeTypes: List<PromptDialogModel.DialogType<*>>,
+    toHumanReadable: ConvertToHumanReadableFn
 ) {
     val model = promptModel as AndroidPromptModel
 
@@ -25,10 +26,16 @@ actual fun PromptDialogs(
         ScanNfcTagPromptDialog(model.getDialogModel(ScanNfcPromptDialogModel.DialogType))
     }
     if (!excludeTypes.contains(BiometricPromptDialogModel.DialogType)) {
-        BiometricPromptDialog(model.getDialogModel(BiometricPromptDialogModel.DialogType))
+        BiometricPromptDialog(
+            model = model.getDialogModel(BiometricPromptDialogModel.DialogType),
+            toHumanReadable = { reason -> toHumanReadable(reason, null) }
+        )
     }
     if (!excludeTypes.contains(PassphrasePromptDialogModel.DialogType)) {
-        PassphrasePromptDialog(model.getDialogModel(PassphrasePromptDialogModel.DialogType))
+        PassphrasePromptDialog(
+            model = model.getDialogModel(PassphrasePromptDialogModel.DialogType),
+            toHumanReadable = toHumanReadable
+        )
     }
     if (!excludeTypes.contains(ConsentPromptDialogModel.DialogType)) {
         ConsentPromptDialog(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/DefaultToHumanReadable.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/DefaultToHumanReadable.kt
@@ -1,0 +1,52 @@
+package org.multipaz.compose.prompt
+
+import org.jetbrains.compose.resources.getString
+import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.aks_unlock_present_pin_subtitle
+import org.multipaz.multipaz_compose.generated.resources.key_unlock_default_subtitle
+import org.multipaz.multipaz_compose.generated.resources.key_unlock_default_title
+import org.multipaz.multipaz_compose.generated.resources.key_unlock_present_bio_subtitle
+import org.multipaz.multipaz_compose.generated.resources.key_unlock_present_passphrase_subtitle
+import org.multipaz.multipaz_compose.generated.resources.key_unlock_present_title
+import org.multipaz.presentment.PresentmentUnlockReason
+import org.multipaz.prompt.ConvertToHumanReadableFn
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.PassphraseConstraints
+
+/**
+ * Default implementation of [ConvertToHumanReadableFn] for use in [PromptDialogs].
+ *
+ * Uses translated string resources from the multipaz-compose module. Handles
+ * [Reason.HumanReadable] (passes through as-is) and [PresentmentUnlockReason] with
+ * appropriate subtitle based on whether the expected input is biometric, PIN, or passphrase.
+ * All other [Reason] values are mapped to a generic unlock prompt.
+ *
+ * @param unlockReason the reason a secure unlock prompt is being requested.
+ * @param passphraseConstraints optional constraints that indicate whether passphrase input is
+ * expected, and if so, whether it must be numerical.
+ * @return a [Reason.HumanReadable] containing localized title/subtitle text for display.
+ */
+suspend fun defaultToHumanReadable(
+    unlockReason: Reason,
+    passphraseConstraints: PassphraseConstraints?
+): Reason.HumanReadable = when (unlockReason) {
+    is Reason.HumanReadable -> unlockReason
+    is PresentmentUnlockReason -> {
+        val subtitle = when {
+            passphraseConstraints == null -> getString(Res.string.key_unlock_present_bio_subtitle)
+            passphraseConstraints.requireNumerical -> getString(Res.string.aks_unlock_present_pin_subtitle)
+            else -> getString(Res.string.key_unlock_present_passphrase_subtitle)
+        }
+        Reason.HumanReadable(
+            title = getString(Res.string.key_unlock_present_title),
+            subtitle = subtitle,
+            requireConfirmation = false
+        )
+    }
+
+    else -> Reason.HumanReadable(
+        title = getString(Res.string.key_unlock_default_title),
+        subtitle = getString(Res.string.key_unlock_default_subtitle),
+        requireConfirmation = false
+    )
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/PassphrasePromptDialog.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/PassphrasePromptDialog.kt
@@ -3,8 +3,13 @@ package org.multipaz.compose.prompt
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import org.multipaz.prompt.PromptDialogModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,10 +18,26 @@ import org.multipaz.compose.passphrase.PassphrasePromptBottomSheet
 import org.multipaz.prompt.PassphraseEvaluation
 import org.multipaz.prompt.PassphrasePromptDialogModel
 import org.multipaz.prompt.PromptDismissedException
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.PassphraseConstraints
 
+/**
+ * A composable dialog that prompts the user to enter a passphrase.
+ *
+ * This dialog is driven by a [PromptDialogModel] and displays a bottom sheet
+ * when a passphrase request is active. It supports optional passphrase evaluation
+ * and converts the raw [Reason] into human-readable title/subtitle strings.
+ *
+ * @param model The dialog model managing the passphrase request state and result channel.
+ * @param toHumanReadable A suspend function that converts a [Reason] and optional
+ *   [PassphraseConstraints] into a [Reason.HumanReadable] for display in the UI.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PassphrasePromptDialog(model: PromptDialogModel<PassphrasePromptDialogModel.PassphraseRequest, String>) {
+fun PassphrasePromptDialog(
+    model: PromptDialogModel<PassphrasePromptDialogModel.PassphraseRequest, String>,
+    toHumanReadable: suspend (Reason, PassphraseConstraints?) -> Reason.HumanReadable
+) {
     val dialogState = model.dialogState.collectAsState(PromptDialogModel.NoDialogState())
     val coroutineScope = rememberCoroutineScope()
     val showKeyboard = MutableStateFlow<Boolean>(false)
@@ -28,12 +49,26 @@ fun PassphrasePromptDialog(model: PromptDialogModel<PassphrasePromptDialogModel.
         }
     )
     val dialogStateValue = dialogState.value
-    if (dialogStateValue is PromptDialogModel.DialogShownState) {
+    var humanReadable by remember { mutableStateOf<Reason.HumanReadable?>(null) }
+    LaunchedEffect(dialogStateValue) {
+        humanReadable = if (dialogStateValue is PromptDialogModel.DialogShownState) {
+            val parameters = dialogStateValue.parameters
+            try {
+                toHumanReadable(parameters.reason, parameters.passphraseConstraints)
+            } catch (e: Exception) {
+                null
+            }
+        } else {
+            null
+        }
+    }
+
+    if (dialogStateValue is PromptDialogModel.DialogShownState && humanReadable != null) {
         val dialogParameters = dialogStateValue.parameters
         PassphrasePromptBottomSheet(
             sheetState = sheetState,
-            title = dialogParameters.title,
-            subtitle = dialogParameters.subtitle,
+            title = humanReadable?.title.orEmpty(),
+            subtitle = humanReadable?.subtitle.orEmpty(),
             passphraseConstraints = dialogParameters.passphraseConstraints,
             showKeyboard = showKeyboard.asStateFlow(),
             onPassphraseEntered = { enteredPassphrase ->

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.kt
@@ -1,9 +1,9 @@
 package org.multipaz.compose.prompt
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import coil3.ImageLoader
+import org.multipaz.prompt.ConvertToHumanReadableFn
 import org.multipaz.prompt.PromptDialogModel
 import org.multipaz.prompt.PromptModel
 
@@ -17,11 +17,15 @@ import org.multipaz.prompt.PromptModel
  * @param imageLoader an [ImageLoader] to load images from the network or `null`.
  * @param maxHeight the maximum height of a dialog or `null` if not restricted.
  * @param excludeTypes a list of prompt model dialog types to not show.
+ * @param toHumanReadable a function to convert a [org.multipaz.prompt.Reason] to a
+ *   [org.multipaz.prompt.Reason.HumanReadable] for display in prompts. Defaults to
+ *   [defaultToHumanReadable] which uses translated strings from multipaz-compose.
  */
 @Composable
 expect fun PromptDialogs(
     promptModel: PromptModel,
     imageLoader: ImageLoader? = null,
     maxHeight: Dp? = null,
-    excludeTypes: List<PromptDialogModel.DialogType<*>> = emptyList()
+    excludeTypes: List<PromptDialogModel.DialogType<*>> = emptyList(),
+    toHumanReadable: ConvertToHumanReadableFn = ::defaultToHumanReadable
 )

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.ios.kt
@@ -1,32 +1,30 @@
 package org.multipaz.compose.prompt
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.unit.Dp
 import coil3.ImageLoader
-import org.multipaz.compose.camera.toSkiaImage
 import org.multipaz.prompt.ConsentPromptDialogModel
+import org.multipaz.prompt.ConvertToHumanReadableFn
 import org.multipaz.prompt.IosPromptModel
 import org.multipaz.prompt.PassphrasePromptDialogModel
 import org.multipaz.prompt.PromptDialogModel
 import org.multipaz.prompt.PromptModel
-import platform.Foundation.NSBundle
-import platform.UIKit.UIImage
 
 @Composable
 actual fun PromptDialogs(
     promptModel: PromptModel,
     imageLoader: ImageLoader?,
     maxHeight: Dp?,
-    excludeTypes: List<PromptDialogModel.DialogType<*>>
+    excludeTypes: List<PromptDialogModel.DialogType<*>>,
+    toHumanReadable: ConvertToHumanReadableFn
 ) {
     val model = promptModel as IosPromptModel
 
     if (!excludeTypes.contains(PassphrasePromptDialogModel.DialogType)) {
-        PassphrasePromptDialog(model.getDialogModel(PassphrasePromptDialogModel.DialogType))
+        PassphrasePromptDialog(
+            model = model.getDialogModel(PassphrasePromptDialogModel.DialogType),
+            toHumanReadable = toHumanReadable
+        )
     }
     if (!excludeTypes.contains(ConsentPromptDialogModel.DialogType)) {
         ConsentPromptDialog(

--- a/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.web.kt
+++ b/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/prompt/PromptDialogs.web.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import coil3.ImageLoader
 import org.multipaz.prompt.ConsentPromptDialogModel
+import org.multipaz.prompt.ConvertToHumanReadableFn
 import org.multipaz.prompt.PassphrasePromptDialogModel
 import org.multipaz.prompt.PromptDialogModel
 import org.multipaz.prompt.PromptModel
@@ -15,12 +16,16 @@ actual fun PromptDialogs(
     promptModel: PromptModel,
     imageLoader: ImageLoader?,
     maxHeight: Dp?,
-    excludeTypes: List<PromptDialogModel.DialogType<*>>
+    excludeTypes: List<PromptDialogModel.DialogType<*>>,
+    toHumanReadable: ConvertToHumanReadableFn
 ) {
     val model = promptModel as WebPromptModel
 
     if (!excludeTypes.contains(PassphrasePromptDialogModel.DialogType)) {
-        PassphrasePromptDialog(model.getDialogModel(PassphrasePromptDialogModel.DialogType))
+        PassphrasePromptDialog(
+            model = model.getDialogModel(PassphrasePromptDialogModel.DialogType),
+            toHumanReadable = toHumanReadable
+        )
     }
     if (!excludeTypes.contains(ConsentPromptDialogModel.DialogType)) {
         ConsentPromptDialog(

--- a/multipaz-swiftui/src/iosMain/swift/DefaultToHumanReadable.swift
+++ b/multipaz-swiftui/src/iosMain/swift/DefaultToHumanReadable.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Default implementation for converting a [Reason] to a [ReasonHumanReadable] for display
+/// in prompt dialogs.
+///
+/// Handles ``ReasonHumanReadable`` (passes through as-is) and ``PresentmentUnlockReason``
+/// with an appropriate subtitle based on whether the expected input is biometric, PIN, or
+/// passphrase. All other ``Reason`` values are mapped to a generic unlock prompt.
+///
+/// - Parameters:
+///   - reason: The reason a secure unlock prompt is being requested.
+///   - passphraseConstraints: Optional constraints indicating whether passphrase input is
+///     expected, and if so, whether it must be numerical.
+/// - Returns: A ``ReasonHumanReadable`` containing localized title/subtitle text for display.
+@MainActor
+public func defaultToHumanReadable(
+    reason: Reason,
+    passphraseConstraints: PassphraseConstraints?
+) async -> ReasonHumanReadable {
+    if let humanReadable = reason as? ReasonHumanReadable {
+        return humanReadable
+    }
+    if reason is PresentmentUnlockReason {
+        let subtitle: String
+        if passphraseConstraints == nil {
+            subtitle = NSLocalizedString(
+                "key_unlock_present_bio_subtitle",
+                value: "Authentication is required",
+                comment: "Subtitle for biometric unlock when presenting a document"
+            )
+        } else if passphraseConstraints!.requireNumerical {
+            subtitle = NSLocalizedString(
+                "aks_unlock_present_pin_subtitle",
+                value: "Enter the PIN associated with the document",
+                comment: "Subtitle for PIN unlock when presenting a document"
+            )
+        } else {
+            subtitle = NSLocalizedString(
+                "key_unlock_present_passphrase_subtitle",
+                value: "Enter the passphrase associated with the document",
+                comment: "Subtitle for passphrase unlock when presenting a document"
+            )
+        }
+        return ReasonHumanReadable(
+            title: NSLocalizedString(
+                "key_unlock_present_title",
+                value: "Verify it's you to share the document",
+                comment: "Title for unlock prompt when presenting a document"
+            ),
+            subtitle: subtitle,
+            requireConfirmation: false
+        )
+    }
+    return ReasonHumanReadable(
+        title: NSLocalizedString(
+            "key_unlock_default_title",
+            value: "Verify it's you",
+            comment: "Title for generic unlock prompt"
+        ),
+        subtitle: NSLocalizedString(
+            "key_unlock_default_subtitle",
+            value: "Authentication is required",
+            comment: "Subtitle for generic unlock prompt"
+        ),
+        requireConfirmation: false
+    )
+}

--- a/multipaz-swiftui/src/iosMain/swift/PassphrasePromptDialog.swift
+++ b/multipaz-swiftui/src/iosMain/swift/PassphrasePromptDialog.swift
@@ -7,11 +7,17 @@ private struct PassphrasePromptDialogData: Identifiable, Equatable {
 
 struct PassphrasePromptDialog: View {
     let model: PassphrasePromptDialogModel
+    let toHumanReadable: @MainActor (Reason, PassphraseConstraints?) async -> ReasonHumanReadable
 
     @State private var data: PassphrasePromptDialogData? = nil
+    @State private var humanReadableReason: ReasonHumanReadable? = nil
     
-    init(model: PassphrasePromptDialogModel) {
+    init(
+        model: PassphrasePromptDialogModel,
+        toHumanReadable: @escaping @MainActor (Reason, PassphraseConstraints?) async -> ReasonHumanReadable
+    ) {
         self.model = model
+        self.toHumanReadable = toHumanReadable
     }
     
     var body: some View {
@@ -31,6 +37,16 @@ struct PassphrasePromptDialog: View {
                 oldValue?.state.resultChannel.close(cause: PromptDismissedException())
             }
         }
+        .task(id: data?.id) {
+            if let data {
+                humanReadableReason = await toHumanReadable(
+                    data.state.parameters!.reason,
+                    data.state.parameters!.passphraseConstraints
+                )
+            } else {
+                humanReadableReason = nil
+            }
+        }
         .sheet(item: $data) { data in
             SmartSheet(maxHeight: .infinity) {
                 HStack {
@@ -46,10 +62,11 @@ struct PassphrasePromptDialog: View {
                     }
                 }
             } content: {
-                PassphraseInputView(
-                    title: data.state.parameters!.title,
-                    subtitle: data.state.parameters!.subtitle,
-                    constraints: data.state.parameters!.passphraseConstraints,
+                if let humanReadableReason {
+                    PassphraseInputView(
+                        title: humanReadableReason.title,
+                        subtitle: humanReadableReason.subtitle,
+                        constraints: data.state.parameters!.passphraseConstraints,
                     passphraseEvaluator: { enteredPassphrase in
                         let evaluation = try! await data.state.parameters?.passphraseEvaluator?.invoke(p1: enteredPassphrase)
                         let kfType = if data.state.parameters!.passphraseConstraints.requireNumerical {
@@ -82,7 +99,8 @@ struct PassphrasePromptDialog: View {
                             self.data = nil
                         }
                     }
-                )
+                    )
+                }
             } footer: { isAtBottom, scrollDown in
             }
             .presentationDragIndicator(.hidden)

--- a/multipaz-swiftui/src/iosMain/swift/PromptDialogs.swift
+++ b/multipaz-swiftui/src/iosMain/swift/PromptDialogs.swift
@@ -2,13 +2,21 @@ import SwiftUI
 
 public struct PromptDialogs: View {
     let promptModel: PromptModel
-    
-    public init(promptModel: PromptModel) {
+    let toHumanReadable: @MainActor (Reason, PassphraseConstraints?) async -> ReasonHumanReadable
+
+    public init(
+        promptModel: PromptModel,
+        toHumanReadable: @escaping @MainActor (Reason, PassphraseConstraints?) async -> ReasonHumanReadable = defaultToHumanReadable
+    ) {
         self.promptModel = promptModel
+        self.toHumanReadable = toHumanReadable
     }
-    
+
     public var body: some View {
-        PassphrasePromptDialog(model: promptModel.getPassphraseDialogModel())
+        PassphrasePromptDialog(
+            model: promptModel.getPassphraseDialogModel(),
+            toHumanReadable: toHumanReadable
+        )
         ConsentPromptDialog(model: promptModel.getConsentPromptDialogModel())
     }
 }

--- a/multipaz-swiftui/src/iosMain/swift/PromptModelExt.swift
+++ b/multipaz-swiftui/src/iosMain/swift/PromptModelExt.swift
@@ -1,19 +1,39 @@
 
+public enum PromptModelError: Error {
+    case unexpectedType(expected: String, actual: Any.Type)
+}
+
 extension PromptModel {
     public func requestPassphrase(
-        title: String,
-        subtitle: String,
+        reason: Reason,
         passphraseConstraints: PassphraseConstraints,
         passphraseEvaluatorFn: @escaping @Sendable (
-            _ enteredPassphrase: String,
+            _ enteredPassphrase: String
         ) async -> PassphraseEvaluation?
     ) async throws -> String {
         return try await self.requestPassphrase(
-            title: title,
-            subtitle: subtitle,
+            reason: reason,
             passphraseConstraints: passphraseConstraints,
             passphraseEvaluator: PassphraseEvalulatorHandler(f: passphraseEvaluatorFn)
         )
+    }
+
+    @MainActor
+    public func convertToHumanReadable(
+        reason: Reason,
+        passphraseConstraints: PassphraseConstraints?
+    ) async throws -> ReasonHumanReadable {
+        let result = try await self.toHumanReadable.invoke(
+            p1: reason,
+            p2: passphraseConstraints
+        )
+        guard let humanReadable = result as? ReasonHumanReadable else {
+            throw PromptModelError.unexpectedType(
+                expected: "ReasonHumanReadable",
+                actual: type(of: result)
+            )
+        }
+        return humanReadable
     }
 }
 

--- a/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModelExt.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/prompt/AndroidPromptModelExt.kt
@@ -8,29 +8,22 @@ import org.multipaz.securearea.UserAuthenticationType
  *
  * To dismiss the prompt programmatically, cancel the job the coroutine was launched in.
  *
- * To obtain [title] and [subtitle] back-end code generally should create a [Reason] object and
- * use [PromptModel.toHumanReadable] to convert it to human-readable form. This gives
- * application code a chance to customize user-facing messages.
- *
  * @param cryptoObject optional [CryptoObject] to be associated with the authentication.
- * @param title the title for the authentication prompt.
- * @param subtitle the subtitle for the authentication prompt.
+ * @param reason a [Reason] describing why authentication is needed.
  * @param userAuthenticationTypes the set of allowed user authentication types, must contain at least one element.
  * @param requireConfirmation set to `true` to require explicit user confirmation after presenting passive biometric.
  * @return `true` if authentication succeed, `false` if the user dismissed the prompt.
  */
 suspend fun AndroidPromptModel.showBiometricPrompt(
     cryptoObject: CryptoObject?,
-    title: String,
-    subtitle: String,
+    reason: Reason,
     userAuthenticationTypes: Set<UserAuthenticationType>,
     requireConfirmation: Boolean
 ): Boolean {
     return getDialogModel(BiometricPromptDialogModel.DialogType).displayPrompt(
         BiometricPromptDialogModel.BiometricPromptState(
             cryptoObject,
-            title,
-            subtitle,
+            reason,
             userAuthenticationTypes,
             requireConfirmation
         )

--- a/multipaz/src/androidMain/kotlin/org/multipaz/prompt/BiometricPromptDialogModel.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/prompt/BiometricPromptDialogModel.kt
@@ -19,15 +19,14 @@ class BiometricPromptDialogModel:
      * Parameters for the biometric prompt.
      *
      * @property cryptoObject optional [CryptoObject] to be associated with the authentication.
-     * @property title the title for the authentication prompt.
-     * @property subtitle the subtitle for the authentication prompt.
+     * @property reason semantic context for the authentication request, converted to user-visible
+     *    prompt content by the configured reason-to-text converter.
      * @property userAuthenticationTypes the set of allowed user authentication types, must contain at least one element.
      * @property requireConfirmation set to `true` to require explicit user confirmation after presenting passive biometric.
      */
     data class BiometricPromptState(
         val cryptoObject: CryptoObject?,
-        val title: String,
-        val subtitle: String,
+        val reason: Reason,
         val userAuthenticationTypes: Set<UserAuthenticationType>,
         val requireConfirmation: Boolean
     )

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreDefaultKeyUnlockDataProvider.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreDefaultKeyUnlockDataProvider.kt
@@ -1,6 +1,5 @@
 package org.multipaz.securearea
 
-import kotlinx.coroutines.currentCoroutineContext
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.PromptModelNotAvailableException
 import org.multipaz.prompt.Reason
@@ -23,8 +22,7 @@ object AndroidKeystoreDefaultKeyUnlockDataProvider: KeyUnlockDataProvider {
         val humanReadable = promptModel.toHumanReadable(unlockReason, null)
         if (!promptModel.showBiometricPrompt(
                 cryptoObject = unlockData.getCryptoObjectForSigning(),
-                title = humanReadable.title,
-                subtitle = humanReadable.subtitle,
+                reason = unlockReason,
                 userAuthenticationTypes = keyInfo.userAuthenticationTypes,
                 requireConfirmation = humanReadable.requireConfirmation
             )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PassphrasePromptDialogModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PassphrasePromptDialogModel.kt
@@ -17,14 +17,13 @@ class PassphrasePromptDialogModel():
 
     /**
      * Data for the UI to display and run passphrase dialog.
-     * @property title the title for the passphrase prompt.
-     * @property subtitle the subtitle for the passphrase prompt.
+     * @property reason the reason for the prompt, to be converted to human-readable `title` and
+     *   `subtitle` text for UI.
      * @property passphraseConstraints the [PassphraseConstraints] for the passphrase.
      * @property passphraseEvaluator an optional function to evaluate the passphrase and give the user feedback.
      */
     class PassphraseRequest(
-        val title: String,
-        val subtitle: String,
+        val reason: Reason,
         val passphraseConstraints: PassphraseConstraints,
         val passphraseEvaluator: (suspend (enteredPassphrase: String) -> PassphraseEvaluation)?
     )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PromptModelExt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/PromptModelExt.kt
@@ -23,12 +23,7 @@ fun PromptModel.getConsentPromptDialogModel() = getDialogModel(ConsentPromptDial
  *
  * To dismiss the prompt programmatically, cancel the job the coroutine was launched in.
  *
- * To obtain [title] and [subtitle] back-end code generally should create a [Reason] object and
- * use [PromptModel.toHumanReadable] to convert it to human-readable form. This gives
- * application code a chance to customize user-facing messages.
- *
- * @param title the title for the passphrase prompt.
- * @param subtitle the subtitle for the passphrase prompt.
+ * @param reason a [Reason] describing why passphrase authentication is needed.
  * @param passphraseConstraints the [PassphraseConstraints] for the passphrase.
  * @param passphraseEvaluator an optional function to evaluate the passphrase and give the user feedback.
  * @return the passphrase entered by the user.
@@ -45,15 +40,13 @@ fun PromptModel.getConsentPromptDialogModel() = getDialogModel(ConsentPromptDial
     PromptUiNotAvailableException::class
 )
 suspend fun PromptModel.requestPassphrase(
-    title: String,
-    subtitle: String,
+    reason: Reason,
     passphraseConstraints: PassphraseConstraints,
     passphraseEvaluator: (suspend (enteredPassphrase: String) -> PassphraseEvaluation)?
 ): String {
     return getDialogModel(PassphrasePromptDialogModel.DialogType).displayPrompt(
         PassphraseRequest(
-            title,
-            subtitle,
+            reason,
             passphraseConstraints,
             passphraseEvaluator
         )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/Reason.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/Reason.kt
@@ -11,7 +11,8 @@ import org.multipaz.securearea.PassphraseConstraints
  *
  * A reason can be taken into account when implementing
  * [org.multipaz.securearea.KeyUnlockDataProvider] or when using a user prompt to obtain
- * authorization in [PromptModel.toHumanReadable].
+ * authorization via a configured reason-to-text converter (for example, the
+ * `toHumanReadable` parameter on `PromptDialogs`).
  *
  * This is an interface and thus the set of possible values is not restricted. Applications are
  * encouraged to create application-specific implementation of this interface for use in the
@@ -26,7 +27,7 @@ interface Reason {
      *  [org.multipaz.securearea.SecureArea] keys that are not expected to be locked (and would
      *  outright cause an exception if the key is locked).
      */
-    object Unspecified: Reason
+    object Unspecified : Reason
 
     /**
      * Human-readable explanation for the operation.
@@ -34,9 +35,9 @@ interface Reason {
      * Note: [title] and [subtitle] are presented to the user and thus **must** be localized.
      *
      * Multipaz library itself never uses values of this type for back-end operations. However,
-     * when [PromptModel] is used for key unlock prompts, every other [Reason] value is
-     * ultimately converted to a [Reason.HumanReadable]. See [PromptModel.toHumanReadable]
-     * property (which can be used to customize unlock prompts).
+     * when prompt-based key unlock is used, every other [Reason] value is ultimately converted
+     * to a [Reason.HumanReadable] by the configured reason-to-text converter (such as the
+     * `toHumanReadable` parameter on `PromptDialogs`).
      *
      * @property title the title to show in the authentication prompt.
      * @property subtitle the subtitle to show in the authentication prompt.
@@ -47,7 +48,7 @@ interface Reason {
         val title: String,
         val subtitle: String,
         val requireConfirmation: Boolean
-    ): Reason
+    ) : Reason
 }
 
 /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
@@ -20,7 +20,8 @@ import org.multipaz.prompt.Reason
  *
  * If [KeyUnlockDataProvider] is not found, [SecureArea] can use its own default implementation
  * that requires [PromptModel] in the current coroutine context. Use [PromptModel.toHumanReadable]
- * to customize text that is used in the prompts.
+ * or the `toHumanReadable` parameter on `PromptDialogs` to customize text that is used in the
+ * prompts.
  */
 interface KeyUnlockDataProvider : CoroutineContext.Element {
     object Key: CoroutineContext.Key<KeyUnlockDataProvider>

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -981,11 +981,9 @@ open class CloudSecureArea protected constructor(
                 throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
             }
             val passphraseConstraints = secureArea.getPassphraseConstraints()
-            val humanReadable = promptModel.toHumanReadable(unlockReason, passphraseConstraints)
             unlockData.passphrase = try {
                 promptModel.requestPassphrase(
-                    title = humanReadable.title,
-                    subtitle = humanReadable.subtitle,
+                    reason = unlockReason,
                     passphraseConstraints = passphraseConstraints,
                     passphraseEvaluator = { enteredPassphrase: String ->
                         when (val result = secureArea.checkPassphrase(enteredPassphrase)) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -308,11 +308,9 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             } catch (_: PromptModelNotAvailableException) {
                 throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
             }
-            val humanReadable = promptModel.toHumanReadable(unlockReason, constraints)
             val passphrase = try {
                 promptModel.requestPassphrase(
-                    title = humanReadable.title,
-                    subtitle = humanReadable.subtitle,
+                    reason = unlockReason,
                     passphraseConstraints = constraints,
                     passphraseEvaluator = { enteredPassphrase: String ->
                         try {

--- a/multipaz/src/commonTest/kotlin/org/multipaz/prompt/PromptModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/prompt/PromptModelTest.kt
@@ -49,8 +49,7 @@ class PromptModelTest {
     fun noPromptUI() = runTest {
         val exception = try {
             promptModel.requestPassphrase(
-                title = "Title",
-                subtitle = "Subtitle",
+                reason = Reason.HumanReadable("Title", "Subtitle", false),
                 passphraseConstraints = PassphraseConstraints.NONE,
                 passphraseEvaluator = null
             )
@@ -67,8 +66,7 @@ class PromptModelTest {
         // Bind UI
         collectDialogState { "Unused" }
         promptModel.requestPassphrase(
-            title = "Unused",
-            subtitle = "Unused",
+            reason = Reason.HumanReadable("Unused", "Unused", false),
             passphraseConstraints = PassphraseConstraints.NONE,
             passphraseEvaluator = null
         )
@@ -79,8 +77,7 @@ class PromptModelTest {
 
         assertFailsWith<PromptUiNotAvailableException> {
             promptModel.requestPassphrase(
-                title = "Title",
-                subtitle = "Subtitle",
+                reason = Reason.HumanReadable("Title", "Subtitle", false),
                 passphraseConstraints = PassphraseConstraints.NONE,
                 passphraseEvaluator = null
             )
@@ -92,16 +89,15 @@ class PromptModelTest {
     fun simplePromptLocalScope() = runTest {
         val dialogState = collectDialogState { "Foo" }
         val passphrase = promptModel.requestPassphrase(
-            title = "Title",
-            subtitle = "Subtitle",
+            reason = Reason.HumanReadable("Title", "Subtitle", false),
             passphraseConstraints = PassphraseConstraints.NONE,
             passphraseEvaluator = null
         )
         assertEquals("Foo", passphrase)
 
         val promptState = dialogState[0] as PromptDialogModel.DialogShownState
-        assertEquals("Title", promptState.parameters.title)
-        assertEquals("Subtitle", promptState.parameters.subtitle)
+        assertEquals("Title", (promptState.parameters.reason as Reason.HumanReadable).title)
+        assertEquals("Subtitle", (promptState.parameters.reason as Reason.HumanReadable).subtitle)
         assertEquals(PassphraseConstraints.NONE, promptState.parameters.passphraseConstraints)
         assertNull(promptState.parameters.passphraseEvaluator)
         assertTrue(dialogState[1] is PromptDialogModel.NoDialogState)
@@ -112,8 +108,7 @@ class PromptModelTest {
         val dialogState = collectDialogState { "Bar" }
         val promptJob = promptModel.promptModelScope.launch {
             val passphrase = PromptModel.get().requestPassphrase(
-                title = "Title Top",
-                subtitle = "Subtitle Top",
+                reason = Reason.HumanReadable("Title Top", "Subtitle Top", false),
                 passphraseConstraints = PassphraseConstraints.NONE,
                 passphraseEvaluator = null
             )
@@ -122,8 +117,8 @@ class PromptModelTest {
         promptJob.join()
 
         val promptState = dialogState[0] as PromptDialogModel.DialogShownState
-        assertEquals("Title Top", promptState.parameters.title)
-        assertEquals("Subtitle Top", promptState.parameters.subtitle)
+        assertEquals("Title Top", (promptState.parameters.reason as Reason.HumanReadable).title)
+        assertEquals("Subtitle Top", (promptState.parameters.reason as Reason.HumanReadable).subtitle)
         assertEquals(PassphraseConstraints.NONE, promptState.parameters.passphraseConstraints)
         assertNull(promptState.parameters.passphraseEvaluator)
         assertTrue(dialogState[1] is PromptDialogModel.NoDialogState)
@@ -135,8 +130,7 @@ class PromptModelTest {
         val dialogState = collectDialogState { IGNORE }
         val promptJob = launch(UnconfinedTestDispatcher(testScheduler) + promptModel) {
             PromptModel.get().requestPassphrase(
-                title = "Title",
-                subtitle = "Subtitle",
+                reason = Reason.HumanReadable("Title", "Subtitle", false),
                 passphraseConstraints = PassphraseConstraints.NONE,
                 passphraseEvaluator = null
             )
@@ -156,8 +150,7 @@ class PromptModelTest {
         val exception = async(UnconfinedTestDispatcher(testScheduler) + promptModel) {
             try {
                 PromptModel.get().requestPassphrase(
-                    title = "Title",
-                    subtitle = "Subtitle",
+                    reason = Reason.HumanReadable("Title", "Subtitle", false),
                     passphraseConstraints = PassphraseConstraints.NONE,
                     passphraseEvaluator = null
                 )
@@ -190,8 +183,7 @@ class PromptModelTest {
         val firstRequest = promptModel.promptModelScope.async {
             try {
                 PromptModel.get().requestPassphrase(
-                    title = "Title First",
-                    subtitle = "Subtitle First",
+                    reason = Reason.HumanReadable("Title First", "Subtitle First", false),
                     passphraseConstraints = PassphraseConstraints.NONE,
                     passphraseEvaluator = null
                 )
@@ -202,12 +194,11 @@ class PromptModelTest {
         }
         // Wait until the dialog is "up"
         val request = req.receive()
-        assertEquals("Title First", request.title)
+        assertEquals("Title First", (request.reason as Reason.HumanReadable).title)
         // From a different coroutine, call the PromptModel again
         val secondRequest = promptModel.promptModelScope.launch {
             PromptModel.get().requestPassphrase(
-                title = "Title Second",
-                subtitle = "Subtitle Second",
+                reason = Reason.HumanReadable("Title Second", "Subtitle Second", false),
                 passphraseConstraints = PassphraseConstraints.NONE,
                 passphraseEvaluator = null
             )

--- a/samples/SwiftTestApp/SwiftTestApp/PassphrasePromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/PassphrasePromptScreen.swift
@@ -19,8 +19,11 @@ struct PassphrasePromptScreen: View {
                 let promptModel = try await PromptModel.Companion.shared.get()
                 print("PromptModel.get() from Swift: \(promptModel)")
                 let passphrase = try await promptModel.requestPassphrase(
-                    title: "Verify knowledge factor",
-                    subtitle: "Enter your \(kfType) to continue. It's '\(expectedPassphrase)' but also try entering something else to see an error message",
+                    reason: ReasonHumanReadable(
+                        title: "Verify knowledge factor",
+                        subtitle: "Enter your \(kfType) to continue. It's '\(expectedPassphrase)' but also try entering something else to see an error message",
+                        requireConfirmation: false
+                    ),
                     passphraseConstraints: constraint,
                     passphraseEvaluatorFn: { enteredPassphrase in
                         print("numTries=\(await numTries) and passphrase: \(enteredPassphrase)")

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
@@ -17,9 +17,6 @@ import org.multipaz.compose.notifications.NotificationManagerAndroid
 import org.multipaz.compose.prompt.PresentmentActivity
 import org.multipaz.digitalcredentials.getAppOrigin
 import org.multipaz.presentment.PresentmentSource
-import org.multipaz.prompt.AndroidPromptModel
-import org.multipaz.prompt.PromptDialogModel
-import org.multipaz.prompt.PromptModel
 import org.multipaz.util.Logger
 import java.net.NetworkInterface
 import java.security.Security
@@ -33,39 +30,6 @@ actual object TestAppConfiguration {
         Res.drawable.app_icon_red
     } else {
         Res.drawable.app_icon
-    }
-
-    actual val promptModel: PromptModel by lazy {
-        AndroidPromptModel.Builder(::uiLauncher).apply { addCommonDialogs() }.build()
-    }
-
-    private suspend fun uiLauncher(dialogModel: PromptDialogModel<*, *>) {
-        // This is how we could start an activity:
-        /*
-    val intent = Intent(
-        applicationContext,
-        TestAppMdocNfcPresentmentActivity::class.java
-    )
-    intent.addFlags(
-        Intent.FLAG_ACTIVITY_NEW_TASK or
-                Intent.FLAG_ACTIVITY_NO_HISTORY or
-                Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
-                Intent.FLAG_ACTIVITY_NO_ANIMATION
-    )
-    Logger.i(TAG, "startActivity on $intent")
-    applicationContext.startActivity(intent)
-    // Poll waiting for the activity to launch (this works for an arbitrary activity).
-    // TODO: we should be able to eliminate this polling by making bound property a flow
-    //  (basically making it listenable).
-    repeat(200) {
-        if (dialogModel.bound) {
-            Logger.i(TAG, "Activity is bound to PromptModel UI")
-            return
-        }
-        delay(20.milliseconds)
-    }
-    Logger.i(TAG, "Failed to bind to PromptModel UI")
-     */
     }
 
     actual val platform = TestAppPlatform.ANDROID

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.android.kt
@@ -12,13 +12,13 @@ import org.multipaz.presentment.CredentialPresentmentSelection
 import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentCanceledException
 import org.multipaz.presentment.PresentmentSource
+import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.showBiometricPrompt
+import org.multipaz.prompt.Reason
 import org.multipaz.request.Requester
-import org.multipaz.securearea.UserAuthenticationType
+import org.multipaz.securearea.UserAuthenticationType as PromptUserAuthenticationType
 import org.multipaz.trustmanagement.TrustMetadata
-
-private const val TAG = "ConsentPromptScreen"
 
 actual suspend fun launchAndroidPresentmentActivity(
     source: PresentmentSource,
@@ -61,11 +61,17 @@ actual suspend fun launchAndroidPresentmentActivity(
                 )
             }
             if (paData.requireAuth) {
-                if (!PresentmentActivity.promptModel.showBiometricPrompt(
+                if (!(PresentmentActivity.promptModel as AndroidPromptModel).showBiometricPrompt(
                     cryptoObject = null,
-                    title = "Verify it's you",
-                    subtitle = "Authenticate to present credentials",
-                    userAuthenticationTypes = setOf(UserAuthenticationType.BIOMETRIC, UserAuthenticationType.LSKF),
+                    reason = Reason.HumanReadable(
+                        title = "Verify it's you",
+                        subtitle = "Authenticate to present credentials",
+                        requireConfirmation = paData.authRequireConfirmation
+                    ),
+                    userAuthenticationTypes = setOf(
+                        PromptUserAuthenticationType.BIOMETRIC,
+                        PromptUserAuthenticationType.LSKF
+                    ),
                     requireConfirmation = paData.authRequireConfirmation
                 )) {
                     throw PresentmentCanceledException("Presentment cancelled because user dismissed biometric prompt")
@@ -77,11 +83,7 @@ actual suspend fun launchAndroidPresentmentActivity(
             PresentmentActivity.presentmentModel.setCompleted(null)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            if (e is CancellationException) {
-                PresentmentActivity.presentmentModel.setCompleted(PresentmentCanceledException("Presentment was cancelled"))
-            } else {
-                PresentmentActivity.presentmentModel.setCompleted(e)
-            }
+            PresentmentActivity.presentmentModel.setCompleted(e)
         }
     }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -899,7 +899,7 @@ class App private constructor (val promptModel: PromptModel) {
         private var app: App? = null
         fun getInstance(): App {
             if (app == null) {
-                app = App(TestAppConfiguration.promptModel)
+                app = App(Platform.promptModel)
             }
             return app!!
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppConfiguration.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppConfiguration.kt
@@ -3,7 +3,6 @@ package org.multipaz.testapp
 import io.ktor.client.engine.HttpClientEngineFactory
 import org.jetbrains.compose.resources.DrawableResource
 import org.multipaz.presentment.PresentmentSource
-import org.multipaz.prompt.PromptModel
 import org.multipaz.storage.Storage
 
 enum class TestAppPlatform(val displayName: String) {
@@ -17,8 +16,6 @@ expect object TestAppConfiguration {
     val appName: String
 
     val appIcon: DrawableResource
-
-    val promptModel: PromptModel
 
     val platform: TestAppPlatform
 

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
@@ -1,9 +1,7 @@
 package org.multipaz.testapp
 
-import androidx.sqlite.driver.NativeSQLiteDriver
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.darwin.Darwin
-import org.multipaz.storage.Storage
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocArray
@@ -17,27 +15,20 @@ import kotlinx.cinterop.toKString
 import kotlinx.cinterop.value
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.app_icon
-import org.multipaz.document.DocumentStore
-import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.nfc.NfcTagReader
 import org.multipaz.presentment.PresentmentSource
-import org.multipaz.prompt.IosPromptModel
-import org.multipaz.prompt.PromptModel
+import org.multipaz.storage.Storage
 import org.multipaz.storage.ios.IosStorage
-import org.multipaz.storage.sqlite.SqliteStorage
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSURLIsExcludedFromBackupKey
 import platform.darwin.freeifaddrs
 import platform.darwin.getifaddrs
 import platform.darwin.ifaddrs
 import platform.darwin.inet_ntop
 import platform.posix.AF_INET
 import platform.posix.AF_INET6
-import platform.posix.INET_ADDRSTRLEN
 import platform.posix.INET6_ADDRSTRLEN
+import platform.posix.INET_ADDRSTRLEN
 import platform.posix.sa_family_t
 import platform.posix.sockaddr_in
 import platform.posix.sockaddr_in6
@@ -47,10 +38,6 @@ actual object TestAppConfiguration {
     actual val appName = "Multipaz Test App"
 
     actual val appIcon = Res.drawable.app_icon
-
-    actual val promptModel: PromptModel by lazy {
-        IosPromptModel.Builder().apply { addCommonDialogs() }.build()
-    }
 
     actual val platform = TestAppPlatform.IOS
 

--- a/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/TestAppConfiguration.wasmJs.kt
+++ b/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/TestAppConfiguration.wasmJs.kt
@@ -4,12 +4,7 @@ import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.js.Js
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.app_icon
-import org.multipaz.document.DocumentStore
-import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.nfc.NfcTagReader
 import org.multipaz.presentment.PresentmentSource
-import org.multipaz.prompt.PromptModel
-import org.multipaz.prompt.WebPromptModel
 import org.multipaz.util.Platform
 
 actual object TestAppConfiguration {
@@ -17,10 +12,6 @@ actual object TestAppConfiguration {
     actual val appName = "Multipaz Test App"
 
     actual val appIcon = Res.drawable.app_icon
-
-    actual val promptModel: PromptModel by lazy {
-        WebPromptModel.Builder().apply { addCommonDialogs() }.build()
-    }
 
     actual val platform = TestAppPlatform.WASMJS
 


### PR DESCRIPTION
Fixes #1651

## Summary
Unified prompt flows to consistently use the app-configured PromptModel instead of fallback/default model instances.
Standardized prompt copy derivation to Reason -> toHumanReadable so title/subtitle are consistent across entry points and platforms.
Updated related docs/KDocs to reflect the current contract prompt UI text comes from human-readable reason conversion, not direct request fields.


- [x] Tests pass
- [x] Appropriate changes to README are included in PR