### PR TITLE
Refresh token for openid4vci-to-records server communication.

### DIFF
--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/Main.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/Main.kt
@@ -11,7 +11,6 @@ import org.multipaz.openid4vci.credential.CredentialFactoryUtopiaMovieTicket
 import org.multipaz.openid4vci.credential.CredentialFactoryUtopiaNaturalization
 import org.multipaz.server.common.ServerConfiguration
 import org.multipaz.server.common.runServer
-import kotlin.collections.mutableListOf
 
 /**
  * Main entry point to launch the server.
@@ -25,7 +24,7 @@ import kotlin.collections.mutableListOf
  * or with a System of Record back-end:
  *
  * ```
- * ./gradlew multipaz-openid4vci-server:run --args="-param system_of_record_url=http://localhost:8004 -param system_of_record_jwk='$(cat key.jwk)'"
+ * ./gradlew multipaz-openid4vci-server:run --args="-param enrollment_server_url=http://localhost:8004 -param system_of_record_url=http://localhost:8004"
  * ```
  */
 class Main {

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -2,11 +2,13 @@ package org.multipaz.openid4vci.request
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
+import io.ktor.client.request.headers
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.headers
+import io.ktor.http.parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respondText
@@ -21,6 +23,7 @@ import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -35,7 +38,6 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.openid4vci.credential.CredentialDisplay
 import org.multipaz.webtoken.ChallengeInvalidException
-import org.multipaz.openid4vci.credential.CredentialFactory
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
 import org.multipaz.openid4vci.util.IssuanceState
 import org.multipaz.openid4vci.util.OpaqueIdType
@@ -48,12 +50,15 @@ import org.multipaz.webtoken.WebTokenCheck
 import org.multipaz.util.Logger
 import org.multipaz.webtoken.validateJwt
 import org.multipaz.openid4vci.util.CredentialState
+import org.multipaz.openid4vci.util.SystemOfRecordAccess
 import org.multipaz.openid4vci.util.respondWithNewDPoPNonce
 import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.rpc.backend.Configuration
 import org.multipaz.server.enrollment.ServerIdentity
 import org.multipaz.server.enrollment.validateServerIdentityCertificateChain
 import org.multipaz.util.toBase64Url
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Issues a credential based on DPoP authentication with access token.
@@ -88,7 +93,7 @@ suspend fun credential(call: ApplicationCall) {
 
     state.purgeExpiredCredentials()
 
-    val credentialData = readSystemOfRecord(state)
+    val credentialData = readSystemOfRecord(id, state)
 
     val display = factory.display(credentialData)
     val locale = BackendEnvironment.getInterface(Configuration::class)!!
@@ -284,12 +289,15 @@ private fun JsonObjectBuilder.addDisplay(locale: String, display: CredentialDisp
 
 private const val TAG = "credential"
 
-private suspend fun readSystemOfRecord(state: IssuanceState): DataItem {
-    val systemOfRecordAccess = state.systemOfRecordAccess!!
+private suspend fun readSystemOfRecord(
+    stateId: String,
+    state: IssuanceState
+): DataItem {
     val systemOfRecordUrl = BackendEnvironment.getSystemOfRecordUrl()
     if (systemOfRecordUrl == null) {
         // Running without System of Record (demo/dev mode). Expect basic data encoded
         // as fake access token
+        val systemOfRecordAccess = state.systemOfRecordAccess!!
         val (givenName, familyName, birthDate) = systemOfRecordAccess.accessToken.split(":")
         return buildCborMap {
             putCborMap("core") {
@@ -317,18 +325,68 @@ private suspend fun readSystemOfRecord(state: IssuanceState): DataItem {
         }
     } else {
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
-        val request = httpClient.get("$systemOfRecordUrl/data") {
-            headers {
-                bearerAuth(systemOfRecordAccess.accessToken)
+        var refreshed = false
+        while (true) {
+            val systemOfRecordAccess = state.systemOfRecordAccess!!
+            if (!refreshed &&
+                systemOfRecordAccess.accessTokenExpiration - 1.seconds < Clock.System.now()) {
+                Logger.e(TAG, "System of Record access token expired")
+                refreshSystemOfRecordToken(stateId, state, systemOfRecordUrl)
+                refreshed = true
+                continue
             }
-        }
-        if (request.status != HttpStatusCode.OK) {
+            val request = httpClient.get("$systemOfRecordUrl/data") {
+                headers {
+                    bearerAuth(systemOfRecordAccess.accessToken)
+                }
+            }
+            if (request.status == HttpStatusCode.OK) {
+                return Cbor.decode(request.readRawBytes())
+            }
             val text = request.readRawBytes().decodeToString()
             Logger.e(TAG, "Error accessing data from the System of Record: $text")
-            throw IllegalStateException("Could not access data from System of Record")
+            if (refreshed || request.status != HttpStatusCode.BadRequest) {
+                throw IllegalStateException("Could not access data from System of Record")
+            }
+            refreshSystemOfRecordToken(stateId, state, systemOfRecordUrl)
+            refreshed = true
         }
-        return Cbor.decode(request.readRawBytes())
     }
+}
+
+private suspend fun refreshSystemOfRecordToken(
+    stateId: String,
+    state: IssuanceState,
+    systemOfRecordUrl: String,
+) {
+    Logger.i(TAG, "Updating System of Record access token...")
+    val systemOfRecordAccess = state.systemOfRecordAccess!!
+    val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+    val response = httpClient.submitForm(
+        url = "$systemOfRecordUrl/token",
+        formParameters = parameters {
+            append("grant_type", "refresh_token")
+            append("refresh_token", systemOfRecordAccess.refreshToken!!)
+        }
+    )
+    val responseText = response.readRawBytes().decodeToString()
+    if (response.status != HttpStatusCode.OK) {
+        Logger.e(TAG, "token request error: ${response.status}: $responseText")
+        throw IllegalStateException("Could not access refresh System of Record token")
+    }
+    val parsedResponse = Json.parseToJsonElement(responseText).jsonObject
+    state.systemOfRecordAccess = SystemOfRecordAccess(
+        parsedResponse["access_token"]!!.jsonPrimitive.content,
+        accessTokenExpiration = Clock.System.now() +
+                (parsedResponse["expires_in"]?.jsonPrimitive?.intOrNull ?: 60).seconds,
+        refreshToken = parsedResponse["refresh_token"]!!.jsonPrimitive.content,
+    )
+    Logger.i(TAG, "Updated System of Record access token")
+    IssuanceState.updateIssuanceState(
+        issuanceStateId = stateId,
+        issuanceState = state,
+        expiration = null
+    )
 }
 
 private suspend fun keyHash(key: EcPublicKey): String =

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
@@ -1,14 +1,12 @@
 package org.multipaz.openid4vci.request
 
 import io.ktor.client.HttpClient
-import io.ktor.client.request.headers
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
+import io.ktor.client.request.forms.submitForm
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
-import io.ktor.http.encodeURLParameter
+import io.ktor.http.parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.request.receiveParameters
@@ -201,20 +199,15 @@ private suspend fun establishDPopKey(
 private const val TAG = "token"
 
 private suspend fun obtainSystemOfRecordToken(systemOfRecordUrl: String, state: IssuanceState) {
-    val req = buildMap {
-        put("grant_type", "authorization_code")
-        put("code", state.systemOfRecordAuthCode!!)
-        put("code_verifier", state.systemOfRecordCodeVerifier!!.toByteArray().toBase64Url())
-    }
     val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
-    val response = httpClient.post("$systemOfRecordUrl/token") {
-        headers {
-            append("Content-Type", "application/x-www-form-urlencoded")
+    val response = httpClient.submitForm(
+        url = "$systemOfRecordUrl/token",
+        formParameters = parameters {
+            append("grant_type", "authorization_code")
+            append("code", state.systemOfRecordAuthCode!!)
+            append("code_verifier", state.systemOfRecordCodeVerifier!!.toByteArray().toBase64Url())
         }
-        setBody(req.map { (name, value) ->
-            name.encodeURLParameter() + "=" + value.encodeURLParameter()
-        }.joinToString("&"))
-    }
+    )
     val responseText = response.readRawBytes().decodeToString()
     if (response.status != HttpStatusCode.OK) {
         Logger.e(TAG, "token request error: ${response.status}: $responseText")

--- a/multipaz-records-server/src/main/java/org/multipaz/records/data/token.kt
+++ b/multipaz-records-server/src/main/java/org/multipaz/records/data/token.kt
@@ -5,6 +5,7 @@ import kotlinx.io.bytestring.ByteStringBuilder
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Uint
 import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.rpc.handler.SimpleCipher
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
@@ -52,7 +53,7 @@ suspend fun tokenToId(type: TokenType, code: String): String {
     val cipher = BackendEnvironment.getInterface(SimpleCipher::class)!!
     val buf = cipher.decrypt(code.fromBase64Url())
     if (buf[0] != type.code) {
-        throw IllegalArgumentException(
+        throw InvalidRequestException(
             "Not required token type, need ${type.code}, got ${buf[0].toInt()}")
     }
     val len = buf[1].toInt()
@@ -60,11 +61,11 @@ suspend fun tokenToId(type: TokenType, code: String): String {
         val offsetAndExpirationTimeEpochSeconds = Cbor.decode(buf, 2 + len)
         // returned offset should be at the end of the string
         if (offsetAndExpirationTimeEpochSeconds.first != buf.size) {
-            throw IllegalArgumentException("Decoding error")
+            throw InvalidRequestException("Decoding error")
         }
         // expiration time should not be in the past
         if (offsetAndExpirationTimeEpochSeconds.second.asNumber < Clock.System.now().epochSeconds) {
-            throw IllegalArgumentException("Token expired")
+            throw InvalidRequestException("Token expired")
         }
     }
     return String(buf, 2, len)


### PR DESCRIPTION
Detect when System of Record access token expires and refresh it. Also refresh it on an unexpected error, just in case. This should in turn enable refreshing credentials from OpenID4VCI server.

Test: tested by running servers locally