### PR TITLE
Introduce Multipaz Pass file format.

### DIFF
--- a/mpzpass/README.md
+++ b/mpzpass/README.md
@@ -1,0 +1,114 @@
+# Multipaz Pass file format
+
+The Multipaz `.mpzpass` file format provides a standardized, lightweight mechanism
+for the exchange of low-assurance verifiable credentials.
+
+In scenarios where strict cryptographic device-binding introduces unnecessary
+friction — such as when a user expects their digital assets to seamlessly synchronize
+across their entire ecosystem of devices — this format offers a pragmatic, portable
+solution. It is engineered specifically for use cases where the risk of credential
+sharing is negligible, such as event and movie ticketing, transit passes, or generic
+membership cards.
+
+## Security Boundary and Anti-Cloning
+
+This format explicitly trades anti-cloning guarantees for portability. Because the
+credential data and any associated keys are stored in a highly portable container,
+the credential can be trivially copied.
+
+For high-value credentials where cloning or replay attacks are active threat
+vectors (e.g., mobile driving licenses or financial instruments), this file format
+is inherently unsuitable. In those high-assurance scenarios, issuers must leverage
+a robust provisioning protocol like [OpenID4VCI](https://github.com/openid/OpenID4VCI) to ensure secure delivery and
+hardware-backed device-binding at the time of issuance.
+
+## Data format
+
+The data is encoded in [CBOR](https://datatracker.ietf.org/doc/html/rfc8949) conforming to the following [CDDL](https://datatracker.ietf.org/doc/html/rfc8610):
+
+```cddl
+; Top-level container.
+;
+MpzPass = [
+  "MpzPass",
+  CompressedCredentialDataBytes,
+]
+
+; Contains CredentialDataBytes compressed using DEFLATE algorithm according
+; to [RFC 1951](https://www.ietf.org/rfc/rfc1951.txt).
+;
+CompressedCredentialDataBytes = bstr
+
+CredentialDataBytes = bstr .cbor CredentialData
+
+CredentialData = {
+  "display": Display,
+  "credential": Credential,
+}
+
+; Display data.
+;
+Display = {
+  ? "name": tstr,         ; Display name, e.g. "Erika's Driving License"
+  ? "typeName" : tstr     ; Credential type, e.g. "Utopia Driving License"
+  ? "cardArt" bstr,       ; PNG or JPEG with aspect ratio of 1.586 (cf. ID-1 from ISO/IEC 7810)
+}
+
+; The data for the credential.
+;
+; At least one of the credential formats must be present. If both credential formats
+; are present they must include identical data.
+;
+; To protect the holder's privacy and prevent RP collusion, multiple credentials may be
+; included for a single format, allowing the wallet to rotate between credentials and/or
+; implement policy decisions such as single-use. If multiple credentials are included,
+; they must all include the same data except for key material and slight variances in
+; the validity period necessary to avoid RPs being able to correlate credentials from the
+; same batch.
+;
+Credential = {
+  ? "isoMdoc": [+ IsoMdocCredential],
+  ? "sdJwtVc": [+ SdJwtVcCredential],
+}
+
+SdJwtVcCredential = {
+  ; The verifiable credential type.
+  ;
+  vct: tstr,
+  
+  ; The private key for the key-binding JWT, if used.
+  ;
+  ? "deviceKeyPrivate": COSE_Key,
+
+  ; The compact serialization of the SD-JWT VC, according to RFC 9901.
+  ;
+  "compactSerialization": tstr,
+}
+
+IsoMdocCredential = {
+  ; The document type.
+  ;
+  "docType": tstr,
+
+  ; The private key corresponding to DeviceKey in `issuerSigned`.
+  ;
+  "deviceKeyPrivate": COSE_Key,
+
+  ; IssuerSigned according to ISO/IEC 18013-5:2021 clause 8.3.2.1.2.2
+  ;
+  "issuerSigned": IssuerSigned,
+}
+```
+
+## MIME Type and file extension
+
+The MIME type `application/vnd.multipaz.mpzpass` shall be used for data containing credentials
+encoded in this format and the file extension `.mpzpass` shall be used for files containing
+credentials encoded in this format.
+
+## Examples files
+
+- [Driving license ISO mdoc](https://apps.multipaz.org/mpzpass/mDL.mpzpass)
+- [EU PID SD-JWT VC](https://apps.multipaz.org/mpzpass/EuPidSdJwt.mpzpass)
+- [Utopia Movie ticket SD-JWT VC w/o key-binding key](https://apps.multipaz.org/mpzpass/MovieTicketSdJwtKeyless.mpzpass)
+

--- a/multipaz-dcapi/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
+++ b/multipaz-dcapi/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
@@ -142,10 +142,10 @@ class DocumentStoreTestHarness {
             documentTypeRepository = documentTypeRepository,
             showConsentPromptFn = ::promptModelSilentConsent,
             preferSignatureToKeyAgreement = true,
-            domainMdocSignature = "mdoc",
-            domainMdocKeyAgreement = "mdoc_key_agreement",
-            domainKeylessSdJwt = "sdjwt_keyless",
-            domainKeyBoundSdJwt = "sdjwt"
+            domainsMdocSignature = listOf("mdoc"),
+            domainsMdocKeyAgreement = listOf("mdoc_key_agreement"),
+            domainsKeylessSdJwt = listOf("sdjwt_keyless"),
+            domainsKeyBoundSdJwt = listOf("sdjwt")
         )
 
         val now = Clock.System.now().truncateToWholeSeconds()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/credential/Credential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/credential/Credential.kt
@@ -31,8 +31,12 @@ import kotlinx.coroutines.sync.withLock
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.buildCborMap
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.securearea.KeyUnlockData
+import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.tags.Tags
 import kotlin.concurrent.Volatile
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Base class for credentials.
@@ -326,7 +330,7 @@ abstract class Credential {
 
     // Deleted identifier for which this one is a replacement
     // Called by Document.deleteCredential()
-    suspend fun replacementForDeleted() {
+    internal suspend fun replacementForDeleted() {
         lock.withLock {
             replacementForIdentifier = null
             save()
@@ -340,6 +344,22 @@ abstract class Credential {
      * @param builder a [MapBuilder] which can be used to add data.
      */
     open fun addSerializedData(builder: MapBuilder<CborBuilder>) {}
+
+    /**
+     * Exports the credential as a [MpzPass] which can be shared with other applications.
+     *
+     * Note: If the credential is using key-binding, it must be backed by a [SoftwareSecureArea] in order
+     * for this to work.
+     *
+     * @param keyUnlockData Optional unlock data required to read the underlying private key, if applicable.
+     * @return The generated [MpzPass].
+     * @throws IllegalStateException if the credential does not use a SoftwareSecureArea or if the credential
+     * doesn't support being exported.
+     */
+    @Throws(IllegalStateException::class, CancellationException::class)
+    open suspend fun exportToMpzPass(keyUnlockData: KeyUnlockData? = null): MpzPass {
+        throw IllegalStateException("This credential does not support export")
+    }
 
     /**
      * Serializes the credential.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
@@ -27,12 +27,21 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.credential.Credential
 import org.multipaz.credential.CredentialLoaderBuilder
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.mpzpass.MpzPass
 import org.multipaz.provisioning.Provisioning
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
+import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
+import org.multipaz.securearea.software.SoftwareCreateKeySettings
+import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.NoRecordStorageException
 import org.multipaz.tags.Tags
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlin.time.Instant
 
@@ -260,6 +269,112 @@ class DocumentStore private constructor(
 
     internal suspend fun getDocumentTable(): StorageTable {
         return storage.getTable(documentTableSpec)
+    }
+
+    /**
+     * Imports an [MpzPass] into a [DocumentStore].
+     *
+     * Reconstructs the [Document] and internal credential objects (either ISO mDoc, SD-JWT VC, or both)
+     * using the extracted data and keys in the passed-in [mpzPass] for credentials.
+     *
+     * The returned document will have the [Document.provisioned] flag set to `true`.
+     *
+     * @param mpzPass The []MpzPass] to import.
+     * @param isoMdocDomain The domain string to use when creating ISO mdoc credentials.
+     * @param sdJwtVcDomain The domain string to use when creating SD-JWT VC credentials.
+     * @param keylessSdJwtVcDomain the domain string to use when creating keyless SD-JWT VC credentials.
+     * @return The newly created [Document] containing the provisioned credentials.
+     * @throws IllegalStateException if a SoftwareSecureArea implementation cannot be found in the repository.
+     * @throws ImportMpzPassException if credential creation or certification fails.
+     */
+    @Throws(IllegalStateException::class, ImportMpzPassException::class, CancellationException::class)
+    suspend fun importMpzPass(
+        mpzPass: MpzPass,
+        isoMdocDomain: String = "mdoc",
+        sdJwtVcDomain: String = "sdjwtvc",
+        keylessSdJwtVcDomain: String = "sdjwtvc_keyless"
+    ): Document {
+        val softwareSecureArea = secureAreaRepository.getImplementation(SoftwareSecureArea.IDENTIFIER)
+            ?: throw IllegalStateException(
+                "No SoftwareSecureArea implementation found"
+            )
+
+        val document = try {
+            createDocument(
+                displayName = mpzPass.name,
+                typeDisplayName = mpzPass.typeName,
+                cardArt = mpzPass.cardArt,
+            )
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw ImportMpzPassException("Failed to create document", e)
+        }
+
+        try {
+            mpzPass.isoMdoc.forEach { isoMdoc ->
+                val importedKeyInfo = softwareSecureArea.createKey(
+                    alias = null,
+                    createKeySettings = SoftwareCreateKeySettings.Builder()
+                        .setPrivateKey(isoMdoc.deviceKeyPrivate)
+                        .build()
+                )
+                val credential = MdocCredential.createForExistingAlias(
+                    document = document,
+                    asReplacementForIdentifier = null,
+                    domain = isoMdocDomain,
+                    secureArea = softwareSecureArea,
+                    docType = isoMdoc.docType,
+                    existingKeyAlias = importedKeyInfo.alias,
+                )
+                credential.certify(
+                    issuerProvidedAuthenticationData = ByteString(
+                        Cbor.encode(buildCborMap {
+                            put("nameSpaces", isoMdoc.issuerNamespaces.toDataItem())
+                            put("issuerAuth", isoMdoc.issuerAuth.toDataItem())
+                        })
+                    )
+                )
+            }
+
+            mpzPass.sdJwtVc.forEach { sdJwtVc ->
+                val credential = if (sdJwtVc.deviceKeyPrivate != null) {
+                    val importedKeyInfo = softwareSecureArea.createKey(
+                        alias = null,
+                        createKeySettings = SoftwareCreateKeySettings.Builder()
+                            .setPrivateKey(sdJwtVc.deviceKeyPrivate)
+                            .build()
+                    )
+                    KeyBoundSdJwtVcCredential.createForExistingAlias(
+                        document = document,
+                        asReplacementForIdentifier = null,
+                        domain = sdJwtVcDomain,
+                        secureArea = softwareSecureArea,
+                        vct = sdJwtVc.vct,
+                        existingKeyAlias = importedKeyInfo.alias,
+                    )
+                } else {
+                    KeylessSdJwtVcCredential.create(
+                        document = document,
+                        asReplacementForIdentifier = null,
+                        domain = keylessSdJwtVcDomain,
+                        vct = sdJwtVc.vct
+                    )
+                }
+
+                credential.certify(
+                    issuerProvidedAuthenticationData = sdJwtVc.compactSerialization.encodeToByteString()
+                )
+            }
+
+            document.edit {
+                provisioned = true
+            }
+            return document
+        } catch (e: Exception) {
+            deleteDocument(document.identifier)
+            if (e is CancellationException) throw e
+            throw ImportMpzPassException("Failed importing credentials", e)
+        }
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/ImportMpzPassException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/ImportMpzPassException.kt
@@ -1,0 +1,9 @@
+package org.multipaz.document
+
+/**
+ * Thrown when importing a [org.multipaz.mpzpass.MpzPass] into [DocumentStore] fails.
+ *
+ * @property message the message or `null`.
+ * @property cause the cause of `null`.
+ */
+class ImportMpzPassException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -17,9 +17,13 @@
 package org.multipaz.documenttype
 
 import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
 import kotlin.time.Instant
 import org.multipaz.cbor.DataItem
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.RawCbor
@@ -29,14 +33,22 @@ import org.multipaz.cbor.toDataItem
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
+import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.document.Document
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
 import org.multipaz.mdoc.mso.MobileSecurityObject
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
+import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
+import org.multipaz.sdjwt.credential.SdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
 import kotlin.random.Random
 
 /**
@@ -441,5 +453,125 @@ class DocumentType private constructor(
         // Now that we have issuer-provided authentication data we ccan ertify the authentication key.
         mdocCredential.certify(ByteString(issuerProvidedAuthenticationData))
         return mdocCredential
+    }
+
+    /**
+     * Adds a [KeylessSdJwtVcCredential] to a [Document] with sample data for the document type.
+     *
+     * @param document the [Document] to add the credential to.
+     * @param dsKey the key to sign the MSO with and its certificate chain.
+     * @param signedAt the time the MSO was signed.
+     * @param validFrom the time at which the credential is valid from.
+     * @param validUntil the time at which the credential is valid until.
+     * @param domain the domain to use for the credential.
+     * @return the [MdocCredential] that was added to [document].
+     */
+    suspend fun createKeylessSdJwtVcCredentialWithSampleData(
+        document: Document,
+        dsKey: AsymmetricKey.X509Certified,
+        signedAt: Instant,
+        validFrom: Instant,
+        validUntil: Instant,
+        domain: String = "sdjwt",
+        randomProvider: Random = Random,
+    ): KeylessSdJwtVcCredential {
+        require(jsonDocumentType != null)
+
+        val identityAttributes = buildJsonObject {
+            for ((claimName, attribute) in jsonDocumentType.claims) {
+                // Skip sub-claims.
+                if (claimName.contains('.')) {
+                    continue
+                }
+                attribute.sampleValueJson?.let {
+                    put(claimName, it)
+                }
+            }
+        }
+        val credential = KeylessSdJwtVcCredential.create(
+            document = document,
+            asReplacementForIdentifier = null,
+            domain = domain,
+            vct = jsonDocumentType.vct,
+        )
+
+        val sdJwt = SdJwt.create(
+            issuerKey = dsKey,
+            kbKey = null,
+            claims = identityAttributes,
+            nonSdClaims = buildJsonObject {
+                put("iss", "https://example-issuer.com")
+                put("vct", credential.vct)
+                put("iat", signedAt.epochSeconds)
+                put("nbf", validFrom.epochSeconds)
+                put("exp", validUntil.epochSeconds)
+            },
+            random = randomProvider
+        )
+        credential.certify(sdJwt.compactSerialization.encodeToByteString())
+        return credential
+    }
+
+    /**
+     * Adds a [KeyBoundSdJwtVcCredential] to a [Document] with sample data for the document type.
+     *
+     * @param document the [Document] to add the credential to.
+     * @param secureArea the [SecureArea] to use for `DeviceKey`.
+     * @param createKeySettings the [CreateKeySettings] to use.
+     * @param dsKey the key to sign the MSO with and its certificate chain.
+     * @param signedAt the time the MSO was signed.
+     * @param validFrom the time at which the credential is valid from.
+     * @param validUntil the time at which the credential is valid until.
+     * @param domain the domain to use for the credential.
+     * @return the [MdocCredential] that was added to [document].
+     */
+    suspend fun createKeyBoundSdJwtVcCredentialWithSampleData(
+        document: Document,
+        secureArea: SecureArea,
+        createKeySettings: CreateKeySettings,
+        dsKey: AsymmetricKey.X509Certified,
+        signedAt: Instant,
+        validFrom: Instant,
+        validUntil: Instant,
+        domain: String = "sdjwt",
+        randomProvider: Random = Random,
+    ): KeyBoundSdJwtVcCredential {
+        require(jsonDocumentType != null)
+
+        val identityAttributes = buildJsonObject {
+            for ((claimName, attribute) in jsonDocumentType.claims) {
+                // Skip sub-claims.
+                if (claimName.contains('.')) {
+                    continue
+                }
+                attribute.sampleValueJson?.let {
+                    put(claimName, it)
+                }
+            }
+        }
+        val credential = KeyBoundSdJwtVcCredential.create(
+            document = document,
+            asReplacementForIdentifier = null,
+            domain = domain,
+            secureArea = secureArea,
+            vct = jsonDocumentType.vct,
+            createKeySettings = createKeySettings
+        )
+
+        val sdJwt = SdJwt.create(
+            issuerKey = dsKey,
+            kbKey = credential.getAttestation().publicKey,
+            claims = identityAttributes,
+            nonSdClaims = buildJsonObject {
+                put("iss", "https://example-issuer.com")
+                put("vct", credential.vct)
+                put("iat", signedAt.epochSeconds)
+                put("nbf", validFrom.epochSeconds)
+                put("exp", validUntil.epochSeconds)
+            },
+            random = randomProvider
+        )
+        credential.certify(sdJwt.compactSerialization.encodeToByteString())
+        return credential
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -31,9 +31,13 @@ import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.issuersigned.IssuerNamespaces
 import org.multipaz.mdoc.mso.MobileSecurityObject
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.mpzpass.MpzPassIsoMdoc
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.KeyUnlockData
 import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.util.Logger
 
 /**
@@ -300,5 +304,25 @@ class MdocCredential : SecureAreaBoundCredential {
         issuerAuth.unprotectedHeaders[
             CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN)
         ]!!.asX509CertChain
+    }
+
+    override suspend fun exportToMpzPass(keyUnlockData: KeyUnlockData?): MpzPass {
+        check(secureArea is SoftwareSecureArea) {
+            "You can only export a credential if it's using a SoftwareSecureArea"
+        }
+        val deviceKeyPrivate = (secureArea as SoftwareSecureArea).getPrivateKey(alias, keyUnlockData)
+        val issuerNamespaces = IssuerNamespaces.fromDataItem(issuerSigned["nameSpaces"])
+        val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
+        return MpzPass(
+            name = document.displayName,
+            typeName = document.typeDisplayName,
+            cardArt = document.cardArt,
+            isoMdoc = listOf(MpzPassIsoMdoc(
+                docType = docType,
+                deviceKeyPrivate = deviceKeyPrivate,
+                issuerNamespaces = issuerNamespaces,
+                issuerAuth = issuerAuth
+            ))
+        )
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPass.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPass.kt
@@ -1,0 +1,126 @@
+package org.multipaz.mpzpass
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.CborArray
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborArray
+import org.multipaz.cbor.putCborMap
+import org.multipaz.util.Logger
+import org.multipaz.util.deflate
+import org.multipaz.util.inflate
+
+/**
+ * Represents a Multipaz `.mpzpass` credential container.
+ *
+ * This format provides a highly portable, lightweight mechanism to exchange low-assurance
+ * verifiable credentials (such as transit passes or movie tickets) where strict
+ * hardware device-binding is unnecessary.
+ *
+ * See [this page](https://github.com/openwallet-foundation/multipaz/tree/main/mpzpass/README.md)
+ * for the definition of the Multipaz Pass file format.
+ *
+ * @property name The display name of the credential (e.g., "Erika's Driving License").
+ * @property typeName The display type of the credential (e.g., "Utopia Driving License").
+ * @property cardArt The card art for the pass as a PNG ByteString.
+ * @property isoMdoc The ISO mDoc credentials in the payload.
+ * @property sdJwtVc The SD-JWT VC credentials in the payload.
+ * @throws IllegalArgumentException if both [isoMdoc] and [sdJwtVc] are empty.
+ */
+data class MpzPass(
+    val name: String?,
+    val typeName: String?,
+    val cardArt: ByteString?,
+    val isoMdoc: List<MpzPassIsoMdoc> = emptyList(),
+    val sdJwtVc: List<MpzPassSdJwtVc> = emptyList()
+) {
+
+    init {
+        if (isoMdoc.isEmpty() && sdJwtVc.isEmpty()) {
+            throw IllegalArgumentException("Both isoMdoc and sdJwtVc cannot be empty")
+        }
+    }
+
+    /**
+     * Serializes and compresses this [MpzPass] into a [DataItem].
+     *
+     * The credential data payload is encoded to CBOR and then compressed using the DEFLATE algorithm.
+     *
+     * @param compressionLevel The DEFLATE compression level to use (0-9). Defaults to 5.
+     * @return A [DataItem].
+     * @throws IllegalArgumentException if the compression level is out of range.
+     */
+    @Throws(IllegalArgumentException::class, CancellationException::class)
+    suspend fun toDataItem(compressionLevel: Int = 5) = buildCborArray {
+        add("MpzPass")
+        val credentialData = buildCborMap {
+            putCborMap("credential") {
+                if (isoMdoc.isNotEmpty()) {
+                    putCborArray("isoMdoc") {
+                        isoMdoc.forEach { add(it.toDataItem()) }
+                    }
+                }
+                if (sdJwtVc.isNotEmpty()) {
+                    putCborArray("sdJwtVc") {
+                        sdJwtVc.forEach { add(it.toDataItem()) }
+                    }
+                }
+            }
+            putCborMap("display") {
+                name?.let { put("name", it) }
+                typeName?.let { put("typeName", it) }
+                cardArt?.let { put("cardArt", it.toByteArray()) }
+            }
+        }
+        val credentialDataBytes = Cbor.encode(credentialData)
+        val compressedCredentialDataBytes = credentialDataBytes.deflate(compressionLevel)
+        add(compressedCredentialDataBytes)
+    }
+
+    companion object {
+        private const val TAG = "MpzPass"
+
+        /**
+         * Parses a CBOR array [DataItem] into an [MpzPass].
+         *
+         * This decompresses the embedded DEFLATE payload and reconstructs the pass details.
+         *
+         * @param dataItem The top-level CBOR array containing the MpzPass string tag and compressed bytes.
+         * @return The parsed [MpzPass].
+         * @throws IllegalArgumentException if CBOR decoding or decompression fails.
+         */
+        @Throws(IllegalArgumentException::class, CancellationException::class)
+        suspend fun fromDataItem(dataItem: DataItem): MpzPass {
+            check(dataItem is CborArray) { "Expected an array" }
+            require(dataItem[0].asTstr == "MpzPass") { "Wrong string at start" }
+
+            val compressedCredentialDataBytes = dataItem[1].asBstr
+            val credentialDataBytes = compressedCredentialDataBytes.inflate()
+            val credentialData = Cbor.decode(credentialDataBytes)
+
+            val display = credentialData["display"]
+            val name = display.getOrNull("name")?.asTstr
+            val typeName = display.getOrNull("typeName")?.asTstr
+            val cardArt = display.getOrNull("cardArt")?.asBstr?.let { ByteString(it) }
+
+            val credential = credentialData["credential"]
+            val isoMdoc = credential.getOrNull("isoMdoc")?.asArray?.map {
+                MpzPassIsoMdoc.fromDataItem(it)
+            } ?: emptyList()
+            val sdJwtVc = credential.getOrNull("sdJwtVc")?.asArray?.map {
+                MpzPassSdJwtVc.fromDataItem(it)
+            } ?: emptyList()
+
+            return MpzPass(
+                name = name,
+                typeName = typeName,
+                cardArt = cardArt,
+                isoMdoc = isoMdoc,
+                sdJwtVc = sdJwtVc
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPassIsoMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPassIsoMdoc.kt
@@ -1,0 +1,61 @@
+package org.multipaz.mpzpass
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborMap
+import org.multipaz.cose.CoseSign1
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.mdoc.issuersigned.IssuerNamespaces
+
+/**
+ * Represents the ISO mDoc specific data within an MpzPass container.
+ *
+ * @property docType The ISO document type string (e.g., "org.iso.18013.5.1.mDL").
+ * @property deviceKeyPrivate The private key corresponding to the DeviceKey mapped in `issuerSigned`.
+ * @property issuerNamespaces The namespaces containing issuer-signed data items.
+ * @property issuerAuth The `CoseSign1` structure authenticating the issuer namespaces.
+ */
+data class MpzPassIsoMdoc(
+    val docType: String,
+    val deviceKeyPrivate: EcPrivateKey,
+    val issuerNamespaces: IssuerNamespaces,
+    val issuerAuth: CoseSign1
+) {
+    /**
+     * Serializes this [MpzPassIsoMdoc] instance into a CBOR map [DataItem].
+     *
+     * @return A CBOR map containing the ISO mDoc data.
+     */
+    fun toDataItem() = buildCborMap {
+        put("docType", docType)
+        put("deviceKeyPrivate", deviceKeyPrivate.toDataItem())
+        putCborMap("issuerSigned") {
+            put("nameSpaces", issuerNamespaces.toDataItem())
+            put("issuerAuth", issuerAuth.toDataItem())
+        }
+    }
+
+    companion object {
+        /**
+         * Parses a CBOR map [DataItem] into an [MpzPassIsoMdoc] instance.
+         *
+         * @param dataItem The CBOR map containing the ISO mDoc representation.
+         * @return The parsed [MpzPassIsoMdoc].
+         * @throws IllegalArgumentException if the expected fields are missing or incorrectly typed.
+         */
+        @Throws(IllegalArgumentException::class)
+        fun fromDataItem(dataItem: DataItem): MpzPassIsoMdoc {
+            val docType = dataItem["docType"].asTstr
+            val deviceKeyPrivate = dataItem["deviceKeyPrivate"].asCoseKey.ecPrivateKey
+            val issuerSigned = dataItem["issuerSigned"]
+            val issuerNamespaces = IssuerNamespaces.fromDataItem(issuerSigned["nameSpaces"])
+            val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
+            return MpzPassIsoMdoc(
+                docType = docType,
+                deviceKeyPrivate = deviceKeyPrivate,
+                issuerNamespaces = issuerNamespaces,
+                issuerAuth = issuerAuth
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPassSdJwtVc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPassSdJwtVc.kt
@@ -1,0 +1,50 @@
+package org.multipaz.mpzpass
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.EcPrivateKey
+
+/**
+ * Represents the SD-JWT VC specific data within an MpzPass container.
+ *
+ * @property vct The verifiable credential type (VCT) string.
+ * @property deviceKeyPrivate The private key used for key-binding, or null if the credential is not key-bound.
+ * @property compactSerialization The compact serialization string of the SD-JWT VC according to RFC 9901.
+ */
+data class MpzPassSdJwtVc(
+    val vct: String,
+    val deviceKeyPrivate: EcPrivateKey?,
+    val compactSerialization: String
+) {
+    /**
+     * Serializes this [MpzPassSdJwtVc] instance into a CBOR map [DataItem].
+     *
+     * @return A CBOR map containing the SD-JWT VC data.
+     */
+    fun toDataItem() = buildCborMap {
+        put("vct", vct)
+        deviceKeyPrivate?.let { put("deviceKeyPrivate", it.toDataItem()) }
+        put("compactSerialization", compactSerialization)
+    }
+
+    companion object {
+        /**
+         * Parses a CBOR map [DataItem] into an [MpzPassSdJwtVc] instance.
+         *
+         * @param dataItem The CBOR map containing the SD-JWT VC representation.
+         * @return The parsed [MpzPassSdJwtVc].
+         * @throws IllegalArgumentException if the expected fields are missing or incorrectly typed.
+         */
+        @Throws(IllegalArgumentException::class)
+        fun fromDataItem(dataItem: DataItem): MpzPassSdJwtVc {
+            val vct = dataItem["vct"].asTstr
+            val deviceKeyPrivate = dataItem.getOrNull("deviceKeyPrivate")?.asCoseKey?.ecPrivateKey
+            val compactSerialization = dataItem["compactSerialization"].asTstr
+            return MpzPassSdJwtVc(
+                vct = vct,
+                deviceKeyPrivate = deviceKeyPrivate,
+                compactSerialization = compactSerialization
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -17,6 +17,7 @@ import org.multipaz.request.Requester
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
 import org.multipaz.trustmanagement.TrustMetadata
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 
 private data class CredentialForPresentment(
@@ -38,10 +39,13 @@ private data class CredentialForPresentment(
  * @property showConsentPrompt a [ShowConsentPromptFn] used show a consent prompt is required.
  * @property preferSignatureToKeyAgreement whether to use mdoc ECDSA authentication even if mdoc MAC authentication
  *   is possible (ISO mdoc only).
- * @property domainMdocSignature the domain to use for [org.multipaz.mdoc.credential.MdocCredential] instances using mdoc ECDSA authentication or `null`.
- * @property domainMdocKeyAgreement the domain to use for [org.multipaz.mdoc.credential.MdocCredential] instances using mdoc MAC authentication or `null`.
- * @property domainKeylessSdJwt the domain to use for [KeylessSdJwtVcCredential] instances or `null`.
- * @property domainKeyBoundSdJwt the domain to use for [org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential] instances or `null`.
+ * @property domainsMdocSignature the domains to use for [org.multipaz.mdoc.credential.MdocCredential] instances using
+ * mdoc ECDSA authentication, will be tried in order.
+ * @property domainsMdocKeyAgreement the domains to use for [org.multipaz.mdoc.credential.MdocCredential] instances
+ * using mdoc MAC authentication, will be tried in order.
+ * @property domainsKeylessSdJwt the domains to use for [KeylessSdJwtVcCredential] instances, will be tried in order.
+ * @property domainsKeyBoundSdJwt the domains to use for [org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential]
+ * instances, will be tried in order.
  */
 class SimplePresentmentSource(
     override val documentStore: DocumentStore,
@@ -51,10 +55,10 @@ class SimplePresentmentSource(
     private val resolveTrustFn: suspend (requester: Requester) -> TrustMetadata? = { requester -> null },
     private val showConsentPromptFn: ShowConsentPromptFn = ::promptModelRequestConsent,
     val preferSignatureToKeyAgreement: Boolean = true,
-    val domainMdocSignature: String? = null,
-    val domainMdocKeyAgreement: String? = null,
-    val domainKeylessSdJwt: String? = null,
-    val domainKeyBoundSdJwt: String? = null,
+    val domainsMdocSignature: List<String> = emptyList(),
+    val domainsMdocKeyAgreement: List<String> = emptyList(),
+    val domainsKeylessSdJwt: List<String> = emptyList(),
+    val domainsKeyBoundSdJwt: List<String> = emptyList(),
 ): PresentmentSource(
     documentStore = documentStore,
     documentTypeRepository = documentTypeRepository,
@@ -81,6 +85,15 @@ class SimplePresentmentSource(
         )
     }
 
+    private suspend fun Document.findCredential(domains: List<String>, now: Instant): Credential? {
+        for (domain in domains) {
+            findCredential(domain, now)?.let {
+                return it
+            }
+        }
+        return null
+    }
+
     override suspend fun selectCredential(
         document: Document,
         requestedClaims: List<RequestedClaim>,
@@ -91,27 +104,19 @@ class SimplePresentmentSource(
         val credsForPresentment = when (requestedClaims[0]) {
             is MdocRequestedClaim -> {
                 CredentialForPresentment(
-                    credential = domainMdocSignature?.let {
-                        document.findCredential(domain = it, now = now)
-                    },
-                    credentialKeyAgreement = domainMdocKeyAgreement?.let {
-                        document.findCredential(domain = it, now = now)
-                    }
+                    credential = document.findCredential(domains = domainsMdocSignature, now = now),
+                    credentialKeyAgreement = document.findCredential(domains = domainsMdocKeyAgreement, now = now)
                 )
             }
             is JsonRequestedClaim -> {
                 if (document.getCertifiedCredentials().firstOrNull() is KeylessSdJwtVcCredential) {
                     CredentialForPresentment(
-                        credential = domainKeylessSdJwt?.let {
-                            document.findCredential(domain = it, now = now)
-                        },
+                        credential = document.findCredential(domains = domainsKeylessSdJwt, now = now),
                         credentialKeyAgreement = null
                     )
                 } else {
                     CredentialForPresentment(
-                        credential = domainKeyBoundSdJwt?.let {
-                            document.findCredential(domain = it, now = now)
-                        },
+                        credential = document.findCredential(domains = domainsKeyBoundSdJwt, now = now),
                         credentialKeyAgreement = null
                     )
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
@@ -1,5 +1,6 @@
 package org.multipaz.sdjwt.credential
 
+import kotlinx.io.bytestring.decodeToString
 import org.multipaz.cbor.CborBuilder
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.MapBuilder
@@ -8,8 +9,12 @@ import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.mpzpass.MpzPassSdJwtVc
 import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.KeyUnlockData
 import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.software.SoftwareSecureArea
 import kotlin.time.Instant
 
 /**
@@ -189,4 +194,21 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
 
     override suspend fun extractValidityFromIssuerData(): Pair<Instant, Instant> =
         extractValidityFromIssuerDataImpl()
+
+    override suspend fun exportToMpzPass(keyUnlockData: KeyUnlockData?): MpzPass {
+        check(secureArea is SoftwareSecureArea) {
+            "You can only export a credential if it's using a SoftwareSecureArea"
+        }
+        val deviceKeyPrivate = (secureArea as SoftwareSecureArea).getPrivateKey(alias, keyUnlockData)
+        return MpzPass(
+            name = document.displayName,
+            typeName = document.typeDisplayName,
+            cardArt = document.cardArt,
+            sdJwtVc = listOf(MpzPassSdJwtVc(
+                vct = vct,
+                deviceKeyPrivate = deviceKeyPrivate,
+                compactSerialization = issuerProvidedData.decodeToString()
+            ))
+        )
+    }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeylessSdJwtVcCredential.kt
@@ -1,5 +1,6 @@
 package org.multipaz.sdjwt.credential
 
+import kotlinx.io.bytestring.decodeToString
 import org.multipaz.cbor.CborBuilder
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.MapBuilder
@@ -7,6 +8,9 @@ import org.multipaz.claim.JsonClaim
 import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.mpzpass.MpzPassSdJwtVc
+import org.multipaz.securearea.KeyUnlockData
 import org.multipaz.securearea.SecureArea
 import kotlin.time.Instant
 
@@ -62,6 +66,19 @@ class KeylessSdJwtVcCredential : Credential, SdJwtVcCredential {
 
     override suspend fun extractValidityFromIssuerData(): Pair<Instant, Instant> =
         extractValidityFromIssuerDataImpl()
+
+    override suspend fun exportToMpzPass(keyUnlockData: KeyUnlockData?): MpzPass {
+        return MpzPass(
+            name = document.displayName,
+            typeName = document.typeDisplayName,
+            cardArt = document.cardArt,
+            sdJwtVc = listOf(MpzPassSdJwtVc(
+                vct = vct,
+                deviceKeyPrivate = null,
+                compactSerialization = issuerProvidedData.decodeToString()
+            ))
+        )
+    }
 
     companion object {
         const val CREDENTIAL_TYPE: String = "KeylessSdJwtVcCredential"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareCreateKeySettings.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareCreateKeySettings.kt
@@ -6,9 +6,12 @@ import org.multipaz.securearea.PassphraseConstraints
 import org.multipaz.securearea.config.SecureAreaConfigurationSoftware
 import kotlin.time.Instant;
 import kotlinx.io.bytestring.buildByteString
+import org.multipaz.crypto.EcPrivateKey
 
 /**
  * Class used to indicate key creation settings for software-backed keys.
+ *
+ * @property privateKey private key material to use for the key or `null`.
  */
 class SoftwareCreateKeySettings internal constructor(
     val passphraseRequired: Boolean,
@@ -17,7 +20,8 @@ class SoftwareCreateKeySettings internal constructor(
     algorithm: Algorithm,
     val subject: String?,
     validFrom: Instant?,
-    validUntil: Instant?
+    validUntil: Instant?,
+    val privateKey: EcPrivateKey?
 ) : CreateKeySettings(
     algorithm = algorithm,
     nonce = buildByteString {},
@@ -35,6 +39,7 @@ class SoftwareCreateKeySettings internal constructor(
         private var subject: String? = null
         private var validFrom: Instant? = null
         private var validUntil: Instant? = null
+        private var privateKey: EcPrivateKey? = null
 
         /**
          * Apply settings from configuration object.
@@ -109,13 +114,25 @@ class SoftwareCreateKeySettings internal constructor(
         }
 
         /**
+         * Sets the private key material.
+         *
+         * @param privateKey the private key material.
+         * @return the builder.
+         */
+        fun setPrivateKey(
+            privateKey: EcPrivateKey
+        ) = apply {
+            this.privateKey = privateKey
+        }
+
+        /**
          * Builds the [SoftwareCreateKeySettings].
          *
          * @return a new [SoftwareCreateKeySettings].
          */
         fun build(): SoftwareCreateKeySettings {
             return SoftwareCreateKeySettings(
-                passphraseRequired, passphrase, passphraseConstraints, algorithm, subject, validFrom, validUntil
+                passphraseRequired, passphrase, passphraseConstraints, algorithm, subject, validFrom, validUntil, privateKey
             )
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -41,6 +41,7 @@ import org.multipaz.prompt.PromptModel
 import org.multipaz.prompt.PromptModelNotAvailableException
 import org.multipaz.securearea.KeyUnlockDataProvider
 import org.multipaz.prompt.Reason
+import org.multipaz.securearea.KeyInfo
 import kotlin.random.Random
 
 /**
@@ -95,7 +96,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             builder.build()
         }
         try {
-            val privateKey = Crypto.createEcPrivateKey(settings.algorithm.curve!!)
+            val privateKey = settings.privateKey ?: Crypto.createEcPrivateKey(settings.algorithm.curve!!)
             val encodedPublicKey = Cbor.encode(privateKey.publicKey.toCoseKey().toDataItem())
             val keyMetadata = if (settings.passphraseRequired) {
                 val secretKey = derivePrivateKeyEncryptionKey(encodedPublicKey, settings.passphrase!!)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mpzpass/MpzPassTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mpzpass/MpzPassTest.kt
@@ -1,0 +1,149 @@
+package org.multipaz.mpzpass
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.credential.SecureAreaBoundCredential
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.presentment.DocumentStoreTestHarness
+import org.multipaz.securearea.CreateKeySettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class MpzPassTest {
+
+    @Test
+    fun testIsoMdocExportImport() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+
+        val doc = harness.documentStore.createDocument(
+            displayName = "Driving license specimen",
+            typeDisplayName = "Utopia driving license",
+            cardArt = ByteString(1, 2, 3),
+        )
+        val credential = DrivingLicense.getDocumentType().createMdocCredentialWithSampleData(
+            document = doc,
+            secureArea = harness.softwareSecureArea,
+            createKeySettings = CreateKeySettings(),
+            dsKey = harness.dsKey,
+            signedAt = harness.signedAt,
+            validFrom = harness.validFrom,
+            validUntil = harness.validUntil,
+            expectedUpdate = null,
+            domain = "mdoc",
+        )
+        doc.edit { provisioned = true }
+
+        val pass = credential.exportToMpzPass()
+        assertEquals(
+            pass,
+            MpzPass.fromDataItem(pass.toDataItem())
+        )
+        val importedDoc = harness.documentStore.importMpzPass(pass)
+        assertNotEquals(doc.identifier, importedDoc.identifier)
+        assertNotEquals(doc.created, importedDoc.created)
+        assertEquals(doc.displayName, importedDoc.displayName)
+        assertEquals(doc.typeDisplayName, importedDoc.typeDisplayName)
+        assertEquals(doc.cardArt, importedDoc.cardArt)
+        assertEquals(doc.provisioned, importedDoc.provisioned)
+        assertEquals(1, importedDoc.getCredentials().size)
+        val importedCredential = importedDoc.getCredentials().first()
+        assertNotEquals(credential.identifier, importedCredential.identifier)
+        assertEquals(credential::class, importedCredential::class)
+        assertEquals(credential.credentialType, importedCredential.credentialType)
+        assertEquals(credential.issuerProvidedData, importedCredential.issuerProvidedData)
+        importedCredential as MdocCredential
+        assertNotEquals(credential.alias, importedCredential.alias)
+        assertEquals(credential.secureArea, importedCredential.secureArea)
+    }
+
+    @Test
+    fun testKeyBoundSdJwtExportImport() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+
+        val doc = harness.documentStore.createDocument(
+            displayName = "EU PID specimen",
+            typeDisplayName = "EU PID",
+            cardArt = ByteString(1, 2, 3),
+        )
+        val credential = EUPersonalID.getDocumentType().createKeyBoundSdJwtVcCredentialWithSampleData(
+            document = doc,
+            secureArea = harness.softwareSecureArea,
+            createKeySettings = CreateKeySettings(),
+            dsKey = harness.dsKey,
+            signedAt = harness.signedAt,
+            validFrom = harness.validFrom,
+            validUntil = harness.validUntil,
+            domain = "sdjwt",
+        )
+        doc.edit { provisioned = true }
+
+        val pass = credential.exportToMpzPass()
+        assertEquals(
+            pass,
+            MpzPass.fromDataItem(pass.toDataItem())
+        )
+        val importedDoc = harness.documentStore.importMpzPass(pass)
+        assertNotEquals(doc.identifier, importedDoc.identifier)
+        assertNotEquals(doc.created, importedDoc.created)
+        assertEquals(doc.displayName, importedDoc.displayName)
+        assertEquals(doc.typeDisplayName, importedDoc.typeDisplayName)
+        assertEquals(doc.cardArt, importedDoc.cardArt)
+        assertEquals(doc.provisioned, importedDoc.provisioned)
+        assertEquals(1, importedDoc.getCredentials().size)
+        val importedCredential = importedDoc.getCredentials().first()
+        assertNotEquals(credential.identifier, importedCredential.identifier)
+        assertEquals(credential::class, importedCredential::class)
+        assertEquals(credential.credentialType, importedCredential.credentialType)
+        assertEquals(credential.issuerProvidedData, importedCredential.issuerProvidedData)
+        importedCredential as SecureAreaBoundCredential
+        assertNotEquals(credential.alias, importedCredential.alias)
+        assertEquals(credential.secureArea, importedCredential.secureArea)
+    }
+
+    @Test
+    fun testKeylessSdJwtExportImport() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+
+        val doc = harness.documentStore.createDocument(
+            displayName = "Back to Utopia",
+            typeDisplayName = "Utopia movie ticket",
+            cardArt = ByteString(1, 2, 3),
+        )
+        val credential = UtopiaMovieTicket.getDocumentType().createKeylessSdJwtVcCredentialWithSampleData(
+            document = doc,
+            dsKey = harness.dsKey,
+            signedAt = harness.signedAt,
+            validFrom = harness.validFrom,
+            validUntil = harness.validUntil,
+            domain = "sdjwt",
+        )
+        doc.edit { provisioned = true }
+
+        val pass = credential.exportToMpzPass()
+        assertEquals(
+            pass,
+            MpzPass.fromDataItem(pass.toDataItem())
+        )
+        val importedDoc = harness.documentStore.importMpzPass(pass)
+        assertNotEquals(doc.identifier, importedDoc.identifier)
+        assertNotEquals(doc.created, importedDoc.created)
+        assertEquals(doc.displayName, importedDoc.displayName)
+        assertEquals(doc.typeDisplayName, importedDoc.typeDisplayName)
+        assertEquals(doc.cardArt, importedDoc.cardArt)
+        assertEquals(doc.provisioned, importedDoc.provisioned)
+        assertEquals(1, importedDoc.getCredentials().size)
+        val importedCredential = importedDoc.getCredentials().first()
+        assertNotEquals(credential.identifier, importedCredential.identifier)
+        assertEquals(credential::class, importedCredential::class)
+        assertEquals(credential.credentialType, importedCredential.credentialType)
+        assertEquals(credential.issuerProvidedData, importedCredential.issuerProvidedData)
+    }
+
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
@@ -141,10 +141,10 @@ class DocumentStoreTestHarness {
             documentTypeRepository = documentTypeRepository,
             showConsentPromptFn = ::promptModelSilentConsent,
             preferSignatureToKeyAgreement = true,
-            domainMdocSignature = "mdoc",
-            domainMdocKeyAgreement = "mdoc_key_agreement",
-            domainKeylessSdJwt = "sdjwt_keyless",
-            domainKeyBoundSdJwt = "sdjwt"
+            domainsMdocSignature = listOf("mdoc"),
+            domainsMdocKeyAgreement = listOf("mdoc_key_agreement"),
+            domainsKeylessSdJwt = listOf("sdjwt_keyless"),
+            domainsKeyBoundSdJwt = listOf("sdjwt")
         )
 
         val now = Clock.System.now().truncateToWholeSeconds()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/digitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/digitalCredentialsPresentmentTest.kt
@@ -85,8 +85,8 @@ class DigitalCredentialsPresentmentTest {
             documentTypeRepository = documentStoreTestHarness.documentTypeRepository,
             showConsentPromptFn = ::promptModelSilentConsent,
             preferSignatureToKeyAgreement = true,
-            domainMdocSignature = "mdoc",
-            domainKeyBoundSdJwt = "sdjwt",
+            domainsMdocSignature = listOf("mdoc"),
+            domainsKeyBoundSdJwt = listOf("sdjwt"),
         )
 
         val nonce = Random.nextBytes(16).toBase64Url()

--- a/multipaz/src/iosMain/swift/SimplePresentmentSourceExt.swift
+++ b/multipaz/src/iosMain/swift/SimplePresentmentSourceExt.swift
@@ -14,10 +14,10 @@ extension SimplePresentmentSource.Companion {
     ///   - resolveTrustFn: a function which can be used to determine if a requester is trusted.
     ///   - showConsentPromptFn: a [ShowConsentPromptFn] used show a consent prompt is required.
     ///   - preferSignatureToKeyAgreement: whether to use mdoc ECDSA authentication even if mdoc MAC authentication is possible (ISO mdoc only).
-    ///   - domainMdocSignature: the domain to use for ``MdocCredential`` instances using mdoc ECDSA authentication or `nil`.
-    ///   - domainMdocKeyAgreement: the domain to use for ``MdocCredential`` instances using mdoc MAC authentication or `nil`.
-    ///   - domainKeylessSdJwt: the domain to use for ``KeylessSdJwtVcCredential`` instances or `nil`.
-    ///   - domainKeyBoundSdJwt: the domain to use for ``KeyBoundSdJwtVcCredential`` instances or `nil`.
+    ///   - domainsMdocSignature: the domains to use for ``MdocCredential`` instances using mdoc ECDSA authentication.
+    ///   - domainsMdocKeyAgreement: the domains to use for ``MdocCredential`` instances using mdoc MAC authentication.
+    ///   - domainsKeylessSdJwt: the domains to use for ``KeylessSdJwtVcCredential`` instances.
+    ///   - domainsKeyBoundSdJwt: the domains to use for ``KeyBoundSdJwtVcCredential`` instances.
     public func create(
         documentStore: DocumentStore,
         documentTypeRepository: DocumentTypeRepository,
@@ -34,10 +34,10 @@ extension SimplePresentmentSource.Companion {
             _ onDocumentsInFocus: @escaping @Sendable (_ documents: [Document]) -> Void,
         ) async -> CredentialPresentmentSelection?,
         preferSignatureToKeyAgreement: Bool = true,
-        domainMdocSignature: String? = nil,
-        domainMdocKeyAgreement: String? = nil,
-        domainKeylessSdJwt: String? = nil,
-        domainKeyBoundSdJwt: String? = nil,
+        domainsMdocSignature: [ String ] = [],
+        domainsMdocKeyAgreement: [ String ] = [],
+        domainsKeylessSdJwt: [ String ] = [],
+        domainsKeyBoundSdJwt: [ String ] = [],
     ) -> SimplePresentmentSource {
         return SimplePresentmentSource(
             documentStore: documentStore,
@@ -47,10 +47,10 @@ extension SimplePresentmentSource.Companion {
             resolveTrustFn: ResolveTrustHandler(f: resolveTrustFn),
             showConsentPromptFn: ShowConsentPromptHandler(f: showConsentPromptFn),
             preferSignatureToKeyAgreement: preferSignatureToKeyAgreement,
-            domainMdocSignature: domainMdocSignature,
-            domainMdocKeyAgreement: domainMdocKeyAgreement,
-            domainKeylessSdJwt: domainKeylessSdJwt,
-            domainKeyBoundSdJwt: domainKeyBoundSdJwt
+            domainsMdocSignature: domainsMdocSignature,
+            domainsMdocKeyAgreement: domainsMdocKeyAgreement,
+            domainsKeylessSdJwt: domainsKeylessSdJwt,
+            domainsKeyBoundSdJwt: domainsKeyBoundSdJwt
         )
     }
 

--- a/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -87,7 +87,7 @@ func getPresentmentSource() async -> PresentmentSource {
             )
         },
         preferSignatureToKeyAgreement: false,
-        domainMdocSignature: "mdoc"
+        domainsMdocSignature: ["mdoc"]
     )
 }
 

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -581,8 +581,8 @@ private func calcConsentData(
                 onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
             )
         },
-        domainMdocSignature: "mdoc",
-        domainKeyBoundSdJwt: "sdjwt"
+        domainsMdocSignature: ["mdoc"],
+        domainsKeyBoundSdJwt: ["sdjwt"]
     )
 
     let query = try! DcqlQuery.companion.fromJsonString(dcql: dcqlString)

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -83,7 +83,39 @@ struct ContentView: View {
         }
         .onOpenURL { url in
             print("handling \(url)")
-            if url.absoluteString.starts(with: "openid-credential-offer://") ||
+            if url.isFileURL {
+                if url.pathExtension.lowercased() == "mpzpass" {
+                    guard url.startAccessingSecurityScopedResource() else {
+                        print("Error: Permission denied to access the mpzpass file at \(url.lastPathComponent)")
+                        return
+                    }
+                    
+                    defer {
+                        url.stopAccessingSecurityScopedResource()
+                    }
+                    
+                    Task {
+                        do {
+                            let fileData = try Data(contentsOf: url)
+                            let dataItem = try Cbor.shared.decode(encodedCbor: fileData.toByteArray())
+                            let mpzPass = try await MpzPass.companion.fromDataItem(dataItem: dataItem)
+                            let document = try await viewModel.documentStore.importMpzPass(
+                                mpzPass: mpzPass,
+                                isoMdocDomain: "mdoc",
+                                sdJwtVcDomain: "sdjwt",
+                                keylessSdJwtVcDomain: "sdjwt"
+                            )
+                            // TODO: use returned document and navigate to that screen
+                            viewModel.path.append(Destination.documentStoreScreen)
+                        } catch {
+                            print("Error reading mpzpass file: \(error.localizedDescription)")
+                        }
+                    }
+                } else {
+                    print("Unhandled file extension: \(url.pathExtension)")
+                }
+                return
+            } else if url.absoluteString.starts(with: "openid-credential-offer://") ||
                 url.absoluteString.starts(with: "haip-vci://") {
                 Task {
                     //await viewModel.provisioningSupport.processAppLinkInvocation(

--- a/samples/SwiftTestApp/SwiftTestApp/Info.plist
+++ b/samples/SwiftTestApp/SwiftTestApp/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Multipaz Pass Document</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.multipaz.mpzpass</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -53,6 +66,33 @@
 			<array>
 				<string>mdoc</string>
 			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Multipaz Pass</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>org.multipaz.mpzpass</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mpzpass</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/vnd.multipaz.mpzpass</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -14,6 +14,7 @@ class ViewModel {
 
     var storage: Storage!
     var secureArea: SecureArea!
+    var softwareSecureArea: SecureArea!
     var secureAreaRepository: SecureAreaRepository!
     var documentTypeRepository: DocumentTypeRepository!
     var documentStore: DocumentStore!
@@ -36,8 +37,10 @@ class ViewModel {
             excludeFromBackup: true
         )
         secureArea = try! await Platform.shared.getSecureArea(storage: storage)
+        softwareSecureArea = try! await SoftwareSecureArea.companion.create(storage: storage)
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(secureArea: secureArea)
+            .add(secureArea: softwareSecureArea)
             .build()
         documentTypeRepository = DocumentTypeRepository()
         documentTypeRepository.addDocumentType(documentType: DrivingLicense.shared.getDocumentType())
@@ -310,7 +313,7 @@ class ViewModel {
                 )
             },
             preferSignatureToKeyAgreement: false,
-            domainMdocSignature: "mdoc",
+            domainsMdocSignature: ["mdoc"],
         )
     }
 }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -61,12 +61,24 @@ kotlin {
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
+            freeCompilerArgs += listOf(
+                // This is how we specify the minimum iOS version as 26.0
+                "-Xoverride-konan-properties=" +
+                        "osVersionMin.ios_arm64=26.0;" +
+                        "osVersionMin.ios_simulator_arm64=26.0;" +
+                        "osVersionMin.ios_x64=26.0",
+                // Uncomment the following to get Garbage Collection logging when using the framework:
+                //
+                // "-Xruntime-logs=gc=info"
+            )
+            linkerOpts("-lsqlite3")
             baseName = "Multipaz"
             isStatic = true
             export(project(":multipaz"))
             export(project(":multipaz-doctypes"))
             export(project(":multipaz-longfellow"))
             export(project(":multipaz-dcapi"))
+            export(project(":multipaz-swiftui"))
             export(libs.ktor.client.darwin)
             export(libs.kotlinx.io.bytestring)
             export(libs.kotlinx.datetime)
@@ -89,6 +101,7 @@ kotlin {
                 api(project(":multipaz-doctypes"))
                 api(project(":multipaz-longfellow"))
                 api(project(":multipaz-dcapi"))
+                api(project(":multipaz-swiftui"))
                 api(libs.ktor.client.darwin)
                 api(libs.kotlinx.io.bytestring)
                 api(libs.kotlinx.datetime)
@@ -153,6 +166,7 @@ kotlin {
                 implementation(project(":multipaz-dcapi"))
                 implementation(project(":multipaz-doctypes"))
                 implementation(project(":multipaz-longfellow"))
+                implementation(project(":multipaz-swiftui"))
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.io.core)
                 implementation(libs.ktor.client.core)

--- a/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
@@ -139,10 +139,10 @@ func getPresentmentSource() async -> PresentmentSource {
             )
         },
         preferSignatureToKeyAgreement: false,
-        domainMdocSignature: TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_USER_AUTH,
-        domainMdocKeyAgreement: TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_MAC_USER_AUTH,
-        domainKeylessSdJwt: nil,
-        domainKeyBoundSdJwt: nil
+        domainsMdocSignature: [TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_USER_AUTH],
+        domainsMdocKeyAgreement: [TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_MAC_USER_AUTH],
+        domainsKeylessSdJwt: [],
+        domainsKeyBoundSdJwt: []
     )
 }
 

--- a/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
+++ b/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
@@ -10,41 +10,9 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
-		51804B232EF70CAF00A95196 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51804B222EF70CAF00A95196 /* Extensions.swift */; };
 		51D0CF4A2E9682B1004EC0DB /* DocumentProviderExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 51D0CF432E9682B1004EC0DB /* DocumentProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
-		7B1E53ED2EF5EDE2007C8E8D /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1E53EB2EF5EDE2007C8E8D /* DocumentModel.swift */; };
-		7B1E53EE2EF5EE16007C8E8D /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF29922EF40D730077E722 /* RequestAuthorizationView.swift */; };
-		7B7E65C52F19ED96000736E1 /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E65C42F19ED96000736E1 /* SimplePresentmentSourceExt.swift */; };
-		7B7E66372F2436C7000736E1 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E66362F2436C7000736E1 /* SmartSheet.swift */; };
-		7B7E66382F2436C7000736E1 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E66362F2436C7000736E1 /* SmartSheet.swift */; };
 		7BAB1AC82DB687B000CAC98C /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */; };
-		7BCB40972F2D5392003506B8 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408F2F2D5392003506B8 /* MdocProximityQrPresentment.swift */; };
-		7BCB40982F2D5392003506B8 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408D2F2D5392003506B8 /* ConsentPromptDialog.swift */; };
-		7BCB40992F2D5392003506B8 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40932F2D5392003506B8 /* PromptDialogs.swift */; };
-		7BCB409A2F2D5392003506B8 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408E2F2D5392003506B8 /* DocumentExt.swift */; };
-		7BCB409B2F2D5392003506B8 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40912F2D5392003506B8 /* PassphraseInputView.swift */; };
-		7BCB409C2F2D5392003506B8 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40922F2D5392003506B8 /* PassphrasePromptDialog.swift */; };
-		7BCB409D2F2D5392003506B8 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40952F2D5392003506B8 /* QrCode.swift */; };
-		7BCB409E2F2D5392003506B8 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40962F2D5392003506B8 /* X509CertViewer.swift */; };
-		7BCB409F2F2D5392003506B8 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40902F2D5392003506B8 /* MdocProximityQrSettings.swift */; };
-		7BCB40A02F2D5392003506B8 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40942F2D5392003506B8 /* PromptModelExt.swift */; };
-		7BCB40A12F2D5392003506B8 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408F2F2D5392003506B8 /* MdocProximityQrPresentment.swift */; };
-		7BCB40A22F2D5392003506B8 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408D2F2D5392003506B8 /* ConsentPromptDialog.swift */; };
-		7BCB40A32F2D5392003506B8 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40932F2D5392003506B8 /* PromptDialogs.swift */; };
-		7BCB40A42F2D5392003506B8 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB408E2F2D5392003506B8 /* DocumentExt.swift */; };
-		7BCB40A52F2D5392003506B8 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40912F2D5392003506B8 /* PassphraseInputView.swift */; };
-		7BCB40A62F2D5392003506B8 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40922F2D5392003506B8 /* PassphrasePromptDialog.swift */; };
-		7BCB40A72F2D5392003506B8 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40952F2D5392003506B8 /* QrCode.swift */; };
-		7BCB40A82F2D5392003506B8 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40962F2D5392003506B8 /* X509CertViewer.swift */; };
-		7BCB40A92F2D5392003506B8 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40902F2D5392003506B8 /* MdocProximityQrSettings.swift */; };
-		7BCB40AA2F2D5392003506B8 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40942F2D5392003506B8 /* PromptModelExt.swift */; };
-		7BCB40AC2F2D557C003506B8 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40AB2F2D557C003506B8 /* Consent.swift */; };
-		7BCB40AD2F2D557C003506B8 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB40AB2F2D557C003506B8 /* Consent.swift */; };
-		7BFDDA902F3BB92B00C220A3 /* Provisioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDDA8E2F3BB92B00C220A3 /* Provisioning.swift */; };
-		7BFDDA912F3BB92B00C220A3 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDDA8F2F3BB92B00C220A3 /* TagsExt.swift */; };
-		7BFDDA932F3BB92B00C220A3 /* Provisioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDDA8E2F3BB92B00C220A3 /* Provisioning.swift */; };
-		7BFDDA942F3BB92B00C220A3 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFDDA8F2F3BB92B00C220A3 /* TagsExt.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,31 +43,13 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
-		51804B222EF70CAF00A95196 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		51D0CF432E9682B1004EC0DB /* DocumentProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = DocumentProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		51EF29922EF40D730077E722 /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* Multipaz Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Multipaz Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7B1E53EB2EF5EDE2007C8E8D /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
 		7B39212C2C27D97A00A18AB5 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
-		7B7E65C42F19ED96000736E1 /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
-		7B7E66362F2436C7000736E1 /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
 		7B9C61172DBA8D46000484FF /* AdditionalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AdditionalConfig.xcconfig; sourceTree = "<group>"; };
 		7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DeveloperConfig.xcconfig; sourceTree = "<group>"; };
-		7BCB408D2F2D5392003506B8 /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
-		7BCB408E2F2D5392003506B8 /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
-		7BCB408F2F2D5392003506B8 /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
-		7BCB40902F2D5392003506B8 /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
-		7BCB40912F2D5392003506B8 /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
-		7BCB40922F2D5392003506B8 /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
-		7BCB40932F2D5392003506B8 /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
-		7BCB40942F2D5392003506B8 /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
-		7BCB40952F2D5392003506B8 /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
-		7BCB40962F2D5392003506B8 /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
-		7BCB40AB2F2D557C003506B8 /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
-		7BFDDA8E2F3BB92B00C220A3 /* Provisioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provisioning.swift; sourceTree = "<group>"; };
-		7BFDDA8F2F3BB92B00C220A3 /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -142,36 +92,9 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		51B083112EF4028400A90AA1 /* MultipazSwift */ = {
-			isa = PBXGroup;
-			children = (
-				7BFDDA8E2F3BB92B00C220A3 /* Provisioning.swift */,
-				7BFDDA8F2F3BB92B00C220A3 /* TagsExt.swift */,
-				7BCB40AB2F2D557C003506B8 /* Consent.swift */,
-				7BCB408D2F2D5392003506B8 /* ConsentPromptDialog.swift */,
-				7BCB408E2F2D5392003506B8 /* DocumentExt.swift */,
-				7BCB408F2F2D5392003506B8 /* MdocProximityQrPresentment.swift */,
-				7BCB40902F2D5392003506B8 /* MdocProximityQrSettings.swift */,
-				7BCB40912F2D5392003506B8 /* PassphraseInputView.swift */,
-				7BCB40922F2D5392003506B8 /* PassphrasePromptDialog.swift */,
-				7BCB40932F2D5392003506B8 /* PromptDialogs.swift */,
-				7BCB40942F2D5392003506B8 /* PromptModelExt.swift */,
-				7BCB40952F2D5392003506B8 /* QrCode.swift */,
-				7BCB40962F2D5392003506B8 /* X509CertViewer.swift */,
-				7B7E66362F2436C7000736E1 /* SmartSheet.swift */,
-				7B7E65C42F19ED96000736E1 /* SimplePresentmentSourceExt.swift */,
-				51804B222EF70CAF00A95196 /* Extensions.swift */,
-				7B1E53EB2EF5EDE2007C8E8D /* DocumentModel.swift */,
-				51EF29922EF40D730077E722 /* RequestAuthorizationView.swift */,
-			);
-			name = MultipazSwift;
-			path = "../../../multipaz-swift/Sources/MultipazSwift";
-			sourceTree = "<group>";
-		};
 		7555FF72242A565900829871 = {
 			isa = PBXGroup;
 			children = (
-				51B083112EF4028400A90AA1 /* MultipazSwift */,
 				7B9C61172DBA8D46000484FF /* AdditionalConfig.xcconfig */,
 				7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */,
 				7555FF7D242A565900829871 /* TestApp */,
@@ -351,24 +274,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51804B232EF70CAF00A95196 /* Extensions.swift in Sources */,
-				7B7E66372F2436C7000736E1 /* SmartSheet.swift in Sources */,
-				7BCB40972F2D5392003506B8 /* MdocProximityQrPresentment.swift in Sources */,
-				7BCB40982F2D5392003506B8 /* ConsentPromptDialog.swift in Sources */,
-				7BCB40992F2D5392003506B8 /* PromptDialogs.swift in Sources */,
-				7BCB409A2F2D5392003506B8 /* DocumentExt.swift in Sources */,
-				7BCB409B2F2D5392003506B8 /* PassphraseInputView.swift in Sources */,
-				7BCB409C2F2D5392003506B8 /* PassphrasePromptDialog.swift in Sources */,
-				7BCB409D2F2D5392003506B8 /* QrCode.swift in Sources */,
-				7BCB409E2F2D5392003506B8 /* X509CertViewer.swift in Sources */,
-				7BFDDA932F3BB92B00C220A3 /* Provisioning.swift in Sources */,
-				7BFDDA942F3BB92B00C220A3 /* TagsExt.swift in Sources */,
-				7BCB409F2F2D5392003506B8 /* MdocProximityQrSettings.swift in Sources */,
-				7BCB40A02F2D5392003506B8 /* PromptModelExt.swift in Sources */,
-				7B1E53ED2EF5EDE2007C8E8D /* DocumentModel.swift in Sources */,
-				7B7E65C52F19ED96000736E1 /* SimplePresentmentSourceExt.swift in Sources */,
-				7B1E53EE2EF5EE16007C8E8D /* RequestAuthorizationView.swift in Sources */,
-				7BCB40AD2F2D557C003506B8 /* Consent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,21 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B7E66382F2436C7000736E1 /* SmartSheet.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
-				7BCB40AC2F2D557C003506B8 /* Consent.swift in Sources */,
-				7BCB40A12F2D5392003506B8 /* MdocProximityQrPresentment.swift in Sources */,
-				7BCB40A22F2D5392003506B8 /* ConsentPromptDialog.swift in Sources */,
-				7BCB40A32F2D5392003506B8 /* PromptDialogs.swift in Sources */,
-				7BCB40A42F2D5392003506B8 /* DocumentExt.swift in Sources */,
-				7BCB40A52F2D5392003506B8 /* PassphraseInputView.swift in Sources */,
-				7BCB40A62F2D5392003506B8 /* PassphrasePromptDialog.swift in Sources */,
-				7BCB40A72F2D5392003506B8 /* QrCode.swift in Sources */,
-				7BFDDA902F3BB92B00C220A3 /* Provisioning.swift in Sources */,
-				7BFDDA912F3BB92B00C220A3 /* TagsExt.swift in Sources */,
-				7BCB40A82F2D5392003506B8 /* X509CertViewer.swift in Sources */,
-				7BCB40A92F2D5392003506B8 /* MdocProximityQrSettings.swift in Sources */,
-				7BCB40AA2F2D5392003506B8 /* PromptModelExt.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -624,7 +515,7 @@
 					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = TestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -659,7 +550,7 @@
 					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = TestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/samples/testapp/iosApp/TestApp/ContentView.swift
+++ b/samples/testapp/iosApp/TestApp/ContentView.swift
@@ -15,10 +15,37 @@ struct ContentView: View {
         ComposeView()
                 .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
                 .onOpenURL(perform: { url in
+                    if url.isFileURL {
+                        if url.pathExtension.lowercased() == "mpzpass" {
+                            processMpzpassFile(url)
+                        } else {
+                            print("Unhandled file extension: \(url.pathExtension)")
+                        }
+                        return
+                    }
                     MainViewControllerKt.HandleUrl(url: url.absoluteString)
                 })
     }
 }
+
+private func processMpzpassFile(_ url: URL) {
+    guard url.startAccessingSecurityScopedResource() else {
+        print("Error: Permission denied to access the mpzpass file at \(url.lastPathComponent)")
+        return
+    }
+    
+    defer {
+        url.stopAccessingSecurityScopedResource()
+    }
+    
+    do {
+        let fileData = try Data(contentsOf: url)
+        MainViewControllerKt.processMpzPassPayload(encodedMpzPass: fileData.toByteArray())
+    } catch {
+        print("Error reading mpzpass file: \(error.localizedDescription)")
+    }
+}
+
 
 
 

--- a/samples/testapp/iosApp/TestApp/Info.plist
+++ b/samples/testapp/iosApp/TestApp/Info.plist
@@ -123,5 +123,45 @@
 		<string>A0000002471001</string>
 		<string>A0000002480400</string>
 	</array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>org.multipaz.mpzpass</string> <key>UTTypeDescription</key>
+            <string>Multipaz Pass</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+                <string>public.content</string>
+            </array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>mpzpass</string>
+                </array>
+                <key>public.mime-type</key>
+                <array>
+                    <string>application/vnd.multipaz.mpzpass</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Multipaz Pass Document</string>
+            <key>LSHandlerRank</key>
+            <string>Owner</string> <key>LSItemContentTypes</key>
+            <array>
+                <string>org.multipaz.mpzpass</string> </array>
+        </dict>
+    </array>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
+    <key>UIFileSharingEnabled</key>
+    <true/>
 </dict>
 </plist>

--- a/samples/testapp/iosApp/TestApp/iOSApp.swift
+++ b/samples/testapp/iosApp/TestApp/iOSApp.swift
@@ -8,11 +8,3 @@ struct iOSApp: App {
         }
     }
 }
-
-// Hack to work around the "shared source" problem. This will break if we
-// ever call any Swift functions to load resources in the MultipazSwift
-// framework but that's unlikely since this is mostly Kotlin anyway.
-//
-extension Foundation.Bundle {
-    static var module: Bundle = main
-}

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -57,7 +57,7 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -118,6 +118,32 @@
             </intent-filter>
             <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                 android:resource="@xml/usb_nfc_readers" />
+
+            <!-- CredentialContainer support for application/vnd.multipaz.mpzpass MIME type and
+                 associated .mpzpass file extension
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="application/vnd.multipaz.mpzpass" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="*/*" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.mpzpass" />
+                <data android:pathPattern=".*\\..*\\.mpzpass" />
+                <data android:pathPattern=".*\\..*\\..*\\.mpzpass" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.mpzpass" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
@@ -4,9 +4,11 @@ import android.content.ComponentName
 import android.content.Intent
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
+import android.net.Uri
 import android.nfc.NfcAdapter
 import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
+import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -15,6 +17,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.coroutineScope
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.multipaz.applinks.AppLinksCheck
 import org.multipaz.context.initializeApplication
@@ -97,6 +101,26 @@ class MainActivity : FragmentActivity() {
                 }
             }
         } else if (intent.action == Intent.ACTION_VIEW) {
+
+            intent.data?.let { uri ->
+                val mimeType = contentResolver.getType(uri) ?: intent.type
+                val fileName = getFileNameFromUri(uri)
+                if (mimeType == "application/vnd.multipaz.mpzpass" || fileName?.endsWith(".mpzpass", ignoreCase = true) == true) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        try {
+                            contentResolver.openInputStream(uri)?.use { inputStream ->
+                                val fileContent: ByteArray = inputStream.readBytes()
+                                val app = App.getInstance()
+                                app.importMpzPass(fileContent)
+                            }
+                        } catch (e: Exception) {
+                            Logger.e(TAG, "Error reading file content from URI", e)
+                        }
+                    }
+                    return
+                }
+            }
+
             val url = intent.dataString
             if (url != null) {
                 lifecycle.coroutineScope.launch {
@@ -120,4 +144,29 @@ class MainActivity : FragmentActivity() {
             }
         }
     }
-}
+
+    private fun getFileNameFromUri(uri: Uri): String? {
+        var result: String? = null
+
+        // If it's a content URI, query the ContentResolver for the display name
+        if (uri.scheme == "content") {
+            contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (index != -1) {
+                        result = cursor.getString(index)
+                    }
+                }
+            }
+        }
+
+        // Fallback: If it's a file URI or the query failed, try to extract it from the path
+        if (result == null) {
+            result = uri.path?.let { path ->
+                val cut = path.lastIndexOf('/')
+                if (cut != -1) path.substring(cut + 1) else path
+            }
+        }
+
+        return result
+    }}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -1,6 +1,5 @@
 package org.multipaz.testapp
 
-import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +42,7 @@ import io.ktor.client.HttpClient
 import io.ktor.http.Url
 import io.ktor.http.decodeURLPart
 import io.ktor.http.protocolWithAuthority
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -86,10 +86,10 @@ import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.knowntypes.Aadhaar
 import org.multipaz.documenttype.knowntypes.AgeVerification
+import org.multipaz.documenttype.knowntypes.DigitalPaymentCredential
 import org.multipaz.documenttype.knowntypes.DrivingLicense
 import org.multipaz.documenttype.knowntypes.EUPersonalID
 import org.multipaz.documenttype.knowntypes.IDPass
-import org.multipaz.documenttype.knowntypes.DigitalPaymentCredential
 import org.multipaz.documenttype.knowntypes.Loyalty
 import org.multipaz.documenttype.knowntypes.PhotoID
 import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
@@ -97,6 +97,7 @@ import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.longfellow.LongfellowZkSystem
+import org.multipaz.mpzpass.MpzPass
 import org.multipaz.nfc.ExternalNfcReaderStore
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.presentment.SimplePresentmentSource
@@ -123,11 +124,11 @@ import org.multipaz.testapp.ui.ConsentPromptScreen
 import org.multipaz.testapp.ui.CredentialClaimsViewerScreen
 import org.multipaz.testapp.ui.CredentialViewerScreen
 import org.multipaz.testapp.ui.DcRequestScreen
-import org.multipaz.testapp.ui.VerticalDocumentListScreen
 import org.multipaz.testapp.ui.DocumentStoreScreen
 import org.multipaz.testapp.ui.DocumentViewerScreen
 import org.multipaz.testapp.ui.EventLoggerScreen
 import org.multipaz.testapp.ui.EventViewerScreen
+import org.multipaz.testapp.ui.GenerateMpzPassScreen
 import org.multipaz.testapp.ui.IsoMdocMultiDeviceTestingScreen
 import org.multipaz.testapp.ui.IsoMdocProximityReadingScreen
 import org.multipaz.testapp.ui.IsoMdocProximitySharingScreen
@@ -149,9 +150,10 @@ import org.multipaz.testapp.ui.SoftwareSecureAreaScreen
 import org.multipaz.testapp.ui.StartScreen
 import org.multipaz.testapp.ui.TrustEntryEditScreen
 import org.multipaz.testapp.ui.TrustEntryRicalEntryScreen
-import org.multipaz.testapp.ui.TrustManagerScreen
 import org.multipaz.testapp.ui.TrustEntryScreen
 import org.multipaz.testapp.ui.TrustEntryVicalEntryScreen
+import org.multipaz.testapp.ui.TrustManagerScreen
+import org.multipaz.testapp.ui.VerticalDocumentListScreen
 import org.multipaz.trustmanagement.CompositeTrustManager
 import org.multipaz.trustmanagement.TrustManager
 import org.multipaz.trustmanagement.TrustMetadata
@@ -216,6 +218,8 @@ class App private constructor (val promptModel: PromptModel) {
 
     private val credentialOffers = Channel<String>()
 
+    private val mpzPassesToImport = Channel<ByteString>()
+
     private val urlsToOpen = Channel<String>()
 
     private val documentsToView = Channel<String>()
@@ -240,21 +244,21 @@ class App private constructor (val promptModel: PromptModel) {
             },
             resolveTrustFn = ::resolveTrust,
             preferSignatureToKeyAgreement = settingsModel.presentmentPreferSignatureToKeyAgreement.value,
-            domainMdocSignature = if (useAuth) {
-                TestAppUtils.CREDENTIAL_DOMAIN_MDOC_USER_AUTH
+            domainsMdocSignature = if (useAuth) {
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_MDOC_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE)
             } else {
-                TestAppUtils.CREDENTIAL_DOMAIN_MDOC_NO_USER_AUTH
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_MDOC_NO_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE)
             },
-            domainMdocKeyAgreement = if (useAuth) {
-                TestAppUtils.CREDENTIAL_DOMAIN_MDOC_MAC_USER_AUTH
+            domainsMdocKeyAgreement = if (useAuth) {
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_MDOC_MAC_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE)
             } else {
-                TestAppUtils.CREDENTIAL_DOMAIN_MDOC_MAC_NO_USER_AUTH
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_MDOC_MAC_NO_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE)
             },
-            domainKeylessSdJwt = TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_KEYLESS,
-            domainKeyBoundSdJwt = if (useAuth) {
-                TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_USER_AUTH
+            domainsKeylessSdJwt = listOf(TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_KEYLESS),
+            domainsKeyBoundSdJwt = if (useAuth) {
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_SOFTWARE)
             } else {
-                TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_NO_USER_AUTH
+                listOf(TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_NO_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_SOFTWARE)
             },
         )
     }
@@ -806,7 +810,7 @@ class App private constructor (val promptModel: PromptModel) {
     }
 
     /**
-     * Handle a link (either a app link, universal link, or custom URL schema link).
+     * Handle a link (either a app link, universal link or custom URL schema link).
      */
     fun handleUrl(url: String) {
         if (url.startsWith(OID4VCI_CREDENTIAL_OFFER_URL_SCHEME)
@@ -829,6 +833,12 @@ class App private constructor (val promptModel: PromptModel) {
             }
         } else {
             Logger.e(TAG, "Unhandled URL: '$url'")
+        }
+    }
+
+    fun importMpzPass(encodedMpzPass: ByteArray) {
+        CoroutineScope(Dispatchers.Default).launch {
+            mpzPassesToImport.send(ByteString(encodedMpzPass))
         }
     }
 
@@ -926,6 +936,27 @@ class App private constructor (val promptModel: PromptModel) {
                         clientPreferences = provisioningSupport.getOpenID4VCIClientPreferences(),
                         backend = provisioningSupport.getOpenID4VCIBackend()
                     )
+                }
+            }
+        }
+
+        LaunchedEffect(true) {
+            while (true) {
+                val mpzPassToImport = mpzPassesToImport.receive()
+                try {
+                    val mpzPass = MpzPass.fromDataItem(Cbor.decode(mpzPassToImport.toByteArray()))
+                    val document = documentStore.importMpzPass(
+                        mpzPass = mpzPass,
+                        isoMdocDomain = TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE,
+                        sdJwtVcDomain = TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_SOFTWARE,
+                        keylessSdJwtVcDomain = TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_KEYLESS
+                    )
+                    navController.navigate(DocumentViewerDestination(document.identifier))
+                    showToast("MpzPass file successfully imported")
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    e.printStackTrace()
+                    showToast("Error importing mpzpass: ${e.message}")
                 }
             }
         }
@@ -1074,6 +1105,7 @@ class App private constructor (val promptModel: PromptModel) {
                             },
                             onClickEventLog = { navController.navigate(EventLogDestination) },
                             onClickShareSheet = { navController.navigate(ShareSheetDestination) },
+                            onClickCredentialContainer = { navController.navigate(GenerateMpzPassDestination) }
                         )
                     }
                 }
@@ -1659,6 +1691,15 @@ class App private constructor (val promptModel: PromptModel) {
                         ShareSheetScreen(
                             onBack = { navController.navigateUp() },
                             promptModel = promptModel,
+                            showToast = { message -> showToast(message) },
+                        )
+                    }
+                }
+                composable<GenerateMpzPassDestination> { backStackEntry ->
+                    WithAppBar(navController, "MpzPass generation") {
+                        GenerateMpzPassScreen(
+                            promptModel = promptModel,
+                            documentTypeRepository = documentTypeRepository,
                             showToast = { message -> showToast(message) },
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -158,3 +158,6 @@ data class EventViewerDestination(
 @Serializable
 data object ShareSheetDestination: Destination()
 
+
+@Serializable
+data object GenerateMpzPassDestination: Destination()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -86,11 +86,17 @@ object TestAppUtils {
     // This domain is for MdocCredential using mdoc MAC authentication and not requiring user authentication.
     const val CREDENTIAL_DOMAIN_MDOC_MAC_NO_USER_AUTH = "mdoc_mac_no_user_auth"
 
+    // This domain is for MdocCredential with software-backed keys (no auth)
+    const val CREDENTIAL_DOMAIN_MDOC_SOFTWARE = "mdoc_software"
+
     // This domain is for KeyBoundSdJwtVcCredential and requiring user authentication.
     const val CREDENTIAL_DOMAIN_SDJWT_USER_AUTH = "sdjwt_user_auth"
 
     // This domain is for KeyBoundSdJwtVcCredential and not requiring user authentication.
     const val CREDENTIAL_DOMAIN_SDJWT_NO_USER_AUTH = "sdjwt_no_user_auth"
+
+    // This domain is for KeyBoundSdJwtVcCredential with software-backed keys (no auth)
+    const val CREDENTIAL_DOMAIN_SDJWT_SOFTWARE = "sdjwt_software"
 
     // This domain is for KeylessSdJwtVcCredential
     const val CREDENTIAL_DOMAIN_SDJWT_KEYLESS = "sdjwt_keyless"

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -765,8 +765,8 @@ private suspend fun getQueryResult(
             // Otherwise, just return the trustMetadata
             trustMetadata
         },
-        domainMdocSignature = "mdoc",
-        domainKeyBoundSdJwt = "sdjwt"
+        domainsMdocSignature = listOf("mdoc"),
+        domainsKeyBoundSdJwt = listOf("sdjwt")
     )
     val dcqlQuery = DcqlQuery.fromJson(dcql = dcql)
     val dcqlResponse = dcqlQuery.execute(presentmentSource = source)

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/GenerateMpzPassScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/GenerateMpzPassScreen.kt
@@ -1,0 +1,247 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.cbor.Cbor
+import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.encodeImageToPng
+import org.multipaz.compose.rememberUiBoundCoroutineScope
+import org.multipaz.compose.sharemanager.ShareManager
+import org.multipaz.compose.text.fromMarkdown
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.document.buildDocumentStore
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.util.MdocUtil
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.prompt.PromptModel
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.util.truncateToWholeSeconds
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+
+@Composable
+fun GenerateMpzPassScreen(
+    promptModel: PromptModel,
+    documentTypeRepository: DocumentTypeRepository,
+    showToast: (message: String) -> Unit,
+) {
+    val coroutineScope = rememberUiBoundCoroutineScope { promptModel }
+
+    LazyColumn(
+        modifier = Modifier.padding(8.dp)
+    ) {
+        item {
+            Text(AnnotatedString.fromMarkdown(
+                "To generate a `.mpzpass` file for a particular document type, " +
+                        "click one of the buttons below. This file will then be shared using a sharesheet so you can " +
+                        "import it on other devices"
+            ))
+        }
+
+        for (documentType in documentTypeRepository.documentTypes) {
+            item {
+                if (documentType.mdocDocumentType != null) {
+                    TextButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                try {
+                                    val container = generateMpzPass(
+                                        documentType = documentType,
+                                        generateMdoc = true,
+                                    )
+                                    val shareManager = ShareManager()
+                                    val epochSeconds = Clock.System.now().epochSeconds
+                                    val typeStr = documentType.displayName.replace(" ", "-").lowercase()
+                                    shareManager.shareDocument(
+                                        content = Cbor.encode(container.toDataItem()),
+                                        filename = "specimen-$typeStr-$epochSeconds.mpzpass",
+                                        mimeType = "application/vnd.multipaz.mpzpass",
+                                        title = "Share MpzPass for document type ${documentType.displayName} (ISO mdoc)"
+                                    )
+                                } catch (e: Exception) {
+                                    if (e is CancellationException) throw e
+                                    e.printStackTrace()
+                                    showToast("Error generating specimen: ${e.message}")
+                                }
+                            }
+                        },
+                        content = { Text("MpzPass for ${documentType.displayName} (ISO mdoc)") }
+                    )
+                }
+
+                if (documentType.jsonDocumentType != null) {
+                    val format = if (documentType.jsonDocumentType!!.keyBound) {
+                        "IETF SD-JWT VC"
+                    } else {
+                        "Keyless IETF SD-JWT VC"
+                    }
+                    TextButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                try {
+                                    val container = generateMpzPass(
+                                        documentType = documentType,
+                                        generateMdoc = false,
+                                    )
+                                    val shareManager = ShareManager()
+                                    val epochSeconds = Clock.System.now().epochSeconds
+                                    val typeStr = documentType.displayName.replace(" ", "-").lowercase()
+                                    shareManager.shareDocument(
+                                        content = Cbor.encode(container.toDataItem()),
+                                        filename = "specimen-$typeStr-$epochSeconds.mpzpass",
+                                        mimeType = "application/vnd.multipaz.mpzpass",
+                                        title = "Share MpzPass for document type ${documentType.displayName} ($format)"
+                                    )
+                                } catch (e: Exception) {
+                                    if (e is CancellationException) throw e
+                                    e.printStackTrace()
+                                    showToast("Error generating specimen: ${e.message}")
+                                }
+                            }
+                        },
+                        content = { Text("MpzPass for ${documentType.displayName} ($format)") }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private suspend fun generateMpzPass(
+    documentType: DocumentType,
+    generateMdoc: Boolean
+): MpzPass {
+    val now = Clock.System.now().truncateToWholeSeconds()
+    val signedAt = now - 1.days
+    val expectedUpdate = now + 30.days
+    val validFrom = now - 1.days
+    val validUntil = now + 365.days
+    val iacaValidFrom = validFrom
+    val iacaValidUntil = validUntil
+    val dsValidFrom = validFrom
+    val dsValidUntil = validUntil
+
+    val iacaKeyPub = EcPublicKey.fromPem(
+        """
+                    -----BEGIN PUBLIC KEY-----
+                    MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+QDye70m2O0llPXMjVjxVZz3m5k6agT+
+                    wih+L79b7jyqUl99sbeUnpxaLD+cmB3HK3twkA7fmVJSobBc+9CDhkh3mx6n+YoH
+                    5RulaSWThWBfMyRjsfVODkosHLCDnbPV
+                    -----END PUBLIC KEY-----
+                """.trimIndent().trim(),
+    )
+    val iacaKey = EcPrivateKey.fromPem(
+        """
+                    -----BEGIN PRIVATE KEY-----
+                    MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCcRuzXW3pW2h9W8pu5
+                    /CSR6JSnfnZVATq+408WPoNC3LzXqJEQSMzPsI9U1q+wZ2yhZANiAAT5APJ7vSbY
+                    7SWU9cyNWPFVnPebmTpqBP7CKH4vv1vuPKpSX32xt5SenFosP5yYHccre3CQDt+Z
+                    UlKhsFz70IOGSHebHqf5igflG6VpJZOFYF8zJGOx9U4OSiwcsIOds9U=
+                    -----END PRIVATE KEY-----
+                """.trimIndent().trim(),
+        iacaKeyPub
+    )
+
+    val iacaCert = MdocUtil.generateIacaCertificate(
+        iacaKey = AsymmetricKey.anonymous(iacaKey),
+        subject = X500Name.fromName("C=US,CN=OWF Multipaz TEST IACA"),
+        serial = ASN1Integer.fromRandom(numBits = 128),
+        validFrom = iacaValidFrom,
+        validUntil = iacaValidUntil,
+        issuerAltNameUrl = "https://github.com/openwallet-foundation/multipaz",
+        crlUrl = "https://github.com/openwallet-foundation/multipaz/crl"
+    )
+
+    val dsPrivateKey = Crypto.createEcPrivateKey(EcCurve.P256)
+    val dsCert = MdocUtil.generateDsCertificate(
+        iacaKey = AsymmetricKey.X509CertifiedExplicit(X509CertChain(listOf(iacaCert)), iacaKey),
+        dsKey = dsPrivateKey.publicKey,
+        subject = X500Name.fromName("C=US,CN=OWF Multipaz TEST DS"),
+        serial = ASN1Integer.fromRandom(numBits = 128),
+        validFrom = dsValidFrom,
+        validUntil = dsValidUntil,
+    )
+    val dsKey = AsymmetricKey.X509CertifiedExplicit(X509CertChain(listOf(dsCert)), dsPrivateKey)
+
+
+    val storage = EphemeralStorage()
+
+    val softwareSecureArea = SoftwareSecureArea.create(storage)
+    val secureAreaRepository = SecureAreaRepository.Builder()
+        .add(softwareSecureArea)
+        .build()
+
+    val documentStore = buildDocumentStore(
+        storage = storage,
+        secureAreaRepository = secureAreaRepository
+    ) {}
+
+    val doc = documentStore.createDocument(
+        displayName = "SPECIMEN",
+        typeDisplayName = documentType.displayName
+    )
+    val specimenCardArt = Branding.Current.value.renderFallbackCardArt(
+        doc
+    )
+    doc.edit {
+        cardArt = encodeImageToPng(specimenCardArt)
+    }
+
+    if (generateMdoc) {
+        val credential = documentType.createMdocCredentialWithSampleData(
+            document = doc,
+            secureArea = softwareSecureArea,
+            createKeySettings = CreateKeySettings(),
+            dsKey = dsKey,
+            signedAt = signedAt,
+            validFrom = validFrom,
+            validUntil = validUntil,
+            expectedUpdate = expectedUpdate,
+            domain = "mdoc",
+        )
+        return credential.exportToMpzPass()
+    } else {
+        if (documentType.jsonDocumentType!!.keyBound) {
+            val credential = documentType.createKeyBoundSdJwtVcCredentialWithSampleData(
+                document = doc,
+                secureArea = softwareSecureArea,
+                createKeySettings = CreateKeySettings(),
+                dsKey = dsKey,
+                signedAt = signedAt,
+                validFrom = validFrom,
+                validUntil = validUntil,
+                domain = "sdjwtvc",
+            )
+            return credential.exportToMpzPass()
+        } else {
+            val credential = documentType.createKeylessSdJwtVcCredentialWithSampleData(
+                document = doc,
+                dsKey = dsKey,
+                signedAt = signedAt,
+                validFrom = validFrom,
+                validUntil = validUntil,
+                domain = "sdjwtvc",
+            )
+            return credential.exportToMpzPass()
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -55,7 +55,8 @@ fun StartScreen(
     onClickDocumentListScreen: () -> Unit = {},
     onClickQuickAccessWallet: () -> Unit = {},
     onClickEventLog: () -> Unit = {},
-    onClickShareSheet: () -> Unit = {}
+    onClickShareSheet: () -> Unit = {},
+    onClickCredentialContainer: () -> Unit = {},
 ) {
     val blePermissionState = rememberBluetoothPermissionState()
     val coroutineScope = rememberCoroutineScope()
@@ -292,6 +293,12 @@ fun StartScreen(
                 item {
                     TextButton(onClick = onClickShareSheet) {
                         Text("Share sheet")
+                    }
+                }
+
+                item {
+                    TextButton(onClick = onClickCredentialContainer) {
+                        Text("MpzPass generation")
                     }
                 }
             }

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/MainViewController.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/MainViewController.kt
@@ -10,3 +10,5 @@ fun MainViewController() = ComposeUIViewController {
 }
 
 fun HandleUrl(url: String) = app.handleUrl(url)
+
+fun processMpzPassPayload(encodedMpzPass: ByteArray) = app.importMpzPass(encodedMpzPass)


### PR DESCRIPTION
The Multipaz `.mpzpass` file format provides a standardized, lightweight mechanism for the exchange of low-assurance verifiable credentials.

In scenarios where strict cryptographic device-binding introduces unnecessary friction — such as when a user expects their digital assets to seamlessly synchronize across their entire ecosystem of devices — this format offers a pragmatic, portable solution. It is engineered specifically for use cases where the risk of credential sharing is negligible, such as event and movie ticketing, transit passes, or generic membership cards.

This format explicitly trades anti-cloning guarantees for portability. Because the credential data and any associated keys are stored in a highly portable container, the credential can be trivially copied.

For high-value credentials where cloning or replay attacks are active threat vectors (e.g., mobile driving licenses or financial instruments), this file format is inherently unsuitable. In those high-assurance scenarios, issuers must leverage a robust provisioning protocol like [OpenID4VCI](https://github.com/openid/OpenID4VCI) to ensure secure delivery and hardware-backed device-binding at the time of issuance.

This PR has three main components

- Defintion of the format with example files, in the `mpzpass` directory
- Support routines and import/export in the core Multipaz library
- Support in TestApp for generating and importing `.mpzpass` files

This PR also fixes problems with the compose TestApp on iOS and it also makes Credential.replacementForDeleted() internal which it should have been from the start.

Test: Unit test and manually tested on both Android and iOS.
