### PR TITLE
Android keystore key attestation for OpenID4VCI

### DIFF
--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
@@ -3,6 +3,7 @@ package org.multipaz.openid4vci.credential
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.device.AndroidKeystoreSecurityLevel
 import org.multipaz.openid4vci.request.wellKnownOpenidCredentialIssuer
 import org.multipaz.openid4vci.util.CredentialId
 import org.multipaz.provisioning.CredentialFormat
@@ -26,6 +27,9 @@ import org.multipaz.rpc.backend.BackendEnvironment
  * @param format format of the credential issued by this factory
  * @param requireKeyAttestation if this credential can only be bound to an attested key (i.e.
  *  mere proof-of-possession is not acceptable)
+ * @param acceptAndroidKeyAttestation if true "android_keystore_attestation" proof type is accepted
+ * @param keyMintSecurityLevel minimal accepted security level for Android Keystore Attestation
+ * @param acceptAndroidKeyAttestation if true "android_keystore_attestation" proof type is accepted
  * @param proofSigningAlgorithms algorithms that correspond to `proof_signing_alg_values_supported`
  *  property in OpenID4VCI; must be empty for keyless credentials
  * @param cryptographicBindingMethods key binding methods that correspond to
@@ -40,6 +44,9 @@ interface CredentialFactory {
     val scope: String
     val format: CredentialFormat
     val requireKeyAttestation: Boolean get() = true
+    val acceptAndroidKeyAttestation: Boolean get() = false
+    val keyMintSecurityLevel: AndroidKeystoreSecurityLevel get() =
+        AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT
     val proofSigningAlgorithms: List<String>
     val cryptographicBindingMethods: List<String>
     val name: String

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -55,6 +55,8 @@ class CredentialFactoryMdocPid : CredentialFactory {
     override val proofSigningAlgorithms: List<String>
         get() = CredentialFactory.DEFAULT_PROOF_SIGNING_ALGORITHMS
 
+    override val acceptAndroidKeyAttestation: Boolean get() = true
+
     override val cryptographicBindingMethods: List<String>
         get() = listOf("cose_key")
 

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -13,6 +13,8 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respondText
 import kotlinx.datetime.LocalDate
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.decodeToString
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.util.fromBase64Url
@@ -36,6 +38,7 @@ import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItemFullDate
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.X509CertChain
 import org.multipaz.openid4vci.credential.CredentialDisplay
 import org.multipaz.webtoken.ChallengeInvalidException
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
@@ -57,6 +60,7 @@ import org.multipaz.rpc.backend.Configuration
 import org.multipaz.server.enrollment.ServerIdentity
 import org.multipaz.server.enrollment.validateServerIdentityCertificateChain
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.validateAndroidKeyAttestation
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 
@@ -145,7 +149,10 @@ suspend fun credential(call: ApplicationCall) {
         proofType = proof.jsonObject["proof_type"]?.jsonPrimitive?.content!!
         proofs = buildJsonArray { add(proof.jsonObject[proofType]!!) }
     } else {
-        proofType = if (proofsObj.containsKey("attestation")) {
+        proofType = if (proofsObj.containsKey("android_keystore_attestation")) {
+            // prefer Android attestation to everything else
+            "android_keystore_attestation"
+        } else if (proofsObj.containsKey("attestation")) {
             // prefer attestation
             "attestation"
         } else if (proofsObj.containsKey("jwt")) {
@@ -183,6 +190,38 @@ suspend fun credential(call: ApplicationCall) {
                         id = key.jsonObject["kid"]?.jsonPrimitive?.content ?: keyHash(publicKey)
                     )
                 }
+            }
+        }
+        "android_keystore_attestation" -> {
+            if (!factory.acceptAndroidKeyAttestation) {
+                throw InvalidRequestException(
+                    "android_keystore_attestation proof cannot be used for this credential")
+            }
+            var expectedNonce: ByteString? = null
+            proofs.map { proof ->
+                val chain = X509CertChain.fromX5c(proof)
+                val nonce = validateAndroidKeyAttestation(
+                    chain = chain,
+                    challenge = null,
+                    requireGmsAttestation = true,
+                    requireVerifiedBootGreen = true,
+                    requireKeyMintSecurityLevel = factory.keyMintSecurityLevel,
+                    requireAppSignatureCertificateDigests = setOf(),
+                    requireAppPackages = setOf()
+                )
+                // All nonce values must be the same. Validate the first one and ensure that
+                // the rest of them match the first one.
+                if (expectedNonce == null) {
+                    expectedNonce = nonce
+                    validateAndConsumeCredentialChallenge(nonce.decodeToString())
+                } else if (nonce != expectedNonce) {
+                    throw InvalidRequestException("nonce mismatch")
+                }
+                val publicKey = chain.certificates.first().ecPublicKey
+                KeyAndId(
+                    publicKey,
+                    keyHash(publicKey)
+                )
             }
         }
         "jwt" -> {

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
-import org.multipaz.openid4vci.credential.CredentialFactory
+import org.multipaz.device.AndroidKeystoreSecurityLevel
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
 import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.rpc.backend.BackendEnvironment
@@ -80,6 +80,24 @@ suspend fun wellKnownOpenidCredentialIssuer(call: ApplicationCall) {
                                     putJsonArray("proof_signing_alg_values_supported") {
                                         credentialFactory.proofSigningAlgorithms.forEach {
                                             add(it)
+                                        }
+                                    }
+                                }
+                                if (credentialFactory.acceptAndroidKeyAttestation) {
+                                    putJsonObject("android_keystore_attestation") {
+                                        put("key_mint_security_level",
+                                            when (credentialFactory.keyMintSecurityLevel) {
+                                                AndroidKeystoreSecurityLevel.SOFTWARE ->
+                                                    "Software"
+                                                AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT ->
+                                                    "TrustedEnvironment"
+                                                AndroidKeystoreSecurityLevel.STRONG_BOX ->
+                                                    "StrongBox"
+                                            })
+                                        putJsonArray("proof_signing_alg_values_supported") {
+                                            credentialFactory.proofSigningAlgorithms.forEach {
+                                                add(it)
+                                            }
                                         }
                                     }
                                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
@@ -10,7 +10,6 @@ import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.annotation.CborSerializationImplemented
 import org.multipaz.cbor.buildCborArray
-import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.util.fromBase64
 import kotlin.io.encoding.Base64
 import kotlin.time.Clock

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialConfiguration.kt
@@ -1,5 +1,6 @@
 package org.multipaz.provisioning.openid4vci
 
 internal class CredentialConfiguration(
-    val scope: String?
+    val scope: String?,
+    val useAndroidAttestation: Boolean
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
@@ -15,7 +15,6 @@ import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.provisioning.CredentialMetadata
 import org.multipaz.provisioning.KeyBindingType
 import org.multipaz.provisioning.ProvisioningMetadata
-import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.util.Logger
 
 internal data class IssuerConfiguration(
@@ -81,15 +80,16 @@ internal data class IssuerConfiguration(
                     Logger.e(TAG, "Unsupported credential format", err)
                     continue
                 }
-                credentialConfigurations[id] = CredentialConfiguration(
-                    scope = config.stringOrNull("scope")
-                )
-                val keyProofType = try {
+                val (keyProofType, useAndroidAttestation) = try {
                     extractKeyProofType(config, url, clientPreferences)
                 } catch (err: IllegalArgumentException) {
                     Logger.e(TAG, "Unsupported key proof type", err)
                     continue
                 }
+                credentialConfigurations[id] = CredentialConfiguration(
+                    scope = config.stringOrNull("scope"),
+                    useAndroidAttestation = useAndroidAttestation
+                )
                 credentials[id] = CredentialMetadata(
                     display = extractDisplay(
                         element = config.objOrNull("credential_metadata") ?: config,
@@ -134,24 +134,30 @@ internal data class IssuerConfiguration(
             config: JsonObject,
             issuerId: String,
             clientPreferences: OpenID4VCIClientPreferences
-        ): KeyBindingType {
+        ): Pair<KeyBindingType, Boolean> {
             val proofTypes = config.objOrNull("proof_types_supported")
-                ?: return KeyBindingType.Keyless
+                ?: return Pair(KeyBindingType.Keyless, false)
+            val androidAttestation = proofTypes.objOrNull("android_keystore_attestation")
             val attestation = proofTypes.objOrNull("attestation")
             val jwt = proofTypes.objOrNull("jwt")
-            val proof = attestation ?: jwt
+            val proof = androidAttestation ?: attestation ?: jwt
             if (proof != null) {
                 val alg = preferredAlgorithm(
                     available = proof.arrayOrNull("proof_signing_alg_values_supported"),
                     clientPreferences = clientPreferences
                 )
-                return if (attestation != null) {
-                    KeyBindingType.Attestation(alg)
+                return if (androidAttestation != null) {
+                    Pair(KeyBindingType.Attestation(alg), true)
+                } else if (attestation != null) {
+                    Pair(KeyBindingType.Attestation(alg), false)
                 } else {
-                    KeyBindingType.OpenidProofOfPossession(
-                        algorithm = alg,
-                        clientId = clientPreferences.clientId,
-                        aud = issuerId
+                    Pair(
+                        KeyBindingType.OpenidProofOfPossession(
+                            algorithm = alg,
+                            clientId = clientPreferences.clientId,
+                            aud = issuerId
+                        ),
+                        false
                     )
                 }
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -53,6 +53,7 @@ import org.multipaz.securearea.SecureAreaRepository
 import org.multipaz.storage.Storage
 import org.multipaz.util.Logger
 import org.multipaz.util.fromBase64Url
+import org.multipaz.util.isAndroidAttestation
 import org.multipaz.util.toBase64Url
 import kotlin.random.Random
 import kotlin.time.Clock
@@ -160,7 +161,9 @@ internal class OpenID4VCIProvisioningClient(
         var credentialResponse: HttpResponse
         val credentialMetadata =
             issuerConfiguration.provisioningMetadata.credentials[credentialOffer.configurationId]!!
-        val keyProofs = buildKeyProofs(keyInfo)
+        val credentialConfiguration =
+            issuerConfiguration.credentialConfigurations[credentialOffer.configurationId]!!
+        val keyProofs = buildKeyProofs(keyInfo, credentialConfiguration)
         val dpopKey = getDPopKey()
         while (true) {
             val dpop = OpenID4VCIUtil.generateDPoP(
@@ -237,7 +240,10 @@ internal class OpenID4VCIProvisioningClient(
         return Credentials(idAndData, display)
     }
 
-    private suspend fun buildKeyProofs(keyInfo: KeyBindingInfo): JsonElement? =
+    private suspend fun buildKeyProofs(
+        keyInfo: KeyBindingInfo,
+        credentialConfiguration: CredentialConfiguration
+    ): JsonElement? =
         when (keyInfo) {
             KeyBindingInfo.Keyless -> null
             is KeyBindingInfo.OpenidProofOfPossession -> buildJsonObject {
@@ -248,13 +254,25 @@ internal class OpenID4VCIProvisioningClient(
                 }
             }
             is KeyBindingInfo.Attestation -> buildJsonObject {
-                val backend = BackendEnvironment.getInterface(OpenID4VCIBackend::class)!!
-                val jwtKeyAttestation = backend.createJwtKeyAttestation(
-                    credentialKeyAttestations = keyInfo.attestations,
-                    challenge = keyChallenge!!
-                )
-                putJsonArray("attestation") {
-                    add(jwtKeyAttestation)
+                if (credentialConfiguration.useAndroidAttestation &&
+                    isAndroidAttestation(keyInfo.attestations.first().keyAttestation.certChain)) {
+                    putJsonArray("android_keystore_attestation") {
+                        Logger.i(TAG, "Using android_keystore_attestation proof")
+                        for (attestation in keyInfo.attestations) {
+                            // NB: root is included per-spec. Our server accepts the chain with
+                            // or without the root.
+                            add(attestation.keyAttestation.certChain!!.toX5c(excludeRoot = false))
+                        }
+                    }
+                } else {
+                    val backend = BackendEnvironment.getInterface(OpenID4VCIBackend::class)!!
+                    val jwtKeyAttestation = backend.createJwtKeyAttestation(
+                        credentialKeyAttestations = keyInfo.attestations,
+                        challenge = keyChallenge!!
+                    )
+                    putJsonArray("attestation") {
+                        add(jwtKeyAttestation)
+                    }
                 }
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/validateAndroidKeyAttestation.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/validateAndroidKeyAttestation.kt
@@ -17,13 +17,14 @@ private const val TAG = "validateAndroidKeyAttestation"
  * // TODO: use revocation list from https://android.googleapis.com/attestation/status
  *
  * @param chain Android key attestation
- * @param challenge challenge/nonce used during key creation
+ * @param challenge challenge/nonce used during key creation (if needs to be checked)
  * @param requireGmsAttestation check that certificate chain is rooted in a known Google key
  * @param requireVerifiedBootGreen check that the device has booted securely
  * @param requireKeyMintSecurityLevel identifies acceptable security level
  * @param requireAppSignatureCertificateDigests identifies trusted app signing keys
  * @param requireAppPackages identifies trusted app package names
  * @param validateAt time instant used to validate certificate validity intervals
+ * @return challenge/nonce used during key creation
  *
  * @throws IllegalStateException if Android key attestation is not valid
  */
@@ -36,20 +37,23 @@ suspend fun validateAndroidKeyAttestation(
     requireAppSignatureCertificateDigests: Set<ByteString>,
     requireAppPackages: Set<String>,
     validateAt: Instant = Clock.System.now()
-) {
+): ByteString {
     try {
         if (requireGmsAttestation) {
             // Google root certificate uses RSA private key (and not EC key that we currently support
             // in Kotlin Multiplatform code). Instead of comparing the keys, just replace the root
             // in the chain with the known root certificate before validation.
-            // TODO: add functionality to extract the public key in any format from the certificate.
-            // Then we can compare the key in the root certificate instead of injecting the known root
-            // certificate and worry about its expiration date.
-            val truncatedChain = chain.certificates.subList(0, chain.certificates.lastIndex)
+            val lastCertificate = chain.certificates.last()
+            val rootlessChain = if (lastCertificate.subject == lastCertificate.issuer) {
+                chain.certificates.subList(0, chain.certificates.lastIndex)
+            } else {
+                chain.certificates
+            }
             val trustedRoot =
-                GOOGLE_ATTESTATION_ROOT_CERTIFICATES[chain.certificates.last().subject]
-                    ?: throw IllegalArgumentException("No trusted root in Android Key Attestation")
-            val chainToVerify = truncatedChain + listOf(trustedRoot)
+                GOOGLE_ATTESTATION_ROOT_CERTIFICATES[rootlessChain.last().issuer]
+                    ?: throw IllegalArgumentException(
+                        "No trusted root in Android Key Attestation: ${rootlessChain.last().subject.name}")
+            val chainToVerify = rootlessChain + listOf(trustedRoot)
             X509CertChain(chainToVerify).validate(validateAt)
         } else {
             chain.validate(validateAt)
@@ -67,7 +71,8 @@ suspend fun validateAndroidKeyAttestation(
     }
 
     // Challenge must match...
-    check(challenge == null || challenge == ByteString(parser.attestationChallenge)) {
+    val attestationChallenge = ByteString(parser.attestationChallenge)
+    check(challenge == null || challenge == attestationChallenge) {
         "Challenge didn't match what was expected"
     }
 
@@ -111,6 +116,21 @@ suspend fun validateAndroidKeyAttestation(
         Logger.d(TAG,
             "Digest $n: ${parser.applicationSignatureDigests[n].toByteArray().toBase64Url()}")
     }
+
+    return attestationChallenge
+}
+
+/**
+ * Checks if the given certificate chain represents Android Key Attestation
+ *
+ * @param chain key attestation certificate chain
+ * @return if this certificate chain attests an Android Secure Area key
+ */
+fun isAndroidAttestation(chain: X509CertChain?): Boolean {
+    if (chain == null) {
+        return false
+    }
+    return GOOGLE_ATTESTATION_ROOT_CERTIFICATES.containsKey(chain.certificates.last().issuer)
 }
 
 // This certificates are from


### PR DESCRIPTION
Support "android_keystore_attestation" as a proof type on the server and the client.

Test: manually tested with testapp and openid4vci server
