### PR TITLE
Use individual jars instead of fat jars on the server.

### DIFF
--- a/multipaz-server-deployment/build.gradle.kts
+++ b/multipaz-server-deployment/build.gradle.kts
@@ -1,17 +1,57 @@
 // multipaz-server-deployment/build.gradle.kts
 // Tasks for building Docker images and deployment bundles
 
-tasks.register("buildAllFatJars") {
-    description = "Build fat JARs for all server modules"
+val serverProjects = listOf(
+    "multipaz-verifier-server",
+    "multipaz-openid4vci-server",
+    "multipaz-backend-server",
+    "multipaz-records-server",
+    "multipaz-csa-server"
+)
+
+tasks.register("collectDependencies") {
+    description = "Collect thin server JARs and shared dependency JARs into a staging directory"
     group = "multipaz-server-deployment"
 
-    dependsOn(
-        ":multipaz-verifier-server:buildFatJar",
-        ":multipaz-openid4vci-server:buildFatJar",
-        ":multipaz-backend-server:buildFatJar",
-        ":multipaz-records-server:buildFatJar",
-        ":multipaz-csa-server:buildFatJar"
-    )
+    // Depend on jar tasks for server projects plus their full runtime classpath build dependencies
+    for (name in serverProjects) {
+        val serverProject = project(":${name}")
+        dependsOn("${serverProject.path}:jar")
+        dependsOn(serverProject.configurations.getByName("runtimeClasspath").buildDependencies)
+    }
+
+    val stagingDir = layout.buildDirectory.dir("docker-staging")
+
+    outputs.dir(stagingDir)
+
+    doLast {
+        val jarsDir = stagingDir.get().dir("jars").asFile
+        val libsDir = stagingDir.get().dir("libs").asFile
+        jarsDir.mkdirs()
+        libsDir.mkdirs()
+
+        // Collect all unique dependency JARs from all server projects
+        val seenLibs = mutableSetOf<String>()
+        for (name in serverProjects) {
+            val serverProject = project(":${name}")
+            val runtimeCp = serverProject.configurations.getByName("runtimeClasspath")
+
+            // Copy the thin server JAR
+            val shortName = name.removePrefix("multipaz-").removeSuffix("-server")
+            val jarFile = serverProject.tasks.getByName<Jar>("jar").archiveFile.get().asFile
+            jarFile.copyTo(File(jarsDir, "${shortName}.jar"), overwrite = true)
+
+            // Copy dependency JARs (deduplicated by filename)
+            for (dep in runtimeCp.resolve()) {
+                if (dep.name.endsWith(".jar") && seenLibs.add(dep.name)) {
+                    dep.copyTo(File(libsDir, dep.name), overwrite = true)
+                }
+            }
+        }
+
+        val libCount = libsDir.listFiles()?.size ?: 0
+        println("Collected ${serverProjects.size} server JARs and ${libCount} shared dependency JARs")
+    }
 }
 
 tasks.register("buildWebFrontend") {
@@ -25,7 +65,7 @@ tasks.register("buildAll") {
     description = "Build all server JARs and web frontend"
     group = "multipaz-server-deployment"
 
-    dependsOn("buildAllFatJars", "buildWebFrontend")
+    dependsOn("collectDependencies", "buildWebFrontend")
 }
 
 // Helper function to get container tool (podman or docker)

--- a/multipaz-server-deployment/docker/Dockerfile
+++ b/multipaz-server-deployment/docker/Dockerfile
@@ -12,12 +12,11 @@ RUN groupadd -r multipaz && useradd -r -g multipaz multipaz
 
 WORKDIR /app
 
-# Copy JARs (built by Gradle before docker build)
-COPY multipaz-verifier-server/build/libs/multipaz-verifier-server-all.jar /app/jars/verifier.jar
-COPY multipaz-openid4vci-server/build/libs/multipaz-openid4vci-server-all.jar /app/jars/openid4vci.jar
-COPY multipaz-backend-server/build/libs/multipaz-backend-server-all.jar /app/jars/backend.jar
-COPY multipaz-records-server/build/libs/multipaz-records-server-all.jar /app/jars/records.jar
-COPY multipaz-csa-server/build/libs/multipaz-csa-server-all.jar /app/jars/csa.jar
+# Copy shared dependency JARs (deduplicated across all servers)
+COPY multipaz-server-deployment/build/docker-staging/libs/ /app/libs/
+
+# Copy thin server JARs
+COPY multipaz-server-deployment/build/docker-staging/jars/ /app/jars/
 
 # Copy web frontend (built by Gradle before docker build)
 COPY multipaz-server-frontend/build/dist/js/productionExecutable /app/web

--- a/multipaz-server-deployment/docker/start-servers.sh
+++ b/multipaz-server-deployment/docker/start-servers.sh
@@ -42,6 +42,8 @@ service () {
   shift
   local instance="$1"
   shift
+  local mainclass="$1"
+  shift
   local port="$1"
   shift
   local extra="$EXTRA_PARAMS"
@@ -55,7 +57,7 @@ service () {
     extra="$extra -param enrollment_server_url=${BASE_URL}/records"
   fi
   echo "Starting $service service ($instance) at port $port..."
-  java -jar "/app/jars/$service.jar" \
+  java -cp "/app/jars/$service.jar:/app/libs/*" "$mainclass" \
     -param server_port=$port \
     -param base_url=${BASE_URL}/$instance \
     -param ca_trust_servers="[\"$host\"]" \
@@ -87,11 +89,11 @@ else
 fi
 
 # records server must be started first, as it processes enrollments
-service records records 8004 -param admin_password=$ADMIN_PASS
-service openid4vci openid4vci 8007 -param admin_password=$ADMIN_PASS
-service csa csa 8005
-service verifier verifier 8006
-service backend backend 8008
+service records records org.multipaz.records.server.Main 8004 -param admin_password=$ADMIN_PASS
+service openid4vci openid4vci org.multipaz.openid4vci.server.Main 8007 -param admin_password=$ADMIN_PASS
+service csa csa org.multipaz.csa.server.Main 8005
+service verifier verifier org.multipaz.verifier.server.Main 8006
+service backend backend org.multipaz.backend.server.Main 8008
 
 if [ "$INIT" = "0" ]
 then


### PR DESCRIPTION
Use individual jars instead of fat jars on the server. This allows us to create many variations of the services without bloating the docker image (which fat jar do). This also shaved off almost 40% of the docker image.

Test: tested on a private server