### PR TITLE
FloatingItemList fixes.

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="provisioning_error">Error provisioning (error code: %1$s)</string>
     <string name="provisioning_select_credential">Select credential to provision:</string>
     <string name="provisioning_cancel_button">Cancel provisioning</string>
+    <string name="provisioning_tx_code_fallback_prompt_numeric">Enter the PIN that was previously communicated to you</string>
+    <string name="provisioning_tx_code_fallback_prompt">Enter the passphrase that was previously communicated to you</string>
 
     <!-- durationFromNowText -->
     <string name="duration_just_now">just now</string>
@@ -204,4 +206,10 @@
     <string name="key_unlock_present_bio_subtitle">Authentication is required</string>
     <string name="key_unlock_present_passphrase_subtitle">Enter the passphrase associated with the document</string>
     <string name="aks_unlock_present_pin_subtitle">Enter the PIN associated with the document</string>
+
+    <!-- FloatingItemHeadingAndDate -->
+    <string name="floating_item_heading_and_date_not_set">Not set</string>
+
+    <!-- FloatingItemHeadingAndDateTime -->
+    <string name="floating_item_heading_and_date_time_not_set">Not set</string>
 </resources>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/certificateviewer/X509CertViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/certificateviewer/X509CertViewer.kt
@@ -3,6 +3,7 @@ package org.multipaz.compose.certificateviewer
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -12,6 +13,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.asn1.OID
@@ -80,6 +82,7 @@ private fun BasicInfo(data: CertificateViewData) {
     @Suppress("DEPRECATION")
     val clipboardManager = LocalClipboardManager.current
     FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
         title = stringResource(Res.string.certificate_viewer_sub_basic_info),
     ) {
         FloatingItemHeadingAndText(
@@ -161,6 +164,7 @@ private fun Subject(data: CertificateViewData) {
     if (data.subject.isEmpty()) return
 
     FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
         title = stringResource(Res.string.certificate_viewer_sub_subject),
     ) {
         data.subject.forEach { (oid, value) ->
@@ -179,6 +183,7 @@ private fun Issuer(data: CertificateViewData) {
     if (data.issuer.isEmpty()) return
 
     FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
         title = stringResource(Res.string.certificate_viewer_sub_issuer),
     ) {
         data.issuer.forEach { (oid, value) ->
@@ -195,6 +200,7 @@ private fun Issuer(data: CertificateViewData) {
 @Composable
 private fun PublicKeyInfo(data: CertificateViewData) {
     FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
         title = stringResource(Res.string.certificate_viewer_sub_public_key_info),
     ) {
         FloatingItemHeadingAndText(
@@ -219,6 +225,7 @@ private fun Extensions(data: CertificateViewData) {
     if (data.extensions.isEmpty()) return
 
     FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
         title = stringResource(Res.string.certificate_viewer_sub_extensions),
     ) {
         data.extensions.forEach { (isCritical, oid, value) ->

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndContent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndContent.kt
@@ -1,0 +1,52 @@
+package org.multipaz.compose.items
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * An item showing a heading in bold with content below it.
+ *
+ * @param heading will be shown in bold at the top.
+ * @param content will be shown below the heading.
+ * @param modifier a [Modifier].
+ * @param image optional image, shown to the left of the text.
+ * @param trailingContent optional trailing content.
+ */
+@Composable
+fun FloatingItemHeadingAndContent(
+    heading: String,
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    image: @Composable () -> Unit = {},
+    trailingContent: @Composable () -> Unit = {},
+) {
+    FloatingItemContainer(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp, alignment = Alignment.Start),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            image()
+            Column(
+                modifier = Modifier.weight(1.0f)
+            ) {
+                Text(
+                    text = heading,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                content()
+            }
+            trailingContent()
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndDate.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndDate.kt
@@ -1,0 +1,50 @@
+package org.multipaz.compose.items
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.datetime.TimeZone
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.compose.datetime.formattedDate
+import org.multipaz.datetime.FormatStyle
+import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.floating_item_heading_and_date_not_set
+import kotlin.time.Instant
+
+/**
+ * Like [FloatingItemHeadingAndText], but with a date instead of text.
+ *
+ * @param heading will be shown in bold at the top.
+ * @param date will be shown below the heading or "Not set" if `null`.
+ * @param timeZone the timezone to use for displaying the point in time.
+ * @param dateStyle the amount of data to include in the date component.
+ * @param modifier a [Modifier].
+ * @param image optional image, shown to the left of the text.
+ * @param trailingContent optional trailing content.
+ */
+@Composable
+fun FloatingItemHeadingAndDate(
+    heading: String,
+    date: Instant?,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+    modifier: Modifier = Modifier,
+    image: @Composable () -> Unit = {},
+    trailingContent: @Composable () -> Unit = {},
+) {
+    val text = date?.let { formattedDate(
+        instant = it,
+        timeZone = timeZone,
+        dateStyle = dateStyle,
+    ) }
+        ?: AnnotatedString(stringResource(Res.string.floating_item_heading_and_date_not_set))
+    FloatingItemHeadingAndText(
+        heading = heading,
+        text = text,
+        modifier = modifier,
+        image = image,
+        trailingContent = trailingContent
+    )
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndDateTime.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndDateTime.kt
@@ -1,0 +1,51 @@
+package org.multipaz.compose.items
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.datetime.TimeZone
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.compose.datetime.formattedDateTime
+import org.multipaz.datetime.FormatStyle
+import org.multipaz.multipaz_compose.generated.resources.Res
+import org.multipaz.multipaz_compose.generated.resources.floating_item_heading_and_date_time_not_set
+import kotlin.time.Instant
+
+/**
+ * Like [FloatingItemHeadingAndText], but with a date and time instead of text.
+ *
+ * @param heading will be shown in bold at the top.
+ * @param dateAndTime will be shown below the heading or "Not set" if `null`.
+ * @param timeZone the timezone to use for displaying the point in time.
+ * @param dateStyle the amount of data to include in the date component.
+ * @param timeStyle the amount of data to include in the time component.
+ * @param modifier a [Modifier].
+ * @param image optional image, shown to the left of the text.
+ * @param trailingContent optional trailing content.
+ */
+@Composable
+fun FloatingItemHeadingAndDateTime(
+    heading: String,
+    dateAndTime: Instant?,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+    timeStyle: FormatStyle = FormatStyle.MEDIUM,
+    modifier: Modifier = Modifier,
+    image: @Composable () -> Unit = {},
+    trailingContent: @Composable () -> Unit = {},
+) {
+    val text = dateAndTime?.let { formattedDateTime(
+        instant = it,
+        timeZone = timeZone,
+        dateStyle = dateStyle,
+        timeStyle = timeStyle
+    ) }
+        ?: AnnotatedString(stringResource(Res.string.floating_item_heading_and_date_time_not_set))
+    FloatingItemHeadingAndText(
+        heading = heading,
+        text = text,
+        modifier = modifier,
+        image = image,
+        trailingContent = trailingContent
+    )
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndText.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemHeadingAndText.kt
@@ -31,32 +31,17 @@ fun FloatingItemHeadingAndText(
     image: @Composable () -> Unit = {},
     trailingContent: @Composable () -> Unit = {},
 ) {
-    FloatingItemContainer(modifier = modifier) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp, alignment = Alignment.Start),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            image()
-            Column(
-                modifier = Modifier.weight(1.0f)
-            ) {
-                Text(
-                    text = heading,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                SelectionContainer {
-                    Text(
-                        text = text,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-
+    FloatingItemHeadingAndContent(
+        heading = heading,
+        content = {
+            SelectionContainer {
+                Text(text = text)
             }
-            trailingContent()
-        }
-    }
+        },
+        modifier = modifier,
+        image = image,
+        trailingContent = trailingContent
+    )
 }
 
 /**

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemList.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.unit.dp
  * See [FloatingItemHeadingAndText], [FloatingItemText], [FloatingItemCenteredText] for things that are normally
  * used inside this container. For your own composable, simply wrap it in [FloatingItemContainer].
  *
+ * The list is rendered to appear raised above the parent container. When using this composable,
+ * make sure to leave 10.dp padding around it and 20.dp at the bottom, to leave enough room for
+ * its shadow.
+ *
  * @param modifier a [Modifier].
  * @param title the title to show above the list or `null`.
  * @param content the items to show inside the list.
@@ -42,7 +46,7 @@ fun FloatingItemList(
     Column(modifier = modifier) {
         if (title != null) {
             Text(
-                modifier = Modifier.padding(start = 10.dp, top = 10.dp, end = 10.dp, bottom = 0.dp),
+                modifier = Modifier.padding(bottom = 8.dp),
                 text = title,
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Bold,
@@ -52,13 +56,12 @@ fun FloatingItemList(
 
         Column(
             modifier = Modifier
-                .padding(start = 10.dp, top = 10.dp, end = 10.dp, bottom = 15.dp)
                 .dropShadow(
                     shape = RoundedCornerShape(16.dp),
                     shadow = Shadow(
                         radius = 10.dp,
                         spread = 7.5.dp,
-                        color = Color.Black.copy(alpha = 0.05f),
+                        color = Color.Black.copy(alpha = 0.065f),
                         offset = DpOffset(x = 0.dp, 2.dp)
                     )
                 )

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -348,7 +348,6 @@ private fun ShowRequesterInfoPage(
     onBackClicked: () -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(8.dp),
         verticalArrangement = Arrangement.Bottom
     ) {
         Row(
@@ -394,7 +393,9 @@ private fun ShowRequesterInfoPage(
                     ) { page ->
                         val scrollState = rememberScrollState()
                         X509CertViewer(
-                            modifier = Modifier.verticalScroll(scrollState),
+                            modifier = Modifier
+                                .padding(top = 10.dp, bottom = 20.dp, start = 10.dp, end = 10.dp)
+                                .verticalScroll(scrollState),
                             certificate = certChain.certificates[page]
                         )
                     }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
@@ -65,6 +65,8 @@ import org.multipaz.multipaz_compose.generated.resources.provisioning_requestion
 import org.multipaz.multipaz_compose.generated.resources.provisioning_retry
 import org.multipaz.multipaz_compose.generated.resources.provisioning_select_credential
 import org.multipaz.multipaz_compose.generated.resources.provisioning_title
+import org.multipaz.multipaz_compose.generated.resources.provisioning_tx_code_fallback_prompt
+import org.multipaz.multipaz_compose.generated.resources.provisioning_tx_code_fallback_prompt_numeric
 import org.multipaz.provisioning.AuthorizationChallenge
 import org.multipaz.provisioning.AuthorizationException
 import org.multipaz.provisioning.AuthorizationResponse
@@ -536,12 +538,17 @@ private fun EvidenceRequestSecretText(
         maxLength = passphraseRequest.length ?: 10,
         passphraseRequest.isNumeric
     )
+    val fallback = if (passphraseRequest.isNumeric) {
+        stringResource(Res.string.provisioning_tx_code_fallback_prompt_numeric)
+    } else {
+        stringResource(Res.string.provisioning_tx_code_fallback_prompt)
+    }
     Column {
         Text(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(16.dp, 8.dp),
-            text = passphraseRequest.description
+            text = passphraseRequest.description ?: fallback
         )
         if (challenge.retry) {
             Text(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryRicalEntryViewer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -63,7 +64,10 @@ fun TrustEntryRicalEntryViewer(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        FloatingItemList(title = stringResource(Res.string.trust_entry_rical_entry_title)) {
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+            title = stringResource(Res.string.trust_entry_rical_entry_title)
+        ) {
             FloatingItemHeadingAndText(
                 heading = stringResource(Res.string.trust_entry_rical_is_trust_anchor),
                 text = if (ricalCertInfo.isTrustAnchor) {

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryVicalEntryViewer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,7 +62,10 @@ fun TrustEntryVicalEntryViewer(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        FloatingItemList(title = stringResource(Res.string.trust_entry_vical_entry_title)) {
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+            title = stringResource(Res.string.trust_entry_vical_entry_title)
+        ) {
             FloatingItemHeadingAndText(
                 heading = stringResource(Res.string.trust_entry_vical_entry_document_types),
                 text = vicalCertInfo.docTypes.joinToString("\n")

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/trustmanagement/TrustEntryViewer.kt
@@ -138,7 +138,10 @@ fun TrustEntryViewer(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.Start,
         ) {
-            FloatingItemList(title = null) {
+            FloatingItemList(
+                modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+                title = null
+            ) {
                 FloatingItemHeadingAndText(stringResource(Res.string.trust_entry_test_only_label),
                     if (entryInfo.entry.metadata.testOnly) {
                         stringResource(Res.string.trust_entry_yes)
@@ -180,7 +183,10 @@ private fun VicalDetails(
     onViewVicalEntry: (vicalCertNum: Int) -> Unit,
     onViewCertificateChain: (certificateChain: X509CertChain) -> Unit,
 ) {
-    FloatingItemList(title = stringResource(Res.string.trust_entry_vical_data_title)) {
+    FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+        title = stringResource(Res.string.trust_entry_vical_data_title)
+    ) {
         FloatingItemHeadingAndText(
             heading = stringResource(Res.string.trust_entry_vical_details_version),
             text = signedVical.vical.version
@@ -228,7 +234,10 @@ private fun VicalDetails(
         }
     }
 
-    FloatingItemList(title = stringResource(Res.string.trust_entry_certificates_title)) {
+    FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+        title = stringResource(Res.string.trust_entry_certificates_title)
+    ) {
         signedVical.vical.certificateInfos.forEachIndexed { n, certificateInfo ->
             FloatingItemText(
                 modifier = Modifier.clickable { onViewVicalEntry(n) },
@@ -247,7 +256,10 @@ private fun RicalDetails(
     onViewRicalEntry: (ricalCertNum: Int) -> Unit,
     onViewCertificateChain: (certificateChain: X509CertChain) -> Unit,
 ) {
-    FloatingItemList(title = stringResource(Res.string.trust_entry_rical_data_title)) {
+    FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+        title = stringResource(Res.string.trust_entry_rical_data_title)
+    ) {
         FloatingItemHeadingAndText(
             heading = stringResource(Res.string.trust_entry_rical_details_type),
             text = signedRical.rical.type
@@ -299,7 +311,10 @@ private fun RicalDetails(
         }
     }
 
-    FloatingItemList(title = stringResource(Res.string.trust_entry_certificates_title)) {
+    FloatingItemList(
+        modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+        title = stringResource(Res.string.trust_entry_certificates_title)
+    ) {
         signedRical.rical.certificateInfos.forEachIndexed { n, certificateInfo ->
             FloatingItemText(
                 modifier = Modifier.clickable { onViewRicalEntry(n) },

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/preauthorized.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/preauthorized.kt
@@ -47,7 +47,7 @@ fun parseTxKind(txKind: String?, txPrompt: String?): SecretCodeRequest? {
     val txNumeric = txKind.startsWith("n")
     val txLength = txKind.substring(1).toInt()
     return SecretCodeRequest(
-        description = txPrompt ?: "Transaction Code",
+        description = txPrompt,
         isNumeric = txNumeric,
         length = txLength
     )

--- a/multipaz-swiftui/src/iosMain/swift/Consent.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Consent.swift
@@ -395,6 +395,7 @@ private struct ShowRequesterInfo: View {
                     TabView(selection: $currentPage) {
                         ForEach(0..<certificates.count, id: \.self) { index in
                             X509CertViewer(certificate: certificates[index])
+                                .padding()
                                 .tag(index)
                                 .measurePageHeight(index)
                         }

--- a/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndContent.swift
+++ b/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndContent.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// A list item view that displays a bold heading with content below it,
+/// an optional leading image, and an optional trailing view.
+public struct FloatingItemHeadingAndContent<ContentView: View, ImageView: View, TrailingView: View>: View {
+
+    /// The heading string displayed in a bold font above the primary text.
+    public var heading: String
+
+    /// A view builder that creates the content.
+    @ViewBuilder public var content: () -> ContentView
+
+    /// A view builder that creates the leading image or icon.
+    @ViewBuilder public var image: () -> ImageView
+
+    /// A view builder that creates the trailing content, pushed to the rightmost edge.
+    @ViewBuilder public var trailingContent: () -> TrailingView
+
+    /// Creates a new floating item with a heading and an `AttributedString` body.
+    ///
+    /// - Parameters:
+    ///   - heading: The bold heading to display.
+    ///   - content: A view builder that provides the content.
+    ///   - image: A view builder that provides a leading image or icon. Defaults to an `EmptyView`.
+    ///   - trailingContent: A view builder that provides a trailing view. Defaults to an `EmptyView`.
+    public init(
+        heading: String,
+        @ViewBuilder content: @escaping () -> ContentView,
+        @ViewBuilder image: @escaping () -> ImageView = { EmptyView() },
+        @ViewBuilder trailingContent: @escaping () -> TrailingView = { EmptyView() }
+    ) {
+        self.heading = heading
+        self.content = content
+        self.image = image
+        self.trailingContent = trailingContent
+    }
+
+    public var body: some View {
+        FloatingItemContainer {
+            HStack(alignment: .center, spacing: 16) {
+                image()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(heading)
+                        .font(.system(size: 15))
+                        .fontWeight(.bold)
+
+                    content()
+                }
+
+                // Pushes the trailing content to the rightmost edge
+                Spacer(minLength: 0)
+
+                trailingContent()
+            }
+        }
+    }
+}

--- a/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndDate.swift
+++ b/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndDate.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// A list item view that displays a bold heading with a date below it,
+/// an optional leading image, and an optional trailing view.
+public struct FloatingItemHeadingAndDate<ImageView: View, TrailingView: View>: View {
+
+    /// The heading string displayed in a bold font above the primary text.
+    public var heading: String
+
+    /// The date to show or `nil`.
+    public var date: Date?
+    
+    private let text: String
+
+    /// The time zone to use.
+    public var timeZone: Foundation.TimeZone
+
+    /// The style of formatting to apply.
+    public var dateStyle: DateFormatter.Style
+
+    /// A view builder that creates the leading image or icon.
+    @ViewBuilder public var image: () -> ImageView
+
+    /// A view builder that creates the trailing content, pushed to the rightmost edge.
+    @ViewBuilder public var trailingContent: () -> TrailingView
+
+    /// Creates a new floating item with a heading and date.
+    ///
+    /// - Parameters:
+    ///   - heading: The bold heading to display.
+    ///   - date: The date to display below the heading.
+    ///   - timeZone: The time zone to use.
+    ///   - dateStyle: The style of formatting to apply.
+    ///   - image: A view builder that provides a leading image or icon. Defaults to an `EmptyView`.
+    ///   - trailingContent: A view builder that provides a trailing view. Defaults to an `EmptyView`.
+    public init(
+        heading: String,
+        date: Date?,
+        timeZone: Foundation.TimeZone = TimeZone.current,
+        dateStyle: DateFormatter.Style = .medium,
+        @ViewBuilder image: @escaping () -> ImageView = { EmptyView() },
+        @ViewBuilder trailingContent: @escaping () -> TrailingView = { EmptyView() }
+    ) {
+        self.heading = heading
+        self.date = date
+        self.timeZone = timeZone
+        self.dateStyle = dateStyle
+        self.image = image
+        self.trailingContent = trailingContent
+
+        if date == nil {
+            text = "Not set"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateStyle = dateStyle
+            formatter.timeZone = timeZone
+            text = formatter.string(from: date!)
+        }
+    }
+
+    public var body: some View {
+        FloatingItemHeadingAndText(
+            heading: heading,
+            text: text,
+            image: image,
+            trailingContent: trailingContent
+        )
+    }
+}

--- a/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndDateTime.swift
+++ b/multipaz-swiftui/src/iosMain/swift/FloatingItemHeadingAndDateTime.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// A list item view that displays a bold heading with a date and time below it,
+/// an optional leading image, and an optional trailing view.
+public struct FloatingItemHeadingAndDateTime<ImageView: View, TrailingView: View>: View {
+
+    /// The heading string displayed in a bold font above the primary text.
+    public var heading: String
+
+    /// The date and time to show or `nil`.
+    public var dateTime: Date?
+    
+    private let text: String
+    
+    /// The time zone to use.
+    public var timeZone: Foundation.TimeZone
+    
+    /// The style of formatting to apply.
+    public var dateStyle: DateFormatter.Style
+
+    /// The style of formatting to apply.
+    public var timeStyle: DateFormatter.Style
+
+    /// A view builder that creates the leading image or icon.
+    @ViewBuilder public var image: () -> ImageView
+
+    /// A view builder that creates the trailing content, pushed to the rightmost edge.
+    @ViewBuilder public var trailingContent: () -> TrailingView
+
+    /// Creates a new floating item with a heading and a date and time.
+    ///
+    /// - Parameters:
+    ///   - heading: The bold heading to display.
+    ///   - dateTime: The date and time to display below the heading.
+    ///   - timeZone: The time zone to use.
+    ///   - dateStyle: The style of formatting to apply.
+    ///   - timeStyle: The style of formatting to apply.
+    ///   - image: A view builder that provides a leading image or icon. Defaults to an `EmptyView`.
+    ///   - trailingContent: A view builder that provides a trailing view. Defaults to an `EmptyView`.
+    public init(
+        heading: String,
+        dateTime: Date?,
+        timeZone: Foundation.TimeZone = TimeZone.current,
+        dateStyle: DateFormatter.Style = .medium,
+        timeStyle: DateFormatter.Style = .medium,
+        @ViewBuilder image: @escaping () -> ImageView = { EmptyView() },
+        @ViewBuilder trailingContent: @escaping () -> TrailingView = { EmptyView() }
+    ) {
+        self.heading = heading
+        self.dateTime = dateTime
+        self.timeZone = timeZone
+        self.dateStyle = dateStyle
+        self.timeStyle = timeStyle
+        self.image = image
+        self.trailingContent = trailingContent
+
+        if dateTime == nil {
+            text = "Not set"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateStyle = dateStyle
+            formatter.timeStyle = timeStyle
+            formatter.timeZone = timeZone
+            text = formatter.string(from: dateTime!)
+        }
+    }
+
+    public var body: some View {
+        FloatingItemHeadingAndText(
+            heading: heading,
+            text: text,
+            image: image,
+            trailingContent: trailingContent
+        )
+    }
+}

--- a/multipaz-swiftui/src/iosMain/swift/FloatingItemList.swift
+++ b/multipaz-swiftui/src/iosMain/swift/FloatingItemList.swift
@@ -29,10 +29,13 @@ public struct FloatingItemList<Content: View>: View {
                     .font(.subheadline) // Equivalent to bodyMedium
                     .fontWeight(.bold)
                     .foregroundColor(.secondary)
+                    .padding(.bottom, 8)
+                /*
                     .padding(.leading, 10)
                     .padding(.top, 10)
                     .padding(.trailing, 10)
                     .padding(.bottom, 5) // Adjusted slightly to flow into the list naturally
+                 */
             }
 
             VStack(spacing: 1) { // Spacing creates the divider effect
@@ -47,10 +50,12 @@ public struct FloatingItemList<Content: View>: View {
                 x: 0,
                 y: 2
             )
+            /*
             .padding(.leading, 10)
             .padding(.trailing, 10)
             .padding(.top, title == nil ? 10 : 5)
             .padding(.bottom, 15)
+            */
         }
     }
 }

--- a/multipaz-swiftui/src/iosMain/swift/X509CertViewer.swift
+++ b/multipaz-swiftui/src/iosMain/swift/X509CertViewer.swift
@@ -21,7 +21,7 @@ public struct X509CertViewer: View {
     }
 
     public var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 10) {
             BasicInfoView(data: data)
             SubjectView(data: data)
             IssuerView(data: data)
@@ -29,7 +29,6 @@ public struct X509CertViewer: View {
             ExtensionsView(data: data)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
     }
 }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/SecretCodeRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/SecretCodeRequest.kt
@@ -10,11 +10,11 @@ import org.multipaz.cbor.annotation.CborSerializable
 @CborSerializable
 data class SecretCodeRequest(
     /**
-     * Description for the requested secret text.
+     * Description for the requested secret text, if available.
      *
      * This is plain text (i.e. not HTML or Markdown)
      */
-    val description: String,
+    val description: String?,
     /**
      * True if required text must only contain ASCII decimal digit characters.
      */

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -126,8 +126,7 @@ internal sealed class CredentialOffer {
             } else {
                 val obj = txCodeJson.jsonObject
                 SecretCodeRequest(
-                    description = obj.stringOrNull("description")
-                        ?: "Enter transaction code that was previously communicated to you",
+                    description = obj.stringOrNull("description"),
                     length = obj.integerOrNull("length") ?: Int.MAX_VALUE,
                     isNumeric = obj.stringOrNull("input_mode") != "text"
                 )

--- a/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		512C056C2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */; };
+		512C056D2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */; };
+		512C056F2F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */; };
+		512C05702F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */; };
+		512C05722F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */; };
+		512C05732F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */; };
 		512DAED62F2A31B30061F72B /* IdentityDocumentProviderExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		51BD5C5E2F22604F0082DE19 /* AdditionalConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */; };
 		51BD5C5F2F22604F0082DE19 /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */; };
@@ -90,6 +96,9 @@
 
 /* Begin PBXFileReference section */
 		51100E672F21D4A5006B2ADD /* SwiftTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
+		512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
+		512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
 		512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = IdentityDocumentProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdditionalConfig.xcconfig; path = ../testapp/iosApp/AdditionalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 		51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = DeveloperConfig.xcconfig; path = ../testapp/iosApp/DeveloperConfig.xcconfig; sourceTree = SOURCE_ROOT; };
@@ -207,6 +216,9 @@
 		51F711882F860D320017F68B /* swift */ = {
 			isa = PBXGroup;
 			children = (
+				512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */,
+				512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */,
+				512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */,
 				51F7116E2F860D320017F68B /* Consent.swift */,
 				51F7116F2F860D320017F68B /* ConsentPromptDialog.swift */,
 				51F711702F860D320017F68B /* DocumentCarousel.swift */,
@@ -396,6 +408,7 @@
 			files = (
 				51F711A32F860D320017F68B /* DocumentModel.swift in Sources */,
 				51F711A42F860D320017F68B /* DocumentExtCardart.swift in Sources */,
+				512C056F2F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */,
 				51F711A52F860D320017F68B /* DocumentExt.swift in Sources */,
 				51F711A62F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */,
 				51F711A72F860D320017F68B /* VerticalDocumentList.swift in Sources */,
@@ -419,6 +432,8 @@
 				51F711B92F860D320017F68B /* MdocProximityQrSettings.swift in Sources */,
 				51F711BA2F860D320017F68B /* ConsentPromptDialog.swift in Sources */,
 				51F711BB2F860D320017F68B /* RequestAuthorizationView.swift in Sources */,
+				512C05732F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */,
+				512C056C2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */,
 				51F711BC2F860D320017F68B /* SmartSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -433,11 +448,13 @@
 				51F7118C2F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */,
 				51F7118D2F860D320017F68B /* VerticalDocumentList.swift in Sources */,
 				51F7118E2F860D320017F68B /* Extensions.swift in Sources */,
+				512C056D2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */,
 				51F7118F2F860D320017F68B /* ProvisioningView.swift in Sources */,
 				51F711902F860D320017F68B /* PromptModelExt.swift in Sources */,
 				51F711912F860D320017F68B /* PromptDialogs.swift in Sources */,
 				51F711922F860D320017F68B /* PassphrasePromptDialog.swift in Sources */,
 				51F711932F860D320017F68B /* SimplePresentmentSourceExt.swift in Sources */,
+				512C05702F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */,
 				51F711942F860D320017F68B /* FloatingItemCenteredText.swift in Sources */,
 				51F711952F860D320017F68B /* TagsExt.swift in Sources */,
 				51F711962F860D320017F68B /* MdocProximityQrPresentment.swift in Sources */,
@@ -451,6 +468,7 @@
 				51F7119E2F860D320017F68B /* PassphraseInputView.swift in Sources */,
 				51F7119F2F860D320017F68B /* MdocProximityQrSettings.swift in Sources */,
 				51F711A02F860D320017F68B /* ConsentPromptDialog.swift in Sources */,
+				512C05722F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */,
 				51F711A12F860D320017F68B /* RequestAuthorizationView.swift in Sources */,
 				51F711A22F860D320017F68B /* SmartSheet.swift in Sources */,
 			);

--- a/samples/SwiftTestApp/SwiftTestApp/CertificateExamplesScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/CertificateExamplesScreen.swift
@@ -68,10 +68,10 @@ struct CertificateExamplesScreen: View {
                     Text("Certificate valid in the future w/ unknown X500 component")
                 }
             }
+            .padding(10)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .navigationTitle("Certificate examples")
-        .padding()
     }
 }
 

--- a/samples/SwiftTestApp/SwiftTestApp/CertificateViewerScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/CertificateViewerScreen.swift
@@ -12,6 +12,7 @@ struct CertificateViewerScreen: View {
             certificates: certificates,
             currentPage: $currentPage
         )
+        .navigationTitle("Certificate Viewer")
     }
 }
 
@@ -57,6 +58,7 @@ private struct CertificateViewerInternal: View {
                 .padding(.bottom, 8)
             }
         }
+        .padding()
     }
 }
 

--- a/samples/SwiftTestApp/SwiftTestApp/FloatingItemListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/FloatingItemListScreen.swift
@@ -2,56 +2,82 @@ import SwiftUI
 import Multipaz
 
 struct FloatingItemListScreen: View {
+    
+    private let fiveDaysAgo: Date = Calendar.current.date(byAdding: .day, value: -5, to: Date())!
+    private let fiveDaysFromNow: Date = Calendar.current.date(byAdding: .day, value: 5, to: Date())!
+    
     var body: some View {
         ScrollView {
-            FloatingItemList(title: "FloatingItemText") {
-                FloatingItemText(text: "Primary text")
-                FloatingItemText(text: "Primary text", secondary: "Secondary text")
-                FloatingItemText(text: "Primary text and image", image: { Image(systemName: "star") })
-                FloatingItemText(text: "Primary text and image", secondary: "Secondary text", image: { Image(systemName: "star") })
-                FloatingItemText(
-                    text: "Primary text and trailing content",
-                    trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
-                )
-                FloatingItemText(
-                    text: "Primary text and trailing content",
-                    secondary: "Secondary text",
-                    trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
-                )
-                FloatingItemText(
-                    text: "Primary + image + trailing content",
-                    image: { Image(systemName: "star") },
-                    trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
-                )
-                FloatingItemText(
-                    text: "Primary + image + trailing content",
-                    secondary: "Secondary text",
-                    image: { Image(systemName: "star") },
-                    trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
-                )
+            VStack(spacing: 10) {
+                FloatingItemList(title: "FloatingItemText") {
+                    FloatingItemText(text: "Primary text")
+                    FloatingItemText(text: "Primary text", secondary: "Secondary text")
+                    FloatingItemText(text: "Primary text and image", image: { Image(systemName: "star") })
+                    FloatingItemText(text: "Primary text and image", secondary: "Secondary text", image: { Image(systemName: "star") })
+                    FloatingItemText(
+                        text: "Primary text and trailing content",
+                        trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
+                    )
+                    FloatingItemText(
+                        text: "Primary text and trailing content",
+                        secondary: "Secondary text",
+                        trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
+                    )
+                    FloatingItemText(
+                        text: "Primary + image + trailing content",
+                        image: { Image(systemName: "star") },
+                        trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
+                    )
+                    FloatingItemText(
+                        text: "Primary + image + trailing content",
+                        secondary: "Secondary text",
+                        image: { Image(systemName: "star") },
+                        trailingContent: { Button(action: {}) { Image(systemName: "square.and.arrow.up") } }
+                    )
+                }
+                FloatingItemList(title: "FloatingItemHeadingAndText") {
+                    FloatingItemHeadingAndText(heading: "Heading", text: "Text")
+                    FloatingItemHeadingAndText(heading: "Heading with image", text: "Text", image: { Image(systemName: "star") })
+                    FloatingItemHeadingAndText(
+                        heading: "Heading + trailing",
+                        text: "Text",
+                        trailingContent: { Button(action: {}) { Image(systemName: "folder.badge.plus") } }
+                    )
+                    FloatingItemHeadingAndText(
+                        heading: "Heading + image + trailing",
+                        text: "Text",
+                        image: { Image(systemName: "star") },
+                        trailingContent: { Button(action: {}) { Image(systemName: "folder.badge.plus") } }
+                    )
+                    FloatingItemHeadingAndContent(
+                        heading: "FloatingItemHeadingAndContent",
+                        content: {
+                            Image(.boardingPassUtopiaAirlines)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 200)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))                    }
+                    )
+                    FloatingItemHeadingAndDate(heading: "FloatingItemHeadingAndDate", date: fiveDaysAgo)
+                    FloatingItemHeadingAndDate(heading: "FloatingItemHeadingAndDate (full)", date: fiveDaysAgo, dateStyle: .full)
+                    FloatingItemHeadingAndDateTime(heading: "FloatingItemHeadingAndDateTime", dateTime: fiveDaysFromNow)
+                    FloatingItemHeadingAndDateTime(heading: "FloatingItemHeadingAndDateTime (full)", dateTime: fiveDaysFromNow, dateStyle: .full, timeStyle: .full)
+                }
+                FloatingItemList(title: "FloatingItemCenteredText") {
+                    FloatingItemCenteredText(
+                        text: "Nothing to see here, move along. " +
+                        "This line is really long so should broken across at least two lines"
+                    )
+                }
+                FloatingItemList {
+                    FloatingItemCenteredText(
+                        text: "Titleless FloatingItemList"
+                    )
+                }
             }
-            FloatingItemList(title: "FloatingItemHeadingAndText") {
-                FloatingItemHeadingAndText(heading: "Heading", text: "Text")
-                FloatingItemHeadingAndText(heading: "Heading with image", text: "Text", image: { Image(systemName: "star") })
-                FloatingItemHeadingAndText(
-                    heading: "Heading + trailing",
-                    text: "Text",
-                    trailingContent: { Button(action: {}) { Image(systemName: "folder.badge.plus") } }
-                )
-                FloatingItemHeadingAndText(
-                    heading: "Heading + image + trailing",
-                    text: "Text",
-                    image: { Image(systemName: "star") },
-                    trailingContent: { Button(action: {}) { Image(systemName: "folder.badge.plus") } }
-                )
-            }
-            FloatingItemList(title: "FloatingItemCenteredText") {
-                FloatingItemCenteredText(
-                    text: "Nothing to see here, move along. " +
-                          "This line is really long so should broken across at least two lines"
-                )
-            }
+            .padding(10)
         }
+        .navigationTitle("FloatingItemList examples")
     }
 }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CertificateViewer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CertificateViewer.kt
@@ -64,7 +64,7 @@ private fun CertificateViewerInternal(
 ) {
     check(certificates.isNotEmpty())
     Box(
-        modifier = modifier.fillMaxHeight().padding(8.dp)
+        modifier = modifier.fillMaxHeight()
     ) {
         val listSize = certificates.size
         val pagerState = rememberPagerState(pageCount = { listSize })
@@ -82,7 +82,9 @@ private fun CertificateViewerInternal(
             ) { page ->
                 val scrollState = rememberScrollState()
                 X509CertViewer(
-                    modifier = Modifier.verticalScroll(scrollState),
+                    modifier = Modifier
+                        .verticalScroll(scrollState)
+                        .padding(horizontal = 10.dp),
                     certificate = certificates[page]
                 )
             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -138,9 +138,12 @@ fun EventLoggerScreen(
             .verticalScroll(scrollState)
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(8.dp)
+            .padding(10.dp)
         ) {
-            FloatingItemList(title = "Events") {
+            FloatingItemList(
+                modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+                title = "Events"
+            ) {
                 when (val currentEvents = events) {
                     null -> {
                         CircularProgressIndicator()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -202,10 +202,13 @@ fun EventViewerScreen(
     ) { innerPadding ->
 
         val scrollState = rememberScrollState()
-        Column(modifier = Modifier.fillMaxSize()
-            .verticalScroll(scrollState)
-            .padding(innerPadding)
-            .padding(8.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(innerPadding)
+                .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             when (val currentEvents = events) {
                 null -> {
@@ -260,8 +263,8 @@ private fun EventViewer(
 
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val imageSize = 80.dp
         presentmentData.trustMetadata?.displayIcon?.let {
@@ -288,7 +291,9 @@ private fun EventViewer(
             fontWeight = FontWeight.Bold,
         )
 
-        FloatingItemList(title = null) {
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp)
+        ) {
             FloatingItemHeadingAndText(
                 heading = "Date and time",
                 text = eventDateTimeString
@@ -391,7 +396,10 @@ private fun EventViewer(
                 if (requestedClaim is MdocRequestedClaim) !requestedClaim.intentToRetain else true
             }
             if (sharedClaims.isNotEmpty()) {
-                FloatingItemList(title = "This info was shared") {
+                FloatingItemList(
+                    modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+                    title = "This info was shared",
+                ) {
                     ExtractClaimsItems(sharedClaims, documentTypeRepository)
                 }
             }
@@ -400,7 +408,10 @@ private fun EventViewer(
                 if (requestedClaim is MdocRequestedClaim) requestedClaim.intentToRetain else false
             }
             if (sharedAndStoredClaims.isNotEmpty()) {
-                FloatingItemList(title = "This info was shared and stored") {
+                FloatingItemList(
+                    modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+                    title = "This info was shared and stored",
+                ) {
                     ExtractClaimsItems(sharedAndStoredClaims, documentTypeRepository)
                 }
             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/FloatingItemListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/FloatingItemListScreen.kt
@@ -1,5 +1,8 @@
 package org.multipaz.testapp.ui
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -10,24 +13,39 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import multipazproject.samples.testapp.generated.resources.Res
+import multipazproject.samples.testapp.generated.resources.card_utopia_wholesale
+import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.items.FloatingItemCenteredText
+import org.multipaz.compose.items.FloatingItemHeadingAndContent
+import org.multipaz.compose.items.FloatingItemHeadingAndDate
+import org.multipaz.compose.items.FloatingItemHeadingAndDateTime
 import org.multipaz.compose.items.FloatingItemHeadingAndText
 import org.multipaz.compose.items.FloatingItemList
 import org.multipaz.compose.items.FloatingItemText
+import org.multipaz.datetime.FormatStyle
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 
 @Composable
 fun FloatingItemListScreen(
     showToast: (message: String) -> Unit,
 ) {
     LazyColumn(
-        modifier = Modifier
-            .padding(8.dp)
+        modifier = Modifier.padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
+        item {
+            Text("This screen contains examples of FloatingItemList and all the various things that can be put in it")
+        }
+
         item {
             FloatingItemList(title = "FloatingItemText") {
                 FloatingItemText(text = "Primary text")
                 FloatingItemText(text = "Primary text", secondary = "Secondary text")
-                FloatingItemText(text = "Primary text and image", image = { Icon(Icons.Outlined.Star, null) })
+                FloatingItemText(
+                    text = "Primary text and image",
+                    image = { Icon(Icons.Outlined.Star, null) })
                 FloatingItemText(
                     text = "Primary text and image",
                     secondary = "Secondary text",
@@ -53,6 +71,9 @@ fun FloatingItemListScreen(
                     trailingContent = { Button(onClick = {}) { Icon(Icons.Outlined.Star, null) } }
                 )
             }
+        }
+
+        item {
             FloatingItemList(title = "FloatingItemHeadingAndText") {
                 FloatingItemHeadingAndText(
                     heading = "Heading",
@@ -74,11 +95,53 @@ fun FloatingItemListScreen(
                     image = { Icon(Icons.Outlined.Star, null) },
                     trailingContent = { Button(onClick = {}) { Icon(Icons.Outlined.Star, null) } }
                 )
+                FloatingItemHeadingAndContent(
+                    heading = "FloatingItemHeadingAndContent",
+                    content = {
+                        Image(
+                            modifier = Modifier.height(100.dp),
+                            painter = painterResource(Res.drawable.card_utopia_wholesale),
+                            contentDescription = null
+                        )
+                    },
+                )
+                FloatingItemHeadingAndDate(
+                    heading = "FloatingItemHeadingAndDate",
+                    date = Clock.System.now() - 5.days
+                )
+                FloatingItemHeadingAndDate(
+                    heading = "FloatingItemHeadingAndDate (full)",
+                    date = Clock.System.now() - 5.days,
+                    dateStyle = FormatStyle.FULL
+                )
+                FloatingItemHeadingAndDateTime(
+                    heading = "FloatingItemHeadingAndDateTime",
+                    dateAndTime = Clock.System.now() + 5.days
+                )
+                FloatingItemHeadingAndDateTime(
+                    heading = "FloatingItemHeadingAndDateTime (full)",
+                    dateAndTime = Clock.System.now() + 5.days,
+                    dateStyle = FormatStyle.FULL,
+                    timeStyle = FormatStyle.FULL
+                )
             }
+        }
+
+        item {
             FloatingItemList(title = "FloatingItemCenteredText") {
                 FloatingItemCenteredText(
                     text = "Nothing to see here, move along. " +
                             "This line is really long so should broken across at least two lines"
+                )
+            }
+        }
+
+        item {
+            FloatingItemList(
+                modifier = Modifier.padding(bottom = 20.dp)
+            ) {
+                FloatingItemCenteredText(
+                    text = "Titleless FloatingItemList"
                 )
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
@@ -46,11 +46,16 @@ fun NfcReaderScreen(
     val state = reader.observeState().collectAsState(initial = null).value
 
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(10.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        FloatingItemList(title = "External NFC Reader") {
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+            title = "External NFC Reader"
+        ) {
             FloatingItemHeadingAndText("Name", reader.displayName)
             if (reader is ExternalNfcReaderUsb) {
                 FloatingItemHeadingAndText("Connection", "USB")

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReadersScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReadersScreen.kt
@@ -26,12 +26,17 @@ fun NfcReadersScreen(
 ) {
     val scrollState = rememberScrollState()
     Column(
-        modifier = Modifier.padding(8.dp).verticalScroll(scrollState),
+        modifier = Modifier
+            .padding(10.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
 
         val readers = externalNfcReaderStore.readers.collectAsState().value
-        FloatingItemList(title = "External NFC Readers") {
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+            title = "External NFC Readers"
+        ) {
             if (readers.isEmpty()) {
                 FloatingItemCenteredText(
                     text = "No external NFC readers configured",

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustEntryScreen.kt
@@ -157,7 +157,7 @@ fun TrustEntryScreen(
                 .verticalScroll(scrollState)
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(8.dp),
+                .padding(10.dp),
         ) {
             TrustEntryViewer(
                 trustManagerModel = trustManagerModel,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/TrustManagerScreen.kt
@@ -275,9 +275,10 @@ fun TrustManagerScreen(
             modifier = Modifier
                 .verticalScroll(scrollState)
                 .fillMaxSize()
-                .padding(8.dp),
+                .padding(10.dp),
         ) {
             TrustEntryList(
+                modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
                 trustManagerModel = builtIn,
                 title = "Built-in",
                 imageLoader = imageLoader,
@@ -288,6 +289,7 @@ fun TrustManagerScreen(
                 }
             )
             TrustEntryList(
+                modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
                 trustManagerModel = user,
                 title = "Manually imported",
                 imageLoader = imageLoader,


### PR DESCRIPTION
Remove extra padding for the shadows, instead have the users add it as needed. Do this for both Compose and SwiftUI versions and update sample apps.

Also add new `FloatingItemHeadingAndDate`, `FloatingItemHeadingAndDateTime`, and `FloatingItemHeadingAndContent` items.

Also make `SecretCodeRequest.description` nullable and avoid setting it to a hard-coded string if nothing is received from the issuer. This way we don't need to worry about translations in the core Multipaz library and the UI layer can deal with it instead.

Test: Manually tested.
