### PR TITLE
Nonce interface for our OpenID4VCI server implementation.

### DIFF
--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/customization/NonceManager.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/customization/NonceManager.kt
@@ -1,0 +1,107 @@
+package org.multipaz.openid4vci.customization
+
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.webtoken.ChallengeInvalidException
+
+/**
+ * Interface that is responsible for issuing and validating various nonce/challenge
+ * values in OpenID4VCI protocols.
+ *
+ * There are four kinds of nonce/challenges that can occur:
+ *  - authorization server DPoP nonce
+ *  - client attestation nonce (only used with authorization server)
+ *  - resource/credential server DPoP nonce
+ *  - credential key binding challenge
+ *
+ * Generally speaking all these nonce/challenge values are independent on each other,
+ * but this is not mandated. For instance the same value could be used for authorization
+ * server DPoP and client attestation nonce. The client is not supposed to use a nonce value
+ * repeatedly (client should track this for each nonce type separately). However, the
+ * server may or may not check that (and also the server can re-issue the same nonce
+ * value again).
+ *
+ * Please consult OpenID4VCI specification for details.
+ *
+ * NB: in OpenID4VCI nonce values are not bound to a session.
+ */
+interface NonceManager {
+    /**
+     * Validate authorization server DPoP nonce and possibly mark it as used up.
+     *
+     * @param nonce nonce value
+     * @throws ChallengeInvalidException if nonce is expired, not valid or already used
+     */
+    suspend fun checkAndConsumeAuthorizationDPoPNonce(nonce: String)
+    /**
+     * Validate resource server DPoP nonce and possibly mark it as used up.
+     *
+     * @param nonce nonce value
+     * @throws ChallengeInvalidException if nonce is expired, not valid or already used
+     */
+    suspend fun checkAndConsumeResourceDPoPNonce(nonce: String)
+    /**
+     * Validate client attestation challenge and possibly mark it as used up.
+     *
+     * @param nonce challenge value
+     * @throws ChallengeInvalidException if challenge is expired, not valid or already used
+     */
+    suspend fun checkAndConsumeClientAttestationNonce(nonce: String)
+    /**
+     * Validate credential binding key challenge and possibly mark it as used up.
+     *
+     * @param nonce challenge value
+     * @throws ChallengeInvalidException if challenge is expired, not valid or already used
+     */
+    suspend fun checkAndConsumeCredentialNonce(nonce: String)
+    /**
+     * Issue nonce values for `challenge` authorization endpoint
+     *
+     * @return nonce values
+     */
+    suspend fun challenge(): Nonces
+    /**
+     * Issue nonce values for `par` (Pushed Authorization Request) authorization server endpoint
+     *
+     * @return nonce values
+     */
+    suspend fun pushedAuthorizationRequest(): Nonces
+    /**
+     * Issue nonce values for `token` authorization server endpoint
+     *
+     * @return nonce values
+     */
+    suspend fun token(): Nonces
+    /**
+     * Issue nonce values for `c_nonce` resource server endpoint
+     *
+     * @return nonce values
+     */
+    suspend fun cNonce(): Nonces
+    /**
+     * Issue nonce values for `credential` resource server endpoint
+     *
+     * @return nonce values
+     */
+    suspend fun credential(): Nonces
+
+    /**
+     * A set of nonce values
+     *
+     * @param dpopNonce DPoP nonce (either authorization- or resource-server bound)
+     * @param clientAttestationNonce client attestation challenge (must be null for resource server)
+     * @param credentialNonce credential key binding nonce, must only be ussed for `c_nonce` request
+     */
+    data class Nonces(
+        val dpopNonce: String? = null,
+        val clientAttestationNonce: String? = null,
+        val credentialNonce: String? = null
+    )
+
+    companion object {
+        /**
+         * @return [NonceManager] implementation
+         */
+        suspend fun get(): NonceManager =
+            BackendEnvironment.getInterface(NonceManager::class) ?: NonceManagerDefault
+    }
+}

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/customization/NonceManagerDefault.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/customization/NonceManagerDefault.kt
@@ -1,0 +1,97 @@
+package org.multipaz.openid4vci.customization
+
+import kotlinx.io.bytestring.buildByteString
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.rpc.handler.InvalidRequestException
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.util.Logger
+import org.multipaz.webtoken.Challenge
+import org.multipaz.webtoken.ChallengeInvalidException
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+/** Default implementation for [NonceManager] */
+object NonceManagerDefault: NonceManager {
+    override suspend fun checkAndConsumeAuthorizationDPoPNonce(nonce: String) {
+        if (nonce[0] != 'A') {
+            Logger.e(TAG, "Not an authorization server DPoP nonce: '$nonce'")
+            throw ChallengeInvalidException()
+        }
+        Challenge.validateAndConsume(nonce.substring(1))
+    }
+
+    override suspend fun checkAndConsumeResourceDPoPNonce(nonce: String) {
+        if (nonce[0] != 'R') {
+            Logger.e(TAG, "Not a resource server DPoP nonce: '$nonce'")
+            throw ChallengeInvalidException()
+        }
+        Challenge.validateAndConsume(nonce.substring(1))
+    }
+
+    override suspend fun checkAndConsumeClientAttestationNonce(nonce: String) {
+        if (nonce[0] != 'W') {
+            Logger.e(TAG, "Not a client attestation challenge: '$nonce'")
+            throw ChallengeInvalidException()
+        }
+        Challenge.validateAndConsume(nonce.substring(1))
+    }
+
+    override suspend fun checkAndConsumeCredentialNonce(nonce: String) {
+        val table = BackendEnvironment.getTable(credentialChallengeTableSpec)
+        if (!table.delete(nonce)) {
+            throw InvalidRequestException("Expired or invalid c_nonce")
+        }
+    }
+
+    override suspend fun challenge(): NonceManager.Nonces = generate(false).also {
+        if (it.clientAttestationNonce == null) {
+            throw InvalidRequestException("client attestation challenge is not supported")
+        }
+    }
+
+    override suspend fun token(): NonceManager.Nonces = generate(false)
+
+    override suspend fun pushedAuthorizationRequest(): NonceManager.Nonces = generate(false)
+
+    override suspend fun cNonce(): NonceManager.Nonces {
+        // This is not the most scalable way of managing c_nonce values, but it is the simplest one
+        // that would detect c_nonce reuse.
+        val generic = generate(true)
+        val cNonce = BackendEnvironment.getTable(credentialChallengeTableSpec).insert(
+            key = null,
+            data = buildByteString {},
+            expiration = Clock.System.now() + 10.minutes
+        )
+        return NonceManager.Nonces(
+            dpopNonce = generic.dpopNonce,
+            clientAttestationNonce = generic.credentialNonce,
+            credentialNonce = cNonce
+        )
+    }
+
+    override suspend fun credential(): NonceManager.Nonces = generate(true)
+
+    private suspend fun generate(resourceServer: Boolean): NonceManager.Nonces {
+        val useClientAttestationChallenge = !resourceServer &&
+                BackendEnvironment.getInterface(Configuration::class)!!
+                    .getValue("use_client_attestation_challenge") != "false"
+        return NonceManager.Nonces(
+            dpopNonce = (if (resourceServer) "R" else "A") + Challenge.create(),
+            clientAttestationNonce = if (useClientAttestationChallenge) {
+                "W" + Challenge.create()
+            } else {
+                null
+            }
+        )
+    }
+
+    private val credentialChallengeTableSpec = StorageTableSpec(
+        name = "CredentialChallenge",
+        supportExpiration = true,
+        supportPartitions = false
+    )
+
+    private const val TAG = "NonceManagerDefault"
+}

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/authorizeChallenge.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/authorizeChallenge.kt
@@ -41,9 +41,12 @@ suspend fun authorizeChallenge(call: ApplicationCall) {
     if (authSession != null) {
         authorizeWithDpop(
             call.request,
-            state.dpopKey ?: throw IllegalArgumentException("DPoP is required"),
-            state.clientId!!,
-            null
+            publicKey = state.dpopKey
+                ?: throw IllegalArgumentException("DPoP is required"),
+            clientId = state.clientId!!,
+            accessToken = null,
+            initial = false,
+            isResourceServer = false
         )
     }
     val baseUrl = BackendEnvironment.getBaseUrl()

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/challenge.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/challenge.kt
@@ -6,6 +6,8 @@ import io.ktor.server.response.header
 import io.ktor.server.response.respondText
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.multipaz.openid4vci.customization.NonceManager
+import org.multipaz.openid4vci.customization.NonceManagerDefault
 import org.multipaz.webtoken.Challenge
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Configuration
@@ -15,17 +17,13 @@ import org.multipaz.rpc.handler.InvalidRequestException
  * Issues a fresh wallet attestation challenge
  */
 suspend fun challenge(call: ApplicationCall) {
-    val configuration = BackendEnvironment.getInterface(Configuration::class)!!
-    val useClientAttestationChallenge =
-        configuration.getValue("use_client_attestation_challenge") != "false"
-    if (!useClientAttestationChallenge) {
-        throw InvalidRequestException("client attestation challenge is not supported")
-    }
+    val nonces = NonceManager.get().challenge()
     call.response.header("Cache-Control", "no-store")
-    call.response.header("DPoP-Nonce", Challenge.create())
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    check(nonces.credentialNonce == null)
     call.respondText(
         text = buildJsonObject {
-            put("attestation_challenge", Challenge.create())
+            put("attestation_challenge", nonces.clientAttestationNonce!!)
         }.toString(),
         contentType = ContentType.Application.Json
     )

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
+import io.ktor.client.request.request
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -42,6 +43,7 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.openid4vci.credential.CredentialDisplay
 import org.multipaz.webtoken.ChallengeInvalidException
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
+import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.openid4vci.util.IssuanceState
 import org.multipaz.openid4vci.util.OpaqueIdType
 import org.multipaz.openid4vci.util.authorizeWithDpop
@@ -71,15 +73,18 @@ suspend fun credential(call: ApplicationCall) {
     val accessToken = extractAccessToken(call.request)
     val id = codeToId(OpaqueIdType.ACCESS_TOKEN, accessToken)
     val state = IssuanceState.getIssuanceState(id)
+    val nonceManager = NonceManager.get()
     try {
         authorizeWithDpop(
-            call.request,
-            state.dpopKey!!,
-            state.clientId!!,
-            accessToken
+            request = call.request,
+            publicKey = state.dpopKey!!,
+            clientId = state.clientId!!,
+            accessToken = accessToken,
+            isResourceServer = true,
+            initial = false
         )
     } catch (_: ChallengeInvalidException) {
-        respondWithNewDPoPNonce(call)
+        respondWithNewDPoPNonce(call, nonceManager.credential())
         return
     }
     val registry = BackendEnvironment.getInterface(CredentialFactoryRegistry::class)!!
@@ -182,7 +187,7 @@ suspend fun credential(call: ApplicationCall) {
                                 ServerIdentity.KEY_ATTESTATION, chain, instant)
                         }
                     )
-                validateAndConsumeCredentialChallenge(body["nonce"]!!.jsonPrimitive.content)
+                nonceManager.checkAndConsumeCredentialNonce(body["nonce"]!!.jsonPrimitive.content)
                 body["attested_keys"]!!.jsonArray.map { key ->
                     val publicKey = EcPublicKey.fromJwk(key.jsonObject)
                     KeyAndId(
@@ -213,7 +218,7 @@ suspend fun credential(call: ApplicationCall) {
                 // the rest of them match the first one.
                 if (expectedNonce == null) {
                     expectedNonce = nonce
-                    validateAndConsumeCredentialChallenge(nonce.decodeToString())
+                    nonceManager.checkAndConsumeCredentialNonce(nonce.decodeToString())
                 } else if (nonce != expectedNonce) {
                     throw InvalidRequestException("nonce mismatch")
                 }
@@ -251,7 +256,7 @@ suspend fun credential(call: ApplicationCall) {
                 val nonce = body["nonce"]!!.jsonPrimitive.content
                 if (expectedNonce == null) {
                     expectedNonce = nonce
-                    validateAndConsumeCredentialChallenge(nonce)
+                    nonceManager.checkAndConsumeCredentialNonce(nonce)
                 } else if (nonce != expectedNonce) {
                     throw InvalidRequestException("nonce mismatch")
                 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/nonce.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/nonce.kt
@@ -4,47 +4,28 @@ import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.header
 import io.ktor.server.response.respondText
-import kotlin.time.Clock
-import kotlinx.io.bytestring.buildByteString
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.multipaz.openid4vci.util.addFreshNonceHeaders
+import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.storage.StorageTableSpec
-import kotlin.time.Duration.Companion.minutes
 
 /**
  * Endpoint to obtain fresh `c_nonce` (challenge for device binding key attestation).
  */
 suspend fun nonce(call: ApplicationCall) {
-    // This is not the most scalable way of managing c_nonce values, but it is the simplest one
-    // that would detect c_nonce reuse.
-    val cNonce = BackendEnvironment.getTable(credentialChallengeTableSpec).insert(
-        key = null,
-        data = buildByteString {},
-        expiration = Clock.System.now() + 10.minutes
-    )
+    val nonces = NonceManager.get().cNonce()
     call.response.header("Cache-Control", "no-store")
-    addFreshNonceHeaders(call)
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    nonces.clientAttestationNonce?.let {
+        call.response.header("OAuth-Client-Attestation-Challenge", it)
+    }
     call.respondText(
         text = buildJsonObject {
-            put("c_nonce", cNonce)
+            put("c_nonce", nonces.credentialNonce!!)
         }.toString(),
         contentType = ContentType.Application.Json
     )
 }
-
-internal suspend fun validateAndConsumeCredentialChallenge(cNonce: String) {
-    val table = BackendEnvironment.getTable(credentialChallengeTableSpec)
-    if (!table.delete(cNonce)) {
-        throw InvalidRequestException("Expired or invalid c_nonce")
-    }
-}
-
-private val credentialChallengeTableSpec = StorageTableSpec(
-    name = "CredentialChallenge",
-    supportExpiration = true,
-    supportPartitions = false
-)

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/pushedAuthorizationRequest.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/pushedAuthorizationRequest.kt
@@ -4,12 +4,13 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.header
 import io.ktor.server.response.respondText
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.webtoken.ChallengeInvalidException
 import org.multipaz.openid4vci.util.OpaqueIdType
-import org.multipaz.openid4vci.util.addFreshNonceHeaders
 import org.multipaz.openid4vci.util.createSession
 import org.multipaz.openid4vci.util.idToCode
 import org.multipaz.openid4vci.util.respondWithNewClientAttestationChallenge
@@ -37,19 +38,23 @@ import kotlin.time.Duration.Companion.minutes
 suspend fun pushedAuthorizationRequest(call: ApplicationCall) {
     val parameters = call.receiveParameters()
     val timeout: Duration = 5.minutes
+    val nonces = NonceManager.get().pushedAuthorizationRequest()
 
     val id = try {
         // This is where actual work happens
         createSession(call.request, parameters, Clock.System.now() + timeout)
     } catch (_: ChallengeInvalidException) {
-        respondWithNewClientAttestationChallenge(call)
+        respondWithNewClientAttestationChallenge(call, nonces)
         return
     }
 
     // Format the result (session identifying information).
     val code = idToCode(OpaqueIdType.PAR_CODE, id, timeout)
 
-    addFreshNonceHeaders(call)
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    nonces.clientAttestationNonce?.let {
+        call.response.header("OAuth-Client-Attestation-Challenge", it)
+    }
     call.respondText(
         text = buildJsonObject {
                 put("request_uri", "urn:ietf:params:oauth:request_uri:$code")

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
@@ -10,6 +10,7 @@ import io.ktor.http.parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.header
 import io.ktor.server.response.respondText
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
@@ -23,12 +24,12 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.webtoken.ChallengeInvalidException
 import org.multipaz.openid4vci.util.IssuanceState
 import org.multipaz.openid4vci.util.OpaqueIdType
 import org.multipaz.openid4vci.util.OpenID4VCIRequestError
 import org.multipaz.openid4vci.util.SystemOfRecordAccess
-import org.multipaz.openid4vci.util.addFreshNonceHeaders
 import org.multipaz.openid4vci.util.authorizeWithDpop
 import org.multipaz.openid4vci.util.codeToId
 import org.multipaz.openid4vci.util.getSystemOfRecordUrl
@@ -131,16 +132,23 @@ suspend fun token(call: ApplicationCall) {
         try {
             validateClientAttestationPoP(call.request, clientId, clientAttestationKey)
         } catch (_: ChallengeInvalidException) {
-            respondWithNewClientAttestationChallenge(call)
+            respondWithNewClientAttestationChallenge(call, NonceManager.get().token())
             return
         }
     }
 
     if (state.dpopKey != null) {
         try {
-            authorizeWithDpop(call.request, state.dpopKey!!, clientId, null)
+            authorizeWithDpop(
+                request = call.request,
+                publicKey = state.dpopKey!!,
+                clientId = clientId,
+                accessToken = null,
+                isResourceServer = false,
+                initial = false
+            )
         } catch (_: ChallengeInvalidException) {
-            respondWithNewDPoPNonce(call)
+            respondWithNewDPoPNonce(call, NonceManager.get().token())
             return
         }
     } else {
@@ -163,7 +171,11 @@ suspend fun token(call: ApplicationCall) {
     // If no refresh happens in a year, delete the record
     val refreshExpiration = Clock.System.now() + 365.days
     IssuanceState.updateIssuanceState(id, state, refreshExpiration)
-    addFreshNonceHeaders(call)
+    val nonces = NonceManager.get().token()
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    nonces.clientAttestationNonce?.let {
+        call.response.header("OAuth-Client-Attestation-Challenge", it)
+    }
     call.respondText(
         text = buildJsonObject {
                 put("access_token", accessToken)
@@ -190,7 +202,8 @@ private suspend fun establishDPopKey(
         publicKey = dpopKey,
         clientId = state.clientId!!,
         accessToken = null,
-        initial = true  // no nonce, no need to handle ChallengeInvalidException
+        isResourceServer = false,
+        initial = true
     )
     state.dpopKey = dpopKey
     return dpopKey

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
@@ -84,16 +84,18 @@ suspend fun wellKnownOpenidCredentialIssuer(call: ApplicationCall) {
                                     }
                                 }
                                 if (credentialFactory.acceptAndroidKeyAttestation) {
+                                    val level = when (credentialFactory.keyMintSecurityLevel) {
+                                        AndroidKeystoreSecurityLevel.SOFTWARE ->
+                                            "Software"
+                                        AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT ->
+                                            "TrustedEnvironment"
+                                        AndroidKeystoreSecurityLevel.STRONG_BOX ->
+                                            "StrongBox"
+                                    }
                                     putJsonObject("android_keystore_attestation") {
-                                        put("key_mint_security_level",
-                                            when (credentialFactory.keyMintSecurityLevel) {
-                                                AndroidKeystoreSecurityLevel.SOFTWARE ->
-                                                    "Software"
-                                                AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT ->
-                                                    "TrustedEnvironment"
-                                                AndroidKeystoreSecurityLevel.STRONG_BOX ->
-                                                    "StrongBox"
-                                            })
+                                        putJsonObject("key_attestations_required") {
+                                            put("key_mint_security_level", level)
+                                        }
                                         putJsonArray("proof_signing_alg_values_supported") {
                                             credentialFactory.proofSigningAlgorithms.forEach {
                                                 add(it)

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/auth.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/auth.kt
@@ -22,9 +22,8 @@ import org.multipaz.cbor.Uint
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.webtoken.Challenge
-import org.multipaz.openid4vci.credential.CredentialFactory
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
+import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.rpc.handler.SimpleCipher
@@ -121,7 +120,8 @@ suspend fun authorizeWithDpop(
     publicKey: EcPublicKey,
     clientId: String,
     accessToken: String?,
-    initial: Boolean = false
+    isResourceServer: Boolean,
+    initial: Boolean,
 ) {
     val auth = request.headers["Authorization"]
     if (accessToken == null) {
@@ -140,21 +140,14 @@ suspend fun authorizeWithDpop(
         }
     }
 
-    validateDPoPJwt(request, publicKey, clientId, accessToken, initial)
+    validateDPoPJwt(request, publicKey, clientId, accessToken, isResourceServer, initial)
 }
 
-suspend fun addFreshNonceHeaders(call: ApplicationCall) {
-    val configuration = BackendEnvironment.getInterface(Configuration::class)!!
-    val useClientAttestationChallenge =
-        configuration.getValue("use_client_attestation_challenge") != "false"
-    call.response.header("DPoP-Nonce", Challenge.create())
-    if (useClientAttestationChallenge) {
-        call.response.header("OAuth-Client-Attestation-Challenge", Challenge.create())
+suspend fun respondWithNewDPoPNonce(call: ApplicationCall, nonces: NonceManager.Nonces) {
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    nonces.clientAttestationNonce?.let {
+        call.response.header("OAuth-Client-Attestation-Challenge", it)
     }
-}
-
-suspend fun respondWithNewDPoPNonce(call: ApplicationCall) {
-    addFreshNonceHeaders(call)
     call.response.header("WWW-Authenticate", "DPoP error=\"use_dpop_nonce\"")
     call.respondText(status = HttpStatusCode.Unauthorized, text = "")
 }
@@ -229,12 +222,19 @@ suspend fun validateClientAttestationPoP(
             if (useClientAttestationChallenge) {
                 put(WebTokenCheck.CHALLENGE, "challenge")
             }
-        }
+        },
+        nonceValidator = NonceManager.get()::checkAndConsumeClientAttestationNonce
     )
 }
 
-suspend fun respondWithNewClientAttestationChallenge(call: ApplicationCall) {
-    addFreshNonceHeaders(call)
+suspend fun respondWithNewClientAttestationChallenge(
+    call: ApplicationCall,
+    nonces: NonceManager.Nonces
+) {
+    nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
+    nonces.clientAttestationNonce?.let {
+        call.response.header("OAuth-Client-Attestation-Challenge", it)
+    }
     call.respondText(
         status = HttpStatusCode.BadRequest,
         text = "{\"error\": \"use_attestation_challenge\"}\n",
@@ -285,7 +285,14 @@ suspend fun createSession(
     // Validate DPoP if any
     val dpopKey = processInitialDPoP(request)
     if (dpopKey != null) {
-        validateDPoPJwt(request, dpopKey, clientId, null, true)
+        validateDPoPJwt(
+            request = request,
+            publicKey = dpopKey,
+            clientId = clientId,
+            accessToken = null,
+            isResourceServer = false,
+            initial = true
+        )
     } else {
         // DPoP is not supplied. We are OK with that as long as clientId is authenticated
         // one way or the other.
@@ -366,10 +373,17 @@ private suspend fun validateDPoPJwt(
     publicKey: EcPublicKey,
     clientId: String,
     accessToken: String?,
-    initial: Boolean = false
+    isResourceServer: Boolean,
+    initial: Boolean,
 ) {
     val dpop = request.headers["DPoP"] ?: throw InvalidRequestException("DPoP header required")
     val baseUrl = BackendEnvironment.getBaseUrl()
+    val nonceManager = NonceManager.get()
+    val nonceValidator: suspend (String) -> Unit = if (isResourceServer) {
+        nonceManager::checkAndConsumeResourceDPoPNonce
+    } else {
+        nonceManager::checkAndConsumeAuthorizationDPoPNonce
+    }
     val body = validateJwt(
         jwt = dpop,
         jwtName = "DPoP JWT",
@@ -386,7 +400,8 @@ private suspend fun validateDPoPJwt(
                 val athHash = Crypto.digest(Algorithm.SHA256, accessToken.encodeToByteArray())
                 put(WebTokenCheck.ATH, athHash.toBase64Url())
             }
-        }
+        },
+        nonceValidator = nonceValidator
     )
     if (accessToken == null && body.containsKey("ath")) {
         throw InvalidRequestException("DPoP JWT: 'ath' specified, but not expected")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
@@ -52,22 +52,23 @@ import kotlin.time.Instant
  *
  * [WebTokenCheck.CHALLENGE] defines the nonce/challenge check using the value of the specified
  * property. The value given to this key in [checks] map is used as a property name in the body
- * part of the CWT. That property must exist. Its value is passed to [Challenge.validateAndConsume]
- * method.
+ * part of the CWT. That property must exist. Its value is passed to [nonceValidator] function.
  *
  * @param cwt CWT to validate
  * @param cwtName name for the kind of CWT being validated, this is used to generate more meaningful
- *    exception messages
+ *  exception messages
  * @param publicKey public key to use to check signature, either publicKey or [WebTokenCheck.TRUST]
- *    must be used.
+ *  must be used.
  * @param checks validation checks to perform.
  * @param maxValidity when `exp` is not present determines expiration time based on `iat` claim;
- *     when `exp` claim is present, determines how far in the future it can be.
+ *  when `exp` claim is present, determines how far in the future it can be.
  * @param certificateChainValidator optional function to validate certificate chain in CWT; if
- *     the certificate chain is not valid it should throw [InvalidRequestException] exception,
- *     the returned value should indicate if the chain is trusted (in which case
- *     [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
+ *  the certificate chain is not valid it should throw [InvalidRequestException] exception,
+ *  the returned value should indicate if the chain is trusted (in which case
+ *  [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
  * @param clock clock that determines current time to check for expiration.
+ * @param nonceValidator function that must throw [ChallengeInvalidException] if nonce/challenge
+ *  is not valid; this is used with [WebTokenCheck.CHALLENGE] check.
  * @throws ChallengeInvalidException when nonce or challenge check fails (see [WebTokenCheck.CHALLENGE])
  * @throws InvalidRequestException when any other validation fails
  */
@@ -78,7 +79,8 @@ suspend fun validateCwt(
     checks: Map<WebTokenCheck, String> = mapOf(),
     maxValidity: Duration = 10.hours,
     certificateChainValidator: (suspend (chain: X509CertChain, atTime: Instant) -> Boolean)? = null,
-    clock: Clock = Clock.System
+    clock: Clock = Clock.System,
+    nonceValidator: suspend (nonce: String) -> Unit = Challenge::validateAndConsume
 ): CborMap {
     val cbor = Cbor.decode(cwt)
     val unwrapped = if (cbor is Tagged && cbor.tagNumber == Tagged.COSE_SIGN1) {
@@ -210,7 +212,7 @@ suspend fun validateCwt(
         if (nonce !is Tstr) {
             throw InvalidRequestException("$cwtName: '$nonceName' is invalid")
         }
-        Challenge.validateAndConsume(nonce.asTstr)
+        nonceValidator.invoke(nonce.asTstr)
     }
 
     val jtiPartition = checks[WebTokenCheck.IDENT]

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
@@ -59,21 +59,23 @@ import kotlin.time.Instant
  *
  * [WebTokenCheck.CHALLENGE] defines the nonce/challenge check using the value of the specified property.
  * The value given to this key in [checks] map is used as a property name in the body part of the
- * JWT. That property must exist. Its value is passed to [Challenge.validateAndConsume] method.
+ * JWT. That property must exist. Its value is passed to [nonceValidator] function.
  *
  * @param jwt JWT to validate
  * @param jwtName name for the kind of JWT being validated, this is used to generate more meaningful
- *    exception messages
+ *  exception messages
  * @param publicKey public key to use to check signature, either publicKey or [WebTokenCheck.TRUST]
- *    must be used.
+ *  must be used.
  * @param checks validation checks to perform.
  * @param maxValidity when `exp` is not present determines expiration time based on `iat` claim;
- *     when `exp` claim is present, determines how far in the future it can be.
+ *  when `exp` claim is present, determines how far in the future it can be.
  * @param certificateChainValidator optional function to validate certificate chain in CWT; if
- *     the certificate chain is not valid it should throw [InvalidRequestException] exception,
- *     the returned value should indicate if the chain is trusted (in which case
- *     [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
+ *  the certificate chain is not valid it should throw [InvalidRequestException] exception,
+ *  the returned value should indicate if the chain is trusted (in which case
+ *  [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
  * @param clock clock that determines current time to check for expiration.
+ * @param nonceValidator function that must throw [ChallengeInvalidException] if nonce/challenge
+ *  is not valid; this is used with [WebTokenCheck.CHALLENGE] check.
  * @throws ChallengeInvalidException when nonce or challenge check fails (see [WebTokenCheck.CHALLENGE])
  * @throws InvalidRequestException when any other validation fails
  */
@@ -84,7 +86,8 @@ suspend fun validateJwt(
     checks: Map<WebTokenCheck, String> = mapOf(),
     maxValidity: Duration = 10.hours,
     certificateChainValidator: (suspend (chain: X509CertChain, atTime: Instant) -> Boolean)? = null,
-    clock: Clock = Clock.System
+    clock: Clock = Clock.System,
+    nonceValidator: suspend (nonce: String) -> Unit = Challenge::validateAndConsume
 ): JsonObject {
     require(publicKey == null || certificateChainValidator == null)
     val parts = jwt.split('.')
@@ -209,7 +212,7 @@ suspend fun validateJwt(
         if (nonce !is JsonPrimitive || !nonce.isString) {
             throw InvalidRequestException("$jwtName: '$nonceName' is invalid")
         }
-        Challenge.validateAndConsume(nonce.content)
+        nonceValidator.invoke(nonce.content)
     }
 
     val jtiPartition = checks[WebTokenCheck.IDENT]


### PR DESCRIPTION
This allows server instances to customize how various nonce values are issued and verified. Also tightened our current nonce handling, so that client errors could be caught earlier.

Test: tested with our existing client and freshly-built local OpenID4VCI server.
