### PR TITLE
Transaction data for proximity reading

### DIFF
--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.transactiontype.knowntypes.PingTransaction
 
 /**
  * Object containing the metadata of the EU Personal ID Document Type.
@@ -532,6 +533,23 @@ object EUPersonalID {
                     EUPID_NAMESPACE to mapOf()
                 ),
                 jsonClaims = listOf()
+            )
+            .addSampleRequest(
+                id = "withTransaction",
+                displayName = "With Transaction Data",
+                mdocDataElements = mapOf(
+                    EUPID_NAMESPACE to mapOf(
+                        "family_name" to false,
+                        "given_name" to false,
+                        "birth_date" to false,
+                    )
+                ),
+                jsonClaims = listOf(
+                    "family_name",
+                    "given_name",
+                    "birthdate",
+                ),
+                cannedTransactionData = listOf(PingTransaction.sampleData)
             )
             .build()
     }

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/transactiontype/knowntypes/PingTransaction.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/transactiontype/knowntypes/PingTransaction.kt
@@ -60,4 +60,9 @@ object PingTransaction: TransactionType(
             }
         }
     }
+
+    /** Sample transaction data for this transaction type */
+    val sampleData = buildCanned {
+        put("string", "string data")
+    }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/CannedTransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/CannedTransactionData.kt
@@ -1,0 +1,14 @@
+package org.multipaz.documenttype
+
+import org.multipaz.cbor.CborMap
+
+/**
+ * Sample data for request using a particular transaction data type.
+ *
+ * @param transactionType transaction data type
+ * @param attributes map of attribute names to sample attribute values
+ */
+class CannedTransactionData(
+    val transactionType: TransactionType,
+    val attributes: CborMap
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -21,7 +21,6 @@ import kotlinx.io.bytestring.encodeToByteString
 import kotlin.time.Instant
 import org.multipaz.cbor.DataItem
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.multipaz.cbor.Bstr
@@ -33,7 +32,6 @@ import org.multipaz.cbor.toDataItem
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
-import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.document.Document
@@ -43,7 +41,6 @@ import org.multipaz.mdoc.mso.MobileSecurityObject
 import org.multipaz.sdjwt.SdJwt
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
-import org.multipaz.sdjwt.credential.SdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
 import kotlin.collections.component1
@@ -275,6 +272,7 @@ class DocumentType private constructor(
          * @param jsonClaims the claim names for JSON-based credentials in the request. If the list is empty, all
          *   defined claims will be included. Each claim name must use `.` to separate path components, e.g.
          *   `age_equal_or_over.18`.
+         * @param cannedTransactionData transaction data list for the request
          */
         fun addSampleRequest(
             id: String,
@@ -282,6 +280,7 @@ class DocumentType private constructor(
             mdocDataElements: Map<String, Map<String, Boolean>>? = null,
             mdocUseZkp: Boolean = false,
             jsonClaims: List<String>? = null,
+            cannedTransactionData: List<CannedTransactionData> = listOf()
         ) = apply {
             val mdocRequest = if (mdocDataElements == null) {
                 null
@@ -333,7 +332,8 @@ class DocumentType private constructor(
                     id = id,
                     displayName = displayName,
                     mdocRequest = mdocRequest,
-                    jsonRequest = jsonRequest
+                    jsonRequest = jsonRequest,
+                    transactionData = cannedTransactionData
                 ))
         }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/SingleDocumentCannedRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/SingleDocumentCannedRequest.kt
@@ -3,15 +3,17 @@ package org.multipaz.documenttype
 /**
  * A well-known request for a single document.
  *
- * @param id an identifier for the well-known document request (unique only for the document type).
- * @param displayName a short string with the name of the request, short enough to be used
+ * @property id an identifier for the well-known document request (unique only for the document type).
+ * @property displayName a short string with the name of the request, short enough to be used
  *   for a button. For example "Age Over 21 and Portrait" or "Full mDL".
- * @param mdocRequest the requests for a ISO mdoc credential, if defined.
- * @param jsonRequest the requests for a JSON-based credential, if defined.
+ * @property mdocRequest the requests for a ISO mdoc credential, if defined.
+ * @property jsonRequest the requests for a JSON-based credential, if defined.
+ * @property transactionData transaction data list for this request
  */
 data class SingleDocumentCannedRequest(
     override val id: String,
     override val displayName: String,
     val mdocRequest: MdocCannedRequest?,
-    val jsonRequest: JsonCannedRequest?
+    val jsonRequest: JsonCannedRequest?,
+    val transactionData: List<CannedTransactionData> = listOf()
 ): DocumentCannedRequest(id, displayName)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
@@ -2,7 +2,11 @@ package org.multipaz.documenttype
 
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
+import org.multipaz.cbor.CborBuilder
+import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.MapBuilder
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.presentment.TransactionData
@@ -95,4 +99,17 @@ abstract class TransactionType(
             }
         }
     }
+
+    /**
+     * Builds [CannedTransactionData] for this request type.
+     *
+     * @param builderAction builder action block to initialize transaction attributes.
+     * @return new [CannedTransactionData] initialized with this transaction type and
+     *  given attributes
+     */
+    fun buildCanned(builderAction: MapBuilder<CborBuilder>.() -> Unit) =
+        CannedTransactionData(
+            transactionType = this,
+            attributes = buildCborMap(builderAction) as CborMap
+        )
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -131,11 +131,20 @@ object TestAppUtils {
                         } else {
                             null
                         }
+                        val otherInfo = mutableMapOf<String, DataItem>()
+                        for (transactionData in request.transactionData) {
+                            val type = transactionData.transactionType
+                            otherInfo[type.mdocRequestInfoKeyName] = Tagged(
+                                tagNumber = Tagged.ENCODED_CBOR,
+                                taggedItem = Cbor.encode(transactionData.attributes).toDataItem()
+                            )
+                        }
                         addDocRequest(
                             docType = mdocRequest.docType,
                             nameSpaces = itemsToRequest,
                             docRequestInfo = DocRequestInfo(
-                                zkRequest = zkRequest
+                                zkRequest = zkRequest,
+                                otherInfo = otherInfo
                             ),
                             readerKey = readerKey,
                         )


### PR DESCRIPTION
 - Added canned transaction data object
 - Added a new canned request for PID to use sample transaction data
 - Added code to send transaction data with the request

Test: tested with the testapp
