### PR TITLE
Add DocumentProvisioningSettings for proper credential management.

### DIFF
--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -105,7 +105,7 @@
     <string name="provisioning_processing_authorization">Processing authorization...</string>
     <string name="provisioning_authorized">Authorized</string>
     <string name="provisioning_requestion_credentials">Requesting credentials...</string>
-    <string name="provisioning_credentials_issued">Credentials issued</string>
+    <string name="provisioning_credentials_issued">%1$d credentials issued</string>
     <string name="provisioning_browser">Launching browser, continue there</string>
     <string name="provisioning_retry">Please retry</string>
     <string name="provisioning_error">Error provisioning (error code: %1$s)</string>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
@@ -428,19 +428,19 @@ private fun ProvisioningBottomSheetContent(
         }
 
         else -> {
-            val text = stringResource(
-                when (provisioningState) {
-                    ProvisioningModel.Idle -> throw IllegalStateException()
-                    ProvisioningModel.Initial -> Res.string.provisioning_initial
-                    ProvisioningModel.Connected -> Res.string.provisioning_connected
-                    ProvisioningModel.ProcessingAuthorization -> Res.string.provisioning_processing_authorization
-                    ProvisioningModel.Authorized -> Res.string.provisioning_authorized
-                    ProvisioningModel.RequestingCredentials -> Res.string.provisioning_requestion_credentials
-                    is ProvisioningModel.CredentialsIssued -> Res.string.provisioning_credentials_issued
-                    is ProvisioningModel.Error -> throw IllegalStateException()
-                    is ProvisioningModel.Authorizing -> throw IllegalStateException()
+            val text = when (provisioningState) {
+                ProvisioningModel.Idle -> throw IllegalStateException()
+                ProvisioningModel.Initial -> stringResource(Res.string.provisioning_initial)
+                ProvisioningModel.Connected -> stringResource(Res.string.provisioning_connected)
+                ProvisioningModel.ProcessingAuthorization -> stringResource(Res.string.provisioning_processing_authorization)
+                ProvisioningModel.Authorized -> stringResource(Res.string.provisioning_authorized)
+                ProvisioningModel.RequestingCredentials -> stringResource(Res.string.provisioning_requestion_credentials)
+                is ProvisioningModel.CredentialsIssued -> {
+                    stringResource(Res.string.provisioning_credentials_issued, provisioningState.numCredentialsFetched)
                 }
-            )
+                is ProvisioningModel.Error -> throw IllegalStateException()
+                is ProvisioningModel.Authorizing -> throw IllegalStateException()
+            }
             Text(
                 modifier = Modifier
                     .padding(16.dp, 4.dp),

--- a/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
+++ b/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
@@ -95,7 +95,7 @@ public class DocumentModel {
                     }
                     do {
                         if (index != nil) {
-                            self._documentInfos[index!] = await try getDocumentInfo(self._documentInfos[index!].document)
+                            self._documentInfos[index!] = try await getDocumentInfo(self._documentInfos[index!].document)
                         }
                     } catch {
                         print("Ignoring error in getDocumentInfo() for DocumentUpdated event: \(error)")

--- a/multipaz-swiftui/src/iosMain/swift/Extensions.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Extensions.swift
@@ -36,3 +36,6 @@ extension Tags: @unchecked Sendable {}
 extension Tags.Editor: @unchecked Sendable {}
 extension PassphraseEvaluation: @unchecked Sendable {}
 extension Document.Editor: @unchecked Sendable {}
+extension DocumentProvisioningSettings: @unchecked Sendable {}
+extension CredentialMetadata: @unchecked Sendable {}
+extension ProvisioningMetadata: @unchecked Sendable {}

--- a/multipaz-swiftui/src/iosMain/swift/ProvisioningView.swift
+++ b/multipaz-swiftui/src/iosMain/swift/ProvisioningView.swift
@@ -209,11 +209,13 @@ struct EvidenceRequestSecretText: View {
         )
 
         VStack {
-            Text(passphraseRequest.description_)
-                .font(.title)
-                .multilineTextAlignment(.center)
-                .padding(8)
-                .frame(maxWidth: .infinity, alignment: .center)
+            if let desc = passphraseRequest.description_ {
+                Text(desc)
+                    .font(.title)
+                    .multilineTextAlignment(.center)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
             
             if challenge.retry {
                 Text("Retry")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentUtil.kt
@@ -33,14 +33,12 @@ object DocumentUtil {
      * credentials of a specific type available within the following constraints
      *
      * - If a credential is used more than `maxUsesPerCredential` times, a replacement is generated.
-     * - If a credential expires within `minValidTimeMillis` milliseconds, a replacement is generated.
+     * - If a credential expires within `minValidTime`, a replacement is generated.
      *
-     * This is all implemented on top of [Credential] creation
-     * and [Credential.certify]. The application should examine the return
-     * value and if positive, collect the not-yet-certified credentials via
-     * [Document.pendingCredentials], send them to the issuer for certification,
-     * and then call [Credential.certify] when receiving the certification
-     * from the issuer.
+     * This is all implemented on top of [Credential] creation and [Credential.certify]. The application should
+     * examine the return value and if positive, collect the not-yet-certified credentials via
+     * [Document.pendingCredentials], send them to the issuer for certification, and then call [Credential.certify]
+     * when receiving the certification from the issuer.
      *
      * @param document the document to manage credentials for.
      * @param domain the domain to use for created credentials.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
@@ -53,7 +53,7 @@ interface AbstractDocumentProvisioningHandler {
     suspend fun cleanupDocumentOnError(document: Document, err: Throwable)
 
     /**
-     * Creates a set of pending key-bound credentials.
+     * Gets the pending key-bound credentials for a document.
      *
      * Provisioning will call [Credential.certify] method on these credentials once the data
      * comes from the issuer. When pending credentials are created, it is very important that their
@@ -64,33 +64,38 @@ interface AbstractDocumentProvisioningHandler {
      * to use custom and/or [SecureArea]-specific [CreateKeySettings] to have better control over
      * key properties.
      *
-     * TODO: propagate more metadata about issuer key requirements through [CredentialMetadata].
-     *
      * It is up to the implementation to determine the number of credentials to create, but it
      * should generally not exceed issuer limit given in [CredentialMetadata.maxBatchSize].
      *
-     * @param document [Document] for which credentials are being issued
-     * @param credentialMetadata information about credentials being issued
-     * @param createKeySettings suggested settings for the key to which credentials are bound
-     * @return a list of pending key-bound credentials
+     * @param document [Document] for which credentials are being issued.
+     * @param credentialMetadata information about credentials being issued.
+     * @param issuerMetadata information about the issuer of the credential.
+     * @param createKeySettings suggested settings for the key to which credentials are bound.
+     * @return a list of pending key-bound credentials, if any.
      */
-    suspend fun createKeyBoundCredentials(
+    suspend fun getPendingKeyBoundCredentials(
         document: Document,
         credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata,
         createKeySettings: CreateKeySettings
     ): List<SecureAreaBoundCredential>
 
     /**
-     * Creates a pending keyless credential.
+     * Gets the pending keyless credentials.
      *
-     * @param document [Document] for which the credential is being issued
-     * @param credentialMetadata information about the credential being issued
-     * @return pending keyless credential
+     * It is up to the implementation to determine the number of credentials to create, but it
+     * should generally not exceed issuer limit given in [CredentialMetadata.maxBatchSize].
+     *
+     * @param document [Document] for which the credential is being issued.
+     * @param credentialMetadata information about the credential being issued.
+     * @param issuerMetadata information about the issuer of the credential.
+     * @return a list of pending keyless credentials, if any.
      */
-    suspend fun createKeylessCredential(
+    suspend fun getPendingKeylessCredentials(
         document: Document,
         credentialMetadata: CredentialMetadata,
-    ): Credential
+        issuerMetadata: ProvisioningMetadata
+    ): List<Credential>
 
     /**
      * Clean up after failed not-initial (e.g. credential refresh) provisioning.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
@@ -6,38 +6,70 @@ import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.document.AbstractDocumentMetadata
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
+import org.multipaz.document.DocumentUtil
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
+import org.multipaz.util.Logger
 import kotlin.math.min
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+private const val TAG = "DocumentProvisioningHandler"
 
 /**
  * Implementation of [AbstractDocumentMetadataHandler] suitable for most uses.
  *
- * TODO: integrate with credential replacement logic
+ * This implementation uses [DocumentUtil.managedCredentialHelper] with per-document settings
+ * obtained using [getDocumentProvisioningSettings].
+ *
+ * Applications can fine-tune what kind of credentials to retrieve for a particular document and/or issuer
+ * by overriding [getDocumentProvisioningSettings] if the default [DocumentProvisioningSettings] is not suitable.
+ *
+ * The default settings are to request two domains of credentials, one with user authentication required and a domain
+ * for without. This is to enable an optional "pre-consent" experience, with this setup a wallet app can simply check
+ * if it has credentials in the no-auth-required domain and if so offer a setting for the user to present the
+ * credential to e.g. select RPs without any consent or authentication.
+ *
+ * However, some issuers will not want to mint credentials without user authentication and will enforce this by
+ * e.g. checking the Android Keystore key attestation for whether the key is configured to require user
+ * authentication. For such issuers, the application can disable requesting such credentials by tweaking
+ * the settings for that particular issuer and/or credential type.
  *
  * @param secureArea credentials will be bound to keys from this [SecureArea]
  * @param documentStore new [Document] will be created in this [DocumentStore]
- * @param mdocCredentialDomain credential domain for (key-bound) ISO mdoc credentials
- * @param sdJwtCredentialDomain credential domain for key-bound IETF SD-JWT credentials
- * @param keylessCredentialDomain credential domain for keyless IETF SD-JWT credentials
- * @param batchSize number of key-bound credentials to request in one batch (but not exceeding
- *  issuer-imposed limit)
  * @param metadataHandler interface that initializes and updates document metadata; it may be
  *  provided if [DocumentStore] uses an [AbstractDocumentMetadata] factory (see
  *  [DocumentStore.Builder.setDocumentMetadataFactory]).
+ * @param defaultDocumentProvisioningSettings the default [DocumentProvisioningSettings] to use.
  */
-class DocumentProvisioningHandler(
+open class DocumentProvisioningHandler(
     val secureArea: SecureArea,
     val documentStore: DocumentStore,
-    val mdocCredentialDomain: String = "mdoc_user_auth",
-    val sdJwtCredentialDomain: String = "sdjwt_user_auth",
-    val keylessCredentialDomain: String = "sdjwt_keyless",
-    val batchSize: Int = 3,
-    val metadataHandler: AbstractDocumentMetadataHandler? = null
+    val metadataHandler: AbstractDocumentMetadataHandler? = null,
+    val defaultDocumentProvisioningSettings: DocumentProvisioningSettings = DocumentProvisioningSettings()
 ): AbstractDocumentProvisioningHandler {
+
+    /**
+     * Function to select which [DocumentProvisioningSettings] to use when provisioning.
+     *
+     * The default implementation just returns [defaultDocumentProvisioningSettings], applications can subclass
+     * to override on a per-document or per-issuer basis.
+     *
+     * @param document the [Document] that is being provisioned or refreshed.
+     * @param credentialMetadata metadata about the credential from the issuer.
+     * @param issuerMetadata the issuer that we're provisioning from.
+     * @return the settings to use.
+     */
+    open suspend fun getDocumentProvisioningSettings(
+        document: Document,
+        credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata
+    ): DocumentProvisioningSettings = defaultDocumentProvisioningSettings
+
     override suspend fun createDocument(
         credentialMetadata: CredentialMetadata,
         issuerMetadata: ProvisioningMetadata,
@@ -89,61 +121,126 @@ class DocumentProvisioningHandler(
         pendingCredentials: List<Credential>,
         err: Throwable
     ) {
-        pendingCredentials.forEach { it.document.deleteCredential(it.identifier) }
+        // Since we're using DocumentUtil.managedCredentialHelper() there is no need to clean up
+        // these pending credentials as they'll be reused the next time
     }
 
-    override suspend fun createKeyBoundCredentials(
+    override suspend fun getPendingKeyBoundCredentials(
         document: Document,
         credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata,
         createKeySettings: CreateKeySettings
     ): List<SecureAreaBoundCredential> {
-        if (document.getPendingCredentials().isNotEmpty()) {
-            // Not all credentials were certified yet, wait for them to be certified first.
-            // This should only happen for issuers that support offline certification. If you get
-            // here in other cases, you probably should have cleared up pending credentials before
-            // attempting to obtain more credentials from the issuer.
-            return listOf()
-        }
-        val credentialCount = min(credentialMetadata.maxBatchSize, batchSize)
-        return when (val format = credentialMetadata.format) {
-            is CredentialFormat.Mdoc -> {
-                (0..<credentialCount).map {
-                    MdocCredential.create(
-                        document = document,
-                        asReplacementForIdentifier = null,
-                        domain = mdocCredentialDomain,
-                        secureArea = secureArea,
-                        docType = format.docType,
-                        createKeySettings = createKeySettings
-                    )
-                }
-            }
-
-            is CredentialFormat.SdJwt -> {
-                (0..<credentialCount).map {
-                    KeyBoundSdJwtVcCredential.create(
-                        document = document,
-                        asReplacementForIdentifier = null,
-                        domain = sdJwtCredentialDomain,
-                        secureArea = secureArea,
-                        vct = format.vct,
-                        createKeySettings = createKeySettings
-                    )
-                }
+        val settings = getDocumentProvisioningSettings(document, credentialMetadata, issuerMetadata)
+        val now = Clock.System.now()
+        val numVariants = if (settings.requestUserAuth && settings.requestNoUserAuth) {
+            2
+        } else if (settings.requestUserAuth || settings.requestNoUserAuth) {
+            1
+        } else {
+            0.also {
+                Logger.w(TAG, "Both requestUserAuth and requestNoUserAuth set to false")
+                return emptyList()
             }
         }
+        val maxBatchSize = credentialMetadata.maxBatchSize / numVariants
+        if (settings.requestUserAuth) {
+            doDomain(now, document, settings, createKeySettings, credentialMetadata.format, maxBatchSize, true)
+        }
+        if (settings.requestNoUserAuth) {
+            doDomain(now, document, settings, createKeySettings, credentialMetadata.format, maxBatchSize, false)
+        }
+        if (!settings.requestUserAuth && !settings.requestNoUserAuth) {
+            Logger.w(TAG, "Both requestUserAuth and requestNoUserAuth are false, no credentials will be retrieved")
+        }
+        return document.getPendingCredentials() as List<SecureAreaBoundCredential>
     }
 
-    override suspend fun createKeylessCredential(
+    private suspend fun doDomain(
+        now: Instant,
         document: Document,
-        credentialMetadata: CredentialMetadata
-    ): Credential =
-        KeylessSdJwtVcCredential.create(
-            document,
-            null,
-            keylessCredentialDomain,
-            (credentialMetadata.format as CredentialFormat.SdJwt).vct
+        settings: DocumentProvisioningSettings,
+        createKeySettings: CreateKeySettings,
+        format: CredentialFormat,
+        maxBatchSize: Int,
+        userAuth: Boolean,
+    ) {
+        val cks = CreateKeySettings(
+            algorithm = createKeySettings.algorithm,
+            nonce = createKeySettings.nonce,
+            userAuthenticationRequired = userAuth,
+            userAuthenticationTimeout = if (userAuth) { settings.userAuthTimeout } else { 0.seconds },
+            validFrom = null,
+            validUntil = null
         )
+        val domain = when (format) {
+            is CredentialFormat.Mdoc -> if (userAuth) settings.mdocUserAuthDomain else settings.mdocNoUserAuthDomain
+            is CredentialFormat.SdJwt -> if (userAuth) settings.sdJwtUserAuthDomain else settings.sdJwtNoUserAuthDomain
+        }
+        DocumentUtil.managedCredentialHelper(
+            document = document,
+            domain = domain,
+            createCredential = { credentialIdentifierToReplace ->
+                when (format) {
+                    is CredentialFormat.Mdoc -> {
+                        MdocCredential.create(
+                            document = document,
+                            asReplacementForIdentifier = credentialIdentifierToReplace,
+                            domain = domain,
+                            secureArea = secureArea,
+                            docType = format.docType,
+                            createKeySettings = cks
+                        )
+                    }
+
+                    is CredentialFormat.SdJwt -> {
+                        KeyBoundSdJwtVcCredential.create(
+                            document = document,
+                            asReplacementForIdentifier = credentialIdentifierToReplace,
+                            domain = domain,
+                            secureArea = secureArea,
+                            vct = format.vct,
+                            createKeySettings = cks
+                        )
+                    }
+                }
+            },
+            now = now,
+            numCredentials = min(settings.keyBoundCredentialNumPerDomain, maxBatchSize),
+            maxUsesPerCredential = settings.keyBoundCredentialMaxUses,
+            minValidTime = settings.minValidTime,
+            dryRun = false
+        )
+    }
+
+    override suspend fun getPendingKeylessCredentials(
+        document: Document,
+        credentialMetadata: CredentialMetadata,
+        issuerMetadata: ProvisioningMetadata
+    ): List<Credential> {
+        val settings = getDocumentProvisioningSettings(document, credentialMetadata, issuerMetadata)
+        val now = Clock.System.now()
+        DocumentUtil.managedCredentialHelper(
+            document = document,
+            domain = settings.sdJwtKeylessDomain,
+            createCredential = { credentialIdentifierToReplace ->
+                // KeylessSdJwtVcCredential is the only keyless credential which is supported.
+                require(credentialMetadata.format is CredentialFormat.SdJwt)
+                KeylessSdJwtVcCredential.create(
+                    document = document,
+                    asReplacementForIdentifier = credentialIdentifierToReplace,
+                    domain = settings.sdJwtKeylessDomain,
+                    vct = credentialMetadata.format.vct
+                )
+            },
+            now = now,
+            numCredentials = settings.keylessCredentialNumPerDomain,
+            maxUsesPerCredential = settings.keylessCredentialMaxUses,
+            minValidTime = settings.minValidTime,
+            dryRun = false
+        )
+        return document.getPendingCredentials()
+    }
 
     /**
      * Manager document metadata when the document is created and when the metadata is updated
@@ -174,4 +271,7 @@ class DocumentProvisioningHandler(
             credentialDisplay: Display
         ): AbstractDocumentMetadata?
     }
+
+    // Companion object needed for multipaz-swift, see DocumentProvisioningHandlerExt.swift
+    companion object
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningSettings.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningSettings.kt
@@ -1,0 +1,42 @@
+package org.multipaz.provisioning
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Settings for controlling provisioning of [org.multipaz.credential.Credential]s in a [org.multipaz.document.Document].
+ *
+ * This is used by [DocumentProvisioningHandler].
+ *
+ * @param minValidTime replace a credential if it's going to be valid for less than this amount of time.
+ * @param keyBoundCredentialMaxUses replace a key-bound credential if its use-count is greater or equal than this number.
+ * @param keyBoundCredentialNumPerDomain number of key-bound credentials to maintain, per domain.
+ * @param keylessCredentialMaxUses replace a keyless credential if its use-count is greater or equal than this number.
+ * @param keylessCredentialNumPerDomain number of keyless credentials to maintain, per domain.
+ * @param userAuthTimeout the timeout to use for newly created keys, or 0 for authentication for every use.
+ * @param requestUserAuth if true, will request [keyBoundCredentialNumPerDomain] credentials for user auth, in the domains
+ *   given by [mdocUserAuthDomain] and [sdJwtUserAuthDomain].
+ * @param requestNoUserAuth if true, will request [keyBoundCredentialNumPerDomain] credentials without user auth, in the
+ *   domains given by [mdocNoUserAuthDomain] and [sdJwtNoUserAuthDomain].
+ * @param mdocUserAuthDomain the domain to use when requesting ISO mdoc credentials with user auth required.
+ * @param mdocNoUserAuthDomain the domain to use when requesting ISO mdoc credentials without user auth required.
+ * @param sdJwtUserAuthDomain the domain to use when requesting key-bound IETF SD-JWT VC credentials with user auth required.
+ * @param sdJwtNoUserAuthDomain the domain to use when requesting key-bound IETF SD-JWT VC credentials without user auth required.
+ * @param sdJwtKeylessDomain the domain to use when requesting non-key-bound IETF SD-JWT VC credentials
+ */
+data class DocumentProvisioningSettings(
+    val minValidTime: Duration = 5.days,
+    val keyBoundCredentialMaxUses: Int = 1,
+    val keyBoundCredentialNumPerDomain: Int = 5,
+    val keylessCredentialMaxUses: Int = Int.MAX_VALUE,
+    val keylessCredentialNumPerDomain: Int = 1,
+    val userAuthTimeout: Duration = 0.seconds,
+    val requestUserAuth: Boolean = true,
+    val requestNoUserAuth: Boolean = true,
+    val mdocUserAuthDomain: String = "mdoc_user_auth",
+    val mdocNoUserAuthDomain: String = "mdoc_no_user_auth",
+    val sdJwtUserAuthDomain: String = "sdjwt_user_auth",
+    val sdJwtNoUserAuthDomain: String = "sdjwt_no_user_auth",
+    val sdJwtKeylessDomain: String = "sdjwt_keyless"
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningMetadata.kt
@@ -4,11 +4,14 @@ package org.multipaz.provisioning
  * Credential issuer metadata.
  */
 data class ProvisioningMetadata(
-    /** Issuer name and logo.*/
+    /** The URL of the issuer server. */
+    val url: String,
+
+    /** Issuer name and logo. */
     val display: Display,
+
     /**
-     * Credentials that could be provisioned from the issuer indexed by credential configuration
-     * id.
+     * Credentials that could be provisioned from the issuer indexed by credential configuration id.
      *
      * When [ProvisioningClient] is configured to issue a particular kind of credential, only
      * that credential will be present in the map.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.serialization.json.buildJsonObject
@@ -36,6 +35,8 @@ import org.multipaz.util.Logger
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
+
+private const val TAG = "ProvisioningModel"
 
 /**
  * This model supports UX/UI flow for provisioning of credentials.
@@ -138,6 +139,42 @@ class ProvisioningModel(
         }
 
     /**
+     * Synchronously requests the provisioning of additional credentials to an existing [Document].
+     *
+     * Note that this bypasses the model and throws an exception if something goes wrong.
+     *
+     * @param document [Document] where credentials should be provisioned
+     * @param authorizationData authorization data from a previous provisioning session (see
+     *  [DocumentProvisioningHandler.AbstractDocumentMetadataHandler.updateDocumentMetadata]
+     *  `authorizationData` parameter)
+     * @param clientPreferences configuration parameters for OpenID4VCI client
+     * @param backend interface to the wallet back-end service
+     * @return deferred [Document] value, resolved when credentials are provisioned
+     * @throws Exception if an error occurred
+     */
+    // TODO: be more specific with what exceptions are thrown
+    @Throws(
+        CancellationException::class,
+        Exception::class
+    )
+    suspend fun openID4VCIRefreshCredentials(
+        document: Document,
+        authorizationData: ByteString,
+        clientPreferences: OpenID4VCIClientPreferences,
+        backend: OpenID4VCIBackend,
+    ): Int {
+        val numCredentialsFetched = CoroutineScope(createCoroutineContext(clientPreferences, backend)).async {
+            val provisioningClient = Provisioning.createClientFromAuthorizationData(authorizationData)
+            requestCredentials(
+                provisioningClient = provisioningClient,
+                targetDocument = document,
+                documentProvisioningHandler = documentProvisioningHandler,
+            ).second
+        }
+        return numCredentialsFetched.await()
+    }
+
+    /**
      * Launch provisioning session to provision credentials to a new [Document] using
      * given [ProvisioningClient] factory.
      *
@@ -161,7 +198,35 @@ class ProvisioningModel(
                 targetDocument = document
                 val provisioningClient = provisioningClientFactory.invoke()
                 mutableMetadata.emit(provisioningClient.getMetadata())
-                runProvisioning(provisioningClient)
+
+                var evidenceRequests = provisioningClient.getAuthorizationChallenges()
+                while (evidenceRequests.isNotEmpty()) {
+                    mutableState.emit(Authorizing(evidenceRequests))
+                    val authorizationResponse = authorizationResponseChannel.receive()
+                    mutableState.emit(ProcessingAuthorization)
+                    provisioningClient.authorize(authorizationResponse)
+                    evidenceRequests = provisioningClient.getAuthorizationChallenges()
+                }
+                mutableState.emit(Authorized)
+
+                mutableState.emit(Connected)
+
+                val (document, numCredentialsFetched) = requestCredentials(
+                    provisioningClient = provisioningClient,
+                    targetDocument = targetDocument,
+                    documentProvisioningHandler = documentProvisioningHandler,
+                    onRequestingCredentials = {
+                        mutableState.emit(RequestingCredentials)
+                    }
+                )
+
+                mutableState.emit(CredentialsIssued(
+                    document = document,
+                    isNewlyIssued = targetDocument == null,
+                    numCredentialsFetched = numCredentialsFetched
+                ))
+
+                document
             } catch(err: CancellationException) {
                 launch(NonCancellable) {
                     mutableState.emit(Idle)
@@ -229,129 +294,6 @@ class ProvisioningModel(
     ) = Dispatchers.Default + promptModel + RpcAuthClientSession() +
             ProvisioningEnvironment(clientPreferences, backend)
 
-    private suspend fun runProvisioning(provisioningClient: ProvisioningClient): Document {
-        mutableState.emit(Connected)
-        val issuerMetadata = provisioningClient.getMetadata()
-        val credentialConfig = issuerMetadata.credentials.values.first()
-
-        var evidenceRequests = provisioningClient.getAuthorizationChallenges()
-
-        while (evidenceRequests.isNotEmpty()) {
-            mutableState.emit(Authorizing(evidenceRequests))
-            val authorizationResponse = authorizationResponseChannel.receive()
-            mutableState.emit(ProcessingAuthorization)
-            provisioningClient.authorize(authorizationResponse)
-            evidenceRequests = provisioningClient.getAuthorizationChallenges()
-        }
-
-        mutableState.emit(Authorized)
-
-        val documentAuthorizationData = provisioningClient.getAuthorizationData()
-        val document = targetDocument ?: run {
-            documentProvisioningHandler.createDocument(
-                credentialConfig,
-                issuerMetadata,
-                documentAuthorizationData
-            )
-        }
-        var pendingCredentials: List<Credential> = listOf()
-        try {
-            // get the initial set of credentials
-            val keyInfo = if (credentialConfig.keyBindingType == KeyBindingType.Keyless) {
-                // keyless, no need for keys
-                KeyBindingInfo.Keyless
-            } else {
-                // create keys in the selected secure area and send them to the issuer
-                val keyChallenge = provisioningClient.getKeyBindingChallenge()
-                val createKeySettings = CreateKeySettings(
-                    algorithm = when (val type = credentialConfig.keyBindingType) {
-                        is KeyBindingType.OpenidProofOfPossession -> type.algorithm
-                        is KeyBindingType.Attestation -> type.algorithm
-                        else -> throw IllegalStateException()
-                    },
-                    nonce = keyChallenge.encodeToByteString(),
-                    userAuthenticationRequired = true
-                )
-                pendingCredentials = documentProvisioningHandler.createKeyBoundCredentials(
-                    document,
-                    credentialConfig,
-                    createKeySettings
-                )
-
-                when (val keyProofType = credentialConfig.keyBindingType) {
-                    is KeyBindingType.Attestation -> {
-                        KeyBindingInfo.Attestation(
-                            attestations = pendingCredentials.map {
-                                CredentialKeyAttestation(it.identifier, it.getAttestation())
-                            }
-                        )
-                    }
-                    is KeyBindingType.OpenidProofOfPossession -> {
-                        val jwtList = pendingCredentials.map {
-                            openidProofOfPossession(
-                                challenge = keyChallenge,
-                                keyProofType = keyProofType,
-                                credential = it
-                            )
-                        }
-                        KeyBindingInfo.OpenidProofOfPossession(jwtList)
-                    }
-                    else -> throw IllegalStateException()
-                }
-            }
-
-            mutableState.emit(RequestingCredentials)
-            val credentials = provisioningClient.obtainCredentials(keyInfo)
-            // If we successfully sent keys to the server, we should not unconditionally clean
-            // them up on error if we are past this point.
-            pendingCredentials = listOf()
-
-            val credentialData = credentials.certifications
-
-            if (credentialConfig.keyBindingType == KeyBindingType.Keyless) {
-                if (credentialData.size != 1) {
-                    throw IllegalStateException("Only a single keyless credential must be issued")
-                }
-                val pendingCredential = documentProvisioningHandler.createKeylessCredential(
-                    document = document,
-                    credentialMetadata = credentialConfig
-                )
-                pendingCredential.certify(credentialData.first().issuerData)
-            } else {
-                // Credential minting can happen offline, we can get any number of new credentials
-                // here, some might have been created as pending in the previous calls to this
-                // method.
-                for ((credentialId, credentialData) in credentialData) {
-                    val pendingCredential = document.lookupCredential(credentialId)
-                    if (pendingCredential == null) {
-                        Logger.e(TAG, "Credential '$credentialId' is not found")
-                    } else if (pendingCredential.isCertified) {
-                        Logger.e(TAG, "Credential '$credentialId' is already certified")
-                    } else {
-                        pendingCredential.certify(credentialData)
-                    }
-                }
-                documentProvisioningHandler.updateDocument(
-                    document = document,
-                    display = credentials.display,
-                    documentAuthorizationData = provisioningClient.getAuthorizationData()
-                )
-            }
-        } catch (err: Exception) {
-            // Clean-up after failed provisioning and then rethrow - so we also handle CancellationException here
-            if (targetDocument == null) {
-                // Initial provisioning: failed
-                documentProvisioningHandler.cleanupDocumentOnError(document, err)
-            } else {
-                // Refresh: only delete the pending credentials
-                documentProvisioningHandler.cleanupCredentialsOnError(pendingCredentials, err)
-            }
-            throw err
-        }
-        mutableState.emit(CredentialsIssued(document, targetDocument == null))
-        return document
-    }
-
     /** Represents model's state */
     sealed class State
 
@@ -392,10 +334,12 @@ class ProvisioningModel(
      *
      * @param document [Document] to which new credentials belong
      * @param isNewlyIssued if this is a newly issued document (as opposed to refreshed credentials)
+     * @param numCredentialsFetched the number of credentials that was fetched.
      */
     data class CredentialsIssued(
         val document: Document,
-        val isNewlyIssued: Boolean
+        val isNewlyIssued: Boolean,
+        val numCredentialsFetched: Int
     ): State()
 
     /** Error occurred when provisioning, provisioning has stopped */
@@ -420,33 +364,181 @@ class ProvisioningModel(
             }
         )
     }
+}
 
-    companion object {
-        private const val TAG = "ProvisioningModel"
+/**
+ * Low-level function to request credentials.
+ *
+ * @param provisioningClient a [ProvisioningClient]
+ * @param targetDocument the document to request credentials for or `null`.
+ * @param documentProvisioningHandler a [AbstractDocumentProvisioningHandler].
+ * @param onRequestingCredentials called when requesting credentials.
+ * @return the [Document] (either newly created or [targetDocument] if not null) and how many credentials were fetched.
+ */
+private suspend fun requestCredentials(
+    provisioningClient: ProvisioningClient,
+    targetDocument: Document?,
+    documentProvisioningHandler: AbstractDocumentProvisioningHandler,
+    onRequestingCredentials: suspend () -> Unit = {},
+): Pair<Document, Int> {
+    val issuerMetadata = provisioningClient.getMetadata()
+    val credentialConfig = issuerMetadata.credentials.values.first()
 
-        private suspend fun openidProofOfPossession(
-            challenge: String,
-            keyProofType: KeyBindingType.OpenidProofOfPossession,
-            credential: SecureAreaBoundCredential
-        ): String {
-            val signingKey = AsymmetricKey.anonymous(
-                secureArea = credential.secureArea,
-                alias = credential.alias,
-                unlockReason = ProofOfPossessionUnlockReason
+    val documentAuthorizationData = provisioningClient.getAuthorizationData()
+    val document = targetDocument ?: run {
+        documentProvisioningHandler.createDocument(
+            credentialConfig,
+            issuerMetadata,
+            documentAuthorizationData
+        )
+    }
+
+    // Create a number of pending credentials - the ones with keys are sent to the
+    // issuer for certification.
+    //
+    var pendingCredentials: List<Credential> = listOf()
+    var numCredentialsFetched = 0
+    try {
+        // get the initial set of credentials
+        val keyInfo = if (credentialConfig.keyBindingType == KeyBindingType.Keyless) {
+            pendingCredentials = documentProvisioningHandler.getPendingKeylessCredentials(
+                document = document,
+                credentialMetadata = credentialConfig,
+                issuerMetadata = issuerMetadata
             )
-            return buildJwt(
-                type = "openid4vci-proof+jwt",
-                key = signingKey,
-                header = {
-                    put("jwk", signingKey.publicKey.toJwk(buildJsonObject {
-                        put("kid", credential.identifier)
-                    }))
+            // keyless, no need for proofs
+            KeyBindingInfo.Keyless
+        } else {
+            // create keys in the selected secure area and send them to the issuer
+            val keyChallenge = provisioningClient.getKeyBindingChallenge()
+            val createKeySettings = CreateKeySettings(
+                algorithm = when (val type = credentialConfig.keyBindingType) {
+                    is KeyBindingType.OpenidProofOfPossession -> type.algorithm
+                    is KeyBindingType.Attestation -> type.algorithm
+                    else -> throw IllegalStateException()
+                },
+                nonce = keyChallenge.encodeToByteString(),
+                userAuthenticationRequired = true
+            )
+            pendingCredentials = documentProvisioningHandler.getPendingKeyBoundCredentials(
+                document = document,
+                credentialMetadata = credentialConfig,
+                issuerMetadata = issuerMetadata,
+                createKeySettings = createKeySettings
+            )
+
+            when (val keyProofType = credentialConfig.keyBindingType) {
+                is KeyBindingType.Attestation -> {
+                    KeyBindingInfo.Attestation(
+                        attestations = pendingCredentials.map {
+                            CredentialKeyAttestation(it.identifier, it.getAttestation())
+                        }
+                    )
                 }
-            ) {
-                put("iss", keyProofType.clientId)
-                put("aud", keyProofType.aud)
-                put("nonce", challenge)
+                is KeyBindingType.OpenidProofOfPossession -> {
+                    val jwtList = pendingCredentials.map {
+                        openidProofOfPossession(
+                            challenge = keyChallenge,
+                            keyProofType = keyProofType,
+                            credential = it
+                        )
+                    }
+                    KeyBindingInfo.OpenidProofOfPossession(jwtList)
+                }
+                else -> throw IllegalStateException()
             }
         }
+
+        if (keyInfo == KeyBindingInfo.Keyless) {
+            // For keyless credentials, we can only get a single credential per call
+            pendingCredentials.forEach { pendingCredential ->
+                onRequestingCredentials()
+                val credentials = provisioningClient.obtainCredentials(keyInfo)
+                val credentialData = credentials.certifications
+                if (credentialData.size != 1) {
+                    throw IllegalStateException("Only a single keyless credential is expected to be issued")
+                }
+                pendingCredential.certify(credentialData.first().issuerData)
+
+                documentProvisioningHandler.updateDocument(
+                    document = document,
+                    display = credentials.display,
+                    documentAuthorizationData = provisioningClient.getAuthorizationData()
+                )
+
+                // Modify pendingCredentials so this now certified credential isn't removed on error
+                pendingCredentials = pendingCredentials.filter { it != pendingCredential }
+
+                numCredentialsFetched += 1
+            }
+        } else {
+            // It's entirely possible we have no pending credentials in which case we are done
+            if (pendingCredentials.isNotEmpty()) {
+                onRequestingCredentials()
+                val credentials = provisioningClient.obtainCredentials(keyInfo)
+                // If we successfully sent keys to the server, we should not unconditionally clean
+                // them up on error if we are past this point.
+                pendingCredentials = listOf()
+
+                val credentialData = credentials.certifications
+                numCredentialsFetched = credentialData.size
+
+                // Credential minting can happen offline, we can get any number of new credentials
+                // here, some might have been created as pending in the previous calls to this
+                // method.
+                for ((credentialId, credentialData) in credentialData) {
+                    val pendingCredential = document.lookupCredential(credentialId)
+                    if (pendingCredential == null) {
+                        Logger.e(TAG, "Credential '$credentialId' is not found")
+                    } else if (pendingCredential.isCertified) {
+                        Logger.e(TAG, "Credential '$credentialId' is already certified")
+                    } else {
+                        pendingCredential.certify(credentialData)
+                    }
+                }
+                documentProvisioningHandler.updateDocument(
+                    document = document,
+                    display = credentials.display,
+                    documentAuthorizationData = provisioningClient.getAuthorizationData()
+                )
+            }
+        }
+    } catch (err: Exception) {
+        // Clean-up after failed provisioning and then rethrow - so we also handle CancellationException here
+        if (targetDocument == null) {
+            // Initial provisioning: failed
+            documentProvisioningHandler.cleanupDocumentOnError(document, err)
+        } else {
+            // Refresh: only delete the pending credentials
+            documentProvisioningHandler.cleanupCredentialsOnError(pendingCredentials, err)
+        }
+        throw err
+    }
+    return Pair(document, numCredentialsFetched)
+}
+
+private suspend fun openidProofOfPossession(
+    challenge: String,
+    keyProofType: KeyBindingType.OpenidProofOfPossession,
+    credential: SecureAreaBoundCredential
+): String {
+    val signingKey = AsymmetricKey.anonymous(
+        secureArea = credential.secureArea,
+        alias = credential.alias,
+        unlockReason = ProofOfPossessionUnlockReason
+    )
+    return buildJwt(
+        type = "openid4vci-proof+jwt",
+        key = signingKey,
+        header = {
+            put("jwk", signingKey.publicKey.toJwk(buildJsonObject {
+                put("kid", credential.identifier)
+            }))
+        }
+    ) {
+        put("iss", keyProofType.clientId)
+        put("aud", keyProofType.aud)
+        put("nonce", challenge)
     }
 }
+

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
@@ -104,6 +104,7 @@ internal data class IssuerConfiguration(
 
 
             val provisioningMetadata = ProvisioningMetadata(
+                url = url,
                 display = extractDisplay(credentialMetadata, httpClient, clientPreferences),
                 credentials = credentials.toMap()
             )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -81,6 +81,7 @@ internal class OpenID4VCIProvisioningClient(
         val fullMetadata = issuerConfiguration.provisioningMetadata
         val credentialId = credentialOffer.configurationId
         return ProvisioningMetadata(
+            url = issuerConfiguration.url,
             display = fullMetadata.display,
             credentials = mapOf(credentialId to fullMetadata.credentials[credentialId]!!)
         )

--- a/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
@@ -227,6 +227,7 @@ class ProvisioningModelTest {
         }
 
         val metadata = ProvisioningMetadata(
+            url = "https://example.com/test",
             display = Display("Test Issuer", null),
             credentials = mapOf(
                 "testId" to CredentialMetadata(

--- a/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -69,7 +69,10 @@ func getPresentmentSource() async -> PresentmentSource {
             )
         },
         preferSignatureToKeyAgreement: false,
-        domainsMdocSignature: ["mdoc"]
+        domainsMdocSignature: ["mdoc_user_auth", "mdoc_no_user_auth"],
+        domainsMdocKeyAgreement: [],
+        domainsKeylessSdJwt: ["sdjwt_keyless"],
+        domainsKeyBoundSdJwt: ["sdjwt_user_auth", "sdjwt_no_user_auth"]
     )
 }
 

--- a/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
@@ -7,67 +7,69 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		512C056C2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */; };
-		512C056D2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */; };
-		512C056F2F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */; };
-		512C05702F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */; };
-		512C05722F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */; };
-		512C05732F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */; };
 		512DAED62F2A31B30061F72B /* IdentityDocumentProviderExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		51BD5C5E2F22604F0082DE19 /* AdditionalConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */; };
 		51BD5C5F2F22604F0082DE19 /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */; };
-		51F711892F860D320017F68B /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711732F860D320017F68B /* DocumentModel.swift */; };
-		51F7118A2F860D320017F68B /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711722F860D320017F68B /* DocumentExtCardart.swift */; };
-		51F7118B2F860D320017F68B /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711712F860D320017F68B /* DocumentExt.swift */; };
-		51F7118C2F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711772F860D320017F68B /* FloatingItemHeadingAndText.swift */; };
-		51F7118D2F860D320017F68B /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711862F860D320017F68B /* VerticalDocumentList.swift */; };
-		51F7118E2F860D320017F68B /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711742F860D320017F68B /* Extensions.swift */; };
-		51F7118F2F860D320017F68B /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711802F860D320017F68B /* ProvisioningView.swift */; };
-		51F711902F860D320017F68B /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117F2F860D320017F68B /* PromptModelExt.swift */; };
-		51F711912F860D320017F68B /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117E2F860D320017F68B /* PromptDialogs.swift */; };
-		51F711922F860D320017F68B /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117D2F860D320017F68B /* PassphrasePromptDialog.swift */; };
-		51F711932F860D320017F68B /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711832F860D320017F68B /* SimplePresentmentSourceExt.swift */; };
-		51F711942F860D320017F68B /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711752F860D320017F68B /* FloatingItemCenteredText.swift */; };
-		51F711952F860D320017F68B /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711852F860D320017F68B /* TagsExt.swift */; };
-		51F711962F860D320017F68B /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117A2F860D320017F68B /* MdocProximityQrPresentment.swift */; };
-		51F711972F860D320017F68B /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711782F860D320017F68B /* FloatingItemList.swift */; };
-		51F711982F860D320017F68B /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711812F860D320017F68B /* QrCode.swift */; };
-		51F711992F860D320017F68B /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711702F860D320017F68B /* DocumentCarousel.swift */; };
-		51F7119A2F860D320017F68B /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7116E2F860D320017F68B /* Consent.swift */; };
-		51F7119B2F860D320017F68B /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711792F860D320017F68B /* FloatingItemText.swift */; };
-		51F7119C2F860D320017F68B /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711762F860D320017F68B /* FloatingItemContainer.swift */; };
-		51F7119D2F860D320017F68B /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711872F860D320017F68B /* X509CertViewer.swift */; };
-		51F7119E2F860D320017F68B /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117C2F860D320017F68B /* PassphraseInputView.swift */; };
-		51F7119F2F860D320017F68B /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117B2F860D320017F68B /* MdocProximityQrSettings.swift */; };
-		51F711A02F860D320017F68B /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7116F2F860D320017F68B /* ConsentPromptDialog.swift */; };
-		51F711A12F860D320017F68B /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711822F860D320017F68B /* RequestAuthorizationView.swift */; };
-		51F711A22F860D320017F68B /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711842F860D320017F68B /* SmartSheet.swift */; };
-		51F711A32F860D320017F68B /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711732F860D320017F68B /* DocumentModel.swift */; };
-		51F711A42F860D320017F68B /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711722F860D320017F68B /* DocumentExtCardart.swift */; };
-		51F711A52F860D320017F68B /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711712F860D320017F68B /* DocumentExt.swift */; };
-		51F711A62F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711772F860D320017F68B /* FloatingItemHeadingAndText.swift */; };
-		51F711A72F860D320017F68B /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711862F860D320017F68B /* VerticalDocumentList.swift */; };
-		51F711A82F860D320017F68B /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711742F860D320017F68B /* Extensions.swift */; };
-		51F711A92F860D320017F68B /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711802F860D320017F68B /* ProvisioningView.swift */; };
-		51F711AA2F860D320017F68B /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117F2F860D320017F68B /* PromptModelExt.swift */; };
-		51F711AB2F860D320017F68B /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117E2F860D320017F68B /* PromptDialogs.swift */; };
-		51F711AC2F860D320017F68B /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117D2F860D320017F68B /* PassphrasePromptDialog.swift */; };
-		51F711AD2F860D320017F68B /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711832F860D320017F68B /* SimplePresentmentSourceExt.swift */; };
-		51F711AE2F860D320017F68B /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711752F860D320017F68B /* FloatingItemCenteredText.swift */; };
-		51F711AF2F860D320017F68B /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711852F860D320017F68B /* TagsExt.swift */; };
-		51F711B02F860D320017F68B /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117A2F860D320017F68B /* MdocProximityQrPresentment.swift */; };
-		51F711B12F860D320017F68B /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711782F860D320017F68B /* FloatingItemList.swift */; };
-		51F711B22F860D320017F68B /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711812F860D320017F68B /* QrCode.swift */; };
-		51F711B32F860D320017F68B /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711702F860D320017F68B /* DocumentCarousel.swift */; };
-		51F711B42F860D320017F68B /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7116E2F860D320017F68B /* Consent.swift */; };
-		51F711B52F860D320017F68B /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711792F860D320017F68B /* FloatingItemText.swift */; };
-		51F711B62F860D320017F68B /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711762F860D320017F68B /* FloatingItemContainer.swift */; };
-		51F711B72F860D320017F68B /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711872F860D320017F68B /* X509CertViewer.swift */; };
-		51F711B82F860D320017F68B /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117C2F860D320017F68B /* PassphraseInputView.swift */; };
-		51F711B92F860D320017F68B /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7117B2F860D320017F68B /* MdocProximityQrSettings.swift */; };
-		51F711BA2F860D320017F68B /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7116F2F860D320017F68B /* ConsentPromptDialog.swift */; };
-		51F711BB2F860D320017F68B /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711822F860D320017F68B /* RequestAuthorizationView.swift */; };
-		51F711BC2F860D320017F68B /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F711842F860D320017F68B /* SmartSheet.swift */; };
+		7B4A4F672F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */; };
+		7B4A4F682F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */; };
+		7B4A4F692F97D8EF003719D6 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */; };
+		7B4A4F6A2F97D8EF003719D6 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F492F97D8EF003719D6 /* Consent.swift */; };
+		7B4A4F6B2F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */; };
+		7B4A4F6C2F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */; };
+		7B4A4F6D2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */; };
+		7B4A4F6E2F97D8EF003719D6 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */; };
+		7B4A4F6F2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */; };
+		7B4A4F702F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */; };
+		7B4A4F712F97D8EF003719D6 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */; };
+		7B4A4F722F97D8EF003719D6 /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */; };
+		7B4A4F732F97D8EF003719D6 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */; };
+		7B4A4F742F97D8EF003719D6 /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */; };
+		7B4A4F752F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */; };
+		7B4A4F762F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */; };
+		7B4A4F772F97D8EF003719D6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */; };
+		7B4A4F782F97D8EF003719D6 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */; };
+		7B4A4F792F97D8EF003719D6 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F632F97D8EF003719D6 /* TagsExt.swift */; };
+		7B4A4F7A2F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */; };
+		7B4A4F7B2F97D8EF003719D6 /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */; };
+		7B4A4F7C2F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */; };
+		7B4A4F7D2F97D8EF003719D6 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */; };
+		7B4A4F7E2F97D8EF003719D6 /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */; };
+		7B4A4F7F2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */; };
+		7B4A4F802F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */; };
+		7B4A4F812F97D8EF003719D6 /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */; };
+		7B4A4F822F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */; };
+		7B4A4F832F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */; };
+		7B4A4F842F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */; };
+		7B4A4F852F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */; };
+		7B4A4F862F97D8EF003719D6 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */; };
+		7B4A4F872F97D8EF003719D6 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F492F97D8EF003719D6 /* Consent.swift */; };
+		7B4A4F882F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */; };
+		7B4A4F892F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */; };
+		7B4A4F8A2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */; };
+		7B4A4F8B2F97D8EF003719D6 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */; };
+		7B4A4F8C2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */; };
+		7B4A4F8D2F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */; };
+		7B4A4F8E2F97D8EF003719D6 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */; };
+		7B4A4F8F2F97D8EF003719D6 /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */; };
+		7B4A4F902F97D8EF003719D6 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */; };
+		7B4A4F912F97D8EF003719D6 /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */; };
+		7B4A4F922F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */; };
+		7B4A4F932F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */; };
+		7B4A4F942F97D8EF003719D6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */; };
+		7B4A4F952F97D8EF003719D6 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */; };
+		7B4A4F962F97D8EF003719D6 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F632F97D8EF003719D6 /* TagsExt.swift */; };
+		7B4A4F972F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */; };
+		7B4A4F982F97D8EF003719D6 /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */; };
+		7B4A4F992F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */; };
+		7B4A4F9A2F97D8EF003719D6 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */; };
+		7B4A4F9B2F97D8EF003719D6 /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */; };
+		7B4A4F9C2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */; };
+		7B4A4F9D2F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */; };
+		7B4A4F9E2F97D8EF003719D6 /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */; };
+		7B4A4F9F2F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */; };
+		7B4A4FA02F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */; };
+		7BE862062F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */; };
+		7BE862072F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,38 +98,39 @@
 
 /* Begin PBXFileReference section */
 		51100E672F21D4A5006B2ADD /* SwiftTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
-		512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
-		512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
 		512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = IdentityDocumentProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdditionalConfig.xcconfig; path = ../testapp/iosApp/AdditionalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 		51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = DeveloperConfig.xcconfig; path = ../testapp/iosApp/DeveloperConfig.xcconfig; sourceTree = SOURCE_ROOT; };
-		51F7116E2F860D320017F68B /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
-		51F7116F2F860D320017F68B /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
-		51F711702F860D320017F68B /* DocumentCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCarousel.swift; sourceTree = "<group>"; };
-		51F711712F860D320017F68B /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
-		51F711722F860D320017F68B /* DocumentExtCardart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExtCardart.swift; sourceTree = "<group>"; };
-		51F711732F860D320017F68B /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
-		51F711742F860D320017F68B /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		51F711752F860D320017F68B /* FloatingItemCenteredText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemCenteredText.swift; sourceTree = "<group>"; };
-		51F711762F860D320017F68B /* FloatingItemContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemContainer.swift; sourceTree = "<group>"; };
-		51F711772F860D320017F68B /* FloatingItemHeadingAndText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndText.swift; sourceTree = "<group>"; };
-		51F711782F860D320017F68B /* FloatingItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemList.swift; sourceTree = "<group>"; };
-		51F711792F860D320017F68B /* FloatingItemText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemText.swift; sourceTree = "<group>"; };
-		51F7117A2F860D320017F68B /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
-		51F7117B2F860D320017F68B /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
-		51F7117C2F860D320017F68B /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
-		51F7117D2F860D320017F68B /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
-		51F7117E2F860D320017F68B /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
-		51F7117F2F860D320017F68B /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
-		51F711802F860D320017F68B /* ProvisioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningView.swift; sourceTree = "<group>"; };
-		51F711812F860D320017F68B /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
-		51F711822F860D320017F68B /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
-		51F711832F860D320017F68B /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
-		51F711842F860D320017F68B /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
-		51F711852F860D320017F68B /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
-		51F711862F860D320017F68B /* VerticalDocumentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalDocumentList.swift; sourceTree = "<group>"; };
-		51F711872F860D320017F68B /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
+		7B4A4F492F97D8EF003719D6 /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
+		7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
+		7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCarousel.swift; sourceTree = "<group>"; };
+		7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
+		7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExtCardart.swift; sourceTree = "<group>"; };
+		7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
+		7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemCenteredText.swift; sourceTree = "<group>"; };
+		7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemContainer.swift; sourceTree = "<group>"; };
+		7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
+		7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
+		7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
+		7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndText.swift; sourceTree = "<group>"; };
+		7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemList.swift; sourceTree = "<group>"; };
+		7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemText.swift; sourceTree = "<group>"; };
+		7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
+		7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
+		7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
+		7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
+		7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
+		7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
+		7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningView.swift; sourceTree = "<group>"; };
+		7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
+		7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
+		7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
+		7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
+		7B4A4F632F97D8EF003719D6 /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
+		7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalDocumentList.swift; sourceTree = "<group>"; };
+		7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
+		7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultToHumanReadable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -187,7 +190,7 @@
 		51100E5E2F21D4A5006B2ADD = {
 			isa = PBXGroup;
 			children = (
-				51F711882F860D320017F68B /* swift */,
+				7B4A4F662F97D8EF003719D6 /* swift */,
 				51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */,
 				51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */,
 				51100E692F21D4A5006B2ADD /* SwiftTestApp */,
@@ -213,41 +216,42 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		51F711882F860D320017F68B /* swift */ = {
+		7B4A4F662F97D8EF003719D6 /* swift */ = {
 			isa = PBXGroup;
 			children = (
-				512C05712F940AB500EA25B7 /* FloatingItemHeadingAndContent.swift */,
-				512C056E2F9409F000EA25B7 /* FloatingItemHeadingAndDateTime.swift */,
-				512C056B2F94044E00EA25B7 /* FloatingItemHeadingAndDate.swift */,
-				51F7116E2F860D320017F68B /* Consent.swift */,
-				51F7116F2F860D320017F68B /* ConsentPromptDialog.swift */,
-				51F711702F860D320017F68B /* DocumentCarousel.swift */,
-				51F711712F860D320017F68B /* DocumentExt.swift */,
-				51F711722F860D320017F68B /* DocumentExtCardart.swift */,
-				51F711732F860D320017F68B /* DocumentModel.swift */,
-				51F711742F860D320017F68B /* Extensions.swift */,
-				51F711752F860D320017F68B /* FloatingItemCenteredText.swift */,
-				51F711762F860D320017F68B /* FloatingItemContainer.swift */,
-				51F711772F860D320017F68B /* FloatingItemHeadingAndText.swift */,
-				51F711782F860D320017F68B /* FloatingItemList.swift */,
-				51F711792F860D320017F68B /* FloatingItemText.swift */,
-				51F7117A2F860D320017F68B /* MdocProximityQrPresentment.swift */,
-				51F7117B2F860D320017F68B /* MdocProximityQrSettings.swift */,
-				51F7117C2F860D320017F68B /* PassphraseInputView.swift */,
-				51F7117D2F860D320017F68B /* PassphrasePromptDialog.swift */,
-				51F7117E2F860D320017F68B /* PromptDialogs.swift */,
-				51F7117F2F860D320017F68B /* PromptModelExt.swift */,
-				51F711802F860D320017F68B /* ProvisioningView.swift */,
-				51F711812F860D320017F68B /* QrCode.swift */,
-				51F711822F860D320017F68B /* RequestAuthorizationView.swift */,
-				51F711832F860D320017F68B /* SimplePresentmentSourceExt.swift */,
-				51F711842F860D320017F68B /* SmartSheet.swift */,
-				51F711852F860D320017F68B /* TagsExt.swift */,
-				51F711862F860D320017F68B /* VerticalDocumentList.swift */,
-				51F711872F860D320017F68B /* X509CertViewer.swift */,
+				7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */,
+				7B4A4F492F97D8EF003719D6 /* Consent.swift */,
+				7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */,
+				7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */,
+				7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */,
+				7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */,
+				7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */,
+				7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */,
+				7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */,
+				7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */,
+				7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */,
+				7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */,
+				7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */,
+				7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */,
+				7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */,
+				7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */,
+				7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */,
+				7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */,
+				7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */,
+				7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */,
+				7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */,
+				7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */,
+				7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */,
+				7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */,
+				7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */,
+				7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */,
+				7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */,
+				7B4A4F632F97D8EF003719D6 /* TagsExt.swift */,
+				7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */,
+				7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */,
 			);
 			name = swift;
-			path = "/Users/davidz/StudioProjects/multipaz/multipaz-swiftui/src/iosMain/swift";
+			path = "/Users/zeuthen/StudioProjects/multipaz/multipaz-swiftui/src/iosMain/swift";
 			sourceTree = "<absolute>";
 		};
 /* End PBXGroup section */
@@ -406,35 +410,36 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51F711A32F860D320017F68B /* DocumentModel.swift in Sources */,
-				51F711A42F860D320017F68B /* DocumentExtCardart.swift in Sources */,
-				512C056F2F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				51F711A52F860D320017F68B /* DocumentExt.swift in Sources */,
-				51F711A62F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */,
-				51F711A72F860D320017F68B /* VerticalDocumentList.swift in Sources */,
-				51F711A82F860D320017F68B /* Extensions.swift in Sources */,
-				51F711A92F860D320017F68B /* ProvisioningView.swift in Sources */,
-				51F711AA2F860D320017F68B /* PromptModelExt.swift in Sources */,
-				51F711AB2F860D320017F68B /* PromptDialogs.swift in Sources */,
-				51F711AC2F860D320017F68B /* PassphrasePromptDialog.swift in Sources */,
-				51F711AD2F860D320017F68B /* SimplePresentmentSourceExt.swift in Sources */,
-				51F711AE2F860D320017F68B /* FloatingItemCenteredText.swift in Sources */,
-				51F711AF2F860D320017F68B /* TagsExt.swift in Sources */,
-				51F711B02F860D320017F68B /* MdocProximityQrPresentment.swift in Sources */,
-				51F711B12F860D320017F68B /* FloatingItemList.swift in Sources */,
-				51F711B22F860D320017F68B /* QrCode.swift in Sources */,
-				51F711B32F860D320017F68B /* DocumentCarousel.swift in Sources */,
-				51F711B42F860D320017F68B /* Consent.swift in Sources */,
-				51F711B52F860D320017F68B /* FloatingItemText.swift in Sources */,
-				51F711B62F860D320017F68B /* FloatingItemContainer.swift in Sources */,
-				51F711B72F860D320017F68B /* X509CertViewer.swift in Sources */,
-				51F711B82F860D320017F68B /* PassphraseInputView.swift in Sources */,
-				51F711B92F860D320017F68B /* MdocProximityQrSettings.swift in Sources */,
-				51F711BA2F860D320017F68B /* ConsentPromptDialog.swift in Sources */,
-				51F711BB2F860D320017F68B /* RequestAuthorizationView.swift in Sources */,
-				512C05732F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */,
-				512C056C2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */,
-				51F711BC2F860D320017F68B /* SmartSheet.swift in Sources */,
+				7B4A4F672F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */,
+				7B4A4F682F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */,
+				7B4A4F692F97D8EF003719D6 /* PromptDialogs.swift in Sources */,
+				7B4A4F6A2F97D8EF003719D6 /* Consent.swift in Sources */,
+				7B4A4F6B2F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */,
+				7B4A4F6C2F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */,
+				7B4A4F6D2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */,
+				7B4A4F6E2F97D8EF003719D6 /* PromptModelExt.swift in Sources */,
+				7B4A4F6F2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */,
+				7B4A4F702F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */,
+				7BE862062F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */,
+				7B4A4F712F97D8EF003719D6 /* DocumentExt.swift in Sources */,
+				7B4A4F722F97D8EF003719D6 /* FloatingItemList.swift in Sources */,
+				7B4A4F732F97D8EF003719D6 /* QrCode.swift in Sources */,
+				7B4A4F742F97D8EF003719D6 /* DocumentCarousel.swift in Sources */,
+				7B4A4F752F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */,
+				7B4A4F762F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */,
+				7B4A4F772F97D8EF003719D6 /* Extensions.swift in Sources */,
+				7B4A4F782F97D8EF003719D6 /* X509CertViewer.swift in Sources */,
+				7B4A4F792F97D8EF003719D6 /* TagsExt.swift in Sources */,
+				7B4A4F7A2F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */,
+				7B4A4F7B2F97D8EF003719D6 /* ProvisioningView.swift in Sources */,
+				7B4A4F7C2F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */,
+				7B4A4F7D2F97D8EF003719D6 /* SmartSheet.swift in Sources */,
+				7B4A4F7E2F97D8EF003719D6 /* DocumentModel.swift in Sources */,
+				7B4A4F7F2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */,
+				7B4A4F802F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */,
+				7B4A4F812F97D8EF003719D6 /* FloatingItemText.swift in Sources */,
+				7B4A4F822F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */,
+				7B4A4F832F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -442,35 +447,36 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51F711892F860D320017F68B /* DocumentModel.swift in Sources */,
-				51F7118A2F860D320017F68B /* DocumentExtCardart.swift in Sources */,
-				51F7118B2F860D320017F68B /* DocumentExt.swift in Sources */,
-				51F7118C2F860D320017F68B /* FloatingItemHeadingAndText.swift in Sources */,
-				51F7118D2F860D320017F68B /* VerticalDocumentList.swift in Sources */,
-				51F7118E2F860D320017F68B /* Extensions.swift in Sources */,
-				512C056D2F94045400EA25B7 /* FloatingItemHeadingAndDate.swift in Sources */,
-				51F7118F2F860D320017F68B /* ProvisioningView.swift in Sources */,
-				51F711902F860D320017F68B /* PromptModelExt.swift in Sources */,
-				51F711912F860D320017F68B /* PromptDialogs.swift in Sources */,
-				51F711922F860D320017F68B /* PassphrasePromptDialog.swift in Sources */,
-				51F711932F860D320017F68B /* SimplePresentmentSourceExt.swift in Sources */,
-				512C05702F9409F900EA25B7 /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				51F711942F860D320017F68B /* FloatingItemCenteredText.swift in Sources */,
-				51F711952F860D320017F68B /* TagsExt.swift in Sources */,
-				51F711962F860D320017F68B /* MdocProximityQrPresentment.swift in Sources */,
-				51F711972F860D320017F68B /* FloatingItemList.swift in Sources */,
-				51F711982F860D320017F68B /* QrCode.swift in Sources */,
-				51F711992F860D320017F68B /* DocumentCarousel.swift in Sources */,
-				51F7119A2F860D320017F68B /* Consent.swift in Sources */,
-				51F7119B2F860D320017F68B /* FloatingItemText.swift in Sources */,
-				51F7119C2F860D320017F68B /* FloatingItemContainer.swift in Sources */,
-				51F7119D2F860D320017F68B /* X509CertViewer.swift in Sources */,
-				51F7119E2F860D320017F68B /* PassphraseInputView.swift in Sources */,
-				51F7119F2F860D320017F68B /* MdocProximityQrSettings.swift in Sources */,
-				51F711A02F860D320017F68B /* ConsentPromptDialog.swift in Sources */,
-				512C05722F940ABC00EA25B7 /* FloatingItemHeadingAndContent.swift in Sources */,
-				51F711A12F860D320017F68B /* RequestAuthorizationView.swift in Sources */,
-				51F711A22F860D320017F68B /* SmartSheet.swift in Sources */,
+				7B4A4F842F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */,
+				7B4A4F852F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */,
+				7B4A4F862F97D8EF003719D6 /* PromptDialogs.swift in Sources */,
+				7B4A4F872F97D8EF003719D6 /* Consent.swift in Sources */,
+				7B4A4F882F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */,
+				7B4A4F892F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */,
+				7BE862072F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */,
+				7B4A4F8A2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */,
+				7B4A4F8B2F97D8EF003719D6 /* PromptModelExt.swift in Sources */,
+				7B4A4F8C2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */,
+				7B4A4F8D2F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */,
+				7B4A4F8E2F97D8EF003719D6 /* DocumentExt.swift in Sources */,
+				7B4A4F8F2F97D8EF003719D6 /* FloatingItemList.swift in Sources */,
+				7B4A4F902F97D8EF003719D6 /* QrCode.swift in Sources */,
+				7B4A4F912F97D8EF003719D6 /* DocumentCarousel.swift in Sources */,
+				7B4A4F922F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */,
+				7B4A4F932F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */,
+				7B4A4F942F97D8EF003719D6 /* Extensions.swift in Sources */,
+				7B4A4F952F97D8EF003719D6 /* X509CertViewer.swift in Sources */,
+				7B4A4F962F97D8EF003719D6 /* TagsExt.swift in Sources */,
+				7B4A4F972F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */,
+				7B4A4F982F97D8EF003719D6 /* ProvisioningView.swift in Sources */,
+				7B4A4F992F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */,
+				7B4A4F9A2F97D8EF003719D6 /* SmartSheet.swift in Sources */,
+				7B4A4F9B2F97D8EF003719D6 /* DocumentModel.swift in Sources */,
+				7B4A4F9C2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */,
+				7B4A4F9D2F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */,
+				7B4A4F9E2F97D8EF003719D6 /* FloatingItemText.swift in Sources */,
+				7B4A4F9F2F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */,
+				7B4A4FA02F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/SwiftTestApp/SwiftTestApp/ClaimsScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ClaimsScreen.swift
@@ -5,33 +5,41 @@ struct ClaimsScreen: View {
     
     @Environment(ViewModel.self) private var viewModel
     
-    let credentialInfo: CredentialInfo
-    
+    let documentId: String
+    let credentialId: String
+
     var body: some View {
-        
+        let di = viewModel.documentModel.documentInfos.first {
+            $0.document.identifier == documentId
+        }
+        let ci = di?.credentialInfos.first {
+            $0.credential.identifier == credentialId
+        }
         ScrollView {
-            let tz = TimeZone.Companion.shared.currentSystemDefault()
-            VStack(alignment: .leading, spacing: 20) {
-                ForEach(credentialInfo.claims, id:\.self) { claim in
-                    if claim.attribute?.type is DocumentAttributeType.Picture {
-                        if let mdocClaim = claim as? MdocClaim {
-                            // Some picture attributes might be set to Simple.NULL value, handle this
-                            if mdocClaim.value is Bstr {
+            if let credentialInfo = ci {
+                let tz = TimeZone.Companion.shared.currentSystemDefault()
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(credentialInfo.claims, id:\.self) { claim in
+                        if claim.attribute?.type is DocumentAttributeType.Picture {
+                            if let mdocClaim = claim as? MdocClaim {
+                                // Some picture attributes might be set to Simple.NULL value, handle this
+                                if mdocClaim.value is Bstr {
+                                    KvPair(
+                                        claim.displayName,
+                                        encodedImage: (mdocClaim.value as! Bstr).value.toNSData()
+                                    )
+                                } else {
+                                    KvPair(claim.displayName, string: claim.render(timeZone: tz))
+                                }
+                            } else if let jsonClaim = claim as? JsonClaim {
                                 KvPair(
                                     claim.displayName,
-                                    encodedImage: (mdocClaim.value as! Bstr).value.toNSData()
+                                    encodedImage: jsonClaim.value.jsonPrimitive.content.fromBase64Url().toNSData()
                                 )
-                            } else {
-                                KvPair(claim.displayName, string: claim.render(timeZone: tz))
                             }
-                        } else if let jsonClaim = claim as? JsonClaim {
-                            KvPair(
-                                claim.displayName,
-                                encodedImage: jsonClaim.value.jsonPrimitive.content.fromBase64Url().toNSData()
-                            )
+                        } else {
+                            KvPair(claim.displayName, string: claim.render(timeZone: tz))
                         }
-                    } else {
-                        KvPair(claim.displayName, string: claim.render(timeZone: tz))
                     }
                 }
             }

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -584,7 +584,7 @@ private func calcConsentData(
             return nil
         },
         showConsentPromptFn: { requester, trustMetadata, credentialPresentmentData, preselectedDocuments, onDocumentsInFocus in
-            try! await promptModelSilentConsent(
+            return try! await promptModelSilentConsent(
                 requester: requester,
                 trustMetadata: trustMetadata,
                 credentialPresentmentData: credentialPresentmentData,

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -26,10 +26,12 @@ struct ContentView: View {
                 case .startScreen: StartScreen()
                 case .aboutScreen: AboutScreen()
                 case .documentStoreScreen: DocumentStoreScreen()
-                case .documentScreen(let documentInfo): DocumentScreen(documentInfo: documentInfo)
+                case .documentScreen(let documentId): DocumentScreen(documentId: documentId)
                 case .verticalDocumentListScreen: VerticalDocumentListScreen()
-                case .credentialScreen(let credentialInfo): CredentialScreen(credentialInfo: credentialInfo)
-                case .claimsScreen(let credentialInfo): ClaimsScreen(credentialInfo: credentialInfo)
+                case .credentialScreen(documentId: let documentId, credentialId: let credentialId):
+                    CredentialScreen(documentId: documentId, credentialId: credentialId)
+                case .claimsScreen(documentId: let documentId, credentialId: let credentialId):
+                    ClaimsScreen(documentId: documentId, credentialId: credentialId)
                 case .consentPromptScreen: ConsentPromptScreen()
                 case .passphrasePromptScreen: PassphrasePromptScreen()
                 case .iso18013ProximityPresentmentScreen: Iso18013ProximityPresentmentScreen()

--- a/samples/SwiftTestApp/SwiftTestApp/CredentialScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/CredentialScreen.swift
@@ -4,51 +4,76 @@ import Multipaz
 struct CredentialScreen: View {
     @Environment(ViewModel.self) private var viewModel
     
-    let credentialInfo: CredentialInfo
+    let documentId: String
+    let credentialId: String
     
     var body: some View {
-        
+        let di = viewModel.documentModel.documentInfos.first {
+            $0.document.identifier == documentId
+        }
+        let ci = di?.credentialInfos.first {
+            $0.credential.identifier == credentialId
+        }
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                KvPair("Type", string: credentialInfo.credential.credentialType)
-                KvPair("Identifier", string: credentialInfo.credential.identifier)
-                KvPair("Replacement for", string: credentialInfo.credential.replacementForIdentifier ?? "Not set")
-                KvPair("Domain", string: credentialInfo.credential.domain)
-                KvPair("Usage count", string: credentialInfo.credential.usageCount.formatted())
-                KvPair("Certified", bool: credentialInfo.credential.isCertified)
-                if (credentialInfo.credential.isCertified) {
-                    KvPair("Issuer provided data", numBytes: credentialInfo.credential.issuerProvidedData.size)
-                    KvPair("Valid from", instant: credentialInfo.credential.validFrom)
-                    KvPair("Valid until", instant: credentialInfo.credential.validUntil)
-                }
-                if let mdocCredential = credentialInfo.credential as? MdocCredential {
-                    KvPair("ISO mdoc DocType", string: mdocCredential.docType)
-                    KvPair("ISO mdoc MSO size", numBytes: mdocCredential.issuerAuth.payload!.size)
-                    KvPair("ISO mdoc DS key certificates", string: "Click to view")
-                        .onTapGesture {
-                            viewModel.path.append(Destination.certificateViewerScreen(
+            if let credentialInfo = ci {
+                VStack(alignment: .leading, spacing: 20) {
+                    KvPair("Type", string: credentialInfo.credential.credentialType)
+                    KvPair("Identifier", string: credentialInfo.credential.identifier)
+                    KvPair("Replacement for", string: credentialInfo.credential.replacementForIdentifier ?? "Not set")
+                    KvPair("Domain", string: credentialInfo.credential.domain)
+                    KvPair("Usage count", string: credentialInfo.credential.usageCount.formatted())
+                    KvPair("Certified", bool: credentialInfo.credential.isCertified)
+                    if (credentialInfo.credential.isCertified) {
+                        KvPair("Issuer provided data", numBytes: credentialInfo.credential.issuerProvidedData.size)
+                        KvPair("Valid from", instant: credentialInfo.credential.validFrom)
+                        KvPair("Valid until", instant: credentialInfo.credential.validUntil)
+                    }
+                    if let mdocCredential = credentialInfo.credential as? MdocCredential {
+                        KvPair("ISO mdoc DocType", string: mdocCredential.docType)
+                        KvPair("ISO mdoc MSO size", numBytes: mdocCredential.issuerAuth.payload!.size)
+                        KvPair("ISO mdoc DS key certificates", string: "Click to view")
+                            .onTapGesture {
+                                viewModel.path.append(Destination.certificateViewerScreen(
                                     certificates: mdocCredential.issuerCertChain.certificates
                                 ))
-                        }
-                }
-                if let sdjwtVcCredential = credentialInfo.credential as? SdJwtVcCredential {
-                    KvPair("SD-JWT verifiable credential type", string: sdjwtVcCredential.vct)
-                }
-                if let secureAreaBoundCredential = credentialInfo.credential as? SecureAreaBoundCredential {
-                    KvPair("Secure area", string: secureAreaBoundCredential.secureArea.displayName)
-                    KvPair("Device key algorithm", string: credentialInfo.keyInfo!.algorithm.description_)
-                    KvPair("Device key invalidated", bool: credentialInfo.keyInvalidated)
-                    KvPair("Device key attestation", string: "Click for details")
-                        .onTapGesture {
-                            print("TODO: show attestation")
-                        }
-                }
-                KvPair("Claims", string: "Click for details")
-                    .onTapGesture {
-                        viewModel.path.append(Destination.claimsScreen(credentialInfo: credentialInfo))
+                            }
                     }
+                    if let sdjwtVcCredential = credentialInfo.credential as? SdJwtVcCredential {
+                        KvPair("SD-JWT verifiable credential type", string: sdjwtVcCredential.vct)
+                    }
+                    if let secureAreaBoundCredential = credentialInfo.credential as? SecureAreaBoundCredential {
+                        KvPair("Secure area", string: secureAreaBoundCredential.secureArea.displayName)
+                        KvPair("Device key algorithm", string: credentialInfo.keyInfo!.algorithm.description_)
+                        KvPair("Device key invalidated", bool: credentialInfo.keyInvalidated)
+                        KvPair("Device key attestation", string: "Click for details")
+                            .onTapGesture {
+                                print("TODO: show attestation")
+                            }
+                    }
+                    KvPair("Claims", string: "Click for details")
+                        .onTapGesture {
+                            viewModel.path.append(Destination.claimsScreen(
+                                documentId: di!.document.identifier,
+                                credentialId: credentialInfo.credential.identifier
+                            ))
+                        }
+                    
+                    Button(
+                        role: .destructive,
+                        action: {
+                            Task {
+                                try await credentialInfo.credential.document.deleteCredential(
+                                    credentialIdentifier: credentialInfo.credential.identifier
+                                )
+                            }
+                            viewModel.path.removeLast()
+                        }
+                    ) {
+                        Text("Delete credential")
+                    }.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationTitle("Credential")
         .padding()

--- a/samples/SwiftTestApp/SwiftTestApp/Destination.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/Destination.swift
@@ -4,9 +4,9 @@ enum Destination: Hashable {
     case startScreen
     case aboutScreen
     case documentStoreScreen
-    case documentScreen(documentInfo: DocumentInfo)
-    case credentialScreen(credentialInfo: CredentialInfo)
-    case claimsScreen(credentialInfo: CredentialInfo)
+    case documentScreen(documentId: String)
+    case credentialScreen(documentId: String, credentialId: String)
+    case claimsScreen(documentId: String, credentialId: String)
     case consentPromptScreen
     case passphrasePromptScreen
     case iso18013ProximityPresentmentScreen

--- a/samples/SwiftTestApp/SwiftTestApp/DocumentScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/DocumentScreen.swift
@@ -4,62 +4,104 @@ import Multipaz
 struct DocumentScreen: View {
     @Environment(ViewModel.self) private var viewModel
     
-    let documentInfo: DocumentInfo
+    let documentId: String
 
-    init(documentInfo: DocumentInfo) {
-        self.documentInfo = documentInfo
+    init(documentId: String) {
+        self.documentId = documentId
+    }
+    
+    var documentInfo: DocumentInfo? {
+        viewModel.documentModel.documentInfos.first {
+            $0.document.identifier == documentId
+        }
     }
     
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                Image(uiImage: documentInfo.cardArt)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity)
-                KvPair("Document Name", string: documentInfo.document.displayName ?? "Unknown")
-                KvPair("Document Type", string: documentInfo.document.typeDisplayName ?? "Unknown")
-                KvPair("Identifier", string: documentInfo.document.identifier)
-                KvPair("Created", instant: documentInfo.document.created)
-                KvPair("Provisioned", bool: documentInfo.document.provisioned)
-                KvPair("Card art", numBytes: documentInfo.document.cardArt?.size ?? -1)
-                KvPair("Issuer logo", numBytes: documentInfo.document.issuerLogo?.size ?? -1)
-                KvPair(
-                    "Authorization data",
-                    numBytes: documentInfo.document.authorizationData?.size ?? -1
-                )
-                KvPair("Credentials")
-                let domains = Set(documentInfo.credentialInfos.map(\.credential.domain))
-                ForEach(domains.sorted(), id: \.self) { domain in
-                    Text(domain + " domain").italic()
-                        .padding(.leading, 10)
-                    ForEach(documentInfo.credentialInfos, id: \.self) { credentialInfo in
-                        KvPair(
-                            credentialInfo.credential.credentialType,
-                            string: "Usage count \(credentialInfo.credential.usageCount). Click for details"
-                        )
-                        .padding(.leading, 20)
-                        .onTapGesture {
-                            viewModel.path.append(Destination.credentialScreen(credentialInfo: credentialInfo))
+            if let documentInfo = documentInfo {
+                VStack(alignment: .leading, spacing: 20) {
+                    Image(uiImage: documentInfo.cardArt)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                    KvPair("Document Name", string: documentInfo.document.displayName ?? "Unknown")
+                    KvPair("Document Type", string: documentInfo.document.typeDisplayName ?? "Unknown")
+                    KvPair("Identifier", string: documentInfo.document.identifier)
+                    KvPair("Created", instant: documentInfo.document.created)
+                    KvPair("Provisioned", bool: documentInfo.document.provisioned)
+                    KvPair("Card art", numBytes: documentInfo.document.cardArt?.size ?? -1)
+                    KvPair("Issuer logo", numBytes: documentInfo.document.issuerLogo?.size ?? -1)
+                    KvPair(
+                        "Authorization data",
+                        numBytes: documentInfo.document.authorizationData?.size ?? -1
+                    )
+                    KvPair("Credentials")
+                    let domains = Set(documentInfo.credentialInfos.map(\.credential.domain))
+                    ForEach(domains.sorted(), id: \.self) { domain in
+                        Text(domain + " domain").italic()
+                            .padding(.leading, 10)
+                        ForEach(documentInfo.credentialInfos, id: \.self) { credentialInfo in
+                            if (credentialInfo.credential.domain == domain) {
+                                let trailingType = if credentialInfo.credential.isCertified {
+                                    ""
+                                } else {
+                                    " (Pending)"
+                                }
+                                KvPair(
+                                    credentialInfo.credential.credentialType + trailingType,
+                                    string: "Usage count \(credentialInfo.credential.usageCount). Click for details"
+                                )
+                                .padding(.leading, 20)
+                                .onTapGesture {
+                                    viewModel.path.append(Destination.credentialScreen(
+                                        documentId: documentInfo.document.identifier,
+                                        credentialId: credentialInfo.credential.identifier
+                                    ))
+                                }
+                            }
                         }
                     }
-                }
-                VStack {
-                    Button(
-                        role: .destructive,
-                        action: {
-                            Task {
-                                try await viewModel.documentStore.deleteDocument(identifier: documentInfo.document.identifier)
+                    VStack {
+                        Button(
+                            action: {
+                                Task {
+                                    let authorizationData = documentInfo.document.authorizationData
+                                    if authorizationData == nil {
+                                        print("No authorizationData for credential")
+                                    } else {
+                                        do {
+                                            try await viewModel.provisioningModel.openID4VCIRefreshCredentials(
+                                                document: documentInfo.document,
+                                                authorizationData: authorizationData!,
+                                                clientPreferences: viewModel.provisioningSupport.getOpenID4VCIClientPreferences(),
+                                                backend: viewModel.provisioningSupport.getOpenID4VCIBackend()
+                                            )
+                                        } catch {
+                                            print("Error refreshing: \(error)")
+                                        }
+                                    }
+                                }
                             }
-                            viewModel.path.removeLast()
-                        }
-                    ) {
-                        Text("Delete document")
-                    }.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+                        ) {
+                            Text("Refresh credentials")
+                        }.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+                        
+                        Button(
+                            role: .destructive,
+                            action: {
+                                Task {
+                                    try await viewModel.documentStore.deleteDocument(identifier: documentInfo.document.identifier)
+                                }
+                                viewModel.path.removeLast()
+                            }
+                        ) {
+                            Text("Delete document")
+                        }.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+                    }
+                    .frame(maxWidth: .infinity)
                 }
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationTitle("Document")
         .padding()

--- a/samples/SwiftTestApp/SwiftTestApp/DocumentStoreScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/DocumentStoreScreen.swift
@@ -76,7 +76,7 @@ struct DocumentStoreScreen: View {
                     initialDocumentId: focusedDocumentId,
                     allowReordering: true,
                     onDocumentClicked: { documentInfo in
-                        viewModel.path.append(Destination.documentScreen(documentInfo: documentInfo))
+                        viewModel.path.append(Destination.documentScreen(documentId: documentInfo.document.identifier))
                     },
                     onDocumentFocused: { documentInfo in
                         focusedDocumentId = documentInfo.document.identifier

--- a/samples/SwiftTestApp/SwiftTestApp/VerticalDocumentListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/VerticalDocumentListScreen.swift
@@ -29,7 +29,7 @@ struct VerticalDocumentListScreen: View {
                             Text("Tap card for more info")
                         } else {
                             Button(action: {
-                                viewModel.path.append(Destination.documentScreen(documentInfo: docInfo))
+                                viewModel.path.append(Destination.documentScreen(documentId: docInfo.document.identifier))
                             }) {
                                 Text("Even more info")
                                     .cornerRadius(12)

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -165,16 +165,27 @@ class ViewModel {
                     extensions: [:]
                 )
             )
-
+        
         self.provisioningModel = ProvisioningModel(
             documentProvisioningHandler: DocumentProvisioningHandler(
                 secureArea: secureArea,
                 documentStore: documentStore,
-                mdocCredentialDomain: "mdoc",
-                sdJwtCredentialDomain: "sdJwt",
-                keylessCredentialDomain: "sdJwtKeyless",
-                batchSize: 5,
-                metadataHandler: nil
+                metadataHandler: nil,
+                defaultDocumentProvisioningSettings: DocumentProvisioningSettings(
+                    minValidTime: 5*86400*1000_000_000,
+                    keyBoundCredentialMaxUses: 1,
+                    keyBoundCredentialNumPerDomain: 5,
+                    keylessCredentialMaxUses: Int32.max,
+                    keylessCredentialNumPerDomain: 1,
+                    userAuthTimeout: 0,
+                    requestUserAuth: true,
+                    requestNoUserAuth: true,
+                    mdocUserAuthDomain: "mdoc_user_auth",
+                    mdocNoUserAuthDomain: "mdoc_no_user_auth",
+                    sdJwtUserAuthDomain: "sdjwt_user_auth",
+                    sdJwtNoUserAuthDomain: "sdjwt_no_user_auth",
+                    sdJwtKeylessDomain: "sdjwt_keyless"
+                )
             ),
             httpClient: HttpClient(engineFactory: Darwin()) { config in
                 config.followRedirects = false
@@ -280,7 +291,7 @@ class ViewModel {
             validFrom: validFrom.toKotlinInstant().truncateToWholeSeconds(),
             validUntil: validUntil.toKotlinInstant().truncateToWholeSeconds(),
             expectedUpdate: nil,
-            domain: "mdoc",
+            domain: "mdoc_user_auth",
             randomProvider: KotlinRandom.companion
         )
         try! await document.edit(editActionFn: { editor in
@@ -315,8 +326,12 @@ class ViewModel {
                 )
             },
             preferSignatureToKeyAgreement: false,
-            domainsMdocSignature: ["mdoc"],
+            domainsMdocSignature: ["mdoc_user_auth", "mdoc_no_user_auth"],
+            domainsMdocKeyAgreement: [],
+            domainsKeylessSdJwt: ["sdjwt_keyless"],
+            domainsKeyBoundSdJwt: ["sdjwt_user_auth", "sdjwt_no_user_auth"]
         )
     }
 }
 
+    

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -47,9 +47,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -84,6 +82,7 @@ import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.digitalcredentials.DigitalCredentials
 import org.multipaz.digitalcredentials.getDefault
+import org.multipaz.document.Document
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
@@ -100,7 +99,10 @@ import org.multipaz.presentment.uriSchemePresentment
 import org.multipaz.prompt.PromptModel
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.promptModelSilentConsent
+import org.multipaz.provisioning.CredentialMetadata
 import org.multipaz.provisioning.DocumentProvisioningHandler
+import org.multipaz.provisioning.DocumentProvisioningSettings
+import org.multipaz.provisioning.ProvisioningMetadata
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.request.Requester
 import org.multipaz.secure_area_test_app.ui.CloudSecureAreaScreen
@@ -407,7 +409,7 @@ class App private constructor (val promptModel: PromptModel) {
         provisioningModel = ProvisioningModel(
             documentProvisioningHandler = DocumentProvisioningHandler(
                 documentStore = documentStore,
-                secureArea = secureArea
+                secureArea = secureArea,
             ),
             httpClient = HttpClient(TestAppConfiguration.httpClientEngineFactory) {
                 followRedirects = false
@@ -1183,12 +1185,30 @@ class App private constructor (val promptModel: PromptModel) {
                                 )
                             },
                             onProvisionMore = { document, authorizationData ->
-                                provisioningModel.launchOpenID4VCIRefreshCredentials(
-                                    document,
-                                    authorizationData,
-                                    provisioningSupport.getOpenID4VCIClientPreferences(),
-                                    provisioningSupport.getOpenID4VCIBackend()
-                                )
+                                coroutineScope.launch {
+                                    val tStart = Clock.System.now()
+                                    try {
+                                        val numNewCredentials =
+                                            provisioningModel.openID4VCIRefreshCredentials(
+                                                document = document,
+                                                authorizationData = authorizationData,
+                                                clientPreferences = provisioningSupport.getOpenID4VCIClientPreferences(),
+                                                backend = provisioningSupport.getOpenID4VCIBackend()
+                                            )
+                                        val duration = Clock.System.now() - tStart
+                                        showToast("Refreshed $numNewCredentials credentials in $duration")
+                                    } catch (e: Throwable) {
+                                        if (e is CancellationException) throw e
+                                        showToast("Error refreshing credentials: $e")
+                                    }
+                                }
+                            },
+                            onDeleteAllCredentials = { document ->
+                                coroutineScope.launch {
+                                    document.getCredentials().map { it.identifier }.forEach { identifier ->
+                                        document.deleteCredential(identifier)
+                                    }
+                                }
                             },
                             onDocumentDeleted = {
                                 navController.navigateUp()
@@ -1218,6 +1238,12 @@ class App private constructor (val promptModel: PromptModel) {
                                         credentialId = credentialId
                                     )
                                 )
+                            },
+                            onCredentialDelete = { documentId, credentialId ->
+                                coroutineScope.launch {
+                                    documentStore.lookupDocument(documentId)?.deleteCredential(credentialId)
+                                }
+                                navController.navigateUp()
                             }
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
@@ -3,16 +3,20 @@ package org.multipaz.testapp.ui
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -37,6 +41,7 @@ fun CredentialViewerScreen(
     showToast: (message: String) -> Unit,
     onViewCertificateChain: (encodedCertificateData: String) -> Unit,
     onViewCredentialClaims: (documentId: String, credentialId: String) -> Unit,
+    onCredentialDelete: (documentId: String, credentialId: String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val documentInfos = documentModel.documentInfos.collectAsState().value
@@ -177,6 +182,33 @@ fun CredentialViewerScreen(
                             onViewCredentialClaims(documentId, credentialId)
                         }
                     }
+                )
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp, horizontal = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Button(
+                modifier = Modifier.weight(1.0f),
+                onClick = {
+                    credentialInfo?.let {
+                        onCredentialDelete(
+                            credentialInfo.credential.document.identifier,
+                            credentialInfo.credential.identifier
+                        )
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Red,
+                    contentColor = Color.White
+                )
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    text = "Delete credential"
                 )
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
@@ -42,6 +42,7 @@ fun DocumentViewerScreen(
     showToast: (message: String) -> Unit,
     onViewCredential: (documentId: String, credentialId: String) -> Unit,
     onProvisionMore: (document: Document, authorizationData: ByteString) -> Unit,
+    onDeleteAllCredentials: (document: Document) -> Unit,
     onDocumentDeleted: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -143,6 +144,11 @@ fun DocumentViewerScreen(
                         if (credentialInfo.credential.domain != domain) {
                             continue
                         }
+                        val keyText = if (credentialInfo.credential.isCertified) {
+                            credentialInfo.credential.credentialType
+                        } else {
+                            "${credentialInfo.credential.credentialType} (Pending)"
+                        }
                         KeyValuePairText(
                             modifier = Modifier
                                 .padding(start = 24.dp)
@@ -152,7 +158,7 @@ fun DocumentViewerScreen(
                                         credentialInfo.credential.identifier
                                     )
                                 },
-                            keyText = credentialInfo.credential.credentialType,
+                            keyText = keyText,
                             valueText = buildAnnotatedString {
                                 withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.secondary)) {
                                     append("Usage count ${credentialInfo.credential.usageCount}. Click for details")
@@ -165,7 +171,18 @@ fun DocumentViewerScreen(
                     Button(onClick = {
                         onProvisionMore(documentInfo.document, authorizationData)
                     }) {
-                        Text("Provision more credentials")
+                        Text("Refresh credentials")
+                    }
+                    Button(
+                        onClick = {
+                            onDeleteAllCredentials(documentInfo.document)
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color.Red,
+                            contentColor = Color.White
+                        )
+                    ) {
+                        Text("Delete all credentials")
                     }
                 }
             }


### PR DESCRIPTION
Use `DocumentUtil.managedCredentialHelper()` for credential management in `DocumentProvisioningHandler` and introduce a new class `DocumentProvisioningSettings` which contains settings to use.

Allow app to control which `DocumentProvisioningSettings` instance to use in `DocumentProvisioningHandler` and use sane defaults so most apps don't have to do anything.

The default settings are to request two domains of credentials, one with user authentication required and a domain for without. This is to enable a "pre-consent" experience, with this setup a wallet app can simply check if it has credentials in the no-auth-required domain and if so offer a setting for the user to present the credential to e.g. select RPs without any consent or authentication.

Some issuers will not want to mint credentials without user authentication and they will enforce this by e.g. checking the Android Keystore key attestation for whether the key is configured to require user authentication. For such issuers, the application can disable requesting such credentials by tweaking settings for that particular issuer and/or credential type.

Rename the "Get more credentials" button in testapp to be "Refresh credentials" and also make it possible to delete individual credentials. Also report how many credentials were fetched.

Also introduce `ProvisioningModel.openID4VCIRefreshCredentials()` which bypasses the provisioning model (i.e. no UI shown). This is intended to be called in the background on a regular basis, e.g. daily.

Test: Manually tested on both Android and iOS.
