### PR TITLE
Add WebStorage, an IndexedDB-backed Storage impl for JS and WasmJS.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,7 @@ coil-compose-core = { module = "io.coil-kt.coil3:coil-compose-core", version.ref
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 kotlin-wrappers-web = { module = "org.jetbrains.kotlin-wrappers:kotlin-web", version.ref="kotlin-wrappers" }
+kotlin-wrappers-browser = { module = "org.jetbrains.kotlin-wrappers:kotlin-browser", version.ref="kotlin-wrappers" }
 kotlin-wrappers-react = { module = "org.jetbrains.kotlin-wrappers:kotlin-react", version.ref= "kotlin-wrappers-rx" }
 kotlin-wrappers-react-dom = { module = "org.jetbrains.kotlin-wrappers:kotlin-react-dom", version.ref= "kotlin-wrappers-rx" }
 kotlin-wrappers-emotion-react-js = { module = "org.jetbrains.kotlin-wrappers:kotlin-emotion-react-js", version.ref="kotlin-wrappers-em" }

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -220,8 +220,16 @@ kotlin {
             val webMain by getting {
                 dependencies {
                     implementation(libs.kotlin.wrappers.web)
+                    implementation(libs.kotlin.wrappers.browser)
                     implementation(libs.kotlinx.browser)
                 }
+            }
+            val jsMain by getting {
+                dependencies {
+                    implementation(libs.kotlin.wrappers.browser)
+                }
+            }
+            val wasmJsMain by getting {
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
@@ -13,8 +13,6 @@ import org.multipaz.storage.Storage
 expect object Platform {
     /**
      * The name and version of the platform.
-     *
-     * @throws NotImplementedError if called on a platform which isn't Android or iOS.
      */
     val name: String
 
@@ -33,7 +31,7 @@ expect object Platform {
     /**
      * A [Storage] instance suitable for the platform.
      *
-     * @throws NotImplementedError if called on a platform which isn't Android or iOS.
+     * @throws NotImplementedError if not implemented on the platform.
      */
     val storage: Storage
 
@@ -41,7 +39,7 @@ expect object Platform {
      * A [Storage] instance suitable for the platform in a location where the
      * underlying data file is excluded from backups.
      *
-     * @throws NotImplementedError if called on a platform which isn't Android or iOS.
+     * @throws NotImplementedError if not implemented on the platform.
      */
     val nonBackedUpStorage: Storage
 
@@ -49,7 +47,7 @@ expect object Platform {
      * Gets a [SecureArea] implementation suitable for the platform.
      *
      * @param storage the [Storage] to use for metadata.
-     * @throws NotImplementedError if called on a platform which isn't Android or iOS.
+     * @throws NotImplementedError if not implemented on the platform.
      */
     suspend fun getSecureArea(
         storage: Storage = nonBackedUpStorage

--- a/multipaz/src/jsMain/kotlin/org/multipaz/util/Platform.js.kt
+++ b/multipaz/src/jsMain/kotlin/org/multipaz/util/Platform.js.kt
@@ -1,9 +1,14 @@
 package org.multipaz.util
 
 import kotlinx.browser.window
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.multipaz.prompt.PromptModel
+import org.multipaz.prompt.WebPromptModel
 import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
+import org.multipaz.storage.WebStorage
 
 actual object Platform {
     actual val name: String by lazy {
@@ -13,16 +18,27 @@ actual object Platform {
     actual val version: String
         get() = BuildConfig.VERSION
 
-    actual val promptModel: PromptModel
-        get() = TODO("Platform.promptModel not yet implemented")
+    actual val promptModel: PromptModel by lazy {
+        WebPromptModel.Builder().apply { addCommonDialogs() }.build()
+    }
 
-    actual val storage: Storage
-        get() = TODO("Platform.storage not yet implemented")
+    actual val storage: Storage by lazy {
+        WebStorage("MultipazStorage")
+    }
 
-    actual val nonBackedUpStorage: Storage
-        get() = TODO("Platform.nonBackedUpStorage not yet implemented")
+    actual val nonBackedUpStorage: Storage by lazy {
+        WebStorage("MultipazStorageNonBackedUp")
+    }
+
+    private var secureArea: SecureArea? = null
+    private val secureAreaLock = Mutex()
 
     actual suspend fun getSecureArea(storage: Storage): SecureArea {
-        TODO("Platform.getSecureArea not yet implemented")
+        secureAreaLock.withLock {
+            if (secureArea == null) {
+                secureArea = SoftwareSecureArea.create(storage)
+            }
+            return secureArea!!
+        }
     }
 }

--- a/multipaz/src/wasmJsMain/kotlin/org/multipaz/util/Platform.wasmJs.kt
+++ b/multipaz/src/wasmJsMain/kotlin/org/multipaz/util/Platform.wasmJs.kt
@@ -8,8 +8,7 @@ import org.multipaz.prompt.WebPromptModel
 import org.multipaz.securearea.SecureArea
 import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
-import org.multipaz.storage.ephemeral.EphemeralStorage
-import kotlin.getValue
+import org.multipaz.storage.WebStorage
 
 actual object Platform {
     actual val name: String by lazy {
@@ -24,20 +23,17 @@ actual object Platform {
     }
 
     actual val storage: Storage by lazy {
-        // TODO
-        EphemeralStorage()
+        WebStorage("MultipazStorage")
     }
 
     actual val nonBackedUpStorage: Storage by lazy {
-        // TODO
-        EphemeralStorage()
+        WebStorage("MultipazStorageNonBackedUp")
     }
 
     private var secureArea: SecureArea? = null
     private val secureAreaLock = Mutex()
 
     actual suspend fun getSecureArea(storage: Storage): SecureArea {
-        // TODO
         secureAreaLock.withLock {
             if (secureArea == null) {
                 secureArea = SoftwareSecureArea.create(storage)

--- a/multipaz/src/webMain/kotlin/org/multipaz/storage/WebStorage.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/storage/WebStorage.kt
@@ -1,0 +1,455 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package org.multipaz.storage
+
+import js.array.jsArrayOf
+import js.typedarrays.Uint8Array
+import js.typedarrays.toByteArray
+import js.typedarrays.toUint8Array
+import kotlinx.browser.window
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.storage.base.BaseStorage
+import org.multipaz.storage.base.BaseStorageTable
+import org.multipaz.util.toBase64Url
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.random.Random
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.js.JsAny
+import kotlin.js.JsString
+import kotlin.js.definedExternally
+import kotlin.js.js
+import kotlin.js.toJsString
+import kotlin.js.unsafeCast
+
+// External declarations for Kotlin/Wasm and Kotlin/JS compatibility.
+// All interop types MUST extend JsAny.
+
+internal external interface IDBFactory : JsAny {
+    fun open(name: String, version: Double): IDBOpenDBRequest
+}
+
+internal external interface IDBRequest : JsAny
+
+internal external interface IDBOpenDBRequest : IDBRequest
+
+internal external interface IDBDatabase : JsAny {
+    fun transaction(storeNames: JsAny, mode: String): IDBTransaction
+    fun createObjectStore(name: String, options: JsAny? = definedExternally): IDBObjectStore
+}
+
+internal external interface IDBTransaction : JsAny {
+    fun objectStore(name: String): IDBObjectStore
+}
+
+internal external interface IDBObjectStore : JsAny {
+    fun get(key: JsAny): IDBRequest
+    fun add(value: JsAny): IDBRequest
+    fun put(value: JsAny): IDBRequest
+    fun delete(key: JsAny): IDBRequest
+    fun openCursor(range: JsAny? = definedExternally): IDBRequest
+    fun createIndex(name: String, keyPath: JsAny, options: JsAny? = definedExternally): IDBIndex
+    fun index(name: String): IDBIndex
+}
+
+internal external interface IDBIndex : JsAny {
+    fun openCursor(range: JsAny? = definedExternally): IDBRequest
+}
+
+internal external interface IDBCursor : JsAny {
+    val key: JsAny
+    val value: JsAny
+    fun delete(): IDBRequest
+}
+
+internal external interface IDBKeyRangeFactory : JsAny {
+    fun bound(lower: JsAny, upper: JsAny): JsAny
+    fun upperBound(upper: JsAny): JsAny
+}
+
+internal external interface StorageRecord : JsAny {
+    var t: String
+    var p: String
+    var i: String
+    var e: Double
+    var d: Uint8Array<*>
+}
+
+// Top-level js() expression functions for Kotlin/Wasm compatibility
+
+private fun getIndexedDB(): IDBFactory = js("window.indexedDB")
+private fun getIDBKeyRange(): IDBKeyRangeFactory = js("window.IDBKeyRange")
+
+private fun getRequestResult(request: IDBRequest): JsAny? = js("request.result")
+private fun getRequestError(request: IDBRequest): JsString? = js("request.error ? request.error.message : null")
+private fun getRequestErrorName(request: IDBRequest): JsString? = js("request.error ? request.error.name : null")
+
+private fun setRequestCallback(request: IDBRequest, name: JsString, callback: (JsAny) -> Unit): Unit =
+    js("request[name] = callback")
+
+private fun createIdbOptions(keyPath: JsAny): JsAny = js("({ keyPath: keyPath })")
+private fun createIndexOptions(unique: Boolean): JsAny = js("({ unique: unique })")
+
+private fun createRecord(t: JsString, p: JsString, i: JsString, d: Uint8Array<*>, e: Double): StorageRecord =
+    js("({ t: t, p: p, i: i, d: d, e: e })")
+
+private fun callCursorContinue(cursor: IDBCursor): Unit = js("cursor.continue()")
+
+private fun getCursorValue(cursor: IDBCursor): StorageRecord = js("cursor.value")
+
+private fun toJsNumberFromDouble(value: Double): JsAny = js("value")
+
+/**
+ * [Storage] implementation based on IndexedDB for both Kotlin/JS and Kotlin/Wasm.
+ */
+class WebStorage(
+    val dbName: String = "MultipazStorage",
+    clock: Clock = Clock.System
+) : BaseStorage(clock) {
+
+    private val dbDeferred = CompletableDeferred<IDBDatabase>()
+
+    init {
+        val request = getIndexedDB().open(dbName, 1.0)
+        val dbDef = dbDeferred
+
+        setRequestCallback(request, "onupgradeneeded".toJsString()) {
+            val res = getRequestResult(request)
+            if (res != null) {
+                val db = res.unsafeCast<IDBDatabase>()
+                val keyPath = jsArrayOf("t".toJsString(), "p".toJsString(), "i".toJsString())
+                val store = db.createObjectStore("records", createIdbOptions(keyPath))
+                store.createIndex("by_expiration", "e".toJsString(), createIndexOptions(false))
+            }
+        }
+
+        setRequestCallback(request, "onsuccess".toJsString()) {
+            val res = getRequestResult(request)
+            if (res != null) {
+                dbDef.complete(res.unsafeCast<IDBDatabase>())
+            }
+        }
+
+        setRequestCallback(request, "onerror".toJsString()) {
+            dbDef.completeExceptionally(Throwable("Error opening IndexedDB: ${getRequestError(request)}"))
+        }
+    }
+
+    internal suspend fun getDb(): IDBDatabase = dbDeferred.await()
+
+    override suspend fun createTable(tableSpec: StorageTableSpec): BaseStorageTable {
+        return WebStorageTable(this, tableSpec)
+    }
+
+    internal suspend fun <T : JsAny> awaitRequest(request: IDBRequest): T? = suspendCancellableCoroutine { cont ->
+        setRequestCallback(request, "onsuccess".toJsString()) {
+            val res = getRequestResult(request)
+            cont.resume(res?.unsafeCast<T>())
+        }
+        setRequestCallback(request, "onerror".toJsString()) {
+            val errorName = getRequestErrorName(request)?.toString()
+            if (errorName == "ConstraintError") {
+                cont.resumeWithException(KeyExistsStorageException("Record already exists"))
+            } else {
+                cont.resumeWithException(Throwable("IndexedDB request error: ${getRequestError(request)}"))
+            }
+        }
+    }
+}
+
+private class WebStorageTable(
+    override val storage: WebStorage,
+    spec: StorageTableSpec
+) : BaseStorageTable(spec) {
+
+    override suspend fun get(key: String, partitionId: String?): ByteString? {
+        checkPartition(partitionId)
+        val p = partitionId ?: ""
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readonly")
+        val store = tx.objectStore("records")
+        val idbKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), key.toJsString()).unsafeCast<JsAny>()
+        val result = storage.awaitRequest<StorageRecord>(store.get(idbKey)) ?: return null
+
+        if (result.e != 0.0 && result.e < storage.clock.now().epochSeconds) {
+            return null
+        }
+        return ByteString(result.d.toByteArray())
+    }
+
+    override suspend fun insert(
+        key: String?,
+        data: ByteString,
+        partitionId: String?,
+        expiration: Instant
+    ): String {
+        if (key != null) checkKey(key)
+        checkPartition(partitionId)
+        checkExpiration(expiration)
+
+        val p = partitionId ?: ""
+        val db = storage.getDb()
+        val now = storage.clock.now().epochSeconds
+
+        var done = false
+        var newKey = ""
+        do {
+            newKey = key ?: Random.nextBytes(9).toBase64Url()
+            try {
+                val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+                val store = tx.objectStore("records")
+
+                if (key != null && spec.supportExpiration) {
+                    val idbKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), key.toJsString()).unsafeCast<JsAny>()
+                    val existing = storage.awaitRequest<StorageRecord>(store.get(idbKey))
+                    if (existing != null) {
+                        if (existing.e != 0.0 && existing.e < now) {
+                            storage.awaitRequest<JsAny>(store.delete(idbKey))
+                        } else {
+                            throw KeyExistsStorageException("Record already exists")
+                        }
+                    }
+                }
+
+                val record = createRecord(
+                    spec.name.toJsString(),
+                    p.toJsString(),
+                    newKey.toJsString(),
+                    data.toByteArray().toUint8Array(),
+                    if (spec.supportExpiration && expiration != Instant.DISTANT_FUTURE) expiration.epochSeconds.toDouble() else 0.0
+                )
+                storage.awaitRequest<JsAny>(store.add(record))
+                done = true
+            } catch (e: Throwable) {
+                if (key != null) throw e
+            }
+        } while (!done)
+        return newKey
+    }
+
+    override suspend fun update(
+        key: String,
+        data: ByteString,
+        partitionId: String?,
+        expiration: Instant?
+    ) {
+        checkPartition(partitionId)
+        if (expiration != null) checkExpiration(expiration)
+        val p = partitionId ?: ""
+        val db = storage.getDb()
+        val now = storage.clock.now().epochSeconds
+
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+        val store = tx.objectStore("records")
+        val idbKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), key.toJsString()).unsafeCast<JsAny>()
+        val existing = storage.awaitRequest<StorageRecord>(store.get(idbKey))
+            ?: throw NoRecordStorageException("No record found")
+
+        if (existing.e != 0.0 && existing.e < now) {
+            throw NoRecordStorageException("Record expired")
+        }
+
+        val record = createRecord(
+            spec.name.toJsString(),
+            p.toJsString(),
+            key.toJsString(),
+            data.toByteArray().toUint8Array(),
+            if (expiration != null) {
+                if (expiration != Instant.DISTANT_FUTURE) expiration.epochSeconds.toDouble() else 0.0
+            } else {
+                existing.e
+            }
+        )
+        storage.awaitRequest<JsAny>(store.put(record))
+    }
+
+    override suspend fun delete(key: String, partitionId: String?): Boolean {
+        checkPartition(partitionId)
+        val p = partitionId ?: ""
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+        val store = tx.objectStore("records")
+        val idbKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), key.toJsString()).unsafeCast<JsAny>()
+        val existing = storage.awaitRequest<StorageRecord>(store.get(idbKey))
+        if (existing == null || (existing.e != 0.0 && existing.e < storage.clock.now().epochSeconds)) {
+            return false
+        }
+        storage.awaitRequest<JsAny>(store.delete(idbKey))
+        return true
+    }
+
+    override suspend fun deleteAll() {
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+        val store = tx.objectStore("records")
+        val range = getIDBKeyRange().bound(
+            jsArrayOf(spec.name.toJsString()).unsafeCast<JsAny>(),
+            jsArrayOf(spec.name.toJsString(), "\uffff".toJsString()).unsafeCast<JsAny>()
+        )
+        
+        suspendCancellableCoroutine<Unit> { cont ->
+            val request = store.openCursor(range)
+            
+            setRequestCallback(request, "onsuccess".toJsString()) {
+                val res = getRequestResult(request)
+                if (res != null) {
+                    val cursor = res.unsafeCast<IDBCursor>()
+                    cursor.delete()
+                    callCursorContinue(cursor)
+                } else {
+                    cont.resume(Unit)
+                }
+            }
+            setRequestCallback(request, "onerror".toJsString()) { 
+                cont.resumeWithException(Throwable("deleteAll failed: ${getRequestError(request)}"))
+            }
+        }
+    }
+
+    override suspend fun deletePartition(partitionId: String) {
+        checkPartition(partitionId)
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+        val store = tx.objectStore("records")
+        val range = getIDBKeyRange().bound(
+            jsArrayOf(spec.name.toJsString(), partitionId.toJsString()).unsafeCast<JsAny>(),
+            jsArrayOf(spec.name.toJsString(), partitionId.toJsString(), "\uffff".toJsString()).unsafeCast<JsAny>()
+        )
+        
+        suspendCancellableCoroutine<Unit> { cont ->
+            val request = store.openCursor(range)
+            
+            setRequestCallback(request, "onsuccess".toJsString()) {
+                val res = getRequestResult(request)
+                if (res != null) {
+                    val cursor = res.unsafeCast<IDBCursor>()
+                    cursor.delete()
+                    callCursorContinue(cursor)
+                } else {
+                    cont.resume(Unit)
+                }
+            }
+            setRequestCallback(request, "onerror".toJsString()) { 
+                cont.resumeWithException(Throwable("deletePartition failed: ${getRequestError(request)}"))
+            }
+        }
+    }
+
+    override suspend fun enumerate(
+        partitionId: String?,
+        afterKey: String?,
+        limit: Int
+    ): List<String> {
+        checkPartition(partitionId)
+        checkLimit(limit)
+        if (limit == 0) return listOf()
+
+        val p = partitionId ?: ""
+        val startKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), (afterKey?.plus("\u0000") ?: "").toJsString()).unsafeCast<JsAny>()
+        val endKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), "\uffff".toJsString()).unsafeCast<JsAny>()
+        val range = getIDBKeyRange().bound(startKey, endKey)
+
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readonly")
+        val store = tx.objectStore("records")
+        
+        return suspendCancellableCoroutine { cont ->
+            val list = mutableListOf<String>()
+            val request = store.openCursor(range)
+            val now = storage.clock.now().epochSeconds
+            
+            setRequestCallback(request, "onsuccess".toJsString()) {
+                val res = getRequestResult(request)
+                if (res != null && list.size < limit) {
+                    val cursor = res.unsafeCast<IDBCursor>()
+                    val record = getCursorValue(cursor)
+                    if (record.e == 0.0 || record.e >= now) {
+                        list.add(record.i)
+                    }
+                    callCursorContinue(cursor)
+                } else {
+                    cont.resume(list)
+                }
+            }
+            setRequestCallback(request, "onerror".toJsString()) { 
+                cont.resumeWithException(Throwable("enumerate failed: ${getRequestError(request)}"))
+            }
+        }
+    }
+
+    override suspend fun enumerateWithData(
+        partitionId: String?,
+        afterKey: String?,
+        limit: Int
+    ): List<Pair<String, ByteString>> {
+        checkPartition(partitionId)
+        checkLimit(limit)
+        if (limit == 0) return listOf()
+
+        val p = partitionId ?: ""
+        val startKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), (afterKey?.plus("\u0000") ?: "").toJsString()).unsafeCast<JsAny>()
+        val endKey = jsArrayOf(spec.name.toJsString(), p.toJsString(), "\uffff".toJsString()).unsafeCast<JsAny>()
+        val range = getIDBKeyRange().bound(startKey, endKey)
+
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readonly")
+        val store = tx.objectStore("records")
+        
+        return suspendCancellableCoroutine { cont ->
+            val list = mutableListOf<Pair<String, ByteString>>()
+            val request = store.openCursor(range)
+            val now = storage.clock.now().epochSeconds
+            
+            setRequestCallback(request, "onsuccess".toJsString()) {
+                val res = getRequestResult(request)
+                if (res != null && list.size < limit) {
+                    val cursor = res.unsafeCast<IDBCursor>()
+                    val record = getCursorValue(cursor)
+                    if (record.e == 0.0 || record.e >= now) {
+                        list.add(Pair(record.i, ByteString(record.d.toByteArray())))
+                    }
+                    callCursorContinue(cursor)
+                } else {
+                    cont.resume(list)
+                }
+            }
+            setRequestCallback(request, "onerror".toJsString()) { 
+                cont.resumeWithException(Throwable("enumerateWithData failed: ${getRequestError(request)}"))
+            }
+        }
+    }
+
+    override suspend fun purgeExpired() {
+        val db = storage.getDb()
+        val tx = db.transaction(jsArrayOf("records".toJsString()).unsafeCast<JsAny>(), "readwrite")
+        val store = tx.objectStore("records")
+        val now = storage.clock.now().epochSeconds
+        val range = getIDBKeyRange().upperBound(toJsNumberFromDouble(now.toDouble()))
+
+        suspendCancellableCoroutine<Unit> { cont ->
+            val request = store.index("by_expiration").openCursor(range)
+            
+            setRequestCallback(request, "onsuccess".toJsString()) {
+                val res = getRequestResult(request)
+                if (res != null) {
+                    val cursor = res.unsafeCast<IDBCursor>()
+                    val record = getCursorValue(cursor)
+                    if (record.t == spec.name) {
+                        // Fire and forget delete request
+                        cursor.delete()
+                    }
+                    callCursorContinue(cursor)
+                } else {
+                    cont.resume(Unit)
+                }
+            }
+            setRequestCallback(request, "onerror".toJsString()) { 
+                cont.resumeWithException(Throwable("purgeExpired failed: ${getRequestError(request)}"))
+            }
+        }
+    }
+}

--- a/multipaz/src/webTest/kotlin/org/multipaz/storage/WebStorageTest.kt
+++ b/multipaz/src/webTest/kotlin/org/multipaz/storage/WebStorageTest.kt
@@ -1,0 +1,463 @@
+package org.multipaz.storage
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.decodeToString
+import kotlinx.io.bytestring.encodeToByteString
+import org.multipaz.storage.base.BaseStorageTable
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class WebStorageTest {
+
+    @BeforeTest
+    fun resetSharedState() {
+        TestClock.time = Instant.parse("2024-12-20T11:35:00Z")
+    }
+
+    @Test
+    fun testSimple() = runTest {
+        withTable { table ->
+            assertEquals(0, table.enumerate().size.toLong())
+            assertNull(table.get("foo"))
+
+            val data = "Foobar".encodeToByteString()
+            table.insert(data = data, key = "foo")
+            assertEquals(table.get("foo"), data)
+            assertEquals(1, table.enumerate().size.toLong())
+            assertEquals("foo", table.enumerate().iterator().next())
+            assertNull(table.get("bar"))
+
+            val data2 = "Buzz".encodeToByteString()
+            table.insert(data = data2, key = "bar")
+            assertEquals(table.get("bar"), data2)
+            assertEquals(2, table.enumerate().size.toLong())
+            table.delete("foo")
+            assertNull(table.get("foo"))
+            assertNotNull(table.get("bar"))
+            assertEquals(1, table.enumerate().size.toLong())
+            table.delete("bar")
+            assertNull(table.get("bar"))
+            assertEquals(0, table.enumerate().size.toLong())
+        }
+    }
+
+    @Test
+    fun testGetReturnsCorrectEntry() = runTest {
+        withTable(supportPartitions = true) { table ->
+            table.insert(key = null, "bad1".encodeToByteString(), partitionId = "client0")
+            val key = table.insert(key = null, "good".encodeToByteString(), partitionId = "client1")
+            table.insert(key = null, "bad2".encodeToByteString(), partitionId = "client1")
+            table.insert(key = null, "bad3".encodeToByteString(), partitionId = "client3")
+            assertNotEquals("", key)
+            val data = table.get(key = key, partitionId = "client1")
+            assertEquals("good", data!!.decodeToString())
+        }
+    }
+
+    @Test
+    fun testEnumerate() = runTest {
+        withTable(supportPartitions = true) { table ->
+            (0..19).forEach { i ->
+                table.insert(
+                    key = null,
+                    partitionId = "client0",
+                    data = "bad$i".encodeToByteString()
+                )
+                table.insert(
+                    key = null,
+                    partitionId = "client2",
+                    data = "bad$i".encodeToByteString()
+                )
+            }
+            val valueMap = (0..19).associate { i ->
+                val data = "good$i"
+                val key = table.insert(
+                    key = null,
+                    partitionId = "client1",
+                    data = data.encodeToByteString()
+                )
+                Pair(key, data)
+            }
+            assertEquals(20, valueMap.size)
+            val chunk1 = table.enumerate(
+                partitionId = "client1",
+                limit = 9
+            )
+            val chunk2WithData = table.enumerateWithData(
+                partitionId = "client1",
+                afterKey = chunk1.last(),
+                limit = 14
+            )
+            assertEquals(9, chunk1.size)
+            assertEquals(11, chunk2WithData.size)
+            assertEquals(valueMap.keys.sorted(), chunk1 + chunk2WithData.map { it.first })
+            for ((key, value) in valueMap) {
+                val data = table.get(partitionId = "client1", key = key)!!.decodeToString()
+                assertEquals(value, data)
+            }
+            for ((key, data) in chunk2WithData) {
+                assertEquals(valueMap[key], data.decodeToString())
+            }
+            assertEquals(listOf(), table.enumerate(partitionId = "client1", limit = 0))
+        }
+    }
+
+    @Test
+    fun testUpdate() = runTest {
+        withTable(supportPartitions = true) { table ->
+            val key = table.insert(
+                key = null,
+                partitionId = "client1",
+                data = "bad".encodeToByteString()
+            )
+            table.update(key = key, partitionId = "client1", data = "good".encodeToByteString())
+            val data = table.get(partitionId = "client1", key = key)
+            assertEquals("good", data!!.decodeToString())
+        }
+    }
+
+    @Test
+    fun testUpdateExpiration() = runTest {
+        withTable(supportPartitions = true, supportExpiration = true) { table ->
+            TestClock.time = Instant.parse("2024-12-20T11:35:00Z")
+            val key1 = table.insert(
+                key = null,
+                partitionId = "client1",
+                expiration = TestClock.now() + 2.minutes,
+                data = "entry1".encodeToByteString()
+            )
+            val key2 = table.insert(
+                key = null,
+                partitionId = "client1",
+                expiration = TestClock.now() + 2.minutes,
+                data = "entry2".encodeToByteString()
+            )
+            table.update(
+                key = key1,
+                partitionId = "client1",
+                expiration = TestClock.now() + 10.minutes,
+                data = "updated1".encodeToByteString()
+            )
+            TestClock.time += 5.minutes
+            assertEquals(
+                "updated1".encodeToByteString(),
+                table.get(partitionId = "client1", key = key1)
+            )
+            assertNull(table.get(partitionId = "client1", key = key2))
+            assertEquals(listOf(key1), table.enumerate(partitionId = "client1"))
+        }
+    }
+
+    @Test
+    fun testDelete() = runTest {
+        withTable(supportPartitions = true) { table ->
+            val key = table.insert(key = null, partitionId = "client1", data = "data".encodeToByteString())
+            assertFalse(table.delete(partitionId = "client0", key = key))
+            assertFalse(table.delete(partitionId = "client1", key = "#fake_key"))
+            assertTrue(table.delete(partitionId = "client1", key = key))
+            val data = table.get(partitionId = "client1", key = key)
+            assertNull(data)
+        }
+    }
+
+    @Test
+    fun testExpiration() = runTest {
+        withStorage { storage ->
+            val tableSpec = StorageTableSpec(
+                name = "TestExpiration${uniqueSuffix()}",
+                supportPartitions = false,
+                supportExpiration = true
+            )
+            val table = storage.getTable(tableSpec)
+            TestClock.time = Instant.parse("2024-12-20T11:35:00Z")
+            val time3 = TestClock.time + 3.minutes
+            val time5 = TestClock.time + 5.minutes
+            val time6 = TestClock.time + 6.minutes
+            val time8 = TestClock.time + 8.minutes
+            val id8 = table.insert(null, "8.minutes".encodeToByteString(), expiration = time8)
+            val id3 = table.insert(null, "3.minutes".encodeToByteString(), expiration = time3)
+            val id5 = table.insert(null, "5.minutes".encodeToByteString(), expiration = time5)
+            assertEquals(setOf(id3, id5, id8), table.enumerate().toSet())
+            TestClock.time = time5
+            assertEquals(setOf(id5, id8), table.enumerate().toSet())
+            table.insert(key = id3, data = "reused id".encodeToByteString(), expiration = time5)
+            assertEquals(setOf(id3, id5, id8), table.enumerate().toSet())
+            TestClock.time = time6
+            assertEquals(setOf(id8), table.enumerate().toSet())
+            assertEquals("8.minutes", table.get(id8)!!.decodeToString())
+            storage.purgeExpired()
+            assertEquals(setOf(id8), table.enumerate().toSet())
+        }
+    }
+
+    @Test
+    fun testExpirationWithPartitions() = runTest {
+        withStorage { storage ->
+            val tableSpec = StorageTableSpec(
+                name = "TestExpirationPartitions${uniqueSuffix()}",
+                supportPartitions = true,
+                supportExpiration = true
+            )
+            val table = storage.getTable(tableSpec)
+            TestClock.time = Instant.parse("2024-12-20T11:35:00Z")
+            val id8 = table.insert(null, "8.minutes".encodeToByteString(),
+                partitionId = "A", expiration = TestClock.time + 8.minutes)
+            val id3 = table.insert(null, "3.minutes".encodeToByteString(),
+                partitionId = "B", expiration = TestClock.time + 3.minutes)
+            assertEquals(setOf(id8), table.enumerate("A").toSet())
+            assertEquals("8.minutes", table.get(id8,"A")!!.decodeToString())
+            assertNull(table.get(id8,"B"))
+            assertEquals(setOf(id3), table.enumerate("B").toSet())
+            assertEquals("3.minutes", table.get(id3,"B")!!.decodeToString())
+            assertNull(table.get(id3,"A"))
+
+            TestClock.time += 4.minutes
+            assertEquals(setOf(id8), table.enumerate("A").toSet())
+            assertEquals("8.minutes", table.get(id8,"A")!!.decodeToString())
+            assertNull(table.get(id8,"B"))
+            assertEquals(setOf(), table.enumerate("B").toSet())
+            assertNull(table.get(id3,"B"))
+            assertNull(table.get(id3,"A"))
+        }
+    }
+
+    @Test
+    fun testDuplicateKey() = runTest {
+        withTable { table ->
+            table.insert(key = "foo", "bar".encodeToByteString())
+            assertFailsWith(KeyExistsStorageException::class) {
+                table.insert(key = "foo", "buz".encodeToByteString())
+            }
+        }
+    }
+
+    @Test
+    fun testKeysCaseSensitive() = runTest {
+        withTable(supportPartitions = true) { table ->
+            table.insert(key = "foo", partitionId = "a", data = "bar".encodeToByteString())
+            assertEquals("bar".encodeToByteString(), table.get(key = "foo", partitionId = "a"))
+            assertNull(table.get(key = "FOO", partitionId = "A"))
+            assertNull(table.get(key = "FOO", partitionId = "a"))
+            assertNull(table.get(key = "foo", partitionId = "A"))
+            assertFailsWith(NoRecordStorageException::class) {
+                table.update(key = "FOO", partitionId = "A", data = "buz".encodeToByteString())
+            }
+            assertFailsWith(NoRecordStorageException::class) {
+                table.update(key = "FOO", partitionId = "a", data = "buz".encodeToByteString())
+            }
+            assertFailsWith(NoRecordStorageException::class) {
+                table.update(key = "foo", partitionId = "A", data = "buz".encodeToByteString())
+            }
+            // Non-duplicates
+            table.insert(key = "FOO", partitionId = "A", data = "q".encodeToByteString())
+            table.insert(key = "foo", partitionId = "A", data = "r".encodeToByteString())
+            table.insert(key = "FOO", partitionId = "a", data = "s".encodeToByteString())
+        }
+    }
+
+    @Test
+    fun testUpdateNonexistent() = runTest {
+        withTable { table ->
+            assertFailsWith(NoRecordStorageException::class) {
+                table.update(key = "foo", "buz".encodeToByteString())
+            }
+        }
+    }
+
+    @Test
+    fun testBasicPersistence() = runTest {
+        val dbName = "testBasicPersistence"
+        val spec = StorageTableSpec("table", false, false)
+        val data = "Hello, world!".encodeToByteString()
+        
+        val storage1 = WebStorage(dbName, TestClock)
+        val table1 = storage1.getTable(spec)
+        table1.deleteAll()
+        val key = table1.insert(key = null, data = data)
+        
+        val storage2 = WebStorage(dbName, TestClock)
+        val table2 = storage2.getTable(spec)
+        assertEquals(data, table2.get(key))
+        
+        table2.deleteAll()
+    }
+
+    @Test
+    fun testSchemaUpdate() = runTest {
+        val dbName = "testSchemaUpdate"
+        val spec1 = StorageTableSpec(
+            name = "table",
+            supportPartitions = false,
+            supportExpiration = false
+        )
+        val spec1Uppercase = StorageTableSpec(
+            name = "TABLE",
+            supportPartitions = false,
+            supportExpiration = false
+        )
+        val spec2 = object : StorageTableSpec(
+            name = "table",
+            supportPartitions = false,
+            supportExpiration = false,
+            schemaVersion = 1
+        ) {
+            override suspend fun schemaUpgrade(oldTable: BaseStorageTable) {
+                val ids = oldTable.enumerate()
+                for (id in ids) {
+                    val oldValue = oldTable.get(id)!!.decodeToString()
+                    val newValue = oldValue.replace("old", "new")
+                    oldTable.update(id, newValue.encodeToByteString())
+                }
+            }
+        }
+        
+        val storage1 = WebStorage(dbName, TestClock)
+        val table1 = storage1.getTable(spec1)
+        table1.deleteAll()
+        val key1 = table1.insert(key = null, data = "old value 1".encodeToByteString())
+        val key2 = table1.insert(key = null, data = "old value 2".encodeToByteString())
+        
+        val storage2 = WebStorage(dbName, TestClock)
+        assertFailsWith(IllegalStateException::class) {
+            storage2.getTable(spec1Uppercase)
+        }
+        
+        val storage3 = WebStorage(dbName, TestClock)
+        val table3 = storage3.getTable(spec2)
+        assertEquals("new value 1", table3.get(key1)!!.decodeToString())
+        assertEquals("new value 2", table3.get(key2)!!.decodeToString())
+        
+        val storage4 = WebStorage(dbName, TestClock)
+        assertFailsWith(IllegalStateException::class) {
+            storage4.getTable(spec1)
+        }
+        
+        table3.deleteAll()
+    }
+
+    @Test
+    fun testTableName() = runTest {
+        withStorage { storage ->
+            storage.getTable(StorageTableSpec("foo", true, true))
+            // Duplicate name
+            assertFailsWith(IllegalArgumentException::class) {
+                storage.getTable(StorageTableSpec("foo", true, true))
+            }
+            // Duplicate name (case-insensitive comparison)
+            assertFailsWith(IllegalArgumentException::class) {
+                storage.getTable(StorageTableSpec("Foo", true, true))
+            }
+            // Name is not too long
+            storage.getTable(StorageTableSpec(LONG_NAME_60, true, true))
+            // Name is too long
+            assertFailsWith(IllegalArgumentException::class) {
+                storage.getTable(StorageTableSpec(LONG_NAME_60 + "X", true, true))
+            }
+            // Name does not start with a letter
+            assertFailsWith(IllegalArgumentException::class) {
+                storage.getTable(StorageTableSpec("1", true, true))
+            }
+            // Name contains illegal character
+            assertFailsWith(IllegalArgumentException::class) {
+                storage.getTable(StorageTableSpec("foo@", true, true))
+            }
+        }
+    }
+
+    @Test
+    fun testLargeData() = runTest {
+        withTable { table ->
+            val data = ByteString(Random.nextBytes(LARGE_DATA_SIZE))
+            val key = table.insert(key = null, data = data)
+            assertEquals(data, table.get(key))
+        }
+    }
+
+    @Test
+    fun testDeleteAll() = runTest {
+        withTable(supportExpiration = true, supportPartitions = true) { table ->
+            val time = TestClock.time + 10.minutes
+            val data = "data".encodeToByteString()
+            val key1 = table.insert(key = null, partitionId = "A", data = data)
+            val key2 = table.insert(key = null, partitionId = "A", expiration = time, data = data)
+            val key3 = table.insert(key = null, partitionId = "A", expiration = time, data = data)
+            assertEquals(setOf(key1, key2, key3), table.enumerate(partitionId = "A").toSet())
+            assertEquals(data, table.get(key = key1, partitionId = "A"))
+            assertEquals(data, table.get(key = key2, partitionId = "A"))
+            assertEquals(data, table.get(key = key3, partitionId = "A"))
+            table.deleteAll()
+            assertEquals(setOf(), table.enumerate(partitionId = "A").toSet())
+            assertNull(table.get(key = key1, partitionId = "A"))
+            assertNull(table.get(key = key2, partitionId = "A"))
+            assertNull(table.get(key = key3, partitionId = "A"))
+        }
+    }
+
+    @Test
+    fun testDeletePartition() = runTest {
+        withTable(supportExpiration = false, supportPartitions = true) { table ->
+            val data = "data".encodeToByteString()
+            val key0 = table.insert(key = null, partitionId = "A", data = data)
+            val key1 = table.insert(key = null, partitionId = "B", data = data)
+            val key2 = table.insert(key = null, partitionId = "B", data = data)
+            val key3 = table.insert(key = null, partitionId = "C", data = data)
+            assertEquals(setOf(key0), table.enumerate(partitionId = "A").toSet())
+            assertEquals(setOf(key1, key2), table.enumerate(partitionId = "B").toSet())
+            assertEquals(setOf(key3), table.enumerate(partitionId = "C").toSet())
+            table.deletePartition(partitionId = "B")
+            assertEquals(setOf(key0), table.enumerate(partitionId = "A").toSet())
+            assertEquals(setOf(), table.enumerate(partitionId = "B").toSet())
+            assertEquals(setOf(key3), table.enumerate(partitionId = "C").toSet())
+            assertNull(table.get(key = key1, partitionId = "B"))
+            assertNull(table.get(key = key2, partitionId = "B"))
+        }
+    }
+
+    private suspend fun withStorage(block: suspend (storage: Storage) -> Unit) {
+        val dbName = "TestStorage_${Random.nextInt()}"
+        val storage = WebStorage(dbName, TestClock)
+        block(storage)
+        // Ideally we'd delete the DB here, but for testing it's fine.
+    }
+
+    private suspend fun withTable(
+        supportExpiration: Boolean = false,
+        supportPartitions: Boolean = false,
+        block: suspend (table: StorageTable) -> Unit
+    ) {
+        val tableName = "TestTable${uniqueSuffix()}"
+        val tableSpec = StorageTableSpec(tableName, supportPartitions, supportExpiration)
+        withStorage { storage ->
+            block(storage.getTable(tableSpec))
+        }
+    }
+
+    private fun uniqueSuffix(): String {
+        val timestamp = Clock.System.now().epochSeconds.toString(36)
+        val count = uniqueCount++.toString(36)
+        return "_${timestamp}_${count}"
+    }
+
+    object TestClock : Clock {
+        internal var time: Instant = Instant.DISTANT_PAST
+        override fun now(): Instant = time
+    }
+
+    companion object {
+        var uniqueCount: Long = 0
+        const val LARGE_DATA_SIZE = 1 * 1024 * 1024 // 1Mb (reduced from 4Mb for web tests)
+        const val LONG_NAME_60 = "A12345678901234567890123456789012345678901234567890123456789"
+    }
+}


### PR DESCRIPTION
In addition to unit tests, this was also tested with running TestApp in the browser (via ./gradlew :samples:testapp:wasmJsBrowserDevelopmentRun) and checking that provisioned documents survive app restart (i.e. reloading the tab).

Also update `Platform` such that `WebStorage` is used for both JS and WasmJS and also use `SoftwareSecureArea` as the platform Secure Area on those platforms.

Test: New unit tests and testing in TestApp running in browser.
