### PR TITLE
Handle the case when we fail to process SD-JWT credential

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
@@ -277,7 +277,13 @@ class DocumentModel private constructor(
                     false
                 }
                 val claims = if (credential.isCertified) {
-                    credential.getClaims(documentTypeRepository)
+                    try {
+                        credential.getClaims(documentTypeRepository)
+                    } catch (err: IllegalStateException) {
+                        Logger.e(TAG,
+                            "Error reading claims: '${identifier}.${credential.identifier}'", err)
+                        emptyList()
+                    }
                 } else {
                     emptyList()
                 }

--- a/multipaz-dcapi/src/androidMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentialsExt.android.kt
+++ b/multipaz-dcapi/src/androidMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentialsExt.android.kt
@@ -32,6 +32,7 @@ import org.multipaz.cbor.putCborMap
 import org.multipaz.claim.organizeByNamespace
 import org.multipaz.context.AndroidUiContext
 import org.multipaz.context.applicationContext
+import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.document.Document
@@ -191,7 +192,13 @@ private suspend fun exportMdocCredential(
 
     val cardArtResized = resizedCardArt(cardArt)
 
-    val claims = credential.getClaims(documentTypeRepository)
+    val claims = try {
+        credential.getClaims(documentTypeRepository)
+    } catch (err: IllegalStateException) {
+        Logger.e(TAG,
+            "Error reading claims: '${credential.document.identifier}.${credential.identifier}'", err)
+        emptyList()
+    }
     return buildCborMap {
         put("title", displayName)
         put("subtitle", displayNameSub)
@@ -246,7 +253,14 @@ private suspend fun exportSdJwtVcCredential(
 
     val cardArtResized = resizedCardArt(cardArt)
 
-    val claims = credential.getClaimsImpl(documentTypeRepository)
+    val claims = try {
+        credential.getClaimsImpl(documentTypeRepository)
+    } catch (err: IllegalStateException) {
+        val cred = credential as Credential
+        Logger.e(TAG,
+            "Error reading claims: '${cred.document.identifier}.${credential.identifier}'", err)
+        emptyList()
+    }
     return buildCborMap {
         put("title", displayName)
         put("subtitle", displayNameSub)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/credential/Credential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/credential/Credential.kt
@@ -402,6 +402,8 @@ abstract class Credential {
      *
      * @param documentTypeRepository a [DocumentTypeRepository] or `null`.
      * @return a list of claims with values.
+     * @throws IllegalStateException if claims could not be read (e.g. due to unsupported
+     *  credential syntax)
      */
     abstract suspend fun getClaims(
         documentTypeRepository: DocumentTypeRepository?

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
@@ -149,8 +149,13 @@ data class DcqlQuery(
             val matches = mutableListOf<QueryResponseMatch>()
             // We sort on displayName b/c otherwise it's sorted on Document.identifier which can be unpredictable
             for (cred in credsSatisfyingMeta.sortedBy { it.document.displayName }) {
-                val claimsInCredential =
+                val claimsInCredential = try {
                     cred.getClaims(documentTypeRepository = presentmentSource.documentTypeRepository)
+                } catch (err: IllegalStateException) {
+                    Logger.e(TAG,
+                        "Error reading claims: '${cred.document.identifier}.${cred.identifier}'", err)
+                    listOf()
+                }
                 if (credentialQuery.claimSets.isEmpty()) {
                     var didNotMatch = false
                     val matchingClaimValues = mutableMapOf< RequestedClaim, Claim>()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/SdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/SdJwtVcCredential.kt
@@ -39,7 +39,12 @@ interface SdJwtVcCredential {
     ): List<JsonClaim> {
         val ret = mutableListOf<JsonClaim>()
         val sdJwt = SdJwt.fromCompactSerialization(issuerProvidedData.decodeToString())
-        val issuerKey = sdJwt.x5c!!.certificates.first().ecPublicKey
+        // We only support keys that are certified with the certificate chain. Web-based resolution
+        // is not supported (and it is not clear it is suitable for identity credentials in general
+        // if the future goal is to support (offline) proximity presentment).
+        val x5c = sdJwt.x5c
+            ?: throw IllegalStateException("Only X509-certified keys are supported in SD-JWT")
+        val issuerKey = x5c.certificates.first().ecPublicKey
         val processedJwt = sdJwt.verify(issuerKey)
 
         // By design, we only include the top-level claims.

--- a/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredentialTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredentialTest.kt
@@ -16,10 +16,20 @@
 package org.multipaz.sdjwt.credential
 
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.multipaz.credential.CredentialLoader
 import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import org.multipaz.sdjwt.SdJwt
 import org.multipaz.securearea.BatchCreateKeyResult
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
@@ -30,8 +40,11 @@ import org.multipaz.storage.ephemeral.EphemeralStorage
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 
 class KeyBoundSdJwtVcCredentialTest {
     private lateinit var credentialLoader: CredentialLoader
@@ -87,6 +100,46 @@ class KeyBoundSdJwtVcCredentialTest {
         val credentials = document.getCredentials()
         // assert that document credentials contain all original credentials
         assertTrue(credentials.containsAll(originalCredentials))
+    }
+
+    @Test
+    fun noX5C() = runTest {
+        val document = documentStore.createDocument()
+        // Uncertified issuer key
+        val issuerKey = AsymmetricKey.NamedExplicit(
+            keyId = "foobar",
+            privateKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        )
+        val credential = KeyBoundSdJwtVcCredential.create(
+            document = document,
+            asReplacementForIdentifier = null,
+            domain = "domain",
+            secureArea = secureArea,
+            vct = EUPersonalID.EUPID_VCT,
+            createKeySettings = CreateKeySettings()
+        )
+        val documentTypeRepository = DocumentTypeRepository()
+        documentTypeRepository.addDocumentType(EUPersonalID.getDocumentType())
+        val now = Clock.System.now()
+        val sdJwt = SdJwt.create(
+            issuerKey = issuerKey,
+            kbKey = secureArea.getKeyInfo(credential.alias).publicKey,
+            claims = buildJsonObject {
+                put("given_name", "John")
+                put("family_name", "Dow")
+            },
+            nonSdClaims = buildJsonObject {
+                put("iss", "http://issuer.example.org")
+                put("vct", credential.vct)
+                put("iat", now.epochSeconds)
+                put("nbf", now.epochSeconds)
+                put("exp", (now + 30.days).epochSeconds)
+            }
+        )
+        credential.certify(sdJwt.compactSerialization.encodeToByteString())
+        assertFailsWith(IllegalStateException::class) {
+            credential.getClaims(documentTypeRepository)
+        }
     }
 
     /**


### PR DESCRIPTION
SD-JWT credentials support various ways to identify the key which was used to sign them. We only support keys certified with X509 certificate chain. Ensure that when unsupported credentials are encountered, IllegalStateException is thrown and that exception is then handled.

Test: added a new unit test. Also tested with a testapp and a credential from a hacked provisioning server.

Fixes #1560
