### PR TITLE
Use same TrustManagerModel instance for all screens.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryList.kt
@@ -27,7 +27,7 @@ import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
  * when trust entries are added, removed, or modified. It's using [FloatingItemList] to
  * display items
  *
- * @param trustManager A [TrustEntryBasedTrustManager] holding the trust entries.
+ * @param trustManagerModel A [TrustManagerModel].
  * @param title The title to display at the top of the list.
  * @param imageLoader a [ImageLoader].
  * @param loading A Composable to render when loading entries, normally a [FloatingItemCenteredText].
@@ -37,7 +37,7 @@ import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
  */
 @Composable
 fun TrustEntryList(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     title: String,
     imageLoader: ImageLoader,
     loading: @Composable () -> Unit = {},
@@ -45,11 +45,6 @@ fun TrustEntryList(
     onTrustEntryClicked: (trustEntry: TrustEntry) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val infos = trustManagerModel.trustManagerInfos.collectAsState().value
     FloatingItemList(
         modifier = modifier,

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,22 +30,16 @@ import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
  * A Composable that displays the details of a specific individual certificate
  * embedded within a larger RICAL trust entry.
  *
- * @param trustManager The [TrustEntryBasedTrustManager] holding the root RICAL trust entry.
+ * @param trustManagerModel A [TrustManagerModel].
  * @param ricalTrustEntryId The identifier of the parent RICAL trust entry.
  * @param certNum The index position of the specific certificate within the RICAL's certificate list.
  */
 @Composable
 fun TrustEntryRicalEntryViewer(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     ricalTrustEntryId: String,
     certNum: Int
 ) {
-    val coroutineScope = rememberCoroutineScope()
-
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == ricalTrustEntryId
     } ?: return

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,22 +28,16 @@ import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
  * A Composable that displays the details of a specific individual certificate
  * embedded within a larger VICAL trust entry.
  *
- * @param trustManager The [TrustEntryBasedTrustManager] holding the root VICAL trust entry.
+ * @param trustManagerModel A [TrustManagerModel].
  * @param vicalTrustEntryId The identifier of the parent VICAL trust entry.
  * @param certNum The index position of the specific certificate within the VICAL's certificate list.
  */
 @Composable
 fun TrustEntryVicalEntryViewer(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     vicalTrustEntryId: String,
     certNum: Int
 ) {
-    val coroutineScope = rememberCoroutineScope()
-
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == vicalTrustEntryId
     } ?: return

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -66,8 +67,6 @@ import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustEntryRical
 import org.multipaz.trustmanagement.TrustEntryVical
 import org.multipaz.trustmanagement.TrustEntryX509Cert
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 /**
  * A Composable that displays the full details of a specific trust entry.
@@ -76,7 +75,7 @@ import kotlin.collections.component2
  * (Single X.509 Certificate, VICAL list, or RICAL list). It also provides informational
  * banners for newly imported entries reminding the user to verify the provider.
  *
- * @param trustManager The [TrustEntryBasedTrustManager] holding the trust entries.
+ * @param trustManagerModel A [TrustManagerModel].
  * @param trustEntryId The unique identifier of the trust entry to display.
  * @param justImported True if the entry was recently added, triggering an informational banner.
  * @param imageLoader a [ImageLoader].
@@ -87,7 +86,7 @@ import kotlin.collections.component2
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryViewer(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     trustEntryId: String,
     justImported: Boolean,
     imageLoader: ImageLoader,
@@ -95,12 +94,6 @@ fun TrustEntryViewer(
     onViewVicalEntry: (vicalCertNum: Int) -> Unit,
     onViewRicalEntry: (ricalCertNum: Int) -> Unit,
 ) {
-    val coroutineScope = rememberCoroutineScope()
-
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val entryInfo = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
     } ?: return

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -70,6 +70,7 @@ import org.multipaz.compose.branding.Branding
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.compose.provisioning.ProvisioningBottomSheet
+import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -113,7 +114,6 @@ import org.multipaz.securearea.cloud.CloudSecureArea
 import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.StorageTable
 import org.multipaz.storage.StorageTableSpec
-import org.multipaz.storage.ephemeral.EphemeralStorage
 import org.multipaz.testapp.provisioning.ProvisioningSupport
 import org.multipaz.testapp.ui.AboutScreen
 import org.multipaz.testapp.ui.AndroidKeystoreSecureAreaScreen
@@ -404,12 +404,12 @@ class App private constructor (val promptModel: PromptModel) {
         generateTrustManagers()
     }
 
-    private fun getTrustManagerFromId(identifier: String): TrustEntryBasedTrustManager {
+    private fun getTrustManagerModelFromId(identifier: String): TrustManagerModel {
         return when (identifier) {
-            "builtInIssuerTrustManager" -> builtInIssuerTrustManager
-            "userIssuerTrustManager" -> userIssuerTrustManager
-            "builtInReaderTrustManager" -> builtInReaderTrustManager
-            "userReaderTrustManager" -> userReaderTrustManager
+            "builtInIssuerTrustManager" -> builtInIssuerTrustManagerModel
+            "userIssuerTrustManager" -> userIssuerTrustManagerModel
+            "builtInReaderTrustManager" -> builtInReaderTrustManagerModel
+            "userReaderTrustManager" -> userReaderTrustManagerModel
             else -> throw IllegalStateException("Unexpected TrustManager id $identifier")
         }
     }
@@ -740,7 +740,18 @@ class App private constructor (val promptModel: PromptModel) {
             trustManagers = listOf(builtInReaderTrustManager, userReaderTrustManager),
             identifier = "readers"
         )
+
+        val coroutineScope = CoroutineScope(Dispatchers.Default)
+        builtInReaderTrustManagerModel = TrustManagerModel(builtInReaderTrustManager, coroutineScope)
+        userReaderTrustManagerModel = TrustManagerModel(userReaderTrustManager, coroutineScope)
+        builtInIssuerTrustManagerModel = TrustManagerModel(builtInIssuerTrustManager, coroutineScope)
+        userIssuerTrustManagerModel = TrustManagerModel(userIssuerTrustManager, coroutineScope)
     }
+
+    private lateinit var builtInReaderTrustManagerModel: TrustManagerModel
+    private lateinit var userReaderTrustManagerModel: TrustManagerModel
+    private lateinit var builtInIssuerTrustManagerModel: TrustManagerModel
+    private lateinit var userIssuerTrustManagerModel: TrustManagerModel
 
     lateinit var digitalCredentials: DigitalCredentials
 
@@ -1232,8 +1243,8 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustedIssuersDestination> { backStackEntry ->
                     WithAppBar(navController, "Trusted Issuers") {
                         TrustManagerScreen(
-                            builtIn = builtInIssuerTrustManager,
-                            user = userIssuerTrustManager,
+                            builtIn = builtInIssuerTrustManagerModel,
+                            user = userIssuerTrustManagerModel,
                             isVical = true,
                             imageLoader = imageLoader,
                             onTrustEntryClicked = { trustManagerId, trustEntryId ->
@@ -1260,8 +1271,8 @@ class App private constructor (val promptModel: PromptModel) {
                 composable<TrustedVerifiersDestination> { backStackEntry ->
                     WithAppBar(navController, "Trusted Verifiers") {
                         TrustManagerScreen(
-                            builtIn = builtInReaderTrustManager,
-                            user = userReaderTrustManager,
+                            builtIn = builtInReaderTrustManagerModel,
+                            user = userReaderTrustManagerModel,
                             isVical = false,
                             imageLoader = imageLoader,
                             onTrustEntryClicked = { trustManagerId, trustEntryId ->
@@ -1289,7 +1300,7 @@ class App private constructor (val promptModel: PromptModel) {
                     // TrustEntryScreen has its own AppBar
                     val destination = backStackEntry.toRoute<TrustEntryDestination>()
                     TrustEntryScreen(
-                        trustManager = getTrustManagerFromId(destination.trustManagerId),
+                        trustManagerModel = getTrustManagerModelFromId(destination.trustManagerId),
                         trustEntryId = destination.trustEntryId,
                         justImported = destination.justImported,
                         imageLoader = imageLoader,
@@ -1326,7 +1337,7 @@ class App private constructor (val promptModel: PromptModel) {
                     // TrustEntryEditScreen has its own AppBar
                     val destination = backStackEntry.toRoute<TrustEntryDestination>()
                     TrustEntryEditScreen(
-                        trustManager = getTrustManagerFromId(destination.trustManagerId) as TrustManager,
+                        trustManagerModel = getTrustManagerModelFromId(destination.trustManagerId),
                         trustEntryId = destination.trustEntryId,
                         imageLoader = imageLoader,
                         onBack = { navController.navigateUp() },
@@ -1337,7 +1348,7 @@ class App private constructor (val promptModel: PromptModel) {
                     WithAppBar(navController, "VICAL Entry") {
                         val destination = backStackEntry.toRoute<TrustEntryVicalEntryDestination>()
                         TrustEntryVicalEntryScreen(
-                            trustManager = getTrustManagerFromId(destination.trustManagerId),
+                            trustManagerModel = getTrustManagerModelFromId(destination.trustManagerId),
                             vicalTrustEntryId = destination.trustEntryId,
                             certNum = destination.vicalCertNumber
                         )
@@ -1347,7 +1358,7 @@ class App private constructor (val promptModel: PromptModel) {
                     WithAppBar(navController, "RICAL Entry") {
                         val destination = backStackEntry.toRoute<TrustEntryRicalEntryDestination>()
                         TrustEntryRicalEntryScreen(
-                            trustManager = getTrustManagerFromId(destination.trustManagerId),
+                            trustManagerModel = getTrustManagerModelFromId(destination.trustManagerId),
                             ricalTrustEntryId = destination.trustEntryId,
                             certNum = destination.ricalCertNumber
                         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -45,12 +45,12 @@ import org.multipaz.compose.items.FloatingItemText
 import org.multipaz.datetime.formatLocalized
 import org.multipaz.eventlogger.Event
 import org.multipaz.eventlogger.EventPresentment
-import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsMdocApi
 import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
 import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
 import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
+import org.multipaz.eventlogger.SimpleEventLogger
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,7 +63,7 @@ fun EventLoggerScreen(
     showToast: (message: String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val model = SimpleEventLoggerModel(eventLogger, coroutineScope)
+    val model = remember(eventLogger) { SimpleEventLoggerModel(eventLogger, coroutineScope) }
     val events by model.events.collectAsState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -71,12 +71,12 @@ import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.Icon
 import org.multipaz.eventlogger.Event
 import org.multipaz.eventlogger.EventPresentment
-import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsMdocApi
 import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
 import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
 import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
+import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.toDataItem
 import org.multipaz.prompt.PromptModel
 import org.multipaz.request.MdocRequestedClaim
@@ -97,7 +97,7 @@ fun EventViewerScreen(
     showToast: (message: String) -> Unit
 ) {
     val coroutineScope = rememberUiBoundCoroutineScope { promptModel }
-    val model = SimpleEventLoggerModel(eventLogger, coroutineScope)
+    val model = remember(eventLogger) { SimpleEventLoggerModel(eventLogger, coroutineScope) }
     val events by model.events.collectAsState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryEditScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryEditScreen.kt
@@ -39,7 +39,7 @@ import org.multipaz.trustmanagement.TrustMetadata
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryEditScreen(
-    trustManager: TrustManager,
+    trustManagerModel: TrustManagerModel,
     trustEntryId: String,
     imageLoader: ImageLoader,
     onBack: () -> Unit,
@@ -49,10 +49,6 @@ fun TrustEntryEditScreen(
     val scrollState = rememberScrollState()
     var showConfirmationBeforeExiting by remember { mutableStateOf(false) }
 
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
     } ?: return
@@ -124,7 +120,7 @@ fun TrustEntryEditScreen(
                         enabled = (newMetadata.value != info.entry.metadata),
                         onClick = {
                             coroutineScope.launch {
-                                trustManager.updateMetadata(
+                                (trustManagerModel.trustManager as TrustManager).updateMetadata(
                                     entry = info.entry,
                                     metadata = newMetadata.value
                                 )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryRicalEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryRicalEntryScreen.kt
@@ -9,12 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.multipaz.compose.trustmanagement.TrustEntryRicalEntryViewer
+import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 
 @Composable
 fun TrustEntryRicalEntryScreen(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     ricalTrustEntryId: String,
     certNum: Int
 ) {
@@ -26,7 +27,7 @@ fun TrustEntryRicalEntryScreen(
             .padding(8.dp),
     ) {
         TrustEntryRicalEntryViewer(
-            trustManager = trustManager,
+            trustManagerModel = trustManagerModel,
             ricalTrustEntryId = ricalTrustEntryId,
             certNum = certNum
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
@@ -43,7 +43,7 @@ import org.multipaz.trustmanagement.TrustManager
 @OptIn(ExperimentalResourceApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun TrustEntryScreen(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     trustEntryId: String,
     justImported: Boolean,
     imageLoader: ImageLoader,
@@ -58,10 +58,6 @@ fun TrustEntryScreen(
     val scrollState = rememberScrollState()
     var showDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
-    val trustManagerModel = TrustManagerModel(
-        trustManager = trustManager,
-        coroutineScope = coroutineScope
-    )
     val info = trustManagerModel.trustManagerInfos.collectAsState().value?.find {
         it.entry.identifier == trustEntryId
     } ?: return
@@ -81,7 +77,7 @@ fun TrustEntryScreen(
                     onClick = {
                         coroutineScope.launch {
                             showDeleteConfirmationDialog = false
-                            (trustManager as? TrustManager)?.deleteEntry(info.entry)
+                            (trustManagerModel.trustManager as? TrustManager)?.deleteEntry(info.entry)
                             onBack()
                         }
                     }
@@ -134,7 +130,7 @@ fun TrustEntryScreen(
                     }
                 },
                 actions = {
-                    if (trustManager is TrustManager) {
+                    if (trustManagerModel.trustManager is TrustManager) {
                         IconButton(
                             onClick = { onEdit() }
                         ) {
@@ -164,7 +160,7 @@ fun TrustEntryScreen(
                 .padding(8.dp),
         ) {
             TrustEntryViewer(
-                trustManager = trustManager,
+                trustManagerModel = trustManagerModel,
                 trustEntryId = trustEntryId,
                 justImported = justImported,
                 imageLoader = imageLoader,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryVicalEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryVicalEntryScreen.kt
@@ -9,11 +9,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.multipaz.compose.trustmanagement.TrustEntryVicalEntryViewer
+import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 
 @Composable
 fun TrustEntryVicalEntryScreen(
-    trustManager: TrustEntryBasedTrustManager,
+    trustManagerModel: TrustManagerModel,
     vicalTrustEntryId: String,
     certNum: Int
 ) {
@@ -25,7 +26,7 @@ fun TrustEntryVicalEntryScreen(
             .padding(8.dp),
     ) {
         TrustEntryVicalEntryViewer(
-            trustManager = trustManager,
+            trustManagerModel = trustManagerModel,
             vicalTrustEntryId = vicalTrustEntryId,
             certNum = certNum
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
@@ -1,6 +1,5 @@
 package org.multipaz.testapp.ui
 
-import kotlinx.coroutines.CancellationException
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -9,7 +8,6 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -24,7 +22,6 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -36,25 +33,22 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.multipaz.compose.items.FloatingItemCenteredText
 import org.multipaz.compose.pickers.FilePicker
 import org.multipaz.compose.pickers.rememberFilePicker
-import org.multipaz.compose.trustmanagement.TrustEntryInfo
 import org.multipaz.compose.trustmanagement.TrustEntryList
 import org.multipaz.compose.trustmanagement.TrustManagerModel
 import org.multipaz.crypto.X509Cert
 import org.multipaz.mdoc.rical.SignedRical
 import org.multipaz.mdoc.vical.SignedVical
-import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.trustmanagement.TrustEntryAlreadyExistsException
 import org.multipaz.trustmanagement.TrustEntryBasedTrustManager
 import org.multipaz.trustmanagement.TrustManager
+import org.multipaz.trustmanagement.TrustMetadata
 
 @Composable
 private fun FloatingActionButtonMenu(
@@ -142,8 +136,8 @@ private fun FloatingActionButtonMenu(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrustManagerScreen(
-    builtIn: TrustEntryBasedTrustManager,
-    user: TrustManager,
+    builtIn: TrustManagerModel,
+    user: TrustManagerModel,
     isVical: Boolean,
     imageLoader: ImageLoader,
     onTrustEntryClicked: (trustManagerId: String, trustEntryId: String) -> Unit,
@@ -169,11 +163,11 @@ fun TrustManagerScreen(
                 coroutineScope.launch {
                     try {
                         val cert = X509Cert.fromPem(pemEncoding = files[0].toByteArray().decodeToString())
-                        val entry = user.addX509Cert(
+                        val entry = (user.trustManager as TrustManager).addX509Cert(
                             certificate = cert,
                             metadata = TrustMetadata()
                         )
-                        onTrustEntryAdded(user.identifier, entry.identifier)
+                        onTrustEntryAdded(user.trustManager.identifier, entry.identifier)
                     } catch (_: TrustEntryAlreadyExistsException) {
                         showImportErrorDialog.value = "A certificate with this Subject Key Identifier already exists"
                     } catch (e: Exception) {
@@ -202,11 +196,11 @@ fun TrustManagerScreen(
                             encodedSignedVical = encodedSignedVical.toByteArray(),
                             disableSignatureVerification = false
                         )
-                        val entry = user.addVical(
+                        val entry = (user.trustManager as TrustManager).addVical(
                             encodedSignedVical = encodedSignedVical,
                             metadata = TrustMetadata()
                         )
-                        onTrustEntryAdded(user.identifier, entry.identifier)
+                        onTrustEntryAdded(user.trustManager.identifier, entry.identifier)
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         e.printStackTrace()
@@ -233,11 +227,11 @@ fun TrustManagerScreen(
                             encodedSignedRical = encodedSignedRical.toByteArray(),
                             disableSignatureVerification = false
                         )
-                        val entry = user.addRical(
+                        val entry = (user.trustManager as TrustManager).addRical(
                             encodedSignedRical = encodedSignedRical,
                             metadata = TrustMetadata()
                         )
-                        onTrustEntryAdded(user.identifier, entry.identifier)
+                        onTrustEntryAdded(user.trustManager.identifier, entry.identifier)
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         e.printStackTrace()
@@ -284,23 +278,23 @@ fun TrustManagerScreen(
                 .padding(8.dp),
         ) {
             TrustEntryList(
-                trustManager = builtIn,
+                trustManagerModel = builtIn,
                 title = "Built-in",
                 imageLoader = imageLoader,
                 loading = { FloatingItemCenteredText(text = "Loading...") },
                 noItems = { FloatingItemCenteredText(text = "No built-in trust points") },
                 onTrustEntryClicked = { trustEntry ->
-                    onTrustEntryClicked(builtIn.identifier, trustEntry.identifier)
+                    onTrustEntryClicked(builtIn.trustManager.identifier, trustEntry.identifier)
                 }
             )
             TrustEntryList(
-                trustManager = user,
+                trustManagerModel = user,
                 title = "Manually imported",
                 imageLoader = imageLoader,
                 loading = { FloatingItemCenteredText(text = "Loading...") },
                 noItems = { FloatingItemCenteredText(text = "Certificates and trust lists manually imported will appear in this list") },
                 onTrustEntryClicked = { trustEntry ->
-                    onTrustEntryClicked(user.identifier, trustEntry.identifier)
+                    onTrustEntryClicked(user.trustManager.identifier, trustEntry.identifier)
                 }
             )
         }


### PR DESCRIPTION
The problem with instantiating a new `TrustManagerModel` for every screen is that it's an asynchronous operation. Not only does this involve a bit of overhead when switching screens, it also breaks scrolling. For example, when viewing a VICAL there are typically a lot of certificates so you end up scrolling down. When you navigate back, it will start at the top of the page simply because at the first composition the `TrustManagerModel` is still loading so the page won't scroll at all.

Fix this by sharing the `TrustManagerModel` across all screens.

The code also wasn't remembering the `TrustManagerModel` per screen which lead to infinite recompositions and eventually a memory leak.

Test: Manually tested.