### PR TITLE
Add ConfigurableTrustManager.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryInfo.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryInfo.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import org.multipaz.mdoc.rical.SignedRical
 import org.multipaz.mdoc.vical.SignedVical
 import org.multipaz.trustmanagement.TrustEntry
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustManager
 
 /**
@@ -21,7 +22,7 @@ import org.multipaz.trustmanagement.TrustManager
  */
 data class TrustEntryInfo(
     val entry: TrustEntry,
-    val manager: TrustManager,
+    val manager: TrustEntryBasedTrustManager,
     val signedVical: SignedVical?,
     val signedRical: SignedRical?
 ) {

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryList.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
@@ -16,41 +17,52 @@ import org.multipaz.compose.branding.Branding
 import org.multipaz.compose.decodeImage
 import org.multipaz.compose.items.FloatingItemList
 import org.multipaz.compose.items.FloatingItemText
+import org.multipaz.trustmanagement.TrustEntry
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 /**
- * A Composable that displays a scrollable list of trust entries managed by a [TrustManagerModel].
+ * A Composable that displays a scrollable list of trust entries managed in a [TrustEntryBasedTrustManager].
  *
  * It observes the [TrustManagerModel.trustManagerInfos] state and automatically updates
  * when trust entries are added, removed, or modified. It's using [FloatingItemList] to
  * display items
  *
- * @param trustManagerModel The presentation model observing the underlying TrustManager.
+ * @param trustManager A [TrustEntryBasedTrustManager] holding the trust entries.
  * @param title The title to display at the top of the list.
  * @param imageLoader a [ImageLoader].
+ * @param loading A Composable to render when loading entries, normally a [FloatingItemCenteredText].
  * @param noItems A Composable to render when the trust manager is empty, normally a [FloatingItemCenteredText].
  * @param onTrustEntryClicked Callback invoked when a specific trust entry in the list is clicked.
  * @param modifier The modifier to apply to the list.
  */
 @Composable
 fun TrustEntryList(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     title: String,
     imageLoader: ImageLoader,
+    loading: @Composable () -> Unit = {},
     noItems: @Composable () -> Unit = {},
-    onTrustEntryClicked: (trustEntryInfo: TrustEntryInfo) -> Unit,
+    onTrustEntryClicked: (trustEntry: TrustEntry) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
     val infos = trustManagerModel.trustManagerInfos.collectAsState().value
     FloatingItemList(
         modifier = modifier,
         title = title,
     ) {
-        if (infos.isEmpty()) {
+        if (infos == null) {
+            loading()
+        } else if (infos.isEmpty()) {
             noItems()
         } else {
             infos.forEach { trustEntryInfo ->
                 FloatingItemText(
-                    modifier = Modifier.clickable { onTrustEntryClicked(trustEntryInfo) },
+                    modifier = Modifier.clickable { onTrustEntryClicked(trustEntryInfo.entry) },
                     image = {
                         trustEntryInfo.RenderImage(
                             size = 40.dp,

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -21,25 +23,33 @@ import org.multipaz.multipaz_compose.generated.resources.trust_entry_rical_entry
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_rical_is_trust_anchor
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_rical_is_trust_anchor_false
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_rical_is_trust_anchor_true
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 /**
  * A Composable that displays the details of a specific individual certificate
  * embedded within a larger RICAL trust entry.
  *
- * @param trustManagerModel The presentation model holding the root RICAL trust entry.
+ * @param trustManager The [TrustEntryBasedTrustManager] holding the root RICAL trust entry.
  * @param ricalTrustEntryId The identifier of the parent RICAL trust entry.
  * @param certNum The index position of the specific certificate within the RICAL's certificate list.
  */
 @Composable
 fun TrustEntryRicalEntryViewer(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     ricalTrustEntryId: String,
     certNum: Int
 ) {
-    val trustEntryInfo = trustManagerModel.trustManagerInfos.value.find {
+    val coroutineScope = rememberCoroutineScope()
+
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
+    val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == ricalTrustEntryId
-    }!!
-    val rical = trustEntryInfo.signedRical!!.rical
+    } ?: return
+
+    val rical = info.signedRical!!.rical
     val ricalCertInfo = rical.certificateInfos[certNum]
 
     Column(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -19,25 +21,33 @@ import org.multipaz.multipaz_compose.generated.resources.Res
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_extensions
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_vical_entry_document_types
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_vical_entry_title
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 /**
  * A Composable that displays the details of a specific individual certificate
  * embedded within a larger VICAL trust entry.
  *
- * @param trustManagerModel The presentation model holding the root VICAL trust entry.
+ * @param trustManager The [TrustEntryBasedTrustManager] holding the root VICAL trust entry.
  * @param vicalTrustEntryId The identifier of the parent VICAL trust entry.
  * @param certNum The index position of the specific certificate within the VICAL's certificate list.
  */
 @Composable
 fun TrustEntryVicalEntryViewer(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     vicalTrustEntryId: String,
     certNum: Int
 ) {
-    val trustEntryInfo = trustManagerModel.trustManagerInfos.value.find {
+    val coroutineScope = rememberCoroutineScope()
+
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
+    val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == vicalTrustEntryId
-    }!!
-    val vical = trustEntryInfo.signedVical!!.vical
+    } ?: return
+
+    val vical = info.signedVical!!.vical
     val vicalCertInfo = vical.certificateInfos[certNum]
 
     Column(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
@@ -61,6 +62,7 @@ import org.multipaz.multipaz_compose.generated.resources.trust_entry_warning_ric
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_warning_vical_just_imported
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_warning_x509_just_imported
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_yes
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustEntryRical
 import org.multipaz.trustmanagement.TrustEntryVical
 import org.multipaz.trustmanagement.TrustEntryX509Cert
@@ -74,7 +76,7 @@ import kotlin.collections.component2
  * (Single X.509 Certificate, VICAL list, or RICAL list). It also provides informational
  * banners for newly imported entries reminding the user to verify the provider.
  *
- * @param trustManagerModel The presentation model holding the trust entries.
+ * @param trustManager The [TrustEntryBasedTrustManager] holding the trust entries.
  * @param trustEntryId The unique identifier of the trust entry to display.
  * @param justImported True if the entry was recently added, triggering an informational banner.
  * @param imageLoader a [ImageLoader].
@@ -85,7 +87,7 @@ import kotlin.collections.component2
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryViewer(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     trustEntryId: String,
     justImported: Boolean,
     imageLoader: ImageLoader,
@@ -93,9 +95,15 @@ fun TrustEntryViewer(
     onViewVicalEntry: (vicalCertNum: Int) -> Unit,
     onViewRicalEntry: (ricalCertNum: Int) -> Unit,
 ) {
-    val entryInfo = trustManagerModel.trustManagerInfos.value.find {
+    val coroutineScope = rememberCoroutineScope()
+
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
+    val entryInfo = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
-    }!!
+    } ?: return
 
     Column() {
         if (justImported) {

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustManagerModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustManagerModel.kt
@@ -2,13 +2,11 @@ package org.multipaz.compose.trustmanagement
 
 import androidx.compose.runtime.Composable
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.asn1.OID
@@ -21,43 +19,47 @@ import org.multipaz.multipaz_compose.generated.resources.trust_entry_details_vic
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_rical_fallback_name
 import org.multipaz.multipaz_compose.generated.resources.trust_entry_vical_fallback_name
 import org.multipaz.trustmanagement.TrustEntry
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustEntryRical
 import org.multipaz.trustmanagement.TrustEntryVical
 import org.multipaz.trustmanagement.TrustEntryX509Cert
 import org.multipaz.trustmanagement.TrustManager
 
 /**
- * A presentation model that bridges a [TrustManager] with UI components.
+ * A presentation model that bridges a [TrustEntryBasedTrustManager] with UI components.
  *
- * This class observes the underlying [TrustManager] for changes and exposes the
+ * This class observes the underlying [TrustEntryBasedTrustManager] for changes and exposes the
  * current list of trust entries as a reactive [StateFlow] of [TrustEntryInfo] objects.
  * It handles the parsing of raw trust entries into UI-friendly data structures.
  *
  * @property trustManager The underlying [TrustManager] being observed.
+ * @property coroutineScope The scope used to run background queries for the state flow.
  */
-class TrustManagerModel private constructor(
-    val trustManager: TrustManager
+class TrustManagerModel(
+    val trustManager: TrustEntryBasedTrustManager,
+    coroutineScope: CoroutineScope
 ) {
     /**
-     * The coroutine scope used for observing [TrustManager] events.
-     * Uses a [SupervisorJob] to ensure that an exception during a single flow update
-     * does not cancel the entire observation scope.
-     */
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-
-    private val _trustManagerInfos: MutableStateFlow<List<TrustEntryInfo>> = MutableStateFlow(emptyList())
-
-    /**
      * A [StateFlow] containing the current, parsed list of trust entries.
-     * UI components should collect this flow to stay up-to-date with the [TrustManager] state.
+     *
+     * - The initial value is `null` while the first read and parsing are in progress.
+     * - It automatically re-queries the [trustManager] whenever it emits a change notification.
+     * - Uses [SharingStarted.WhileSubscribed] to pause observations if the UI is completely hidden.
      */
-    val trustManagerInfos: StateFlow<List<TrustEntryInfo>> = _trustManagerInfos.asStateFlow()
+    val trustManagerInfos: StateFlow<List<TrustEntryInfo>?> = trustManager.eventFlow
+        .onStart { emit(Unit) } // Trigger the initial load
+        .map { fetchAndParseEntries() }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
 
     /**
-     * Fetches the latest entries from the [TrustManager], parses their contents
-     * (such as VICALs and RICALs), and updates the [_trustManagerInfos] state.
+     * Fetches the latest entries from the [trustManager] and parses their contents
+     * (such as VICALs and RICALs).
      */
-    private suspend fun updateTrustManagerInfos() {
+    private suspend fun fetchAndParseEntries(): List<TrustEntryInfo> {
         val infos = mutableListOf<TrustEntryInfo>()
         trustManager.getEntries().forEach { entry ->
             val signedVical = if (entry is TrustEntryVical) {
@@ -83,38 +85,7 @@ class TrustManagerModel private constructor(
                 signedRical = signedRical
             ))
         }
-        _trustManagerInfos.value = infos
-    }
-
-    /**
-     * Initializes the model by performing an initial state fetch and subscribing
-     * to future updates from the [TrustManager]'s event flow.
-     */
-    private suspend fun initialize() {
-        updateTrustManagerInfos()
-        trustManager.eventFlow
-            .onEach { updateTrustManagerInfos() }
-            .launchIn(scope)
-    }
-
-    companion object {
-
-        /**
-         * Creates and initializes a [TrustManagerModel].
-         *
-         * This method suspends until the initial state is fully loaded from the
-         * [trustManager] and the observation flow is established.
-         *
-         * @param trustManager The [TrustManager] to bind to this model.
-         * @return A fully initialized [TrustManagerModel].
-         */
-        suspend fun create(
-            trustManager: TrustManager
-        ): TrustManagerModel {
-            val trustManagerModel = TrustManagerModel(trustManager)
-            trustManagerModel.initialize()
-            return trustManagerModel
-        }
+        return infos
     }
 }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/ConfigurableTrustManager.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/ConfigurableTrustManager.kt
@@ -1,0 +1,167 @@
+package org.multipaz.trustmanagement
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.multipaz.crypto.X509Cert
+import org.multipaz.mdoc.rical.SignedRical
+import org.multipaz.mdoc.vical.SignedVical
+import org.multipaz.util.Logger
+import org.multipaz.util.toHex
+import kotlin.time.Instant
+
+/**
+ * A [TrustManagerInterface] implementation backed by a configurable list of [TrustEntry] items.
+ *
+ * The entries may be updated later using [setEntries].
+ *
+ * This is typically used when receiving a lists of [TrustEntry] items from e.g. a backend server.
+ *
+ * @param identifier an identifier for the [TrustManagerInterface] instance.
+ * @param entries A list of [TrustEntry] objects (e.g., [TrustEntryX509Cert], [TrustEntryVical]).
+ */
+class ConfigurableTrustManager(
+    override val identifier: String,
+    entries: List<TrustEntry>
+): TrustEntryBasedTrustManager {
+
+    /**
+     * An internal buffered flow used to broadcast changes to the trust store.
+     * Drops the oldest events if the buffer overflows, preventing slow subscribers from
+     * bottlenecking rapid, concurrent database writes. Emits [Unit] to signal a generic
+     * state invalidation.
+     */
+    private val _eventFlow = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    override val eventFlow
+        get() = _eventFlow.asSharedFlow()
+
+    private var currentEntries = entries
+
+    // Lock to protect in-memory collections from concurrent modifications
+    private val stateLock = Mutex()
+    private val skiToTrustPoint = mutableMapOf<String, TrustPoint>()
+    private val vicalTrustManagers = mutableListOf<VicalTrustManager>()
+    private val ricalTrustManagers = mutableListOf<RicalTrustManager>()
+
+    private val initializationLock = Mutex()
+    private var initializationComplete = false
+
+    /**
+     * Lazily initializes the database table and loads all existing trust entries
+     * into the memory cache. Uses [initializationLock] to ensure it only runs once.
+     */
+    private suspend fun ensureInitialized() {
+        initializationLock.withLock {
+            if (initializationComplete) {
+                return
+            }
+
+            val loadedSkiToTrustPoint = mutableMapOf<String, TrustPoint>()
+            val loadedVicalTrustManagers = mutableListOf<VicalTrustManager>()
+            val loadedRicalTrustManagers = mutableListOf<RicalTrustManager>()
+
+            currentEntries.forEach { entry ->
+                when (entry) {
+                    is TrustEntryX509Cert -> {
+                        val ski = entry.certificate.subjectKeyIdentifier?.toHex()
+                        if (ski == null) {
+                            Logger.w(TAG, "Skipping certificate without SKI")
+                        } else {
+                            loadedSkiToTrustPoint[ski] = TrustPoint(
+                                certificate = entry.certificate,
+                                metadata = entry.metadata,
+                                trustManager = this
+                            )
+                        }
+                    }
+                    is TrustEntryVical -> {
+                        val signedVical = SignedVical.parse(
+                            encodedSignedVical = entry.encodedSignedVical.toByteArray(),
+                            disableSignatureVerification = true
+                        )
+                        loadedVicalTrustManagers.add(VicalTrustManager(signedVical))
+                    }
+                    is TrustEntryRical -> {
+                        val signedRical = SignedRical.parse(
+                            encodedSignedRical = entry.encodedSignedRical.toByteArray(),
+                            disableSignatureVerification = true
+                        )
+                        loadedRicalTrustManagers.add(RicalTrustManager(signedRical))
+                    }
+                }
+            }
+
+            stateLock.withLock {
+                skiToTrustPoint.putAll(loadedSkiToTrustPoint)
+                vicalTrustManagers.addAll(loadedVicalTrustManagers)
+                ricalTrustManagers.addAll(loadedRicalTrustManagers)
+            }
+            initializationComplete = true
+        }
+    }
+
+    override suspend fun getTrustPoints(): List<TrustPoint> {
+        ensureInitialized()
+        return stateLock.withLock {
+            val ret = mutableListOf<TrustPoint>()
+            ret.addAll(skiToTrustPoint.values)
+            vicalTrustManagers.forEach { ret.addAll(it.getTrustPoints()) }
+            ricalTrustManagers.forEach { ret.addAll(it.getTrustPoints()) }
+            ret
+        }
+    }
+
+    override suspend fun verify(
+        chain: List<X509Cert>,
+        atTime: Instant,
+    ): TrustResult {
+        ensureInitialized()
+        return stateLock.withLock {
+            // VICAL trust managers get first dibs...
+            vicalTrustManagers.forEach { trustManager ->
+                val ret = trustManager.verify(chain, atTime)
+                if (ret.isTrusted) {
+                    return@withLock ret
+                }
+            }
+            // Then RICAL..
+            ricalTrustManagers.forEach { trustManager ->
+                val ret = trustManager.verify(chain, atTime)
+                if (ret.isTrusted) {
+                    return@withLock ret
+                }
+            }
+            // Finally certificates...
+            TrustManagerUtil.verifyX509TrustChain(chain, atTime, skiToTrustPoint)
+        }
+    }
+
+    override suspend fun getEntries(): List<TrustEntry> {
+        return currentEntries
+    }
+
+    /**
+     * Sets which [TrustEntry] items to use.
+     *
+     * @param entries A list of [TrustEntry] objects (e.g., [TrustEntryX509Cert], [TrustEntryVical]).
+     */
+    suspend fun setEntries(
+        entries: List<TrustEntry>
+    ) {
+        stateLock.withLock {
+            currentEntries = entries
+            initializationComplete = false
+        }
+        _eventFlow.tryEmit(Unit)
+    }
+
+    companion object {
+        private const val TAG = "ConfigurableTrustManager"
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustEntryBasedTrustManager.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustEntryBasedTrustManager.kt
@@ -1,0 +1,21 @@
+package org.multipaz.trustmanagement
+
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Common interface for [TrustManagerInterface] implementations built on top of [TrustEntry].
+ */
+interface TrustEntryBasedTrustManager: TrustManagerInterface {
+    /**
+     * A reactive stream of events emitted whenever the underlying trust data changes.
+     * Observers can collect this flow to know when to refresh their cached UI states.
+     */
+    val eventFlow: SharedFlow<Unit>
+
+    /**
+     * Retrieves all [TrustEntry] items currently managed.
+     *
+     * @return A list of [TrustEntry] objects (e.g., [TrustEntryX509Cert], [TrustEntryVical]).
+     */
+    suspend fun getEntries(): List<TrustEntry>
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManager.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManager.kt
@@ -5,8 +5,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
@@ -18,6 +16,8 @@ import org.multipaz.storage.Storage
 import org.multipaz.storage.StorageTable
 import org.multipaz.storage.StorageTableSpec
 import org.multipaz.util.toHex
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 private data class LocalTrustEntry(
     val id: String,
@@ -58,14 +58,14 @@ private data class LocalTrustEntry(
  * update their state whenever trust entries are added, modified, or deleted.
  *
  * @param storage the [Storage] interface used for persistent storage.
- * @param identifier an identifier for the [TrustManagerInterface].
+ * @param identifier an identifier for the [TrustManagerInterface] instance.
  * @param partitionId an identifier used to namespace data if multiple [TrustManager] instances share the same [storage].
  */
 class TrustManager(
     private val storage: Storage,
     override val identifier: String = "default",
     private val partitionId: String = "default_$identifier"
-): TrustManagerInterface {
+): TrustEntryBasedTrustManager {
     private lateinit var storageTable: StorageTable
 
     /**
@@ -79,11 +79,7 @@ class TrustManager(
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
 
-    /**
-     * A reactive stream of events emitted whenever the underlying trust data changes.
-     * Observers can collect this flow to know when to refresh their cached UI states.
-     */
-    val eventFlow
+    override val eventFlow
         get() = _eventFlow.asSharedFlow()
 
     // Lock to protect in-memory collections from concurrent modifications
@@ -168,13 +164,7 @@ class TrustManager(
         }
     }
 
-    /**
-     * Retrieves all high-level [TrustEntry] items currently managed, sorted
-     * chronologically by the time they were added.
-     *
-     * @return A list of [TrustEntry] objects (e.g., [TrustEntryX509Cert], [TrustEntryVical]).
-     */
-    suspend fun getEntries(): List<TrustEntry> {
+    override suspend fun getEntries(): List<TrustEntry> {
         ensureInitialized()
         return stateLock.withLock {
             localEntries.sortedBy { it.timeAdded }.map { it.entry }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/trustmanagement/ConfigurableTrustManagerTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/trustmanagement/ConfigurableTrustManagerTest.kt
@@ -1,0 +1,439 @@
+package org.multipaz.trustmanagement
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509Cert
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.crypto.X509KeyUsage
+import org.multipaz.crypto.buildX509Cert
+import org.multipaz.mdoc.rical.Rical
+import org.multipaz.mdoc.rical.RicalCertificateInfo
+import org.multipaz.mdoc.rical.SignedRical
+import org.multipaz.mdoc.util.MdocUtil
+import org.multipaz.mdoc.vical.SignedVical
+import org.multipaz.mdoc.vical.Vical
+import org.multipaz.mdoc.vical.VicalCertificateInfo
+import org.multipaz.util.truncateToWholeSeconds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class ConfigurableTrustManagerTest {
+
+    private lateinit var caCertificate: X509Cert
+    private lateinit var intermediateCertificate: X509Cert
+    private lateinit var dsCertificate: X509Cert
+
+    private fun runTestWithSetup(block: suspend TestScope.() -> Unit) = runTest { setup(); block() }
+
+    private suspend fun setup() {
+        val now = Clock.System.now().truncateToWholeSeconds()
+
+        val caKey = Crypto.createEcPrivateKey(EcCurve.P384)
+        caCertificate = buildX509Cert(
+            publicKey = caKey.publicKey,
+            signingKey = AsymmetricKey.anonymous(caKey, caKey.curve.defaultSigningAlgorithm),
+            serialNumber = ASN1Integer(1L),
+            subject = X500Name.fromName("CN=Test TrustManager CA"),
+            issuer = X500Name.fromName("CN=Test TrustManager CA"),
+            validFrom = now - 1.hours,
+            validUntil = now + 1.hours
+        ) {
+            includeSubjectKeyIdentifier()
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(true, null)
+        }
+
+        val intermediateKey = Crypto.createEcPrivateKey(EcCurve.P384)
+        intermediateCertificate = buildX509Cert(
+            publicKey = intermediateKey.publicKey,
+            signingKey = AsymmetricKey.anonymous(caKey, caKey.curve.defaultSigningAlgorithm),
+            serialNumber = ASN1Integer(1L),
+            subject = X500Name.fromName("CN=Test TrustManager Intermediate CA"),
+            issuer = caCertificate.subject,
+            validFrom = now - 1.hours,
+            validUntil = now + 1.hours
+        ) {
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(caCertificate)
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(true, null)
+        }
+
+        val dsKey = Crypto.createEcPrivateKey(EcCurve.P384)
+        dsCertificate = buildX509Cert(
+            publicKey = dsKey.publicKey,
+            signingKey = AsymmetricKey.anonymous(intermediateKey, intermediateKey.curve.defaultSigningAlgorithm),
+            serialNumber = ASN1Integer(1L),
+            subject = X500Name.fromName("CN=Test TrustManager DS"),
+            issuer = intermediateCertificate.subject,
+            validFrom = now - 1.hours,
+            validUntil = now + 1.hours
+        ) {
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(intermediateCertificate)
+            setKeyUsage(setOf(X509KeyUsage.DIGITAL_SIGNATURE))
+        }
+    }
+
+    private data class TestIaca(
+        val elboniaIaca: X509Cert,
+        val atlantisIaca: X509Cert,
+        val encodedSignedVical: ByteString,
+        val elboniaDs: X509Cert,
+    )
+
+    private data class TestRical(
+        val breweryReaderRootCert: X509Cert,
+        val breweryReaderCert: X509Cert,
+        val encodedSignedRical: ByteString,
+    )
+
+    private suspend fun createTestIaca(): TestIaca {
+        val now = Clock.System.now().truncateToWholeSeconds()
+        val validFrom = now - 10.minutes
+        val validUntil = now + 10.minutes
+
+        val elboniaIacaKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val elboniaIaca = MdocUtil.generateIacaCertificate(
+            iacaKey = AsymmetricKey.anonymous(elboniaIacaKey),
+            subject = X500Name.fromName("CN=Elbonia TrustManager CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = validFrom,
+            validUntil = validUntil,
+            issuerAltNameUrl = "https://example.com/elbonia/altname",
+            crlUrl = "https://example.com/elbonia/crl"
+        )
+        val elboniaDsKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val elboniaDs = MdocUtil.generateDsCertificate(
+            iacaKey = AsymmetricKey.X509CertifiedExplicit(
+                privateKey = elboniaIacaKey,
+                certChain = X509CertChain(listOf(elboniaIaca))
+            ),
+            dsKey = elboniaDsKey.publicKey,
+            subject = X500Name.fromName("CN=Elbonia DS"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = validFrom,
+            validUntil = validUntil
+        )
+
+        val atlantisIacaKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val atlantisIaca = MdocUtil.generateIacaCertificate(
+            iacaKey = AsymmetricKey.anonymous(atlantisIacaKey),
+            subject = X500Name.fromName("CN=Atlantis TrustManager CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = validFrom,
+            validUntil = validUntil,
+            issuerAltNameUrl = "https://example.com/atlantis/altname",
+            crlUrl = "https://example.com/atlantis/crl"
+        )
+
+        val vical = Vical(
+            version = "1",
+            vicalProvider = "Test VICAL provider",
+            date = now,
+            nextUpdate = null,
+            vicalIssueID = null,
+            certificateInfos = listOf(
+                VicalCertificateInfo(
+                    certificate = elboniaIaca,
+                    docTypes = listOf("org.iso.18013.5.1.mDL")
+                ),
+                VicalCertificateInfo(
+                    certificate = atlantisIaca,
+                    docTypes = listOf("org.iso.18013.5.1.mDL")
+                )
+            ),
+            notAfter = null,
+            vicalUrl = null,
+            extensions = emptyMap(),
+        )
+
+        val vicalKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val vicalCert = buildX509Cert(
+            publicKey = vicalKey.publicKey,
+            signingKey = AsymmetricKey.anonymous(vicalKey, vicalKey.curve.defaultSigningAlgorithm),
+            serialNumber = ASN1Integer(1),
+            subject = X500Name.fromName("CN=Test VICAL provider"),
+            issuer = X500Name.fromName("CN=Test VICAL provider"),
+            validFrom = validFrom,
+            validUntil = validUntil
+        ) {
+            includeSubjectKeyIdentifier()
+        }
+
+        val signedVical = SignedVical(vical, X509CertChain(listOf(vicalCert)))
+        return TestIaca(
+            elboniaIaca = elboniaIaca,
+            atlantisIaca = atlantisIaca,
+            encodedSignedVical = ByteString(
+                signedVical.generate(AsymmetricKey.anonymous(vicalKey))
+            ),
+            elboniaDs = elboniaDs,
+        )
+    }
+
+    private suspend fun createTestRical(): TestRical {
+        val now = Clock.System.now().truncateToWholeSeconds()
+        val validFrom = now - 10.minutes
+        val validUntil = now + 10.minutes
+
+        val breweryReaderRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val breweryReaderRootCert = MdocUtil.generateReaderRootCertificate(
+            readerRootKey = AsymmetricKey.anonymous(breweryReaderRootKey),
+            subject = X500Name.fromName("CN=Brewery TrustManager CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = validFrom,
+            validUntil = validUntil,
+            crlUrl = "https://example.com/brewery/crl"
+        )
+        val breweryReaderKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val breweryReaderCert = MdocUtil.generateReaderCertificate(
+            readerRootKey = AsymmetricKey.X509CertifiedExplicit(
+                privateKey = breweryReaderRootKey,
+                certChain = X509CertChain(listOf(breweryReaderRootCert))
+            ),
+            readerKey = breweryReaderKey.publicKey,
+            dnsName = "brewery.multipaz.org",
+            subject = X500Name.fromName("CN=Brewery"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = validFrom,
+            validUntil = validUntil
+        )
+
+        val rical = Rical(
+            type = Rical.RICAL_TYPE_READER_AUTHENTICATION,
+            version = "1",
+            provider = "Test RICAL provider",
+            date = now,
+            nextUpdate = null,
+            notAfter = null,
+            certificateInfos = listOf(
+                RicalCertificateInfo(
+                    certificate = breweryReaderRootCert,
+                )
+            ),
+            id = null,
+            latestRicalUrl = null,
+            extensions = emptyMap(),
+        )
+
+        val ricalKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val ricalCert = buildX509Cert(
+            publicKey = ricalKey.publicKey,
+            signingKey = AsymmetricKey.anonymous(ricalKey, ricalKey.curve.defaultSigningAlgorithm),
+            serialNumber = ASN1Integer(1),
+            subject = X500Name.fromName("CN=Test RICAL provider"),
+            issuer = X500Name.fromName("CN=Test RICAL provider"),
+            validFrom = validFrom,
+            validUntil = validUntil
+        ) {
+            includeSubjectKeyIdentifier()
+        }
+
+        val signedRical = SignedRical(rical, X509CertChain(listOf(ricalCert)))
+        return TestRical(
+            breweryReaderRootCert = breweryReaderRootCert,
+            breweryReaderCert = breweryReaderCert,
+            encodedSignedRical = ByteString(
+                signedRical.generate(AsymmetricKey.anonymous(ricalKey))
+            ),
+        )
+    }
+
+    @Test
+    fun verifyX509Entries() = runTestWithSetup {
+        val entryCa = TrustEntryX509Cert(
+            identifier = "ca",
+            metadata = TrustMetadata(),
+            certificate = caCertificate
+        )
+        val entryIntermediate = TrustEntryX509Cert(
+            identifier = "intermediate",
+            metadata = TrustMetadata(),
+            certificate = intermediateCertificate
+        )
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = listOf(entryCa, entryIntermediate)
+        )
+
+        trustManager.verify(listOf(dsCertificate)).let {
+            assertEquals(null, it.error)
+            assertTrue(it.isTrusted)
+            assertEquals(3, it.trustChain!!.certificates.size)
+            assertEquals(caCertificate, it.trustChain.certificates.last())
+        }
+    }
+
+    @Test
+    fun verifyVicalEntries() = runTestWithSetup {
+        val testIaca = createTestIaca()
+        val entryVical = TrustEntryVical(
+            identifier = "vical",
+            metadata = TrustMetadata(),
+            encodedSignedVical = testIaca.encodedSignedVical
+        )
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = listOf(entryVical)
+        )
+
+        trustManager.verify(listOf(testIaca.elboniaDs)).let {
+            assertEquals(null, it.error)
+            assertTrue(it.isTrusted)
+            assertEquals(2, it.trustChain!!.certificates.size)
+            assertEquals(testIaca.elboniaIaca, it.trustChain.certificates.last())
+        }
+    }
+
+    @Test
+    fun verifyRicalEntries() = runTestWithSetup {
+        val testRical = createTestRical()
+        val entryRical = TrustEntryRical(
+            identifier = "rical",
+            metadata = TrustMetadata(),
+            encodedSignedRical = testRical.encodedSignedRical
+        )
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = listOf(entryRical)
+        )
+
+        trustManager.verify(listOf(testRical.breweryReaderCert)).let {
+            assertEquals(null, it.error)
+            assertTrue(it.isTrusted)
+            assertEquals(2, it.trustChain!!.certificates.size)
+            assertEquals(testRical.breweryReaderRootCert, it.trustChain.certificates.last())
+        }
+    }
+
+    @Test
+    fun emptyEntriesFailVerification() = runTestWithSetup {
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = emptyList()
+        )
+
+        trustManager.verify(listOf(dsCertificate)).let {
+            assertFalse(it.isTrusted)
+            assertEquals("No trusted root certificate could not be found", it.error?.message)
+            assertNull(it.trustChain)
+        }
+    }
+
+    @Test
+    fun updateEntriesDynamically() = runTestWithSetup {
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = emptyList()
+        )
+
+        // Starts with empty trust cache
+        trustManager.verify(listOf(dsCertificate)).let {
+            assertFalse(it.isTrusted)
+        }
+
+        val entryIntermediate = TrustEntryX509Cert(
+            identifier = "intermediate",
+            metadata = TrustMetadata(),
+            certificate = intermediateCertificate
+        )
+
+        // Replace state with a new set of entries
+        trustManager.setEntries(listOf(entryIntermediate))
+
+        // State is updated correctly
+        val currentEntries = trustManager.getEntries()
+        assertEquals(1, currentEntries.size)
+        assertEquals(entryIntermediate, currentEntries[0])
+
+        // Verify it now resolves
+        trustManager.verify(listOf(dsCertificate)).let {
+            assertEquals(null, it.error)
+            assertTrue(it.isTrusted)
+            assertEquals(2, it.trustChain!!.certificates.size)
+            assertEquals(intermediateCertificate, it.trustChain.certificates.last())
+        }
+    }
+
+    @Test
+    fun returnsAllTrustPointsCorrectly() = runTestWithSetup {
+        val testIaca = createTestIaca()
+        val entryX509 = TrustEntryX509Cert(
+            identifier = "x509",
+            metadata = TrustMetadata(),
+            certificate = caCertificate
+        )
+        val entryVical = TrustEntryVical(
+            identifier = "vical",
+            metadata = TrustMetadata(),
+            encodedSignedVical = testIaca.encodedSignedVical
+        )
+
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = listOf(entryX509, entryVical)
+        )
+
+        val points = trustManager.getTrustPoints()
+
+        // Should contain the X509 cert plus the 2 CA certs embedded in the VICAL payload
+        assertEquals(3, points.size)
+
+        val certs = points.map { it.certificate }
+        assertTrue(certs.contains(caCertificate))
+        assertTrue(certs.contains(testIaca.elboniaIaca))
+        assertTrue(certs.contains(testIaca.atlantisIaca))
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun eventFlowEmissions() = runTestWithSetup {
+        val trustManager = ConfigurableTrustManager(
+            identifier = "configurable_test",
+            entries = emptyList()
+        )
+        var numEvents = 0
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            trustManager.eventFlow.collect {
+                numEvents += 1
+            }
+        }
+
+        // 1. Initial setEntries emission
+        val entryCa = TrustEntryX509Cert(
+            identifier = "ca",
+            metadata = TrustMetadata(),
+            certificate = caCertificate
+        )
+        trustManager.setEntries(listOf(entryCa))
+        assertEquals(1, numEvents)
+
+        // 2. Subsequent setEntries emission
+        val entryIntermediate = TrustEntryX509Cert(
+            identifier = "intermediate",
+            metadata = TrustMetadata(),
+            certificate = intermediateCertificate
+        )
+        trustManager.setEntries(listOf(entryCa, entryIntermediate))
+        assertEquals(2, numEvents)
+
+        job.cancel()
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -70,7 +70,6 @@ import org.multipaz.compose.branding.Branding
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.compose.provisioning.ProvisioningBottomSheet
-import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -158,6 +157,9 @@ import org.multipaz.testapp.ui.TrustManagerScreen
 import org.multipaz.testapp.ui.VerticalDocumentListScreen
 import org.multipaz.transactiontype.knowntypes.PingTransaction
 import org.multipaz.trustmanagement.CompositeTrustManager
+import org.multipaz.trustmanagement.ConfigurableTrustManager
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
+import org.multipaz.trustmanagement.TrustEntryX509Cert
 import org.multipaz.trustmanagement.TrustManager
 import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.util.Logger
@@ -202,17 +204,13 @@ class App private constructor (val promptModel: PromptModel) {
     lateinit var readerRootKey: AsymmetricKey.X509Certified
     lateinit var readerKey: AsymmetricKey.X509Certified
 
-    lateinit var builtInIssuerTrustManager: TrustManager
-    lateinit var builtInIssuerTrustManagerModel: TrustManagerModel
+    lateinit var builtInIssuerTrustManager: ConfigurableTrustManager
     lateinit var userIssuerTrustManager: TrustManager
-    lateinit var userIssuerTrustManagerModel: TrustManagerModel
 
     lateinit var issuerTrustManager: CompositeTrustManager
 
-    lateinit var builtInReaderTrustManager: TrustManager
-    lateinit var builtInReaderTrustManagerModel: TrustManagerModel
+    lateinit var builtInReaderTrustManager: ConfigurableTrustManager
     lateinit var userReaderTrustManager: TrustManager
-    lateinit var userReaderTrustManagerModel: TrustManagerModel
 
     lateinit var readerTrustManager: CompositeTrustManager
 
@@ -404,11 +402,18 @@ class App private constructor (val promptModel: PromptModel) {
 
     private suspend fun trustManagersInit() {
         generateTrustManagers()
-        builtInIssuerTrustManagerModel = TrustManagerModel.create(builtInIssuerTrustManager)
-        userIssuerTrustManagerModel = TrustManagerModel.create(userIssuerTrustManager)
-        builtInReaderTrustManagerModel = TrustManagerModel.create(builtInReaderTrustManager)
-        userReaderTrustManagerModel = TrustManagerModel.create(userReaderTrustManager)
     }
+
+    private fun getTrustManagerFromId(identifier: String): TrustEntryBasedTrustManager {
+        return when (identifier) {
+            "builtInIssuerTrustManager" -> builtInIssuerTrustManager
+            "userIssuerTrustManager" -> userIssuerTrustManager
+            "builtInReaderTrustManager" -> builtInReaderTrustManager
+            "userReaderTrustManager" -> userReaderTrustManager
+            else -> throw IllegalStateException("Unexpected TrustManager id $identifier")
+        }
+    }
+
 
     private suspend fun provisioningModelInit() {
         val secureArea = Platform.getSecureArea(TestAppConfiguration.storage)
@@ -581,17 +586,26 @@ class App private constructor (val promptModel: PromptModel) {
 
     @OptIn(ExperimentalResourceApi::class)
     private suspend fun generateTrustManagers() {
-        builtInIssuerTrustManager = TrustManager(
-            storage = EphemeralStorage(),
-            identifier = "builtInIssuerTrustManager"
-        )
-        builtInIssuerTrustManager.addX509Cert(
-            certificate = iacaKey.certChain.certificates.first(),
-            metadata = TrustMetadata(displayName = "OWF Multipaz TestApp Issuer"),
-        )
-        builtInIssuerTrustManager.addX509Cert(
-            certificate = X509Cert.fromPem(
-                """
+        builtInIssuerTrustManager = ConfigurableTrustManager(
+            identifier = "builtInIssuerTrustManager",
+            entries = buildList {
+                var idCount = 0
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "OWF Multipaz TestApp Issuer",
+                        displayIconUrl = "https://www.multipaz.org/multipaz-logo-200x200.png",
+                    ),
+                    certificate = iacaKey.certChain.certificates.first()
+                ))
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "issuer.multipaz.org",
+                        displayIconUrl = "https://www.multipaz.org/multipaz-logo-200x200.png",
+                    ),
+                    certificate = X509Cert.fromPem(
+                        """
                     -----BEGIN CERTIFICATE-----
                     MIICvTCCAkKgAwIBAgIQGae+XGbhr63RY7K+8qcoGTAKBggqhkjOPQQDAzBOMT8wPQYDVQQDDDZP
                     cGVuSUQ0VkNJIFJvb3QgYXQgaHR0cHM6Ly9pc3N1ZXIubXVsdGlwYXoub3JnL3JlY29yZHMxCzAJ
@@ -608,12 +622,16 @@ class App private constructor (val promptModel: PromptModel) {
                     u/YcDSz6dBNZ5mAillH9vpjOP2uZ
                     -----END CERTIFICATE-----
                 """.trimIndent()
-            ),
-            metadata = TrustMetadata(
-                displayName = "issuer.multipaz.org",
-                displayIconUrl = "https://www.multipaz.org/multipaz-logo-200x200.png",
-            ),
+                    )
+                ))
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(displayName = "OWF Multipaz TestApp Issuer"),
+                    certificate = iacaKey.certChain.certificates.first()
+                ))
+            }
         )
+
         userIssuerTrustManager = TrustManager(
             storage = TestAppConfiguration.storage,
             identifier = "userIssuerTrustManager"
@@ -623,30 +641,29 @@ class App private constructor (val promptModel: PromptModel) {
             identifier = "issuers"
         )
 
-        builtInReaderTrustManager = TrustManager(
-            storage = EphemeralStorage(),
-            identifier = "builtInReaderTrustManager"
-        )
-        userReaderTrustManager = TrustManager(
-            storage = TestAppConfiguration.storage,
-            identifier = "userReaderTrustManager"
-        )
-        readerTrustManager = CompositeTrustManager(
-            trustManagers = listOf(builtInReaderTrustManager, userReaderTrustManager),
-            identifier = "readers"
-        )
-        builtInReaderTrustManager.addX509Cert(
-            certificate = readerRootKey.certChain.certificates.first(),
-            metadata = TrustMetadata(
-                displayName = "Multipaz TestApp",
-                displayIcon = ByteString(Res.readBytes("files/utopia-brewery.png")),
-                privacyPolicyUrl = "https://apps.multipaz.org"
-            )
-        )
-        // This is for https://verifier.multipaz.org website.
-        builtInReaderTrustManager.addX509Cert(
-            certificate = X509Cert.fromPem(
-                """
+        builtInReaderTrustManager = ConfigurableTrustManager(
+            identifier = "builtInReaderTrustManager",
+            entries = buildList {
+                var idCount = 0
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "Multipaz TestApp",
+                        displayIcon = ByteString(Res.readBytes("files/utopia-brewery.png")),
+                        privacyPolicyUrl = "https://apps.multipaz.org"
+                    ),
+                    certificate = readerRootKey.certChain.certificates.first(),
+                ))
+                // This is for https://verifier.multipaz.org website.
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "Multipaz Verifier",
+                        displayIconUrl = "https://www.multipaz.org/multipaz-logo-200x200.png",
+                        privacyPolicyUrl = "https://apps.multipaz.org"
+                    ),
+                    certificate = X509Cert.fromPem(
+                        """
                     -----BEGIN CERTIFICATE-----
                     MIICaTCCAe+gAwIBAgIQtzUvFDCKLUBWQAZ4UnCw5zAKBggqhkjOPQQDAzA3MQswCQYDVQQGDAJV
                     UzEoMCYGA1UEAwwfdmVyaWZpZXIubXVsdGlwYXoub3JnIFJlYWRlciBDQTAeFw0yNTA2MTkyMjE2
@@ -661,60 +678,68 @@ class App private constructor (val promptModel: PromptModel) {
                     AjEA2yLSJDZEu1GI8uChAsDBZwJPtv5KHUjq1Vpok69SNn+zzb1mNpqmiey+tchPBjZm
                     -----END CERTIFICATE-----
                 """.trimIndent()
-            ),
-            metadata = TrustMetadata(
-                displayName = "Multipaz Verifier",
-                displayIconUrl = "https://www.multipaz.org/multipaz-logo-200x200.png",
-                privacyPolicyUrl = "https://apps.multipaz.org"
-            )
+                    ),
+                ))
+                // This is for Multipaz Identity Reader app from https://apps.multipaz.org on devices in
+                // the GREEN boot state.
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "Multipaz Identity Reader",
+                        displayIcon = ByteString(Res.readBytes("drawable/mpz_identity_reader.webp")),
+                        privacyPolicyUrl = "https://apps.multipaz.org"
+                    ),
+                    certificate = MULTIPAZ_IDENTITY_READER_CERT,
+                ))
+                // This is for Multipaz Identity Reader either compiled locally or the APK from https://apps.multipaz.org
+                // but running on a device that isn't in the GREEN boot state.
+                add(TrustEntryX509Cert(
+                    identifier = "${idCount++}",
+                    metadata = TrustMetadata(
+                        displayName = "Multipaz Identity Reader (Untrusted Devices)",
+                        displayIcon = ByteString(Res.readBytes("drawable/mpz_identity_reader.webp")),
+                        privacyPolicyUrl = "https://apps.multipaz.org"
+                    ),
+                    certificate = MULTIPAZ_IDENTITY_READER_CERT_UNTRUSTED_DEVICES,
+                ))
+                // Some reader identities from the Multipaz Identity Reader as distributed from apps.multipaz.org
+                for ((displayName: String, displayIcon: ByteString?, cert: X509Cert) in listOf(
+                    Triple(
+                        "Utopia Brewing Company",
+                        "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAAAAAAAA-UO7fwAAAAlwSFlzAAAuIwAALiMBeKU_dgAAAAd0SU1FB-kHGBUYJH7nXpkAABOZSURBVHjavZt5dJTlvcc_zzv7mmXIhCQYIAiIIiKyt1KLdcPtKi703rb2VL22t0W62HrusafLbe05VtvqvfZaq1dblyouLRY3RLEKYiAsIiIkAULIMkkmmSwzmf19n_vHvDOTSSbJJGDfnJyTycw87_P8nt_v-_v-vr_nFQCB9vrlwL1CiM8BFikln8UlhADgdIwvBEiZGnOC48WAD4B7Sivn1gp98dsAG5_hlV58XgMICVJMeLxTNGQEWG0E7k0v_jQMOuo15rgTXPxp8iIbcK8ItNdHActnbYAc12XsHR8-j4mHjgQKMmpMSS9-6M2GuuupuHr-nWPcxY_2uuB5FT59i_JPdfUJGnLozqfHzbdBOa_FxO6vfJaLOB3GlFKOaoi885X6b4GXcfgNT8X9T9ei03MYLfbH3iAxUQ8YCTajGSHtfqdqpBELmmRoTOS9MQwgxrVseuC0C55qiKTHUrU44cE-QEtlhlGMlM_wk92E4d9TRtud4Tc9nbgg0RgMdvPuU7_lrYfupLXxYDY9TiAUT4cnTBgETy0EJFKoNB2q482H1lNUVsH8K77Brqd_Qu3mZ0hEQ0ihjQC8UUMnD1cYbw3D_y8C7UdkOgwKJULZz8nCQUdI4tEQ-976K76P3-T867_PjHOWANDX3cqujY-gJuIsX7eeUu80pBQIJcUZhBB6epMglbyAmfXckURrrHWJgO-IzOKnUhjSiiHINS6PlyAkXScbqd34IMVVs1lyzS1YnSUIqUOQkGjJOJ_s2EL9lj8wb816zl5xMUIYdY9TQGipG0sxIlRzd1ibUDYQgfZ6mRpDFB4KYgh2D1-8yE3EWjLOoZ1v0_DOY5yz5jvMXfJFFMWIRNPfT6AYTSnjKxJfUz27Nz6Es_xMllz7VZzFUzKG0v20INcv2JsD7fVyeM49tZpAZow0EOig9sVHkckIy2--k-KyaSkvRgUkxz7eReP2V7n4tnswWeyp-wLxSIg9bzxP6_4tLLn5bmaesygVEoiCwTA7_7HD1Hi6mODQGASVhn07-eiV_-bMC9ex4AtrMJrtWdwQ0N1-nIYdr9HfspvGj3cy-7yVmCx2AMw2Jyuu-wbNc85jz0sP0Hn0Cs6_5DrMNhcgdUMUCsRiHA_w1Q9JwQWAmtB0t8_nepJ4tJ-6116g5_huFq_dwLTZ5wKQTMSRUsNoshAd7Gfzr2_Hs2QtdqcD3773mLviMs5eeQlSShLRCGabEwSEAp3sfOkx4v2dLL1pA2XTpgPKBI0wRhrMulUKrBDaiIJiaOpLAeXIGwsFfE2f8uZDdyFkgsvX_45pZy7I3sho1EFMxdd0CLN3PuZ4P_7aTXjOWkZP21FCvX5A6p_VQJO4SrxccuuPqFlxJe8-sp4D725GUxM6Z5CTKoDygKDIEJRcYioQKCNAJ_1aIhFIEokIH23bTOvul1lwzQZmnbcCIYwZjwn1d2N3lSCEQmdzAztefpSqJVfQ_NZjWOnHOP8mTEYDDjXEypv-A0UoBPt7cBVNycxHAt1tTdS99AhGm5vF191KsWeq7g2cmgFGoKaO5OndzsWE3DDp87dQ-8LvUUxmVtz4LdyeCn3Oeq5Mpy89TPa-83cSMknH7s1UrriBzpZmXIQwFk3F39HJtbd_F8Vgzs5HSwGLEKk9T8Si7NvyAq11mzj_hv9kxvwLECgFk7Ph6VPJWwRJoRMOkVdpSXlKksO1W3nn4fWcsXAVX7r1Hlyl5dm0KDQQEOzrydy0P9CJarbSuucfEG6j23cSzxkz8TfspmP3M5TOPJOWxkOZiQ70-pEZApRSU0xmC0uv_gpLv_IzPtr0P2zf-CjxWFA39MSLqdwQyIP-ue-l3o8M9lG36U-Euo6y-Ib1eKbVEOzpRqINM5mguKwi86p-9zYOb32CypU30XbiJMWmBKGWjyhaeDXxSAQZOI4CXHz7T3OMH49FGezvQU2GMRjMlEydAVIyOBBg96anCLY3sPzffkhZVc3Y4ZCHtCljFjtDSE3GckLS03aCsP8Yl3z7Psqq5zLQ7cM71UZllZvKSjcVVW4qqlxYTIPEoyEdJAXBbh9EuvHteI7KGTPoOlKLGvYRDgWRgROEW2oZ8DUi1WRmCp3NB4mFTlBeYaNquoeSMgudzXuRUsPhLuWir66n9MwLaPukroDCeqRaYhw75-sZUg4ri5EYnSWYranc7vf38uHT_4WUgotuvYvtzz1BMtpDNDzIhbf9mvKpTno7WkiqcaZ9_su0732L9vefpnr1vyIUhfCJw_SfrKNy8fWYbE6aDu1l1oLlIMBgNuJwO-np6sDudGGyWojGIqhqEqPRjEDBXjwFLREdn_tn6ogsjhnHVVXlyFyPGMrKBOFQGDXoQyAJ-HzEOz5m2oVf5tjuLUSjCYQQqKpGR91GqlfdQtWyK4lFkxjVCMEOH-ayCmZM_yqK0cyJrY9gX_PDtN-BNOJrbqenw4cmJUJAdyCE23MWNrsTq9WiA6QcUSSN3n8QYzPB7OKVvLaRMpf2CqMh5VxCEEwYCEVVmnduAk0vawGzzYKKCUVROL7t_5h75fdo3PIoqFFmXHwHTR9sYvrSy0hIK1anE6SWqdbr64_je__PGAwGkppKQpUMJm0c_vgg6390V5p-FsAJlRHCS8GqcFYgUbK1kD6W1e5AlRKTu5r9rz2Pzarg9NaQjEewWMwgVY7v3cGsL34FYTLhnvF5uo5_ipaMAJIT7z1L9ZJLifQHmHPFLTQd2AGaCkAorNL2yX5UTZJUJaqmYTBYuezqq1mweDGJRELfMKXgFDgpA0i0LCiK3BTpcDnRVEki2o8zdhwDEk1ViSclRUUlgIK1yMvRd__CoL-DWStX4z_yDzA58Z57KSI5gM3txu7x0vDm08ikBkYTAIkk4P8o65QyxViFQPeSVGIWaHnCdXz5TMmJDzE-isp0Th5yFbndhGMqQhE6BxIkgj6Swo3D6SAaCRHsaqZm1U0YrFbMdjsIC1IaMLtK0DSJ1V1CIhFjxqobcZR66Dx5VK_ttSGZSyKkXgxJ8Hf6URSdYgtl1NJgLIlNGdqfkzK10ymio2X-TlPkDAWWuZTZbLUQSQoSoQAm93QwlZCI9OIsn4UQAovNQaC5nt4TDQhM1D19P3O-tA6DfQpgoPqiW2h8_00G29tIhAdp3v0yruJSXQgZQlw0kFKgJeM8fP_9LFm5AqfTSV7Az_ykBFdNZv-TvxwWkmQ8RkdTw3B9FoFACrA6nHirZjJ15hw8lRuQusnD4Qg1S9bgsBkwWW0kYlE0NUlfWEPVUsaavepaPn7-xwjFQMXC1Rzb-hRzr7gdT1UFBzdvxOQoxeGtpP3DZ6m-YB12V4leRSaxGI0ppJdgwsRgLMkdGzbgsKfK47lLv4CiG6qvp5OBHn-GPcoc6i4pKa_CXeTJYwApMBpNlJ8xPY8tU6nDYDSABLPFjtlizxhH0zSSwkl_REIEJBYkFjAZScTjmMxmpp-9iJPzrqL38GY0bTnTll1Hy8E9KCzDbHfjnHoGrR88g7GohvMuWau7tSAYDLHwa79CSjUzk3A4QmhgAIfNBQjsjqKMSuVwu7HZbEMMMLQpCUarPSctZoqh8Vu6clTZS6RjEC03lQqJ1LKfSySi1Ndtp6t-D1Nmn8vsRRdisjhoP3qAxu2v466oYd7nL8dVPCUzejwWIxaLjchIDqczJZUxFLuymuGY5xGGendBBshDE8KDIQYG-rHb7bjdxSAEgR4_8Xg8x-KKwUhZuZd4PEFz03E0CRWV5bjdboRiwNfaBkKgCFBMJkpLPRgUhU6fD4Ap3jIMigGEoNvfhVAMeDyeLKeXMlswC3SjjK8GTzgNDidDg4MhfnH7tbS3taXlTxobGmk92cz777zNY7-5j2gsyvb33qWtpYWH7_sVFouZ4mI3zz_5Z_bu3gtobNn8Cs_84fdEY1H21u7ioV_8F4ODQba98TrPP_6HIYuR_P2FjfzktpsJDvTr3qYhgYa696j_8C2kLKw3MLoBhFZQp04IidVqJSnB7rDr4SooKnIx-6yzKK-qxOZyMaNmFldeew2_v_fnrFl7A9Nn1lBRUcnNX_86T_7ye_ja2ynxTKHU62X6zDO57Kqr6Gg6zIF9-ykqKcZdXIKiGFKldF8_8xctoqx6Lgf27c_ZjUion0gomCXnE2jcGHPjWoyp86cGzvRRMCpiCCUUOiWVekimxjrZ3Ex_60HKvN4sbyh2U1I1h8ZDR1AURT80oYGUaKqGQckSLSFT27Svro6Vq1ahaZJX_vw4S1csw2yyZmu8PDJeIQq3klsppoWQ_I1JKbWcllWqOFFywCHN_YUOwYpiQKQnkO73I1BViUHXCcP9vRxtaGTTCy9y5sKlnHf-ogzmSpECwrod77P19S243C7UeISGI_VDdEEJBbTC8nmGklc-FjLj1jmF8RC0NZlNoNgIh6MZo4RCIcwmU85w06qrKaleSIevIyuj9fbR19XC3LPPQmoaisGExWph1cUX8a27foTN7hjSeJEcPnyYr33zDlZfupq2lhaMBoW3N2_WNyU9ZTmpPmZ-EBzWf5NS5rbCkFitNq7_5t28-MRjHDr4CXV1ewgPDuJ0F-H3dxMMdBONRrGYLXzzxz_l9Ree48inn3KyuZnnnvwTd_7qITxeL_6uLsLhMFMrKvB4ynRU1wh0Bwj4_fT29rDznbcp807Fbndy2ZqruOPHv-Ro7d_Zu7suHXXZ8jnPCZOxQLHgNJiO_7TbDQb7sDld9Pi7GegfwOlyUV5RmUqH3X60ZJzi0lKMRnNKzIxH8bW1o6oqU6sqsdsdSAk9_i40qeKZ4k2lO_3q9vvRNBWH00lkcJApXm-qnBUQjUQIBQcwmU0UFZewb-vfEGqChZeuG1USG617VHg1KFNUVKAQDvbxxoN38d7zj-NyOpg1ezblU3U1WGqUekpJhPsI9nYDKu3HDjE40EtlVQVWo0SqSQKd7fT3dGC3GXE6bPT7fbQ3HQZUOk42IpNhvOXlxIK9mA2aLsCnYt1qtTKlzIvb7ebQzm0ce-8p3FOrJ3TuKO0NE-YBUkrsrhIu33AfajLBq7_9Aa3HjugAqWUwqbezha7WoyiKQk_rUfo6WtFUlV5_OyaTAdDwHTvAsY92YrHa6PO3Y7akCE-g9SjdrU0Ig4H2piMIZeQ0w8E-tj39MA3b_8qq2-9n1nkrxxREpRxZCAEY7v7Bd36WSYEToIJmi4MZ5y5GM9moffbnJBUX3ukz9bwtGegLYHE4cZWUoakaUkgcxVOIhAawO4twl5QRi0Sw2JyUlJ9BeDBIUk1SVOIlHo9jNJsp9pSjauAq9mDU9QEh4MThj3j_iZ_hmTGPC9dtoNhTOT4AZjiOGOV8gJxkf0VIAh0n2bnxf0ExsPzGO_CUn5GZbLrjK4bUJKnSQsvSdylySIzUP5jtU6SmHouG2PvWJjoOvMmi6zfoByyUvClwZC2g8xeZzwDyFE99CUkiHmbf1ldo2v4si9bezewLViCEYYhcJzI1lZQqyUQMg8FAsC9AkcdLMpHAaLLknMBIExkhoKutmR3P_g6Hp5LP3XAbdveUUduCYx6XGUb0CswChYWIFBodTfV8-OwDuKrOZsX1t-AoKqX9-BHUZAKJxrSas1GMCtv_-ieqZs0h2NODJiQ185dR5K2io6meRCIOUmPq9NkYTWYOvPcG9VsfY-G132XO4lUIxTTmbLK9zpx6eNgadK5TWDksh_T7xhfNwqFe9rz6HD2Nu1h04_epPmt-SkwVKVdPJuNs-ePPifYcw2AwoSgGln35HrzVc1LiCxKhQF93B3V_e5L4YIClN3yLKZU1BR4qHELa0jL4CIqfxwCj8uY8B5TGNJbudo37P2Dvi79h5oq1XHDZWowWK4reWPG3nmDHX35HPNDIvCu-zYIvXIWQSkbCajpYx96XHqB66bVccOlaDEZrphdR2NE9mT3KI4V-xEbkyhpC5PeAXBExP3iMbXmR8biBng4-fOlxwv1drFh3J-Vn1GREFjURIxzsx11armOEIBLqZddrz9F3fA9LbvwulbPmp3QnOdkQHX3-oxpgYvEvc4-OiZSnSL2LA4KkGuWT7VtofPuPzLv8O8xbeXGqSBp28tN3ooG6Fx7EWTmHZdfcgt1VWrjLT_KUwOQUoTHdf6g4L7LWF9DVcpTdGx_E7C5n6fW3UuSZihCQTMTYv-1VTtY-z_n_8n1qFqwAYRi1wjtdi5-UAQo6QSY0kMqIz0ohiUVC7H1jI23732TxjT-kuLycXS8_jlAEy9feQXHZtEys_zOO7Z9mAxSYLlFpqT9A3cYHQO1j9up_55wL16AYTAgpChQ0CzgcJv_ZIVAA8KQ9REoIDXQT7uvDO312CgTl-G6ebwPG7gSfbgNMgBOMNUbOfEV28fl3PyvDpTq82uSp-zAvVSa9uwUvVht5fkcKvU7IHBUeR8zU9X6p77Qc_7mBMcc6NVlcTMxbRiu0pBhxWOFUTqjmLFoUPpZxUh4whv6ea3k5IaOd6sMZme9N4OsKqWdpR1VO8u7caLsmmOTi5dj3LMi1J3XFFFIPEk9gN8SoL3NPc-sSe0FgJQrEkvyqzilcHyjAPaQeJC5YVs5xeUTOQ1WnnahkZF_dmJO5R_78GgHuUUor59YCq0k9QR4rqMTMIy7mW_zpMEhqDDE5EM4J26zb62tdXVo5t_b_AdFN7yyheCI4AAAAAElFTkSuQmCC".fromBase64Url().let { ByteString(it) },
+                        "MIICRTCCAcugAwIBAgIQJGQ57Z_GIpsZ1bBj_H9w-TAKBggqhkjOPQQDAzA1MQswCQYDVQQGDAJVVDEmMCQGA1UEAwwdVXRvcGlhIEJyZXdlcnkgVEVTVCBSZWFkZXIgQ0EwHhcNMjUwNzI0MjAzMTUxWhcNMzAwNzI0MjAzMTUxWjA1MQswCQYDVQQGDAJVVDEmMCQGA1UEAwwdVXRvcGlhIEJyZXdlcnkgVEVTVCBSZWFkZXIgQ0EwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATxQFn8bIEIaMONgvtN3ndBNB6piOwHo8XF1vj7Lpd77w-wmdWD60Ia8nHh7z4LmdxbxcgtODb5oDehnW8kR4lR0Pw0V5iUMJRiVb0AsZSOk-WKdfS847NlT0Ip5B608WqjgZ8wgZwwDgYDVR0PAQH_BAQDAgEGMBIGA1UdEwEB_wQIMAYBAf8CAQAwNgYDVR0fBC8wLTAroCmgJ4YlaHR0cHM6Ly9yZWFkZXItY2EuZXhhbXBsZS5jb20vY3JsLmNybDAdBgNVHQ4EFgQUddH-bvOvKZEFSkMWS8ncN1LvXdswHwYDVR0jBBgwFoAUddH-bvOvKZEFSkMWS8ncN1LvXdswCgYIKoZIzj0EAwMDaAAwZQIxAOCgXroeWZOkvMcZHn9hijZesYMTC-3yWZGS39ieBRupLjTalHoy6CDZlE_H9CYAbQIwZa-iyQpLzghYOCiXkhRtoe8V8XCP8JwxuQblWQYdNWGohOeLowR3punD3UcJTAPS".fromBase64Url().let { X509Cert(ByteString(it)) },
+                    ),
+                    Triple(
+                        "Utopia Plumbing Company",
+                        "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAAAAAAAA-UO7fwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB-kHGBUjMFiPZdwAABswSURBVHjarZt7kGVXdd5_a59z7vv2-90z3TOjkeTR6C2BZISewRYvBygSoIxtqMJlIARSEFKOY8c25aSwYyCOsYmxDSmDTTAUtrEDoTACSQZDJCHQICHNaGY0PU91T3dPP-7znLP3yh_n3GffHinlXOnM7fO4Z--99tprfetba8v0Q6uqKOn_7SMCGgpRer39kfY_nY9K981_wke7vk3fNZgwMJ8Fzwin6pZ1FdDu3pl2L3r63L6ife0J_v4saDqA7kdUpD2cWJWmg5qFixaq2i-Q1sf1XtCuU-30Q9JWVJKb0hpEeo4qiusMRIQDPuQMbMTgizIZeOSs43yc_lRb7dN5l7be6XqF2dUv4evL2vOjlipIIs8MUPaEsi-UfUPGEzZDpeIcHrDhoGI1eXX6O1HpUg5NzlW7tEd2zO5Oibb6oYz7wrgv-CJkPUPTKSuRJWuEnBFONhwORRRUtWfwyYi0_d09VgH8Xg3UntlzQANoxMrFWBFRDhU8fKP4FozAlTmPulXONC0VBx29ac1uW9SoKiLSO9hWh3eojbSmlWHPEKDk_GSwRh0zGY9KrGzFyr6McLLp0u4Loq0JURCT9El1h5xVOwvtRX32-FCLHU_XHTWFrBHONSzLkWNP1sOY7oXUdWhySPfqTK8NNAPqUHXpbwWnSt4z4JQojlmNHT-uxRR9IQAsMOl1aY4IRgREOu_pXmIALtEK0-lIp6ODOjZsIOvBqaZjQpLzjcgx6gtjvmHLKpMmmeXkcF2HTb5Jz12cXMOh2OS8daTPtISwEEDRE043Lduxsp2Ox6lyohYxkTEsNy3DfmcuRZWFjGmPQ1UT9e8bl6p2LYEdhk27jAhMZ4SlpiMnwlggrETKRCCcaFgWcz4jnoDnsRbHxIPWtejOZdbW-HTNdtkfEPIoJd9wtG7ZmxUaTnuWawOhEjumA0PolJJARSErUA6Ea4yHdS7VICFjwBjBdHk8f8f6b3emc33IQOygqXAwK5xpOhQ43nQownZkiYGSEQ7mDc_U7C4ern_wOuCets8nA4_1piVSR-w8qrFDnGM2MKxZaKJsRo6cETatY9hLBDJsDKv1mA2r5AU84FKkbV_gC2QEPBF8cbqjp3kRYlWidDbGPGGt6RgWIVlSSkag7pL1umKhaIShrAfAlIEVqwPtiGi_RqTWue0SO8LIGFiJHKhyvhGzLxcw5gsVq0z5hoIn-EBghOVIGTVCVpURD47XHTY14gMhS9q4CQSCVCJZgSxQEphprSlVsgLbDsZ8YTm0zAeGulXEJa4HhYpTlhoxy3XLZMZDXDKYnqNbHbpspKTrVtq2KPlqWKXpFKNgFWqxJRDDROAhqhyvxyw3LaFT8gpDnrA38DjfsNhdMFZ_f_xbyobErkjLOGJViBWaqqynPl5VCVCqLuld5DpLRrWDJDdQZrOGolGq2nH_2mdaehDbAGXxgAuhZcwInioXnZITYSu25Iyh4BkyVhkODE2rDHnCWsNywbrBy68fHqbX_GPbyfptprDXpT40Y2DK89if9TCJu6Cl1eebbgB87fxVjRzjvqESul6Aq4OBb3-n9gZCIMJzoaPkG9ajZIl4AqFNvFHVOuZ8IXZKyTNkBZ4O7QBMsws8Ty_7a_HgtRpaOGsthMqVBR8vfWcOmAsMz9bj5CUDBL4ROeayXqJOl_vsBO0EQMkzHG24VB5K7BJjGztHbB1nIstcJsEdeRHqseNsMx4IK3rg74CP_4KxiQiRTWyCJzBkhIwnLGQNz4eOcMDPtp3iiwwa3wuoAEz4hq0o8c9xurRMujbrVimIsO4cpxrxznhjoN5fvgO-DFozPbMknK5FzGY9coHBGSUAYqfM-8Kphu2DsnRshjqiltntCRZ2b8sqeAILgWGpGScG0CbGdjWyLGY9xGmfMUnskAwY4AuJwe-fDNnhujVd95aVMEFcjVjJeULTaU8E1w6mEKwqRRE2BrjZzsynwujS3dXIsifjsRVZYpd4qGYiUUaNwZMBKt2P8F6EwrXG6SvKbtF8_3mswlpkyRlhwfd4rhn3AqfUjZU9IbKOghE22hrWweqd-KdPGCmMPtPU9uyEVvFQYlUmsgar4KPEAyJ-dvMusvu4_CT27g0WRYQbvEQVN6xywpFGccp1BgKNKfqGhidMimsF7e0353wQHFu-cD5KQ1R1vCJnOJw31KzycNVx1CpiOsTHQZNoDTgMECIcrTWZz_ucCRMsMCXKkA-rFpb6nNH1fmI7agpP2z700yUV7bJOwl-d0h5znKrkxVfOMZTxePC5Te7_0XYbvC3dN8V0KcMPlms8vdrkZw-PIh2KI4n4BJxTvvD0Om872eDtJcMHri1z9UQJ3yT3K82Yh5c2-bdH6xyNk5E8etso108X23PoVKmElofP1_m5H2_jx5bTr5mn6Ht87cQl_vlTlXbXX5kTvvSKOXwjrNUirntgmbUewDHYJJsdqyO1L74IgTF4pmPEVME3yXVfBFGX_G2EoHXdCB6Q8QwZA28vKL9_5zSHp8r40jGQxcDjNVdN8KXbRpnVRABB2mZgBE-EjGeYKGR5wxXDfHxvhpGMR87z8E1CjnRTWG9bKJD3PQJjmC5m-NeTQb9V3sUI6gDLp71RV3IuvetMhC8tRxz99nkA3nPDOHPlLKc26nzqmS08gRNNx6_fNE7BNziFB05u8uWlbUYyhrdePcqhyQKHJgr8lytL_MLxWnsazm81eN8_LjOTC_i1W8eZLmZ4xYFhPr6yilUHJOCsRXx4wMv3FBMX3IwoZwNeu6_Eh5bXd6563SEA7aXylC5gvAuESx_8dj3m77YdgvCLqRrXQstn1iIip7x6xOPgeAEBHjy5ziuPbKVvdnxu7SIP3zPFnuE89yyU0KPb7TatKn9VU6iGvOlijZlSlrwvPLfV7FPUxIi-e9RjbihHrMrnnlrlnTfPcs1UgTv8Nb4TSifg0C6nk56bnvgf7URpfdTADlZVlWIaaqr2wmFJtea6oUzbOnzjXD11Esm9U1Y5slIHYLQQMN_VbjYw_NZslo8v5LhhtgTA8lYDda6jh13EzRv3lQBl6VKdj55ush3G5DzDOxeLncinjQta58m33yEre8GT9i-BAWBHVMkDlT69cqo4TeKH1guDAWjEl05jtou3mypk-Q-3z7T5w8gpn392G0V6iU2nXOXBLfNlBOHxC1VOWnhqucrte4e5c6GEOVbBmd0xaSIA3YkWXApgyjk_GbyDg55Syph2pxTICVRcvxNJQtvHNkOcKkaE1x4Y4pNr60QuISYOB8LNswVQWK40CY1pCzm0jrV6hFNYrcd88fgWn75kGUv5BgAxBhHhPXMZSpkEz_3UFcOcXyxTCJLzPUNZfnFI-OOt3SGSvxtsOrfZYDQfcONcmc8erPPkWpN_cfUIpUyAqvLsRgOjycz2kCoKTZeEzt-vxTy5XOH6mTK3zJb46u3CgxdqjAaGn1ooM1HM4tTxzTNVRnzBpB5npRpy50MrIAkh2gqSciYlOwGMcrjs84orhtuqO5LL9IbURnjTFcP8yeMbCciSFwyGOtbh88c2-dB0GV-En71-Kp2c5A1rtYhPnqygCJkBL92KlelU53_j8XU-eVeGqVKWm6ZL3DRd6iElHzm7zb85uk0dwaWo0aXkSr8FL6trC8SGlgNRzFUTifX_xsl1PnemRhg5okj51RtHuX52iFvmSyw8vs6SSB9OTL6NdDGpoh0T-eGVmN_97nnObNSTDI4IkXP86Pkt3v8PyzwbC4LDmKRDW2HERiOkElliBYvSjJXvNBxv_eYFHj61QTWybVO6XGnyF0cu8qr_s0Y9FX4lsmw2QqqR3cEUtVzeZiNpp-ngZ-ZybDVCNhoRXzxe4YsrId-tO55Q4YGzVbaaEYrj56eCnnSMdKXyRD5_XAdGQ6nl91DuznvMZQxP1WJ-ECXRV94I83lDaB1nmornUhMlhhjIeUJBlKmcx-mapa7CJI7b8h4V6_h2M8k_dsMQH8WQqH0sg2O4INUAJwmiNNYlkyOd7NOIb5jL-2w3Y55vxFjj4XalJD73rA7KSg2KHEQ7sB_gmrLPRtOy3HT4niEjsG2ThyYzhvVYGQ-EiZxHLXLU4oRodSS4vuUtWkytl_5eL0OV7dDiQTnI9H178x6qyumGSwTQA42TH_k7YPAOCrWbve1tpdqivEQInTKZ9ajESZy2EVn25jyebzo2I8t4YCh6hthpOymqKomDUSV0ynbkegKVF5VEHnRNIFY4VYvZk_PZn_c5WYu6XHsXIYIdRAKQJP5I6FhJbUA_KlxpOvaVfDZiS906qrFjX87nVD0mVjjfsMxkDarCpRiq1raDKh0Ub6cC10HQvD9_2B1lt9RfU3hs0rSYwNl6zFzWY0_WcKZud4zTyI6UWHKIKn957RBH7pvmR_fN8Nhdk_ynPRlQx2d-oswP7plmTh2NyDERwCeuLPHwy6e4Oass5A0f2Zfj0bumuT2AX92b57t3TvDHVxbaQdV_ns_yxF1TfPG6YYZQ_uH2cY7cO82Re2d47OWT_O7eHDjl01eVeOLeGV7qKZ84UOBH90zzvrEAUeVnioYn7pnivy7mEIRbM4Yv3zTMifvneO6V83zlplGuN8r5eoQvwnRgEmDY5bYNXVa2-8A5rhjJcs1MmVwgHBjP88E75nnfRIYDo1kOz5YooJytRhR9j33DWQ5NF8nHllqkHBwvcO1MifGsx8JQwOGZId54eIIbczBlLG85PMa1s2X2DweECoemCiyO5RJeYKLAe2-f459lhH3DAYdnywwZZf9whsOzZT542xSHfWEiMFw3N8Ri2WfeWT5_3wyvPTxNPjDkfeH-q8b4pcU8KJyrxYxmPTItHiAdp2mrmPato5a1Be77-jk-9o8XCIzhZdP5rucVi7Bcjdt2KJsNWI-UqBkjImhk2-xwOePx7j0F3jaZY2E0n9SBiKEgya9XKk1-_bFVvn92E2OErNcbgWqa_98zUuDjLxlHXRLFGePxgX0F9o3m-eazaxz827Nc8TdL_Pu_P8X7jtfayHW9HjOb83rD_uQl3Sa-i2hMB_WJG8fYP5pJEWDI3pFsmsV2qBMuNWNcGCEiBL4hq67DMaVxuwLHViu8-upRVqsRS5dqzAzncc61hX1gvMgXX7MPI8JTKxVOYMBLoHc-5yNeAn-PLG9xx_4Rzmw3U-DkuHo8jxjhr49tcG0An71vHiPwlobl1m8tJyRPM-ZgNkteLDXnkJ76gF0MrwHuPjjKzHCev31ymQ8tVdsMrIgB53oKHwIbs1gMyOc8BEljiuTeV05sMVvOcd10ia8e22il8lmLkmBiaa3GLz9wmr95cpnDUyXeMe6hcSKgWi3G2SRX8AePrHBhs8GbrptuI8rNRgKeDo1maChc2AoZyWdYHM2B61jMzaZlPGPS0gO5TF4gHWSscPBzz7CM1wMLjAj_8fAwcezYipWTl5o4dbznhknuuFDlZQtDVMKYI6HyBj9R5e9txZzdalAMDJ9ZbvAOSczwFSUfBApZn-un88yP5pIlkw8QIz2EKyT1Sh_-zgU-dv8-8MD3fT59dI3XXjPG22-dZWFojY16TC4wNGLbqRMA1pqWA2W_HbT5OJem43eWqUROidJ1Jl21N04hdo7XXT-FIFzYavDSvz7JS-aL3LIwwpWTRSphzP949AKPbEZEoSV0js2tJu_6-zNkRXh0OyJ0jjh2nNiKiB0M533ecu0ksXX86PwWf3h0g9-7bYooZYtjl-QknXN8cj3mjiPLvOmmWSJRHg2V3374HO-5bZrXXDuNAhe360mStKsYyylEsWPETwquhE892aqs2ZEh2GuUPMoxJz0C2iOOktAmQ0NVTjpBjHBPFvbmPB7ZinnGJo3PiDIsynFnsF3A7UqjNBTOOOGAcSnPqDSBU2mbc6IMe1DPZQlrESV1LDloAhkRFsWxqcLwUJal7ZC8c9xTDtiKHUfqloIRzqi06q1AYDww5H04W3cdAfTm7xkYOr7Yz4vAcjtqBl6ovaIRhgLD8w27swGB0cCjGAhna7Z9c7c-ZEXYW_I4vh3j43pRlvansfozOvJCucQdjOIuWaGufAjSm0gV2VGxVrWOsp-wxfGAOqZLoWU8F2BI1Lw_KSZdYglVMWrw2nzAbtVafb2dFeWnRwIuNi1frSRRGAL7xHHnUMDZhuNbSR6LKVGuzBg2LDwVpW7Oh_lAOBcmhQ-LWcEIVKzjh2FHgNd4MOQpjzaTCrBAlVtyhlUHTQ-i0HJj3uP5GCY9pW4dP4wNcWS5q2S4WHc8GQ1O3XfDnLy0KLHL1Cq2LvzWYp53_uQc46Us1ilPntvkbQ-c4x37y7z9tjmKGQ-n8PjpDX7-wfO8bjLLb7_mIM-tVrjqy0sgwp-9fIrbD4zzZ4-cY60W84F7FxNSWpUjZ7d47TfOcVGFL71qLwcmS_zK_z7Jx87VuSVnePCthzixUuHl_-sUP10O-MKbD_HZ753hxj0lFseL3PeFZ_mF2SzvvXsff_Tt07z36PbO8t6umgHnlEBavGVLJInukBUY8w1TmeS4v2x4_90LWAf__eEl_u7I84RWublk-KWXzbO63eTjD53mgWcucuviCB-9ZQzPGDwR9o8X-eX5PK8rerxk_zgmNXQGxTeGv_z-eb7-4xVuXRzlvQsF_mVZODhZIowtr79qqJ2D8BCuni7zRzdP4FLzKyiffnyVUsbnV64b4Y03THN2vcpvPFsZUHvYiWoFqEWOkicdDRBgNGMYzno452jGSuwSFX_9Yplc4PGR75zlT881uNis0rSOP79pjIzv8aFvLvHnGxaObfH0eI5bF0d5-HQlBSghb7lujAsbDSrNkLFCrieXem47YrtpUVVyvsdbD41RC2O-_uOLvOraaW7KXsRZi1Ol2oh4_Q0zHFurpqvF8AfP13nzc-u87oYZfGP4nYdPc8le3gRnJGGkSxmTBL2BCHtLATlPOFuJWG0kcXnOT_C4TeGqbcSEVpkvBoxnvLbr7CkQRdqssIjwrWcvcc3sEHdfNck3nr5IO8eU4vp_d-8-3nXnIsdXtvn08Uvctn-EcxsNTm02KWR83nVFEaOJFjx0bJ3zGzXe_bK9mC6z9tHvryIIx1a2-cyFBnvzPmWvU4TtAyVPmM4YFgqGmZxQjSyV0GKyAnuLPpfqMbXIsbfoM5kziCq10NKIHF85U6URO971k3P82mKOjxwa4oH79_Dt57eJrOU3X7HIfzs0xNfumubgdJlHnltPOijwxLkK5y41CK3jfx7bTNPjHQ799x96jrd9_ilu__ISb5grMFHKcvXMEO-_9wBWHfccHGtnpptRxIcfPEMpZX815Qm_utkkdMpaJaQaxpythm0j7qtSMmBU2QhjzlRiTlctl9J9AP5s0We5GjGUMeR84UI1pqGdbI8ofC10_N6DS7zrjnnec_c-rCpPnL7EIxX41GMX-LkbZ_hXdy4Qq_K9k2t88LF1Xj-VIbIWp_Cb3zxN0YO6TWmwNH6wTjmxEfHZ9RgRePVPjLPdDLn3L55h08Hv3DzO62-a54YhQ-QcVoU_WY258_vnefOtc21HZVIm2VrFM4JD2E5TdTHKRryzQHMma4isQ6b-9IgqUMwYTlfjdsjZoWwSnCACC0a5fzzHJWN4aKPJauhYLGfINkLuLAc8V4v5Ri1xjxMoBwJYimAlfV0euCFruGATSLs3gOORsOYSv35zzqAi_KCZnM97hsWMcKZpmckIqxE8ZyEryk25pEbpVIqLXpoVth1sBh6eJDWGsWsnw6hESbFVy6iOBMJQ1keCP_yhLgwFLG2HSRncDhAhPRCxFQUulAM26jF155jJB5yuhD1IEu2tTejBQtJVS5Cea1cavzs92UKI8_mAamjZsA6T4iahp-C03d09eZ9GrDSdI3ZJ8NQD8FLgN5XzMCVfaEYO6zrVk6Zt3ropsk5O0anjfCVkLOcR20SVy570Dl5kQNq9-2_plCe30pOqPRWmrXtFI2SM4JmkXxMZL_FaviHXX_7ioB458oFh2yoN118uI-2K9pW6xc95QiOyaX1OX4H3QEibCCN2SSp8IuOx1YwZCgzbUdyVXdWemqDB-adWJWB3blHT_zoCHc37bYFLWrwhLln7IqBdMFo1YaSH8z4mBVk9dLB2dsWoaJKOsy9YzNefKJB2bF3IeFRjxfdM3_N62erQy1dydfSvlZ-P6GiJST1A5NKNFHTReiQ0XSNyjGVMymh33-8Nc3xrXVK64roKe7tzAi1v0OLy00BFBGKbMj4u9fuuO6nRaUVl9xIVFe3JP0g__Z5Sc-oU55QMnU0Z25FlrpiBRpx6rZZBcKzWIvYMZVhvxO1M984SfTCNWMn5prNzqxsadxc-pI2SgiJ16c4Ql5TOd3bC6C7TLoNDSe2ed2m_s_t9sVWmcj6BJxQ8Q5TSZN17fnr2KrUSLQ3LTN6_bAGhCa0SmC7JI20jlSQPpdN57TSWkBdpubB2R7CSmvWdG5WEbkFID3rslNlJVyImOVZqMdVmzIVKhG-SAmlfhKmsl5bzS2_WRxONuViPMO3nBqxQB2Ys61EPHZOt4oOutbRjDUuno2NZD5EkB68otkXu9qhiKp30aGtHPxWvXW21jHHXs6pJ5jhO6TAvDYQyXiJk01pirve96uDcdpOsb5jOmcRy9bSpGN83VCNHKetRMNIXDg_IGAHjWR9FmMr51EPLaMajFsa9OtZSD9klItf-LYSdaLS_Fql779J25MgFSei9FTp8X2hat6tVdQpnKyFKEu-U_V46yV-phMyWs6xUG0yXs1yshFRiN8BoJR3Ie4ZixqMZO7KecK4SspCWx_VwL9rHc3XXr-qADXw72CDZWe6ebuKwLgnIRJRG02Jt1xockOFWlJV6REaE8ZzHSM4ntEotsvj12LFeDZksZLlUi5guBhSbMRcbMa57AJqUyc8PJUmRWODsdsieUsClWphudO01etKbiO3TkN6SvF0rfwfUWp-vxhS85O9auv9P-6x7b9tpsZXC8zWLoBR9QyEw-KrKRjNJKowWAy7VI7KesH8oR2wdkXNphaghn_WI0gKmhlX2ljNUGxEboR08tj6Vb7vS3TralY_Qy5GtqtTiwX6lBbBU2VnZlmqIAtuxoxKnRVJKEirWYstMKYsRuFRPih1zJsmUV2PHSj0EDGM5j6lCwGolZDNyOzqnl9sSwy6l7fKCmzsGKcMAyvMFCjz7yiH87mebVjm91SDvCSNZj-Gc3y5hL4gwYkyyEcIznNtsUrO9KFH08nS4Xu7u_wuP_v_x838BRFRarEI8qToAAAAASUVORK5CYII".fromBase64Url().let { ByteString(it) },
+                        "MIICRzCCAc2gAwIBAgIQZjjem0ED1YZfrJXIp0QagTAKBggqhkjOPQQDAzA2MQswCQYDVQQGDAJVVDEnMCUGA1UEAwweVXRvcGlhIFBsdW1iaW5nIFRFU1QgUmVhZGVyIENBMB4XDTI1MDcyNDIxMjcxMFoXDTMwMDcyNDIxMjcxMFowNjELMAkGA1UEBgwCVVQxJzAlBgNVBAMMHlV0b3BpYSBQbHVtYmluZyBURVNUIFJlYWRlciBDQTB2MBAGByqGSM49AgEGBSuBBAAiA2IABL6vQpn6zrHonK43hm_WED4i3W63IDDA0mtvIzvsBHSGl7YK0Tu7GiqDBNWXtDvxowB8upQv6Us4JVzqI5kzR4D142vmilOb-J9AhOCWxnqmEvqOTSVi_PX9r4DrDWVHsqOBnzCBnDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH_BAgwBgEB_wIBADA2BgNVHR8ELzAtMCugKaAnhiVodHRwczovL3JlYWRlci1jYS5leGFtcGxlLmNvbS9jcmwuY3JsMB0GA1UdDgQWBBQMJBLQ4z7QV6bb6Hg_NRlsprAzJTAfBgNVHSMEGDAWgBQMJBLQ4z7QV6bb6Hg_NRlsprAzJTAKBggqhkjOPQQDAwNoADBlAjEA4ZdSN9L3fLu2uuLbvctEhFap1myoYongcIlkFaiBnVftzc2U8Ziq9fk0bhzwUoYaAjBhZcjyGABTQYv2KH4-Nasqnjnw6PirUmutpPN15G4jzQ63hUp_X7xMfGSQ8Rd7ibU".fromBase64Url().let { X509Cert(ByteString(it)) },
+                    ),
+                    Triple(
+                        "The Utopians",
+                        null,
+                        "MIIB4DCCAYagAwIBAgIQ6rXL1BAAeNzwRX2GH2BGqjAKBggqhkjOPQQDAjAhMR8wHQYDVQQDDBZUaGUgVXRvcGlhbnMgUmVhZGVyIENBMB4XDTI1MDcyNTE5NDQ1MloXDTMwMDcyNTE5NDQ1MlowITEfMB0GA1UEAwwWVGhlIFV0b3BpYW5zIFJlYWRlciBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLqZ3qQWauWFQo0tbTvhnViU2kBJ4jKPkXxZuFtwlPyF-mYZzygtx5tReifmY9vQXxqi_QVwAAsX6sVZK9p42C6jgZ8wgZwwDgYDVR0PAQH_BAQDAgEGMBIGA1UdEwEB_wQIMAYBAf8CAQAwNgYDVR0fBC8wLTAroCmgJ4YlaHR0cHM6Ly9yZWFkZXItY2EuZXhhbXBsZS5jb20vY3JsLmNybDAdBgNVHQ4EFgQUG2vN6fsoBdTeXaUMbiX9MxtpldkwHwYDVR0jBBgwFoAUG2vN6fsoBdTeXaUMbiX9MxtpldkwCgYIKoZIzj0EAwIDSAAwRQIgWA7vaJVZgg8CebwCTxDgPu8w_2GvLVAHMa_RprUUSScCIQClOLGmxZFQLnKqT7Jy_EHXWM3oJUhyVeehOWauMMJyzQ".fromBase64Url().let { X509Cert(ByteString(it)) },
+                    ),
+                )) {
+                    add(TrustEntryX509Cert(
+                        identifier = "${idCount++}",
+                        metadata = TrustMetadata(
+                            displayName = displayName,
+                            displayIcon = displayIcon,
+                            privacyPolicyUrl = "https://apps.multipaz.org"
+                        ),
+                        certificate = cert,
+                    ))
+                }
+            }
         )
-        // This is for Multipaz Identity Reader app from https://apps.multipaz.org on devices in
-        // the GREEN boot state.
-        builtInReaderTrustManager.addX509Cert(
-            certificate = MULTIPAZ_IDENTITY_READER_CERT,
-            metadata = TrustMetadata(
-                displayName = "Multipaz Identity Reader",
-                displayIcon = ByteString(Res.readBytes("drawable/mpz_identity_reader.webp")),
-                privacyPolicyUrl = "https://apps.multipaz.org"
-            )
+        userReaderTrustManager = TrustManager(
+            storage = TestAppConfiguration.storage,
+            identifier = "userReaderTrustManager"
         )
-        // This is for Multipaz Identity Reader either compiled locally or the APK from https://apps.multipaz.org
-        // but running on a device that isn't in the GREEN boot state.
-        builtInReaderTrustManager.addX509Cert(
-            certificate = MULTIPAZ_IDENTITY_READER_CERT_UNTRUSTED_DEVICES,
-            metadata = TrustMetadata(
-                displayName = "Multipaz Identity Reader (Untrusted Devices)",
-                displayIcon = ByteString(Res.readBytes("drawable/mpz_identity_reader.webp")),
-                privacyPolicyUrl = "https://apps.multipaz.org"
-            )
+        readerTrustManager = CompositeTrustManager(
+            trustManagers = listOf(builtInReaderTrustManager, userReaderTrustManager),
+            identifier = "readers"
         )
-        // Some reader identities from the Multipaz Identity Reader as distributed from apps.multipaz.org
-        for ((displayName: String, displayIcon: ByteString?, cert: X509Cert) in listOf(
-            Triple(
-                "Utopia Brewing Company",
-                "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAAAAAAAA-UO7fwAAAAlwSFlzAAAuIwAALiMBeKU_dgAAAAd0SU1FB-kHGBUYJH7nXpkAABOZSURBVHjavZt5dJTlvcc_zzv7mmXIhCQYIAiIIiKyt1KLdcPtKi703rb2VL22t0W62HrusafLbe05VtvqvfZaq1dblyouLRY3RLEKYiAsIiIkAULIMkkmmSwzmf19n_vHvDOTSSbJJGDfnJyTycw87_P8nt_v-_v-vr_nFQCB9vrlwL1CiM8BFikln8UlhADgdIwvBEiZGnOC48WAD4B7Sivn1gp98dsAG5_hlV58XgMICVJMeLxTNGQEWG0E7k0v_jQMOuo15rgTXPxp8iIbcK8ItNdHActnbYAc12XsHR8-j4mHjgQKMmpMSS9-6M2GuuupuHr-nWPcxY_2uuB5FT59i_JPdfUJGnLozqfHzbdBOa_FxO6vfJaLOB3GlFKOaoi885X6b4GXcfgNT8X9T9ei03MYLfbH3iAxUQ8YCTajGSHtfqdqpBELmmRoTOS9MQwgxrVseuC0C55qiKTHUrU44cE-QEtlhlGMlM_wk92E4d9TRtud4Tc9nbgg0RgMdvPuU7_lrYfupLXxYDY9TiAUT4cnTBgETy0EJFKoNB2q482H1lNUVsH8K77Brqd_Qu3mZ0hEQ0ihjQC8UUMnD1cYbw3D_y8C7UdkOgwKJULZz8nCQUdI4tEQ-976K76P3-T867_PjHOWANDX3cqujY-gJuIsX7eeUu80pBQIJcUZhBB6epMglbyAmfXckURrrHWJgO-IzOKnUhjSiiHINS6PlyAkXScbqd34IMVVs1lyzS1YnSUIqUOQkGjJOJ_s2EL9lj8wb816zl5xMUIYdY9TQGipG0sxIlRzd1ibUDYQgfZ6mRpDFB4KYgh2D1-8yE3EWjLOoZ1v0_DOY5yz5jvMXfJFFMWIRNPfT6AYTSnjKxJfUz27Nz6Es_xMllz7VZzFUzKG0v20INcv2JsD7fVyeM49tZpAZow0EOig9sVHkckIy2--k-KyaSkvRgUkxz7eReP2V7n4tnswWeyp-wLxSIg9bzxP6_4tLLn5bmaesygVEoiCwTA7_7HD1Hi6mODQGASVhn07-eiV_-bMC9ex4AtrMJrtWdwQ0N1-nIYdr9HfspvGj3cy-7yVmCx2AMw2Jyuu-wbNc85jz0sP0Hn0Cs6_5DrMNhcgdUMUCsRiHA_w1Q9JwQWAmtB0t8_nepJ4tJ-6116g5_huFq_dwLTZ5wKQTMSRUsNoshAd7Gfzr2_Hs2QtdqcD3773mLviMs5eeQlSShLRCGabEwSEAp3sfOkx4v2dLL1pA2XTpgPKBI0wRhrMulUKrBDaiIJiaOpLAeXIGwsFfE2f8uZDdyFkgsvX_45pZy7I3sho1EFMxdd0CLN3PuZ4P_7aTXjOWkZP21FCvX5A6p_VQJO4SrxccuuPqFlxJe8-sp4D725GUxM6Z5CTKoDygKDIEJRcYioQKCNAJ_1aIhFIEokIH23bTOvul1lwzQZmnbcCIYwZjwn1d2N3lSCEQmdzAztefpSqJVfQ_NZjWOnHOP8mTEYDDjXEypv-A0UoBPt7cBVNycxHAt1tTdS99AhGm5vF191KsWeq7g2cmgFGoKaO5OndzsWE3DDp87dQ-8LvUUxmVtz4LdyeCn3Oeq5Mpy89TPa-83cSMknH7s1UrriBzpZmXIQwFk3F39HJtbd_F8Vgzs5HSwGLEKk9T8Si7NvyAq11mzj_hv9kxvwLECgFk7Ph6VPJWwRJoRMOkVdpSXlKksO1W3nn4fWcsXAVX7r1Hlyl5dm0KDQQEOzrydy0P9CJarbSuucfEG6j23cSzxkz8TfspmP3M5TOPJOWxkOZiQ70-pEZApRSU0xmC0uv_gpLv_IzPtr0P2zf-CjxWFA39MSLqdwQyIP-ue-l3o8M9lG36U-Euo6y-Ib1eKbVEOzpRqINM5mguKwi86p-9zYOb32CypU30XbiJMWmBKGWjyhaeDXxSAQZOI4CXHz7T3OMH49FGezvQU2GMRjMlEydAVIyOBBg96anCLY3sPzffkhZVc3Y4ZCHtCljFjtDSE3GckLS03aCsP8Yl3z7Psqq5zLQ7cM71UZllZvKSjcVVW4qqlxYTIPEoyEdJAXBbh9EuvHteI7KGTPoOlKLGvYRDgWRgROEW2oZ8DUi1WRmCp3NB4mFTlBeYaNquoeSMgudzXuRUsPhLuWir66n9MwLaPukroDCeqRaYhw75-sZUg4ri5EYnSWYranc7vf38uHT_4WUgotuvYvtzz1BMtpDNDzIhbf9mvKpTno7WkiqcaZ9_su0732L9vefpnr1vyIUhfCJw_SfrKNy8fWYbE6aDu1l1oLlIMBgNuJwO-np6sDudGGyWojGIqhqEqPRjEDBXjwFLREdn_tn6ogsjhnHVVXlyFyPGMrKBOFQGDXoQyAJ-HzEOz5m2oVf5tjuLUSjCYQQqKpGR91GqlfdQtWyK4lFkxjVCMEOH-ayCmZM_yqK0cyJrY9gX_PDtN-BNOJrbqenw4cmJUJAdyCE23MWNrsTq9WiA6QcUSSN3n8QYzPB7OKVvLaRMpf2CqMh5VxCEEwYCEVVmnduAk0vawGzzYKKCUVROL7t_5h75fdo3PIoqFFmXHwHTR9sYvrSy0hIK1anE6SWqdbr64_je__PGAwGkppKQpUMJm0c_vgg6390V5p-FsAJlRHCS8GqcFYgUbK1kD6W1e5AlRKTu5r9rz2Pzarg9NaQjEewWMwgVY7v3cGsL34FYTLhnvF5uo5_ipaMAJIT7z1L9ZJLifQHmHPFLTQd2AGaCkAorNL2yX5UTZJUJaqmYTBYuezqq1mweDGJRELfMKXgFDgpA0i0LCiK3BTpcDnRVEki2o8zdhwDEk1ViSclRUUlgIK1yMvRd__CoL-DWStX4z_yDzA58Z57KSI5gM3txu7x0vDm08ikBkYTAIkk4P8o65QyxViFQPeSVGIWaHnCdXz5TMmJDzE-isp0Th5yFbndhGMqQhE6BxIkgj6Swo3D6SAaCRHsaqZm1U0YrFbMdjsIC1IaMLtK0DSJ1V1CIhFjxqobcZR66Dx5VK_ttSGZSyKkXgxJ8Hf6URSdYgtl1NJgLIlNGdqfkzK10ymio2X-TlPkDAWWuZTZbLUQSQoSoQAm93QwlZCI9OIsn4UQAovNQaC5nt4TDQhM1D19P3O-tA6DfQpgoPqiW2h8_00G29tIhAdp3v0yruJSXQgZQlw0kFKgJeM8fP_9LFm5AqfTSV7Az_ykBFdNZv-TvxwWkmQ8RkdTw3B9FoFACrA6nHirZjJ15hw8lRuQusnD4Qg1S9bgsBkwWW0kYlE0NUlfWEPVUsaavepaPn7-xwjFQMXC1Rzb-hRzr7gdT1UFBzdvxOQoxeGtpP3DZ6m-YB12V4leRSaxGI0ppJdgwsRgLMkdGzbgsKfK47lLv4CiG6qvp5OBHn-GPcoc6i4pKa_CXeTJYwApMBpNlJ8xPY8tU6nDYDSABLPFjtlizxhH0zSSwkl_REIEJBYkFjAZScTjmMxmpp-9iJPzrqL38GY0bTnTll1Hy8E9KCzDbHfjnHoGrR88g7GohvMuWau7tSAYDLHwa79CSjUzk3A4QmhgAIfNBQjsjqKMSuVwu7HZbEMMMLQpCUarPSctZoqh8Vu6clTZS6RjEC03lQqJ1LKfSySi1Ndtp6t-D1Nmn8vsRRdisjhoP3qAxu2v466oYd7nL8dVPCUzejwWIxaLjchIDqczJZUxFLuymuGY5xGGendBBshDE8KDIQYG-rHb7bjdxSAEgR4_8Xg8x-KKwUhZuZd4PEFz03E0CRWV5bjdboRiwNfaBkKgCFBMJkpLPRgUhU6fD4Ap3jIMigGEoNvfhVAMeDyeLKeXMlswC3SjjK8GTzgNDidDg4MhfnH7tbS3taXlTxobGmk92cz777zNY7-5j2gsyvb33qWtpYWH7_sVFouZ4mI3zz_5Z_bu3gtobNn8Cs_84fdEY1H21u7ioV_8F4ODQba98TrPP_6HIYuR_P2FjfzktpsJDvTr3qYhgYa696j_8C2kLKw3MLoBhFZQp04IidVqJSnB7rDr4SooKnIx-6yzKK-qxOZyMaNmFldeew2_v_fnrFl7A9Nn1lBRUcnNX_86T_7ye_ja2ynxTKHU62X6zDO57Kqr6Gg6zIF9-ykqKcZdXIKiGFKldF8_8xctoqx6Lgf27c_ZjUion0gomCXnE2jcGHPjWoyp86cGzvRRMCpiCCUUOiWVekimxjrZ3Ex_60HKvN4sbyh2U1I1h8ZDR1AURT80oYGUaKqGQckSLSFT27Svro6Vq1ahaZJX_vw4S1csw2yyZmu8PDJeIQq3klsppoWQ_I1JKbWcllWqOFFywCHN_YUOwYpiQKQnkO73I1BViUHXCcP9vRxtaGTTCy9y5sKlnHf-ogzmSpECwrod77P19S243C7UeISGI_VDdEEJBbTC8nmGklc-FjLj1jmF8RC0NZlNoNgIh6MZo4RCIcwmU85w06qrKaleSIevIyuj9fbR19XC3LPPQmoaisGExWph1cUX8a27foTN7hjSeJEcPnyYr33zDlZfupq2lhaMBoW3N2_WNyU9ZTmpPmZ-EBzWf5NS5rbCkFitNq7_5t28-MRjHDr4CXV1ewgPDuJ0F-H3dxMMdBONRrGYLXzzxz_l9Ree48inn3KyuZnnnvwTd_7qITxeL_6uLsLhMFMrKvB4ynRU1wh0Bwj4_fT29rDznbcp807Fbndy2ZqruOPHv-Ro7d_Zu7suHXXZ8jnPCZOxQLHgNJiO_7TbDQb7sDld9Pi7GegfwOlyUV5RmUqH3X60ZJzi0lKMRnNKzIxH8bW1o6oqU6sqsdsdSAk9_i40qeKZ4k2lO_3q9vvRNBWH00lkcJApXm-qnBUQjUQIBQcwmU0UFZewb-vfEGqChZeuG1USG617VHg1KFNUVKAQDvbxxoN38d7zj-NyOpg1ezblU3U1WGqUekpJhPsI9nYDKu3HDjE40EtlVQVWo0SqSQKd7fT3dGC3GXE6bPT7fbQ3HQZUOk42IpNhvOXlxIK9mA2aLsCnYt1qtTKlzIvb7ebQzm0ce-8p3FOrJ3TuKO0NE-YBUkrsrhIu33AfajLBq7_9Aa3HjugAqWUwqbezha7WoyiKQk_rUfo6WtFUlV5_OyaTAdDwHTvAsY92YrHa6PO3Y7akCE-g9SjdrU0Ig4H2piMIZeQ0w8E-tj39MA3b_8qq2-9n1nkrxxREpRxZCAEY7v7Bd36WSYEToIJmi4MZ5y5GM9moffbnJBUX3ukz9bwtGegLYHE4cZWUoakaUkgcxVOIhAawO4twl5QRi0Sw2JyUlJ9BeDBIUk1SVOIlHo9jNJsp9pSjauAq9mDU9QEh4MThj3j_iZ_hmTGPC9dtoNhTOT4AZjiOGOV8gJxkf0VIAh0n2bnxf0ExsPzGO_CUn5GZbLrjK4bUJKnSQsvSdylySIzUP5jtU6SmHouG2PvWJjoOvMmi6zfoByyUvClwZC2g8xeZzwDyFE99CUkiHmbf1ldo2v4si9bezewLViCEYYhcJzI1lZQqyUQMg8FAsC9AkcdLMpHAaLLknMBIExkhoKutmR3P_g6Hp5LP3XAbdveUUduCYx6XGUb0CswChYWIFBodTfV8-OwDuKrOZsX1t-AoKqX9-BHUZAKJxrSas1GMCtv_-ieqZs0h2NODJiQ185dR5K2io6meRCIOUmPq9NkYTWYOvPcG9VsfY-G132XO4lUIxTTmbLK9zpx6eNgadK5TWDksh_T7xhfNwqFe9rz6HD2Nu1h04_epPmt-SkwVKVdPJuNs-ePPifYcw2AwoSgGln35HrzVc1LiCxKhQF93B3V_e5L4YIClN3yLKZU1BR4qHELa0jL4CIqfxwCj8uY8B5TGNJbudo37P2Dvi79h5oq1XHDZWowWK4reWPG3nmDHX35HPNDIvCu-zYIvXIWQSkbCajpYx96XHqB66bVccOlaDEZrphdR2NE9mT3KI4V-xEbkyhpC5PeAXBExP3iMbXmR8biBng4-fOlxwv1drFh3J-Vn1GREFjURIxzsx11armOEIBLqZddrz9F3fA9LbvwulbPmp3QnOdkQHX3-oxpgYvEvc4-OiZSnSL2LA4KkGuWT7VtofPuPzLv8O8xbeXGqSBp28tN3ooG6Fx7EWTmHZdfcgt1VWrjLT_KUwOQUoTHdf6g4L7LWF9DVcpTdGx_E7C5n6fW3UuSZihCQTMTYv-1VTtY-z_n_8n1qFqwAYRi1wjtdi5-UAQo6QSY0kMqIz0ohiUVC7H1jI23732TxjT-kuLycXS8_jlAEy9feQXHZtEys_zOO7Z9mAxSYLlFpqT9A3cYHQO1j9up_55wL16AYTAgpChQ0CzgcJv_ZIVAA8KQ9REoIDXQT7uvDO312CgTl-G6ebwPG7gSfbgNMgBOMNUbOfEV28fl3PyvDpTq82uSp-zAvVSa9uwUvVht5fkcKvU7IHBUeR8zU9X6p77Qc_7mBMcc6NVlcTMxbRiu0pBhxWOFUTqjmLFoUPpZxUh4whv6ea3k5IaOd6sMZme9N4OsKqWdpR1VO8u7caLsmmOTi5dj3LMi1J3XFFFIPEk9gN8SoL3NPc-sSe0FgJQrEkvyqzilcHyjAPaQeJC5YVs5xeUTOQ1WnnahkZF_dmJO5R_78GgHuUUor59YCq0k9QR4rqMTMIy7mW_zpMEhqDDE5EM4J26zb62tdXVo5t_b_AdFN7yyheCI4AAAAAElFTkSuQmCC".fromBase64Url().let { ByteString(it) },
-                "MIICRTCCAcugAwIBAgIQJGQ57Z_GIpsZ1bBj_H9w-TAKBggqhkjOPQQDAzA1MQswCQYDVQQGDAJVVDEmMCQGA1UEAwwdVXRvcGlhIEJyZXdlcnkgVEVTVCBSZWFkZXIgQ0EwHhcNMjUwNzI0MjAzMTUxWhcNMzAwNzI0MjAzMTUxWjA1MQswCQYDVQQGDAJVVDEmMCQGA1UEAwwdVXRvcGlhIEJyZXdlcnkgVEVTVCBSZWFkZXIgQ0EwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATxQFn8bIEIaMONgvtN3ndBNB6piOwHo8XF1vj7Lpd77w-wmdWD60Ia8nHh7z4LmdxbxcgtODb5oDehnW8kR4lR0Pw0V5iUMJRiVb0AsZSOk-WKdfS847NlT0Ip5B608WqjgZ8wgZwwDgYDVR0PAQH_BAQDAgEGMBIGA1UdEwEB_wQIMAYBAf8CAQAwNgYDVR0fBC8wLTAroCmgJ4YlaHR0cHM6Ly9yZWFkZXItY2EuZXhhbXBsZS5jb20vY3JsLmNybDAdBgNVHQ4EFgQUddH-bvOvKZEFSkMWS8ncN1LvXdswHwYDVR0jBBgwFoAUddH-bvOvKZEFSkMWS8ncN1LvXdswCgYIKoZIzj0EAwMDaAAwZQIxAOCgXroeWZOkvMcZHn9hijZesYMTC-3yWZGS39ieBRupLjTalHoy6CDZlE_H9CYAbQIwZa-iyQpLzghYOCiXkhRtoe8V8XCP8JwxuQblWQYdNWGohOeLowR3punD3UcJTAPS".fromBase64Url().let { X509Cert(ByteString(it)) },
-            ),
-            Triple(
-                "Utopia Plumbing Company",
-                "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAAAAAAAA-UO7fwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB-kHGBUjMFiPZdwAABswSURBVHjarZt7kGVXdd5_a59z7vv2-90z3TOjkeTR6C2BZISewRYvBygSoIxtqMJlIARSEFKOY8c25aSwYyCOsYmxDSmDTTAUtrEDoTACSQZDJCHQICHNaGY0PU91T3dPP-7znLP3yh_n3GffHinlXOnM7fO4Z--99tprfetba8v0Q6uqKOn_7SMCGgpRer39kfY_nY9K981_wke7vk3fNZgwMJ8Fzwin6pZ1FdDu3pl2L3r63L6ife0J_v4saDqA7kdUpD2cWJWmg5qFixaq2i-Q1sf1XtCuU-30Q9JWVJKb0hpEeo4qiusMRIQDPuQMbMTgizIZeOSs43yc_lRb7dN5l7be6XqF2dUv4evL2vOjlipIIs8MUPaEsi-UfUPGEzZDpeIcHrDhoGI1eXX6O1HpUg5NzlW7tEd2zO5Oibb6oYz7wrgv-CJkPUPTKSuRJWuEnBFONhwORRRUtWfwyYi0_d09VgH8Xg3UntlzQANoxMrFWBFRDhU8fKP4FozAlTmPulXONC0VBx29ac1uW9SoKiLSO9hWh3eojbSmlWHPEKDk_GSwRh0zGY9KrGzFyr6McLLp0u4Loq0JURCT9El1h5xVOwvtRX32-FCLHU_XHTWFrBHONSzLkWNP1sOY7oXUdWhySPfqTK8NNAPqUHXpbwWnSt4z4JQojlmNHT-uxRR9IQAsMOl1aY4IRgREOu_pXmIALtEK0-lIp6ODOjZsIOvBqaZjQpLzjcgx6gtjvmHLKpMmmeXkcF2HTb5Jz12cXMOh2OS8daTPtISwEEDRE043Lduxsp2Ox6lyohYxkTEsNy3DfmcuRZWFjGmPQ1UT9e8bl6p2LYEdhk27jAhMZ4SlpiMnwlggrETKRCCcaFgWcz4jnoDnsRbHxIPWtejOZdbW-HTNdtkfEPIoJd9wtG7ZmxUaTnuWawOhEjumA0PolJJARSErUA6Ea4yHdS7VICFjwBjBdHk8f8f6b3emc33IQOygqXAwK5xpOhQ43nQownZkiYGSEQ7mDc_U7C4ern_wOuCets8nA4_1piVSR-w8qrFDnGM2MKxZaKJsRo6cETatY9hLBDJsDKv1mA2r5AU84FKkbV_gC2QEPBF8cbqjp3kRYlWidDbGPGGt6RgWIVlSSkag7pL1umKhaIShrAfAlIEVqwPtiGi_RqTWue0SO8LIGFiJHKhyvhGzLxcw5gsVq0z5hoIn-EBghOVIGTVCVpURD47XHTY14gMhS9q4CQSCVCJZgSxQEphprSlVsgLbDsZ8YTm0zAeGulXEJa4HhYpTlhoxy3XLZMZDXDKYnqNbHbpspKTrVtq2KPlqWKXpFKNgFWqxJRDDROAhqhyvxyw3LaFT8gpDnrA38DjfsNhdMFZ_f_xbyobErkjLOGJViBWaqqynPl5VCVCqLuld5DpLRrWDJDdQZrOGolGq2nH_2mdaehDbAGXxgAuhZcwInioXnZITYSu25Iyh4BkyVhkODE2rDHnCWsNywbrBy68fHqbX_GPbyfptprDXpT40Y2DK89if9TCJu6Cl1eebbgB87fxVjRzjvqESul6Aq4OBb3-n9gZCIMJzoaPkG9ajZIl4AqFNvFHVOuZ8IXZKyTNkBZ4O7QBMsws8Ty_7a_HgtRpaOGsthMqVBR8vfWcOmAsMz9bj5CUDBL4ROeayXqJOl_vsBO0EQMkzHG24VB5K7BJjGztHbB1nIstcJsEdeRHqseNsMx4IK3rg74CP_4KxiQiRTWyCJzBkhIwnLGQNz4eOcMDPtp3iiwwa3wuoAEz4hq0o8c9xurRMujbrVimIsO4cpxrxznhjoN5fvgO-DFozPbMknK5FzGY9coHBGSUAYqfM-8Kphu2DsnRshjqiltntCRZ2b8sqeAILgWGpGScG0CbGdjWyLGY9xGmfMUnskAwY4AuJwe-fDNnhujVd95aVMEFcjVjJeULTaU8E1w6mEKwqRRE2BrjZzsynwujS3dXIsifjsRVZYpd4qGYiUUaNwZMBKt2P8F6EwrXG6SvKbtF8_3mswlpkyRlhwfd4rhn3AqfUjZU9IbKOghE22hrWweqd-KdPGCmMPtPU9uyEVvFQYlUmsgar4KPEAyJ-dvMusvu4_CT27g0WRYQbvEQVN6xywpFGccp1BgKNKfqGhidMimsF7e0353wQHFu-cD5KQ1R1vCJnOJw31KzycNVx1CpiOsTHQZNoDTgMECIcrTWZz_ucCRMsMCXKkA-rFpb6nNH1fmI7agpP2z700yUV7bJOwl-d0h5znKrkxVfOMZTxePC5Te7_0XYbvC3dN8V0KcMPlms8vdrkZw-PIh2KI4n4BJxTvvD0Om872eDtJcMHri1z9UQJ3yT3K82Yh5c2-bdH6xyNk5E8etso108X23PoVKmElofP1_m5H2_jx5bTr5mn6Ht87cQl_vlTlXbXX5kTvvSKOXwjrNUirntgmbUewDHYJJsdqyO1L74IgTF4pmPEVME3yXVfBFGX_G2EoHXdCB6Q8QwZA28vKL9_5zSHp8r40jGQxcDjNVdN8KXbRpnVRABB2mZgBE-EjGeYKGR5wxXDfHxvhpGMR87z8E1CjnRTWG9bKJD3PQJjmC5m-NeTQb9V3sUI6gDLp71RV3IuvetMhC8tRxz99nkA3nPDOHPlLKc26nzqmS08gRNNx6_fNE7BNziFB05u8uWlbUYyhrdePcqhyQKHJgr8lytL_MLxWnsazm81eN8_LjOTC_i1W8eZLmZ4xYFhPr6yilUHJOCsRXx4wMv3FBMX3IwoZwNeu6_Eh5bXd6563SEA7aXylC5gvAuESx_8dj3m77YdgvCLqRrXQstn1iIip7x6xOPgeAEBHjy5ziuPbKVvdnxu7SIP3zPFnuE89yyU0KPb7TatKn9VU6iGvOlijZlSlrwvPLfV7FPUxIi-e9RjbihHrMrnnlrlnTfPcs1UgTv8Nb4TSifg0C6nk56bnvgf7URpfdTADlZVlWIaaqr2wmFJtea6oUzbOnzjXD11Esm9U1Y5slIHYLQQMN_VbjYw_NZslo8v5LhhtgTA8lYDda6jh13EzRv3lQBl6VKdj55ush3G5DzDOxeLncinjQta58m33yEre8GT9i-BAWBHVMkDlT69cqo4TeKH1guDAWjEl05jtou3mypk-Q-3z7T5w8gpn392G0V6iU2nXOXBLfNlBOHxC1VOWnhqucrte4e5c6GEOVbBmd0xaSIA3YkWXApgyjk_GbyDg55Syph2pxTICVRcvxNJQtvHNkOcKkaE1x4Y4pNr60QuISYOB8LNswVQWK40CY1pCzm0jrV6hFNYrcd88fgWn75kGUv5BgAxBhHhPXMZSpkEz_3UFcOcXyxTCJLzPUNZfnFI-OOt3SGSvxtsOrfZYDQfcONcmc8erPPkWpN_cfUIpUyAqvLsRgOjycz2kCoKTZeEzt-vxTy5XOH6mTK3zJb46u3CgxdqjAaGn1ooM1HM4tTxzTNVRnzBpB5npRpy50MrIAkh2gqSciYlOwGMcrjs84orhtuqO5LL9IbURnjTFcP8yeMbCciSFwyGOtbh88c2-dB0GV-En71-Kp2c5A1rtYhPnqygCJkBL92KlelU53_j8XU-eVeGqVKWm6ZL3DRd6iElHzm7zb85uk0dwaWo0aXkSr8FL6trC8SGlgNRzFUTifX_xsl1PnemRhg5okj51RtHuX52iFvmSyw8vs6SSB9OTL6NdDGpoh0T-eGVmN_97nnObNSTDI4IkXP86Pkt3v8PyzwbC4LDmKRDW2HERiOkElliBYvSjJXvNBxv_eYFHj61QTWybVO6XGnyF0cu8qr_s0Y9FX4lsmw2QqqR3cEUtVzeZiNpp-ngZ-ZybDVCNhoRXzxe4YsrId-tO55Q4YGzVbaaEYrj56eCnnSMdKXyRD5_XAdGQ6nl91DuznvMZQxP1WJ-ECXRV94I83lDaB1nmornUhMlhhjIeUJBlKmcx-mapa7CJI7b8h4V6_h2M8k_dsMQH8WQqH0sg2O4INUAJwmiNNYlkyOd7NOIb5jL-2w3Y55vxFjj4XalJD73rA7KSg2KHEQ7sB_gmrLPRtOy3HT4niEjsG2ThyYzhvVYGQ-EiZxHLXLU4oRodSS4vuUtWkytl_5eL0OV7dDiQTnI9H178x6qyumGSwTQA42TH_k7YPAOCrWbve1tpdqivEQInTKZ9ajESZy2EVn25jyebzo2I8t4YCh6hthpOymqKomDUSV0ynbkegKVF5VEHnRNIFY4VYvZk_PZn_c5WYu6XHsXIYIdRAKQJP5I6FhJbUA_KlxpOvaVfDZiS906qrFjX87nVD0mVjjfsMxkDarCpRiq1raDKh0Ub6cC10HQvD9_2B1lt9RfU3hs0rSYwNl6zFzWY0_WcKZud4zTyI6UWHKIKn957RBH7pvmR_fN8Nhdk_ynPRlQx2d-oswP7plmTh2NyDERwCeuLPHwy6e4Oass5A0f2Zfj0bumuT2AX92b57t3TvDHVxbaQdV_ns_yxF1TfPG6YYZQ_uH2cY7cO82Re2d47OWT_O7eHDjl01eVeOLeGV7qKZ84UOBH90zzvrEAUeVnioYn7pnivy7mEIRbM4Yv3zTMifvneO6V83zlplGuN8r5eoQvwnRgEmDY5bYNXVa2-8A5rhjJcs1MmVwgHBjP88E75nnfRIYDo1kOz5YooJytRhR9j33DWQ5NF8nHllqkHBwvcO1MifGsx8JQwOGZId54eIIbczBlLG85PMa1s2X2DweECoemCiyO5RJeYKLAe2-f459lhH3DAYdnywwZZf9whsOzZT542xSHfWEiMFw3N8Ri2WfeWT5_3wyvPTxNPjDkfeH-q8b4pcU8KJyrxYxmPTItHiAdp2mrmPato5a1Be77-jk-9o8XCIzhZdP5rucVi7Bcjdt2KJsNWI-UqBkjImhk2-xwOePx7j0F3jaZY2E0n9SBiKEgya9XKk1-_bFVvn92E2OErNcbgWqa_98zUuDjLxlHXRLFGePxgX0F9o3m-eazaxz827Nc8TdL_Pu_P8X7jtfayHW9HjOb83rD_uQl3Sa-i2hMB_WJG8fYP5pJEWDI3pFsmsV2qBMuNWNcGCEiBL4hq67DMaVxuwLHViu8-upRVqsRS5dqzAzncc61hX1gvMgXX7MPI8JTKxVOYMBLoHc-5yNeAn-PLG9xx_4Rzmw3U-DkuHo8jxjhr49tcG0An71vHiPwlobl1m8tJyRPM-ZgNkteLDXnkJ76gF0MrwHuPjjKzHCev31ymQ8tVdsMrIgB53oKHwIbs1gMyOc8BEljiuTeV05sMVvOcd10ia8e22il8lmLkmBiaa3GLz9wmr95cpnDUyXeMe6hcSKgWi3G2SRX8AePrHBhs8GbrptuI8rNRgKeDo1maChc2AoZyWdYHM2B61jMzaZlPGPS0gO5TF4gHWSscPBzz7CM1wMLjAj_8fAwcezYipWTl5o4dbznhknuuFDlZQtDVMKYI6HyBj9R5e9txZzdalAMDJ9ZbvAOSczwFSUfBApZn-un88yP5pIlkw8QIz2EKyT1Sh_-zgU-dv8-8MD3fT59dI3XXjPG22-dZWFojY16TC4wNGLbqRMA1pqWA2W_HbT5OJem43eWqUROidJ1Jl21N04hdo7XXT-FIFzYavDSvz7JS-aL3LIwwpWTRSphzP949AKPbEZEoSV0js2tJu_6-zNkRXh0OyJ0jjh2nNiKiB0M533ecu0ksXX86PwWf3h0g9-7bYooZYtjl-QknXN8cj3mjiPLvOmmWSJRHg2V3374HO-5bZrXXDuNAhe360mStKsYyylEsWPETwquhE892aqs2ZEh2GuUPMoxJz0C2iOOktAmQ0NVTjpBjHBPFvbmPB7ZinnGJo3PiDIsynFnsF3A7UqjNBTOOOGAcSnPqDSBU2mbc6IMe1DPZQlrESV1LDloAhkRFsWxqcLwUJal7ZC8c9xTDtiKHUfqloIRzqi06q1AYDww5H04W3cdAfTm7xkYOr7Yz4vAcjtqBl6ovaIRhgLD8w27swGB0cCjGAhna7Z9c7c-ZEXYW_I4vh3j43pRlvansfozOvJCucQdjOIuWaGufAjSm0gV2VGxVrWOsp-wxfGAOqZLoWU8F2BI1Lw_KSZdYglVMWrw2nzAbtVafb2dFeWnRwIuNi1frSRRGAL7xHHnUMDZhuNbSR6LKVGuzBg2LDwVpW7Oh_lAOBcmhQ-LWcEIVKzjh2FHgNd4MOQpjzaTCrBAlVtyhlUHTQ-i0HJj3uP5GCY9pW4dP4wNcWS5q2S4WHc8GQ1O3XfDnLy0KLHL1Cq2LvzWYp53_uQc46Us1ilPntvkbQ-c4x37y7z9tjmKGQ-n8PjpDX7-wfO8bjLLb7_mIM-tVrjqy0sgwp-9fIrbD4zzZ4-cY60W84F7FxNSWpUjZ7d47TfOcVGFL71qLwcmS_zK_z7Jx87VuSVnePCthzixUuHl_-sUP10O-MKbD_HZ753hxj0lFseL3PeFZ_mF2SzvvXsff_Tt07z36PbO8t6umgHnlEBavGVLJInukBUY8w1TmeS4v2x4_90LWAf__eEl_u7I84RWublk-KWXzbO63eTjD53mgWcucuviCB-9ZQzPGDwR9o8X-eX5PK8rerxk_zgmNXQGxTeGv_z-eb7-4xVuXRzlvQsF_mVZODhZIowtr79qqJ2D8BCuni7zRzdP4FLzKyiffnyVUsbnV64b4Y03THN2vcpvPFsZUHvYiWoFqEWOkicdDRBgNGMYzno452jGSuwSFX_9Yplc4PGR75zlT881uNis0rSOP79pjIzv8aFvLvHnGxaObfH0eI5bF0d5-HQlBSghb7lujAsbDSrNkLFCrieXem47YrtpUVVyvsdbD41RC2O-_uOLvOraaW7KXsRZi1Ol2oh4_Q0zHFurpqvF8AfP13nzc-u87oYZfGP4nYdPc8le3gRnJGGkSxmTBL2BCHtLATlPOFuJWG0kcXnOT_C4TeGqbcSEVpkvBoxnvLbr7CkQRdqssIjwrWcvcc3sEHdfNck3nr5IO8eU4vp_d-8-3nXnIsdXtvn08Uvctn-EcxsNTm02KWR83nVFEaOJFjx0bJ3zGzXe_bK9mC6z9tHvryIIx1a2-cyFBnvzPmWvU4TtAyVPmM4YFgqGmZxQjSyV0GKyAnuLPpfqMbXIsbfoM5kziCq10NKIHF85U6URO971k3P82mKOjxwa4oH79_Dt57eJrOU3X7HIfzs0xNfumubgdJlHnltPOijwxLkK5y41CK3jfx7bTNPjHQ799x96jrd9_ilu__ISb5grMFHKcvXMEO-_9wBWHfccHGtnpptRxIcfPEMpZX815Qm_utkkdMpaJaQaxpythm0j7qtSMmBU2QhjzlRiTlctl9J9AP5s0We5GjGUMeR84UI1pqGdbI8ofC10_N6DS7zrjnnec_c-rCpPnL7EIxX41GMX-LkbZ_hXdy4Qq_K9k2t88LF1Xj-VIbIWp_Cb3zxN0YO6TWmwNH6wTjmxEfHZ9RgRePVPjLPdDLn3L55h08Hv3DzO62-a54YhQ-QcVoU_WY258_vnefOtc21HZVIm2VrFM4JD2E5TdTHKRryzQHMma4isQ6b-9IgqUMwYTlfjdsjZoWwSnCACC0a5fzzHJWN4aKPJauhYLGfINkLuLAc8V4v5Ri1xjxMoBwJYimAlfV0euCFruGATSLs3gOORsOYSv35zzqAi_KCZnM97hsWMcKZpmckIqxE8ZyEryk25pEbpVIqLXpoVth1sBh6eJDWGsWsnw6hESbFVy6iOBMJQ1keCP_yhLgwFLG2HSRncDhAhPRCxFQUulAM26jF155jJB5yuhD1IEu2tTejBQtJVS5Cea1cavzs92UKI8_mAamjZsA6T4iahp-C03d09eZ9GrDSdI3ZJ8NQD8FLgN5XzMCVfaEYO6zrVk6Zt3ropsk5O0anjfCVkLOcR20SVy570Dl5kQNq9-2_plCe30pOqPRWmrXtFI2SM4JmkXxMZL_FaviHXX_7ioB458oFh2yoN118uI-2K9pW6xc95QiOyaX1OX4H3QEibCCN2SSp8IuOx1YwZCgzbUdyVXdWemqDB-adWJWB3blHT_zoCHc37bYFLWrwhLln7IqBdMFo1YaSH8z4mBVk9dLB2dsWoaJKOsy9YzNefKJB2bF3IeFRjxfdM3_N62erQy1dydfSvlZ-P6GiJST1A5NKNFHTReiQ0XSNyjGVMymh33-8Nc3xrXVK64roKe7tzAi1v0OLy00BFBGKbMj4u9fuuO6nRaUVl9xIVFe3JP0g__Z5Sc-oU55QMnU0Z25FlrpiBRpx6rZZBcKzWIvYMZVhvxO1M984SfTCNWMn5prNzqxsadxc-pI2SgiJ16c4Ql5TOd3bC6C7TLoNDSe2ed2m_s_t9sVWmcj6BJxQ8Q5TSZN17fnr2KrUSLQ3LTN6_bAGhCa0SmC7JI20jlSQPpdN57TSWkBdpubB2R7CSmvWdG5WEbkFID3rslNlJVyImOVZqMdVmzIVKhG-SAmlfhKmsl5bzS2_WRxONuViPMO3nBqxQB2Ys61EPHZOt4oOutbRjDUuno2NZD5EkB68otkXu9qhiKp30aGtHPxWvXW21jHHXs6pJ5jhO6TAvDYQyXiJk01pirve96uDcdpOsb5jOmcRy9bSpGN83VCNHKetRMNIXDg_IGAHjWR9FmMr51EPLaMajFsa9OtZSD9klItf-LYSdaLS_Fql779J25MgFSei9FTp8X2hat6tVdQpnKyFKEu-U_V46yV-phMyWs6xUG0yXs1yshFRiN8BoJR3Ie4ZixqMZO7KecK4SspCWx_VwL9rHc3XXr-qADXw72CDZWe6ebuKwLgnIRJRG02Jt1xockOFWlJV6REaE8ZzHSM4ntEotsvj12LFeDZksZLlUi5guBhSbMRcbMa57AJqUyc8PJUmRWODsdsieUsClWphudO01etKbiO3TkN6SvF0rfwfUWp-vxhS85O9auv9P-6x7b9tpsZXC8zWLoBR9QyEw-KrKRjNJKowWAy7VI7KesH8oR2wdkXNphaghn_WI0gKmhlX2ljNUGxEboR08tj6Vb7vS3TralY_Qy5GtqtTiwX6lBbBU2VnZlmqIAtuxoxKnRVJKEirWYstMKYsRuFRPih1zJsmUV2PHSj0EDGM5j6lCwGolZDNyOzqnl9sSwy6l7fKCmzsGKcMAyvMFCjz7yiH87mebVjm91SDvCSNZj-Gc3y5hL4gwYkyyEcIznNtsUrO9KFH08nS4Xu7u_wuP_v_x838BRFRarEI8qToAAAAASUVORK5CYII".fromBase64Url().let { ByteString(it) },
-                "MIICRzCCAc2gAwIBAgIQZjjem0ED1YZfrJXIp0QagTAKBggqhkjOPQQDAzA2MQswCQYDVQQGDAJVVDEnMCUGA1UEAwweVXRvcGlhIFBsdW1iaW5nIFRFU1QgUmVhZGVyIENBMB4XDTI1MDcyNDIxMjcxMFoXDTMwMDcyNDIxMjcxMFowNjELMAkGA1UEBgwCVVQxJzAlBgNVBAMMHlV0b3BpYSBQbHVtYmluZyBURVNUIFJlYWRlciBDQTB2MBAGByqGSM49AgEGBSuBBAAiA2IABL6vQpn6zrHonK43hm_WED4i3W63IDDA0mtvIzvsBHSGl7YK0Tu7GiqDBNWXtDvxowB8upQv6Us4JVzqI5kzR4D142vmilOb-J9AhOCWxnqmEvqOTSVi_PX9r4DrDWVHsqOBnzCBnDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH_BAgwBgEB_wIBADA2BgNVHR8ELzAtMCugKaAnhiVodHRwczovL3JlYWRlci1jYS5leGFtcGxlLmNvbS9jcmwuY3JsMB0GA1UdDgQWBBQMJBLQ4z7QV6bb6Hg_NRlsprAzJTAfBgNVHSMEGDAWgBQMJBLQ4z7QV6bb6Hg_NRlsprAzJTAKBggqhkjOPQQDAwNoADBlAjEA4ZdSN9L3fLu2uuLbvctEhFap1myoYongcIlkFaiBnVftzc2U8Ziq9fk0bhzwUoYaAjBhZcjyGABTQYv2KH4-Nasqnjnw6PirUmutpPN15G4jzQ63hUp_X7xMfGSQ8Rd7ibU".fromBase64Url().let { X509Cert(ByteString(it)) },
-            ),
-            Triple(
-                "The Utopians",
-                null,
-                "MIIB4DCCAYagAwIBAgIQ6rXL1BAAeNzwRX2GH2BGqjAKBggqhkjOPQQDAjAhMR8wHQYDVQQDDBZUaGUgVXRvcGlhbnMgUmVhZGVyIENBMB4XDTI1MDcyNTE5NDQ1MloXDTMwMDcyNTE5NDQ1MlowITEfMB0GA1UEAwwWVGhlIFV0b3BpYW5zIFJlYWRlciBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLqZ3qQWauWFQo0tbTvhnViU2kBJ4jKPkXxZuFtwlPyF-mYZzygtx5tReifmY9vQXxqi_QVwAAsX6sVZK9p42C6jgZ8wgZwwDgYDVR0PAQH_BAQDAgEGMBIGA1UdEwEB_wQIMAYBAf8CAQAwNgYDVR0fBC8wLTAroCmgJ4YlaHR0cHM6Ly9yZWFkZXItY2EuZXhhbXBsZS5jb20vY3JsLmNybDAdBgNVHQ4EFgQUG2vN6fsoBdTeXaUMbiX9MxtpldkwHwYDVR0jBBgwFoAUG2vN6fsoBdTeXaUMbiX9MxtpldkwCgYIKoZIzj0EAwIDSAAwRQIgWA7vaJVZgg8CebwCTxDgPu8w_2GvLVAHMa_RprUUSScCIQClOLGmxZFQLnKqT7Jy_EHXWM3oJUhyVeehOWauMMJyzQ".fromBase64Url().let { X509Cert(ByteString(it)) },
-            ),
-        )) {
-            builtInReaderTrustManager.addX509Cert(
-                certificate = cert,
-                metadata = TrustMetadata(
-                    displayName = displayName,
-                    displayIcon = displayIcon,
-                    privacyPolicyUrl = "https://apps.multipaz.org"
-                )
-            )
-        }
     }
 
     lateinit var digitalCredentials: DigitalCredentials
@@ -1207,23 +1232,23 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustedIssuersDestination> { backStackEntry ->
                     WithAppBar(navController, "Trusted Issuers") {
                         TrustManagerScreen(
-                            builtIn = builtInIssuerTrustManagerModel,
-                            user = userIssuerTrustManagerModel,
+                            builtIn = builtInIssuerTrustManager,
+                            user = userIssuerTrustManager,
                             isVical = true,
                             imageLoader = imageLoader,
-                            onTrustEntryClicked = { trustEntryInfo ->
+                            onTrustEntryClicked = { trustManagerId, trustEntryId ->
                                 navController.navigate(
                                     TrustEntryDestination(
-                                        trustManagerId = trustEntryInfo.manager.identifier,
-                                        trustEntryId = trustEntryInfo.entry.identifier
+                                        trustManagerId = trustManagerId,
+                                        trustEntryId = trustEntryId
                                     )
                                 )
                             },
-                            onTrustEntryAdded = { trustEntryInfo ->
+                            onTrustEntryAdded = { trustManagerId, trustEntryId ->
                                 navController.navigate(
                                     TrustEntryDestination(
-                                        trustManagerId = trustEntryInfo.manager.identifier,
-                                        trustEntryId = trustEntryInfo.entry.identifier,
+                                        trustManagerId = trustManagerId,
+                                        trustEntryId = trustEntryId,
                                         justImported = true
                                     )
                                 )
@@ -1235,23 +1260,23 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustedVerifiersDestination> { backStackEntry ->
                     WithAppBar(navController, "Trusted Verifiers") {
                         TrustManagerScreen(
-                            builtIn = builtInReaderTrustManagerModel,
-                            user = userReaderTrustManagerModel,
+                            builtIn = builtInReaderTrustManager,
+                            user = userReaderTrustManager,
                             isVical = false,
                             imageLoader = imageLoader,
-                            onTrustEntryClicked = { trustEntryInfo ->
+                            onTrustEntryClicked = { trustManagerId, trustEntryId ->
                                 navController.navigate(
                                     TrustEntryDestination(
-                                        trustManagerId = trustEntryInfo.manager.identifier,
-                                        trustEntryId = trustEntryInfo.entry.identifier,
+                                        trustManagerId = trustManagerId,
+                                        trustEntryId = trustEntryId
                                     )
                                 )
                             },
-                            onTrustEntryAdded = { trustEntryInfo ->
+                            onTrustEntryAdded = { trustManagerId, trustEntryId ->
                                 navController.navigate(
                                     TrustEntryDestination(
-                                        trustManagerId = trustEntryInfo.manager.identifier,
-                                        trustEntryId = trustEntryInfo.entry.identifier,
+                                        trustManagerId = trustManagerId,
+                                        trustEntryId = trustEntryId,
                                         justImported = true
                                     )
                                 )
@@ -1263,17 +1288,9 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustEntryDestination> { backStackEntry ->
                     // TrustEntryScreen has its own AppBar
                     val destination = backStackEntry.toRoute<TrustEntryDestination>()
-                    val trustManagerModel = when (destination.trustManagerId) {
-                        "builtInIssuerTrustManager" -> builtInIssuerTrustManagerModel
-                        "userIssuerTrustManager" -> userIssuerTrustManagerModel
-                        "builtInReaderTrustManager" -> builtInReaderTrustManagerModel
-                        "userReaderTrustManager" -> userReaderTrustManagerModel
-                        else -> throw IllegalStateException("Unexpected id ${destination.trustManagerId}")
-                    }
                     TrustEntryScreen(
-                        trustManagerModel = trustManagerModel,
+                        trustManager = getTrustManagerFromId(destination.trustManagerId),
                         trustEntryId = destination.trustEntryId,
-                        canEditOrDelete = destination.trustManagerId.startsWith("user"),
                         justImported = destination.justImported,
                         imageLoader = imageLoader,
                         onViewSignerCertificateChain = { certificateChain ->
@@ -1308,15 +1325,8 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustEntryEditDestination> { backStackEntry ->
                     // TrustEntryEditScreen has its own AppBar
                     val destination = backStackEntry.toRoute<TrustEntryDestination>()
-                    val trustManagerModel = when (destination.trustManagerId) {
-                        "builtInIssuerTrustManager" -> builtInIssuerTrustManagerModel
-                        "userIssuerTrustManager" -> userIssuerTrustManagerModel
-                        "builtInReaderTrustManager" -> builtInReaderTrustManagerModel
-                        "userReaderTrustManager" -> userReaderTrustManagerModel
-                        else -> throw IllegalStateException("Unexpected id ${destination.trustManagerId}")
-                    }
                     TrustEntryEditScreen(
-                        trustManagerModel = trustManagerModel,
+                        trustManager = getTrustManagerFromId(destination.trustManagerId) as TrustManager,
                         trustEntryId = destination.trustEntryId,
                         imageLoader = imageLoader,
                         onBack = { navController.navigateUp() },
@@ -1326,15 +1336,8 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustEntryVicalEntryDestination> { backStackEntry ->
                     WithAppBar(navController, "VICAL Entry") {
                         val destination = backStackEntry.toRoute<TrustEntryVicalEntryDestination>()
-                        val trustManagerModel = when (destination.trustManagerId) {
-                            "builtInIssuerTrustManager" -> builtInIssuerTrustManagerModel
-                            "userIssuerTrustManager" -> userIssuerTrustManagerModel
-                            "builtInReaderTrustManager" -> builtInReaderTrustManagerModel
-                            "userReaderTrustManager" -> userReaderTrustManagerModel
-                            else -> throw IllegalStateException("Unexpected id ${destination.trustManagerId}")
-                        }
                         TrustEntryVicalEntryScreen(
-                            trustManagerModel = trustManagerModel,
+                            trustManager = getTrustManagerFromId(destination.trustManagerId),
                             vicalTrustEntryId = destination.trustEntryId,
                             certNum = destination.vicalCertNumber
                         )
@@ -1343,15 +1346,8 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustEntryRicalEntryDestination> { backStackEntry ->
                     WithAppBar(navController, "RICAL Entry") {
                         val destination = backStackEntry.toRoute<TrustEntryRicalEntryDestination>()
-                        val trustManagerModel = when (destination.trustManagerId) {
-                            "builtInIssuerTrustManager" -> builtInIssuerTrustManagerModel
-                            "userIssuerTrustManager" -> userIssuerTrustManagerModel
-                            "builtInReaderTrustManager" -> builtInReaderTrustManagerModel
-                            "userReaderTrustManager" -> userReaderTrustManagerModel
-                            else -> throw IllegalStateException("Unexpected id ${destination.trustManagerId}")
-                        }
                         TrustEntryRicalEntryScreen(
-                            trustManagerModel = trustManagerModel,
+                            trustManager = getTrustManagerFromId(destination.trustManagerId),
                             ricalTrustEntryId = destination.trustEntryId,
                             certNum = destination.ricalCertNumber
                         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryEditScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryEditScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,12 +33,13 @@ import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.trustmanagement.TrustEntryRical
 import org.multipaz.trustmanagement.TrustEntryVical
 import org.multipaz.trustmanagement.TrustEntryX509Cert
+import org.multipaz.trustmanagement.TrustManager
 import org.multipaz.trustmanagement.TrustMetadata
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryEditScreen(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustManager,
     trustEntryId: String,
     imageLoader: ImageLoader,
     onBack: () -> Unit,
@@ -47,9 +49,14 @@ fun TrustEntryEditScreen(
     val scrollState = rememberScrollState()
     var showConfirmationBeforeExiting by remember { mutableStateOf(false) }
 
-    val info = trustManagerModel.trustManagerInfos.value.find {
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
+    val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
     } ?: return
+
     val newMetadata = remember { mutableStateOf<TrustMetadata>(info.entry.metadata) }
 
     if (showConfirmationBeforeExiting) {
@@ -117,7 +124,7 @@ fun TrustEntryEditScreen(
                         enabled = (newMetadata.value != info.entry.metadata),
                         onClick = {
                             coroutineScope.launch {
-                                trustManagerModel.trustManager.updateMetadata(
+                                trustManager.updateMetadata(
                                     entry = info.entry,
                                     metadata = newMetadata.value
                                 )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryRicalEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryRicalEntryScreen.kt
@@ -9,12 +9,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.multipaz.compose.trustmanagement.TrustEntryRicalEntryViewer
-import org.multipaz.compose.trustmanagement.TrustManagerModel
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 
 @Composable
 fun TrustEntryRicalEntryScreen(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     ricalTrustEntryId: String,
     certNum: Int
 ) {
@@ -26,7 +26,7 @@ fun TrustEntryRicalEntryScreen(
             .padding(8.dp),
     ) {
         TrustEntryRicalEntryViewer(
-            trustManagerModel = trustManagerModel,
+            trustManager = trustManager,
             ricalTrustEntryId = ricalTrustEntryId,
             certNum = certNum
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,16 +34,17 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.multipaz.compose.trustmanagement.TrustEntryViewer
 import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.crypto.X509CertChain
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustEntryRical
 import org.multipaz.trustmanagement.TrustEntryVical
 import org.multipaz.trustmanagement.TrustEntryX509Cert
+import org.multipaz.trustmanagement.TrustManager
 
 @OptIn(ExperimentalResourceApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryScreen(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     trustEntryId: String,
-    canEditOrDelete: Boolean,
     justImported: Boolean,
     imageLoader: ImageLoader,
     onViewSignerCertificateChain: (certificateChain: X509CertChain) -> Unit,
@@ -56,7 +58,11 @@ fun TrustEntryScreen(
     val scrollState = rememberScrollState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
-    val info = trustManagerModel.trustManagerInfos.value.find {
+    val trustManagerModel = TrustManagerModel(
+        trustManager = trustManager,
+        coroutineScope = coroutineScope
+    )
+    val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
     } ?: return
 
@@ -75,7 +81,7 @@ fun TrustEntryScreen(
                     onClick = {
                         coroutineScope.launch {
                             showDeleteConfirmationDialog = false
-                            trustManagerModel.trustManager.deleteEntry(info.entry)
+                            (trustManager as? TrustManager)?.deleteEntry(info.entry)
                             onBack()
                         }
                     }
@@ -128,7 +134,7 @@ fun TrustEntryScreen(
                     }
                 },
                 actions = {
-                    if (canEditOrDelete) {
+                    if (trustManager is TrustManager) {
                         IconButton(
                             onClick = { onEdit() }
                         ) {
@@ -158,7 +164,7 @@ fun TrustEntryScreen(
                 .padding(8.dp),
         ) {
             TrustEntryViewer(
-                trustManagerModel = trustManagerModel,
+                trustManager = trustManager,
                 trustEntryId = trustEntryId,
                 justImported = justImported,
                 imageLoader = imageLoader,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryVicalEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryVicalEntryScreen.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.multipaz.compose.trustmanagement.TrustEntryVicalEntryViewer
-import org.multipaz.compose.trustmanagement.TrustManagerModel
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 @Composable
 fun TrustEntryVicalEntryScreen(
-    trustManagerModel: TrustManagerModel,
+    trustManager: TrustEntryBasedTrustManager,
     vicalTrustEntryId: String,
     certNum: Int
 ) {
@@ -25,7 +25,7 @@ fun TrustEntryVicalEntryScreen(
             .padding(8.dp),
     ) {
         TrustEntryVicalEntryViewer(
-            trustManagerModel = trustManagerModel,
+            trustManager = trustManager,
             vicalTrustEntryId = vicalTrustEntryId,
             certNum = certNum
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
@@ -53,6 +53,8 @@ import org.multipaz.mdoc.rical.SignedRical
 import org.multipaz.mdoc.vical.SignedVical
 import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.trustmanagement.TrustEntryAlreadyExistsException
+import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
+import org.multipaz.trustmanagement.TrustManager
 
 @Composable
 private fun FloatingActionButtonMenu(
@@ -140,12 +142,12 @@ private fun FloatingActionButtonMenu(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustManagerScreen(
-    builtIn: TrustManagerModel,
-    user: TrustManagerModel,
+    builtIn: TrustEntryBasedTrustManager,
+    user: TrustManager,
     isVical: Boolean,
     imageLoader: ImageLoader,
-    onTrustEntryClicked: (trustEntryInfo: TrustEntryInfo) -> Unit,
-    onTrustEntryAdded: (trustEntryInfo: TrustEntryInfo) -> Unit,
+    onTrustEntryClicked: (trustManagerId: String, trustEntryId: String) -> Unit,
+    onTrustEntryAdded: (trustManagerId: String, trustEntryId: String) -> Unit,
     showToast: (message: String) -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -167,16 +169,11 @@ fun TrustManagerScreen(
                 coroutineScope.launch {
                     try {
                         val cert = X509Cert.fromPem(pemEncoding = files[0].toByteArray().decodeToString())
-                        val entry = user.trustManager.addX509Cert(
+                        val entry = user.addX509Cert(
                             certificate = cert,
                             metadata = TrustMetadata()
                         )
-                        val updatedInfos = user.trustManagerInfos.first { infos ->
-                            infos.any { it.entry.identifier == entry.identifier }
-                        }
-                        onTrustEntryAdded(
-                            updatedInfos.find { it.entry.identifier == entry.identifier }!!
-                        )
+                        onTrustEntryAdded(user.identifier, entry.identifier)
                     } catch (_: TrustEntryAlreadyExistsException) {
                         showImportErrorDialog.value = "A certificate with this Subject Key Identifier already exists"
                     } catch (e: Exception) {
@@ -205,16 +202,11 @@ fun TrustManagerScreen(
                             encodedSignedVical = encodedSignedVical.toByteArray(),
                             disableSignatureVerification = false
                         )
-                        val entry = user.trustManager.addVical(
+                        val entry = user.addVical(
                             encodedSignedVical = encodedSignedVical,
                             metadata = TrustMetadata()
                         )
-                        val updatedInfos = user.trustManagerInfos.first { infos ->
-                            infos.any { it.entry.identifier == entry.identifier }
-                        }
-                        onTrustEntryAdded(
-                            updatedInfos.find { it.entry.identifier == entry.identifier }!!
-                        )
+                        onTrustEntryAdded(user.identifier, entry.identifier)
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         e.printStackTrace()
@@ -241,16 +233,11 @@ fun TrustManagerScreen(
                             encodedSignedRical = encodedSignedRical.toByteArray(),
                             disableSignatureVerification = false
                         )
-                        val entry = user.trustManager.addRical(
+                        val entry = user.addRical(
                             encodedSignedRical = encodedSignedRical,
                             metadata = TrustMetadata()
                         )
-                        val updatedInfos = user.trustManagerInfos.first { infos ->
-                            infos.any { it.entry.identifier == entry.identifier }
-                        }
-                        onTrustEntryAdded(
-                            updatedInfos.find { it.entry.identifier == entry.identifier }!!
-                        )
+                        onTrustEntryAdded(user.identifier, entry.identifier)
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         e.printStackTrace()
@@ -297,33 +284,23 @@ fun TrustManagerScreen(
                 .padding(8.dp),
         ) {
             TrustEntryList(
-                trustManagerModel = builtIn,
+                trustManager = builtIn,
                 title = "Built-in",
                 imageLoader = imageLoader,
-                noItems = {
-                    Text(
-                        text = "No built-in trust points",
-                        modifier = Modifier.fillMaxWidth(),
-                        color = MaterialTheme.colorScheme.secondary,
-                        fontStyle = FontStyle.Italic,
-                        textAlign = TextAlign.Center
-                    )
-                },
-                onTrustEntryClicked = { trustEntryInfo ->
-                    onTrustEntryClicked(trustEntryInfo)
+                loading = { FloatingItemCenteredText(text = "Loading...") },
+                noItems = { FloatingItemCenteredText(text = "No built-in trust points") },
+                onTrustEntryClicked = { trustEntry ->
+                    onTrustEntryClicked(builtIn.identifier, trustEntry.identifier)
                 }
             )
             TrustEntryList(
-                trustManagerModel = user,
+                trustManager = user,
                 title = "Manually imported",
                 imageLoader = imageLoader,
-                noItems = {
-                    FloatingItemCenteredText(
-                        text = "Certificates and trust lists manually imported will appear in this list",
-                    )
-                },
-                onTrustEntryClicked = { trustEntryInfo ->
-                    onTrustEntryClicked(trustEntryInfo)
+                loading = { FloatingItemCenteredText(text = "Loading...") },
+                noItems = { FloatingItemCenteredText(text = "Certificates and trust lists manually imported will appear in this list") },
+                onTrustEntryClicked = { trustEntry ->
+                    onTrustEntryClicked(user.identifier, trustEntry.identifier)
                 }
             )
         }


### PR DESCRIPTION
This new class can initialized with a list of `TrustEntry` instances, for example received from the backend. It also supports updates and integrates with `TrustManagerModel` just like `TrustManager` does.

And also introduce `TrustEntryBasedTrustManager` and insert that in the inheritance chain so the `TrustManagerInterface` inheritance tree becomes

```
TrustManagerInterface
 + TrustEntryBasedTrustManager
 | + ConfigurableTrustManager
 | + TrustManager
 + CompositeTrustManager
 + RicalTrustManager
 + VicalTrustManager
```

Additionally, rework `TrustManagerModel` to a reactive, cold-started `StateFlow` with a `null` loading state. This means we don't need to keep models around until it's actually used.

Test: Unit tests and manually tested.
