### PR TITLE
Add support for Document badges.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -1,6 +1,5 @@
 package org.multipaz.compose.digitalcredentials
 
-import kotlinx.coroutines.CancellationException
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -21,6 +20,7 @@ import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -74,8 +74,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.cards.VerticalCardList
+import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.compose.document.DocumentModel
-import org.multipaz.compose.document.VerticalDocumentList
 import org.multipaz.compose.prompt.PresentmentActivity.Companion.getPendingIntent
 import org.multipaz.context.applicationContext
 import org.multipaz.context.initializeApplication
@@ -149,7 +150,7 @@ class PresentmentActivity: FragmentActivity() {
          * Get a [PendingIntent] to launch [PresentmentActivity] in document chooser mode.
          *
          * In document chooser mode, the user is presented with a list of documents from [source]
-         * rendered using [VerticalDocumentList]. The document indicated by [initiallySelectedDocumentId]
+         * rendered using [VerticalCardList]. The document indicated by [initiallySelectedDocumentId]
          * is selected and by tapping the document pile at the bottom the user can select another
          * document. The user is also presented with a "Open Wallet" button (replacing "Wallet"
          * with [Branding.Current.appName] if not `null`) which if pressed will launch
@@ -174,12 +175,12 @@ class PresentmentActivity: FragmentActivity() {
         ): PendingIntent {
             presentmentModel.reset(
                 source = source,
+                preselectedDocuments = emptyList(),
                 showDocumentChooser = DocumentChooserData(
                     initiallySelectedDocumentId = initiallySelectedDocumentId,
                     openAppPendingIntentFn = openWalletAppPendingIntentFn,
                     preferredServices = preferredServices
-                ),
-                preselectedDocuments = emptyList()
+                )
             )
 
             var modelWatcherJob: Job? = null;
@@ -229,10 +230,10 @@ class PresentmentActivity: FragmentActivity() {
     override fun onResume() {
         super.onResume()
         val state = presentmentModel.state.value
-        if (state is PresentmentModel.State.Reset && state.documentChooserData != null) {
+        if (state is PresentmentModel.State.Reset && presentmentModel.showDocumentChooser != null) {
             NfcAdapter.getDefaultAdapter(this)?.let { adapter ->
                 val cardEmulation = CardEmulation.getInstance(adapter)
-                for (componentName in state.documentChooserData!!.preferredServices) {
+                for (componentName in presentmentModel.showDocumentChooser!!.preferredServices) {
                     if (!cardEmulation.setPreferredService(this, componentName)) {
                         Logger.w(TAG, "CardEmulation.setPreferredService() returned false for $componentName")
                     }
@@ -247,7 +248,7 @@ class PresentmentActivity: FragmentActivity() {
     override fun onPause() {
         super.onPause()
         val state = presentmentModel.state.value
-        if (state is PresentmentModel.State.Reset && state.documentChooserData != null) {
+        if (state is PresentmentModel.State.Reset && presentmentModel.showDocumentChooser != null) {
             NfcAdapter.getDefaultAdapter(this)?.let {
                 val cardEmulation = CardEmulation.getInstance(it)
                 if (!cardEmulation.unsetPreferredService(this)) {
@@ -341,7 +342,8 @@ internal fun PresentmentActivityContent(
         presentmentModel = getPresentmentModel()
         documentModel = DocumentModel.create(
             documentStore = presentmentModel!!.source.documentStore,
-            documentTypeRepository = presentmentModel!!.source.documentTypeRepository
+            documentTypeRepository = presentmentModel!!.source.documentTypeRepository,
+            badgeFunction = { document -> presentmentModel!!.source.getBadges(document) }
         )
         startFadeIn = true
     }
@@ -415,10 +417,10 @@ internal fun PresentmentActivityContent(
                         ),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    if (state is PresentmentModel.State.Reset && state.documentChooserData != null) {
+                    if (state is PresentmentModel.State.Reset && presentmentModel!!.showDocumentChooser != null) {
                         ShowCardChooser(
                             documentModel = documentModel!!,
-                            initiallySelectedDocumentId = state.documentChooserData!!.initiallySelectedDocumentId,
+                            initiallySelectedDocumentId = presentmentModel!!.showDocumentChooser!!.initiallySelectedDocumentId,
                             selectedDocIdFromCardChooser = selectedDocIdFromCardChooser,
                             contentBelow = {
                                 Column(
@@ -442,7 +444,7 @@ internal fun PresentmentActivityContent(
                                             onClick = {
                                                 coroutineScope.launch {
                                                     switchToAppOnFinishPendingIntent =
-                                                        state.documentChooserData!!.openAppPendingIntentFn(
+                                                        presentmentModel!!.showDocumentChooser!!.openAppPendingIntentFn(
                                                             presentmentModel!!.source.documentStore.lookupDocument(
                                                                 selectedDocIdFromCardChooser.value!!
                                                             )!!
@@ -535,16 +537,17 @@ private fun ShowCard(
     val configuration = LocalConfiguration.current
     val maxCardHeight = configuration.screenHeightDp.dp / 3
 
-    val documentInfo = documentModel.documentInfos.collectAsState().value.find { it.document.identifier == documentId }
+    val docInfos by documentModel.documentInfos.collectAsState()
+    val documentInfo = docInfos.find { it.document.identifier == documentId }
     if (documentInfo != null) {
-        VerticalDocumentList(
-            documentModel = documentModel,
-            focusedDocument = documentInfo,
+        VerticalCardList(
+            cardInfos = docInfos,
+            focusedCard = documentInfo,
             unfocusedVisiblePercent = 25,
-            allowDocumentReordering = false,
+            allowCardReordering = false,
             showStackWhileFocused = false,
             cardMaxHeight = maxCardHeight,
-            showDocumentInfo = { documentInfo ->
+            showCardInfo = { cardInfo ->
                 contentBelow()
             }
         )
@@ -567,10 +570,11 @@ private fun ShowCardChooser(
     val configuration = LocalConfiguration.current
     val maxCardHeight = configuration.screenHeightDp.dp / 3
 
+    val docInfos by documentModel.documentInfos.collectAsState()
     var focusedDocumentId by rememberSaveable { mutableStateOf<String?>(
-        initiallySelectedDocumentId ?: documentModel.documentInfos.value.firstOrNull()?.document?.identifier
+        initiallySelectedDocumentId ?: docInfos.firstOrNull()?.document?.identifier
     )}
-    val focusedDocument = documentModel.documentInfos.collectAsState().value.find { documentInfo ->
+    val focusedDocument = docInfos.find { documentInfo ->
         documentInfo.document.identifier == focusedDocumentId
     }
 
@@ -578,28 +582,29 @@ private fun ShowCardChooser(
         selectedDocIdFromCardChooser.value = focusedDocumentId
     }
 
-    VerticalDocumentList(
-        documentModel = documentModel,
-        focusedDocument = focusedDocument,
+    VerticalCardList(
+        cardInfos = docInfos,
+        focusedCard = focusedDocument,
         unfocusedVisiblePercent = 25,
-        allowDocumentReordering = false,
+        allowCardReordering = false,
         showStackWhileFocused = true,
         cardMaxHeight = maxCardHeight,
-        showDocumentInfo = { documentInfo -> contentBelow() },
-        emptyDocumentContent = {
+        showCardInfo = { cardInfo -> contentBelow() },
+        emptyContent = {
             Text(stringResource(
                 Res.string.presentment_activity_no_documents_available
             ))
         },
-        onDocumentFocused = { documentInfo ->
+        onCardFocused = { cardInfo ->
+            val documentInfo = cardInfo as DocumentInfo
             focusedDocumentId = documentInfo.document.identifier
             selectedDocIdFromCardChooser.value = documentInfo.document.identifier
         },
-        onDocumentFocusedTapped = { _ ->
+        onCardFocusedTapped = { _ ->
             focusedDocumentId = null
             selectedDocIdFromCardChooser.value = null
         },
-        onDocumentFocusedStackTapped = {
+        onCardFocusedStackTapped = {
             focusedDocumentId = null
             selectedDocIdFromCardChooser.value = null
         }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardBadge.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardBadge.kt
@@ -1,0 +1,104 @@
+package org.multipaz.compose.cards
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.multipaz.document.DocumentBadge
+
+/**
+ * A badge to be displayed on a card.
+ *
+ * @property text the text to display.
+ * @property color the color of the badge.
+ */
+data class CardBadge(
+    val text: String,
+    val color: Color
+) {
+    companion object {
+        /**
+         * Generates a [CardBadge] from a [DocumentBadge].
+         *
+         * @param badge the [DocumentBadge] to convert.
+         * @return the generated [CardBadge].
+         */
+        fun fromDocumentBadge(badge: DocumentBadge): CardBadge {
+            return CardBadge(
+                text = badge.text,
+                color = Color(
+                    red = badge.color.red,
+                    green = badge.color.green,
+                    blue = badge.color.blue
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Renders a list of [CardBadge]s as pill-shaped rectangles in the top-right corner.
+ *
+ * @param badges the list of badges to render.
+ * @param elevation the elevation of the badges.
+ * @param modifier the modifier for the container.
+ */
+@Composable
+fun CardBadges(
+    badges: List<CardBadge>,
+    elevation: Dp = 8.dp,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(12.dp),
+        horizontalAlignment = Alignment.End
+    ) {
+        badges.forEach { badge ->
+            val textColor = if (badge.color.luminance() > 0.5f) Color.Black else Color.White
+            Box(
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .graphicsLayer {
+                        this.shadowElevation = elevation.toPx()
+                        this.shape = RoundedCornerShape(50)
+                        this.clip = false
+                        this.ambientShadowColor = Color.Black
+                        this.spotShadowColor = Color.Black
+                    }
+                    .background(badge.color, RoundedCornerShape(50))
+                    .border(BorderStroke(1.dp, Color.Black.copy(alpha = 0.1f)), RoundedCornerShape(50))
+                    .padding(horizontal = 10.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = badge.text,
+                    color = textColor,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontFeatureSettings = "smcp",
+                        fontWeight = FontWeight.Bold,
+                        shadow = Shadow(
+                            color = Color.Black.copy(alpha = 0.6f),
+                            offset = Offset(0f, 2f),
+                            blurRadius = 4f
+                        )
+                    )
+                )
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardCarousel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardCarousel.kt
@@ -1,4 +1,4 @@
-package org.multipaz.compose.document
+package org.multipaz.compose.cards
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
@@ -25,7 +25,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
@@ -41,7 +40,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
@@ -50,6 +48,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -61,70 +60,59 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
-// MARK: - Internal Helper Models
-
-private data class CarouselModel(
-    val id: String,
-    val name: String,
-    val image: ImageBitmap
-)
-
-// MARK: - DocumentCarousel
-
 /**
- * A horizontal carousel composable that displays a collection of documents.
+ * A horizontal carousel composable that displays a collection of cards.
  *
- * [DocumentCarousel] provides a highly interactive way to browse, select, and reorder documents.
+ * [CardCarousel] provides a highly interactive way to browse, select, and reorder cards.
  * It features a "cover flow" style layout where the center item is elevated, and side items are scaled down.
  *
  * ## Features
  * - **Snap Scrolling**: Automatically snaps to the nearest card after dragging.
  * - **Reordering**: Long-press and drag to reorder items (optional).
- * - **Focus Reporting**: Reports which document is currently centered.
+ * - **Focus Reporting**: Reports which card is currently centered.
  * - **Custom Overlays**: Supports custom views for selected item information and empty states.
  *
  * @param modifier a [Modifier].
- * @param documentModel a [DocumentModel] with the documents to show a carousel for.
- * @param initialDocumentId the document to initially select.
- * @param allowReordering if `true` allow the user to reorder documents by long pressing.
- * @param onDocumentClicked action to perform when a document is tapped.
- * @param onDocumentFocused called when a new document is focused.
- * @param onDocumentReordered called when the user has reordered a document, to update the underlying [DocumentStore].
- * @param selectedDocumentInfo a composable to draw text underneath the focused document.
- * @param emptyDocumentContent a composable to draw text when there are no documents. This will be rendered in
+ * @param cardInfos the cards to show in the carousel.
+ * @param initialCardInfo the card to initially select.
+ * @param allowReordering if `true` allow the user to reorder cards by long pressing.
+ * @param onCardClicked action to perform when a card is tapped.
+ * @param onCardFocused called when a new card is focused.
+ * @param onCardReordered called when the user has reordered a card.
+ * @param selectedCardInfo a composable to draw text underneath the focused card.
+ * @param emptyCardContent a composable to draw text when there are no cards. This will be rendered in
  *   the center of a dashed outline of a grey card .
  */
 @Composable
-fun DocumentCarousel(
+fun CardCarousel(
     modifier: Modifier = Modifier,
-    documentModel: DocumentModel,
-    initialDocumentId: String? = null,
+    cardInfos: List<CardInfo>,
+    initialCardInfo: CardInfo? = null,
     allowReordering: Boolean = true,
-    onDocumentClicked: (DocumentInfo) -> Unit = {},
-    onDocumentFocused: (DocumentInfo) -> Unit = {},
-    onDocumentReordered: (document: DocumentInfo, oldIndex: Int, newIndex: Int) -> Unit = { _, _, _ -> },
-    selectedDocumentInfo: @Composable (docInfo: DocumentInfo?, index: Int, total: Int) -> Unit = { _, _, _ -> },
-    emptyDocumentContent: @Composable () -> Unit = { }
+    onCardClicked: (CardInfo) -> Unit = {},
+    onCardFocused: (CardInfo) -> Unit = {},
+    onCardReordered: (cardInfo: CardInfo, oldIndex: Int, newIndex: Int) -> Unit = { _, _, _ -> },
+    selectedCardInfo: @Composable (cardInfo: CardInfo?, index: Int, total: Int) -> Unit = { _, _, _ -> },
+    emptyCardContent: @Composable () -> Unit = { }
 ) {
-    val docInfos by documentModel.documentInfos.collectAsState()
-
     // Local state
-    var items by remember { mutableStateOf(emptyList<CarouselModel>()) }
+    var items by remember(cardInfos) { mutableStateOf(cardInfos) }
     val cardIndex = remember { Animatable(0f) }
     var hasInitialized by remember { mutableStateOf(false) }
-    var lastReportedFocusId by remember { mutableStateOf<String?>(null) }
+    var lastReportedFocusCard by remember { mutableStateOf<CardInfo?>(null) }
     var isReordering by remember { mutableStateOf(false) }
 
-    // Sync Items from Model
-    LaunchedEffect(docInfos) {
-        val newItems = docInfos.map { info ->
-            CarouselModel(
-                id = info.document.identifier,
-                name = info.document.displayName ?: "",
-                image = info.cardArt
-            )
+    // Initial Index Logic
+    LaunchedEffect(items) {
+        if (!hasInitialized && items.isNotEmpty()) {
+            val targetIndex = if (initialCardInfo != null) {
+                items.indexOfFirst { it.identifier == initialCardInfo.identifier }.takeIf { it >= 0 } ?: 0
+            } else {
+                0
+            }
+            cardIndex.snapTo(targetIndex.toFloat())
+            hasInitialized = true
         }
-        items = newItems
 
         // Clamp index if items reduced
         if (items.isNotEmpty()) {
@@ -132,17 +120,6 @@ fun DocumentCarousel(
             if (cardIndex.value > maxIndex) {
                 cardIndex.snapTo(maxIndex)
             }
-        }
-
-        // Initial Index Logic
-        if (!hasInitialized && items.isNotEmpty()) {
-            val targetIndex = if (initialDocumentId != null) {
-                items.indexOfFirst { it.id == initialDocumentId }.takeIf { it >= 0 } ?: 0
-            } else {
-                0
-            }
-            cardIndex.snapTo(targetIndex.toFloat())
-            hasInitialized = true
         }
     }
 
@@ -154,20 +131,17 @@ fun DocumentCarousel(
                 if (items.isEmpty() || isReordering) return@collect
 
                 val index = currentIndex.roundToInt().coerceIn(0, items.size - 1)
-                val focusedItem = items[index]
+                val focusedCard = items[index]
 
-                if (focusedItem.id != lastReportedFocusId) {
-                    val realDoc = docInfos.firstOrNull { it.document.identifier == focusedItem.id }
-                    if (realDoc != null) {
-                        lastReportedFocusId = focusedItem.id
-                        onDocumentFocused(realDoc)
-                    }
+                if (focusedCard != lastReportedFocusCard) {
+                    lastReportedFocusCard = focusedCard
+                    onCardFocused(focusedCard)
                 }
             }
     }
 
-    if (items.isEmpty() && docInfos.isEmpty()) {
-        EmptyStateView(modifier, emptyDocumentContent)
+    if (items.isEmpty()) {
+        EmptyStateView(modifier, emptyCardContent)
     } else {
         Column(
             modifier = modifier.fillMaxWidth(),
@@ -180,18 +154,13 @@ fun DocumentCarousel(
                 isReordering = isReordering,
                 onIsReorderingChange = { isReordering = it },
                 allowReordering = allowReordering,
-                onCarouselItemClick = { item ->
-                    val info = docInfos.firstOrNull { it.document.identifier == item.id }
-                    if (info != null) onDocumentClicked(info)
+                onCarouselItemClick = { cardInfo ->
+                    onCardClicked(cardInfo)
                 },
                 onReorder = { oldIndex, newIndex ->
                     if (newIndex in items.indices) {
-                        val movedItem = items[newIndex]
-                        // Parent has access to docInfos, so we do the lookup here
-                        val realDoc = docInfos.firstOrNull { it.document.identifier == movedItem.id }
-                        if (realDoc != null) {
-                            onDocumentReordered(realDoc, oldIndex, newIndex)
-                        }
+                        val movedCard = items[newIndex]
+                        onCardReordered(movedCard, oldIndex, newIndex)
                     }
                 },
                 onItemsChanged = { newItems -> items = newItems }
@@ -201,8 +170,7 @@ fun DocumentCarousel(
                 items = items,
                 cardIndex = cardIndex.value,
                 isReordering = isReordering,
-                documentInfos = docInfos,
-                selectedDocumentInfo = selectedDocumentInfo
+                selectedCardInfo = selectedCardInfo
             )
         }
     }
@@ -248,11 +216,10 @@ private fun EmptyStateView(modifier: Modifier, content: @Composable () -> Unit) 
 
 @Composable
 private fun InfoOverlayView(
-    items: List<CarouselModel>,
+    items: List<CardInfo>,
     cardIndex: Float,
     isReordering: Boolean,
-    documentInfos: List<DocumentInfo>,
-    selectedDocumentInfo: @Composable (DocumentInfo?, Int, Int) -> Unit
+    selectedCardInfo: @Composable (CardInfo?, Int, Int) -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -262,7 +229,7 @@ private fun InfoOverlayView(
     ) {
         val totalCount = items.size
 
-        items.forEachIndexed { index, item ->
+        items.forEachIndexed { index, cardInfo ->
             val dist = index.toFloat() - cardIndex
             val absDist = abs(dist)
 
@@ -276,12 +243,9 @@ private fun InfoOverlayView(
                         .graphicsLayer { alpha = opacity }
                 ) {
                     if (isReordering) {
-                        selectedDocumentInfo(null, index, totalCount)
+                        selectedCardInfo(null, index, totalCount)
                     } else {
-                        val realDoc = documentInfos.firstOrNull { it.document.identifier == item.id }
-                        if (realDoc != null) {
-                            selectedDocumentInfo(realDoc, index, totalCount)
-                        }
+                        selectedCardInfo(cardInfo, index, totalCount)
                     }
                 }
             }
@@ -293,14 +257,14 @@ private fun InfoOverlayView(
 
 @Composable
 private fun CardCarousel(
-    items: List<CarouselModel>,
+    items: List<CardInfo>,
     cardIndexAnimatable: Animatable<Float, AnimationVector1D>,
     isReordering: Boolean,
     onIsReorderingChange: (Boolean) -> Unit,
     allowReordering: Boolean,
-    onCarouselItemClick: (CarouselModel) -> Unit,
+    onCarouselItemClick: (CardInfo) -> Unit,
     onReorder: (Int, Int) -> Unit,
-    onItemsChanged: (List<CarouselModel>) -> Unit
+    onItemsChanged: (List<CardInfo>) -> Unit
 ) {
     val scope = rememberCoroutineScope()
     val hapticFeedback = LocalHapticFeedback.current
@@ -311,8 +275,8 @@ private fun CardCarousel(
     var lastHapticIndex by remember { mutableIntStateOf(0) }
 
     // Reorder State
-    // We track WHICH item is being dragged by ID to survive list swaps
-    var draggingItemId by remember { mutableStateOf<String?>(null) }
+    // We track WHICH item is being dragged by reference to survive list swaps
+    var draggingItem by remember { mutableStateOf<CardInfo?>(null) }
     var originalReorderIndex by remember { mutableStateOf<Int?>(null) }
     var dragOffsetX by remember { mutableFloatStateOf(0f) }
 
@@ -401,9 +365,9 @@ private fun CardCarousel(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            items.forEachIndexed { index, item ->
-                // key(item.id) is crucial for correct state retention during swaps
-                key(item.id) {
+            items.forEachIndexed { index, cardInfo ->
+                // key(cardInfo) is crucial for correct state retention during swaps
+                key(cardInfo) {
                     val i = index.toFloat()
                     val offset = i - cardIndex
                     val absOffset = abs(offset)
@@ -442,7 +406,7 @@ private fun CardCarousel(
                     val translationY = verticalOffsetPx * interpolation
 
                     // --- Reorder State Calculations ---
-                    val isBeingDragged = (item.id == draggingItemId)
+                    val isBeingDragged = (cardInfo == draggingItem)
 
                     // If dragged, use the cumulative drag offset + where it "should" be
                     val finalTranslationX = if (isBeingDragged) standardTranslationX + dragOffsetX else standardTranslationX
@@ -453,14 +417,14 @@ private fun CardCarousel(
                     Box(
                         modifier = Modifier
                             // 1. GESTURES FIRST: So they don't get lost when zIndex changes
-                            .pointerInput(item.id) {
+                            .pointerInput(cardInfo) {
                                 detectTapGestures {
                                     if (!isReordering && absOffset < 0.5f) {
-                                        onCarouselItemClick(item)
+                                        onCarouselItemClick(cardInfo)
                                     }
                                 }
                             }
-                            .pointerInput(item.id) {
+                            .pointerInput(cardInfo) {
                                 if (allowReordering) {
                                     detectDragGesturesAfterLongPress(
                                         onDragStart = {
@@ -468,9 +432,9 @@ private fun CardCarousel(
                                             if (!isReordering && isCurrentCard) {
                                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 onIsReorderingChange(true)
-                                                draggingItemId = item.id
+                                                draggingItem = cardInfo
 
-                                                val currentIndex = currentItems.indexOfFirst { it.id == item.id }
+                                                val currentIndex = currentItems.indexOfFirst { it.identifier == cardInfo.identifier }
                                                 originalReorderIndex = currentIndex
                                                 dragOffsetX = 0f
                                             }
@@ -479,11 +443,11 @@ private fun CardCarousel(
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
 
                                             onIsReorderingChange(false)
-                                            draggingItemId = null
+                                            draggingItem = null
                                             dragOffsetX = 0f
 
                                             // Notify listener of final move
-                                            val finalIdx = currentItems.indexOfFirst { it.id == item.id }
+                                            val finalIdx = currentItems.indexOfFirst { it.identifier == cardInfo.identifier }
                                             val origIdx = originalReorderIndex
                                             if (origIdx != null && finalIdx != -1 && origIdx != finalIdx) {
                                                 onReorder(origIdx, finalIdx)
@@ -492,12 +456,12 @@ private fun CardCarousel(
                                         },
                                         onDragCancel = {
                                             onIsReorderingChange(false)
-                                            draggingItemId = null
+                                            draggingItem = null
                                             dragOffsetX = 0f
                                             originalReorderIndex = null
                                         },
                                         onDrag = { change, dragAmount ->
-                                            if (draggingItemId != item.id) return@detectDragGesturesAfterLongPress
+                                            if (draggingItem != cardInfo) return@detectDragGesturesAfterLongPress
                                             change.consume()
 
                                             // Accumulate drag
@@ -505,7 +469,7 @@ private fun CardCarousel(
 
                                             // Logic to check for swaps
                                             val currentList = currentItems
-                                            val currentIndex = currentList.indexOfFirst { it.id == item.id }
+                                            val currentIndex = currentList.indexOfFirst { it.identifier == cardInfo.identifier }
                                             if (currentIndex == -1) return@detectDragGesturesAfterLongPress
 
                                             // Check Right Swap
@@ -557,11 +521,11 @@ private fun CardCarousel(
                                 this.translationY = translationY
                                 shadowElevation = finalShadow.toPx()
                                 shape = RoundedCornerShape(24.dp)
-                                clip = true
+                                clip = false
                             }
                     ) {
                         CarouselItem(
-                            item = item,
+                            cardInfo = cardInfo,
                             overlayAlpha = calculateOverlay(
                                 isReordering = isReordering,
                                 isCurrentCard = isCurrentCard,
@@ -594,27 +558,43 @@ private fun calculateOverlay(
 
 @Composable
 private fun CarouselItem(
-    item: CarouselModel,
+    cardInfo: CardInfo,
     overlayAlpha: Float
 ) {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.White)
+        modifier = Modifier.fillMaxSize()
     ) {
-        Image(
-            bitmap = item.image,
-            contentDescription = item.name,
-            contentScale = ContentScale.FillBounds,
-            modifier = Modifier.fillMaxSize()
-        )
-
-        if (overlayAlpha > 0) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.White.copy(alpha = overlayAlpha))
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    shape = RoundedCornerShape(24.dp)
+                    clip = true
+                }
+                .background(Color.White)
+        ) {
+            Image(
+                bitmap = cardInfo.cardArt,
+                contentDescription = null,
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier.fillMaxSize()
             )
+
+            if (overlayAlpha > 0) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White.copy(alpha = overlayAlpha))
+                )
+            }
         }
+
+        CardBadges(
+            badges = cardInfo.badges,
+            elevation = 8.dp,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .zIndex(100f)
+        )
     }
 }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardInfo.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardInfo.kt
@@ -1,0 +1,16 @@
+package org.multipaz.compose.cards
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+/**
+ * Interface for information about a card to be displayed in a list.
+ *
+ * @property identifier a unique identifier for this card.
+ * @property cardArt an image that represents this card to the user in the UI.
+ * @property badges a list of badges to display on the card.
+ */
+interface CardInfo {
+    val identifier: String
+    val cardArt: ImageBitmap
+    val badges: List<CardBadge>
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
@@ -1,4 +1,4 @@
-package org.multipaz.compose.document
+package org.multipaz.compose.cards
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -6,12 +6,13 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,9 +22,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
@@ -33,12 +35,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -47,6 +52,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
@@ -59,72 +65,71 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 /**
- * A vertically scrolling list of documents that mimics a physical wallet experience.
+ * A vertically scrolling list of cards that mimics a physical wallet experience.
  *
- * In its default state, documents are displayed as a vertical list of cards. The amount of
+ * In its default state, cards are displayed as a vertical list. The amount of
  * overlap between cards is configurable. Users can long-press a card to drag and drop it into
  * a new position.
  *
  * When a user taps a card, it enters a "focused" state. The focused card elevates and animates
- * to the top of the viewport. A dynamic content section ([showDocumentInfo]) fades in immediately
+ * to the top of the viewport. A dynamic content section ([showCardInfo]) fades in immediately
  * below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
  * bottom of the screen.
  *
  * @param modifier The modifier to be applied to the list container.
- * @param documentModel The [DocumentModel] providing the reactive flow of documents to display.
- * @param focusedDocument The currently focused document. When null, the component operates in
- * standard list mode. When set to a [DocumentInfo], that document is brought to the top and
+ * @param cardInfos The list of [CardInfo] objects to display.
+ * @param focusedCard The currently focused card. When null, the component operates in
+ * standard list mode. When set to a [CardInfo], that card is brought to the top and
  * detailed information is displayed.
  * @param unfocusedVisiblePercent Determines how much of each card is visible when not focused. A
  * value of `100` displays cards with standard spacing (no overlap). Lower values cause cards to
  * overlap, allowing more cards to fit on screen. Must be between 0 and 100.
- * @param allowDocumentReordering If true, users can long-press and drag cards to reorder them
+ * @param allowCardReordering If true, users can long-press and drag cards to reorder them
  * when in standard list mode. Defaults to true.
  * @param showStackWhileFocused If true, unfocused cards will collapse into a 3D stack at the bottom
- * of the screen when a document is focused. If false, unfocused cards fade away entirely to maximize
+ * of the screen when a card is focused. If false, unfocused cards fade away entirely to maximize
  * screen real estate for the detail view. Defaults to true.
  * @param cardMaxHeight An optional max height constraint for the cards. Useful for foldables and wide screens.
- * @param showDocumentInfo A composable slot that renders the detailed content below the focused card.
+ * @param showCardInfo A composable slot that renders the detailed content below the focused card.
  * It is horizontally centered by default.
- * @param emptyDocumentContent A composable slot displayed inside a dashed placeholder card when the
- * [documentModel] is empty.
- * @param onDocumentReordered Callback invoked when a drag-and-drop reordering operation completes.
- * Provides the [DocumentInfo] of the moved card and its new index position in the list.
- * @param onDocumentFocused Callback invoked when a document is tapped to be focused.
- * @param onDocumentFocusedTapped Callback invoked when the currently focused document is tapped.
- * @param onDocumentFocusedStackTapped Callback invoked when the unfocused document stack is tapped while another document is in focus.
+ * @param emptyContent A composable slot displayed inside a dashed placeholder card when the
+ * [cardInfos] list is empty.
+ * @param onCardReordered Callback invoked when a drag-and-drop reordering operation completes.
+ * Provides the [CardInfo] of the moved card and its new index position in the list.
+ * @param onCardFocused Callback invoked when a card is tapped to be focused.
+ * @param onCardFocusedTapped Callback invoked when the currently focused card is tapped.
+ * @param onCardFocusedStackTapped Callback invoked when the unfocused card stack is tapped while another card is in focus.
  *
  * @throws IllegalArgumentException if [unfocusedVisiblePercent] is not between 0 and 100.
  */
 @Composable
-fun VerticalDocumentList(
+fun VerticalCardList(
     modifier: Modifier = Modifier,
-    documentModel: DocumentModel,
-    focusedDocument: DocumentInfo?,
+    cardInfos: List<CardInfo>,
+    focusedCard: CardInfo?,
     unfocusedVisiblePercent: Int = 25,
-    allowDocumentReordering: Boolean = true,
+    allowCardReordering: Boolean = true,
     showStackWhileFocused: Boolean = true,
     cardMaxHeight: Dp = Dp.Unspecified,
-    showDocumentInfo: @Composable (DocumentInfo) -> Unit = {},
-    emptyDocumentContent: @Composable () -> Unit = { },
-    onDocumentReordered: (documentInfo: DocumentInfo, newPosition: Int) -> Unit = { _, _ -> },
-    onDocumentFocused: (documentInfo: DocumentInfo) -> Unit = {},
-    onDocumentFocusedTapped: (documentInfo: DocumentInfo) -> Unit = {},
-    onDocumentFocusedStackTapped: (documentInfo: DocumentInfo) -> Unit = {}
+    showCardInfo: @Composable (CardInfo) -> Unit = {},
+    emptyContent: @Composable () -> Unit = { },
+    onCardReordered: (cardInfo: CardInfo, newPosition: Int) -> Unit = { _, _ -> },
+    onCardFocused: (cardInfo: CardInfo) -> Unit = {},
+    onCardFocusedTapped: (cardInfo: CardInfo) -> Unit = {},
+    onCardFocusedStackTapped: (cardInfo: CardInfo) -> Unit = {}
 ) {
     if (unfocusedVisiblePercent !in 0..100) {
         throw IllegalArgumentException("unfocusedVisiblePercent must be between 0 and 100")
     }
 
-    val docInfos by documentModel.documentInfos.collectAsState()
     val scrollState = rememberScrollState()
     val haptic = LocalHapticFeedback.current
 
     // Local state to handle visual reordering without waiting for DB updates
-    var displayOrder by remember(docInfos) { mutableStateOf(docInfos) }
+    var displayOrder by remember(cardInfos) { mutableStateOf(cardInfos) }
 
     // Drag tracking state
-    var draggedDocId by remember { mutableStateOf<String?>(null) }
+    var draggedCard by remember { mutableStateOf<CardInfo?>(null) }
     var dragCurrentY by remember { mutableFloatStateOf(0f) }
     var dragJustEnded by remember { mutableStateOf(false) }
 
@@ -136,9 +141,8 @@ fun VerticalDocumentList(
         }
     }
 
-    val isAnyFocused = focusedDocument != null
-    val focusedId = focusedDocument?.document?.identifier
-    val focusedIndex = displayOrder.indexOfFirst { it.document.identifier == focusedId }.coerceAtLeast(0)
+    val isAnyFocused = focusedCard != null
+    val focusedIndex = displayOrder.indexOfFirst { it.identifier == focusedCard?.identifier }.coerceAtLeast(0)
 
     // A nested scroll connection to intercept and consume the overscroll effect cleanly
     val overscrollConsumer = remember {
@@ -156,7 +160,7 @@ fun VerticalDocumentList(
         }
     }
 
-    if (docInfos.isEmpty()) {
+    if (cardInfos.isEmpty()) {
         BoxWithConstraints(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.TopCenter
@@ -194,7 +198,7 @@ fun VerticalDocumentList(
                     },
                 contentAlignment = Alignment.Center
             ) {
-                emptyDocumentContent()
+                emptyContent()
             }
         }
         return
@@ -282,20 +286,18 @@ fun VerticalDocumentList(
                         .padding(top = topOffsetDp, bottom = detailBottomPaddingDp),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    if (focusedDocument != null) {
-                        showDocumentInfo(focusedDocument)
+                    if (focusedCard != null) {
+                        showCardInfo(focusedCard)
                     }
                 }
             }
 
             // Iterate over displayOrder so dragged positions instantly update visually
-            displayOrder.forEachIndexed { index, docInfo ->
-                val identifier = docInfo.document.identifier
-
+            displayOrder.forEachIndexed { index, cardInfo ->
                 // key block prevents the layout from destroying gesture state when cards swap indices
-                key(identifier) {
-                    val isFocused = identifier == focusedId
-                    val isDragged = identifier == draggedDocId
+                key(cardInfo) {
+                    val isFocused = cardInfo == focusedCard
+                    val isDragged = cardInfo == draggedCard
                     val viewportTop = scrollState.value.toFloat()
 
                     val targetY: Float
@@ -357,14 +359,14 @@ fun VerticalDocumentList(
                                 shadowElevation = animatedElevation.dp.toPx()
                                 alpha = animatedAlpha
                                 shape = RoundedCornerShape(24.dp)
-                                clip = true
+                                clip = false
                             }
-                            .pointerInput(isAnyFocused, allowDocumentReordering) {
-                                if (!isAnyFocused && allowDocumentReordering) {
+                            .pointerInput(isAnyFocused, allowCardReordering) {
+                                if (!isAnyFocused && allowCardReordering) {
                                     detectDragGesturesAfterLongPress(
                                         onDragStart = { _ ->
-                                            draggedDocId = identifier
-                                            val currentIndex = displayOrder.indexOfFirst { it.document.identifier == identifier }
+                                            draggedCard = cardInfo
+                                            val currentIndex = displayOrder.indexOfFirst { it.identifier == cardInfo.identifier }
                                             dragCurrentY = paddingTopPx + currentIndex * listStepPx
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         },
@@ -377,7 +379,7 @@ fun VerticalDocumentList(
                                                 .roundToInt()
                                                 .coerceIn(0, displayOrder.lastIndex)
 
-                                            val currentIndex = displayOrder.indexOfFirst { it.document.identifier == identifier }
+                                            val currentIndex = displayOrder.indexOfFirst { it.identifier == cardInfo.identifier }
 
                                             if (currentIndex != -1 && newIndex != currentIndex) {
                                                 // Swap the items visually in the local state
@@ -391,49 +393,60 @@ fun VerticalDocumentList(
                                         },
                                         onDragEnd = {
                                             dragJustEnded = true
-                                            if (draggedDocId != null) {
-                                                val finalIndex = displayOrder.indexOfFirst { it.document.identifier == draggedDocId }
-                                                val finalDoc = displayOrder.getOrNull(finalIndex)
+                                            if (draggedCard != null) {
+                                                val finalIndex = displayOrder.indexOfFirst { it.identifier == draggedCard?.identifier }
+                                                val finalCard = draggedCard!!
 
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                draggedDocId = null
+                                                draggedCard = null
 
-                                                if (finalDoc != null) {
-                                                    onDocumentReordered(finalDoc, finalIndex)
-                                                }
+                                                onCardReordered(finalCard, finalIndex)
                                             }
                                         },
                                         onDragCancel = {
                                             dragJustEnded = true
-                                            draggedDocId = null
+                                            draggedCard = null
                                         }
                                     )
                                 }
                             }
                             .clickable {
                                 // Block clicks if a drag is occurring, or ended in the last 300ms
-                                if (dragJustEnded || draggedDocId != null) return@clickable
+                                if (dragJustEnded || draggedCard != null) return@clickable
 
                                 if (isAnyFocused) {
-                                    focusedDocument?.let {
+                                    focusedCard.let {
                                         if (isFocused) {
                                             // The user tapped the card that is currently focused
-                                            onDocumentFocusedTapped(it)
+                                            onCardFocusedTapped(it)
                                         } else {
                                             // The user tapped a card in the unfocused stack
-                                            onDocumentFocusedStackTapped(it)
+                                            onCardFocusedStackTapped(it)
                                         }
                                     }
                                 } else {
-                                    onDocumentFocused(docInfo)
+                                    onCardFocused(cardInfo)
                                 }
                             }
                     ) {
                         Image(
-                            bitmap = docInfo.cardArt,
-                            contentDescription = docInfo.document.displayName ?: "Document Card",
+                            bitmap = cardInfo.cardArt,
+                            contentDescription = "Card Image",
                             contentScale = ContentScale.FillWidth,
-                            modifier = Modifier.fillMaxSize()
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .graphicsLayer {
+                                    shape = RoundedCornerShape(24.dp)
+                                    clip = true
+                                }
+                        )
+
+                        CardBadges(
+                            badges = cardInfo.badges,
+                            elevation = 8.dp,
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .zIndex(100f)
                         )
                     }
                 }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentInfo.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentInfo.kt
@@ -1,6 +1,8 @@
 package org.multipaz.compose.document
 
 import androidx.compose.ui.graphics.ImageBitmap
+import org.multipaz.compose.cards.CardBadge
+import org.multipaz.compose.cards.CardInfo
 import org.multipaz.document.Document
 
 /**
@@ -8,10 +10,15 @@ import org.multipaz.document.Document
  *
  * @property document the [Document] instance as stored in the [org.multipaz.document.DocumentStore]
  * @property cardArt an image that represents this document to the user in the UI.
+ * @property badges badges for the document.
  * @property credentialInfos list of [CredentialInfo]
  */
 data class DocumentInfo(
     val document: Document,
-    val cardArt: ImageBitmap,
+    override val cardArt: ImageBitmap,
+    override val badges: List<CardBadge>,
     val credentialInfos: List<CredentialInfo>
-)
+): CardInfo {
+    override val identifier: String
+        get() = document.identifier
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
@@ -10,13 +10,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborMap
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.cards.CardBadge
 import org.multipaz.compose.decodeImage
 import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
@@ -24,15 +24,13 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.document.Document
 import org.multipaz.document.DocumentAdded
+import org.multipaz.document.DocumentBadge
 import org.multipaz.document.DocumentDeleted
 import org.multipaz.document.DocumentEvent
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.DocumentUpdated
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.storage.Storage
 import org.multipaz.storage.StorageTable
-import org.multipaz.storage.StorageTableSpec
-import org.multipaz.storage.ephemeral.EphemeralStorage
 import org.multipaz.util.Logger
 import org.multipaz.util.LruCache
 
@@ -84,6 +82,7 @@ class DocumentModel private constructor(
     private val documentStore: DocumentStore,
     private val documentTypeRepository: DocumentTypeRepository?,
     private val documentOrderKey: String = "org.multipaz.DocumentModel.orderingKey",
+    private val badgeFunction: suspend (document: Document) -> List<DocumentBadge>,
 ) {
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default)
     private val _documentInfos = MutableStateFlow<List<DocumentInfo>>(emptyList())
@@ -218,7 +217,7 @@ class DocumentModel private constructor(
     private val cardArtCache = LruCache<ByteString, ImageBitmap>(5)
 
     private suspend fun Document.toDocumentInfo(): DocumentInfo {
-        cardArt?.let {
+        cardArt?.let { it ->
             val image = it.toByteArray()
             val imageSha256 = ByteString(Crypto.digest(Algorithm.SHA256, image))
             var cardArt = cardArtCache.get(imageSha256)
@@ -229,12 +228,14 @@ class DocumentModel private constructor(
             return DocumentInfo(
                 document = this,
                 cardArt = cardArt,
+                badges = badgeFunction(this).map { docBadge -> CardBadge.fromDocumentBadge(docBadge) },
                 credentialInfos = buildCredentialInfos(documentTypeRepository)
             )
         }
         return DocumentInfo(
             document = this,
             cardArt = Branding.Current.value.renderFallbackCardArt(this),
+            badges = badgeFunction(this).map { docBadge -> CardBadge.fromDocumentBadge(docBadge) },
             credentialInfos = buildCredentialInfos(documentTypeRepository)
         )
     }
@@ -247,16 +248,19 @@ class DocumentModel private constructor(
          * @param documentTypeRepository a [DocumentTypeRepository] with information about document types or `null`.
          * @param documentOrderKey the name of the key to use for storing the document order in the [Tags] object
          *   associated with  [documentStore].
+         * @param badgeFunction a function that takes a [Document] and returns a list of badges to show.
          */
         suspend fun create(
             documentStore: DocumentStore,
             documentTypeRepository: DocumentTypeRepository?,
             documentOrderKey: String = "org.multipaz.DocumentModel.orderingKey",
+            badgeFunction: suspend (document: Document) -> List<DocumentBadge> = { emptyList() }
         ): DocumentModel {
             val documentModel = DocumentModel(
-                documentStore,
-                documentTypeRepository,
-                documentOrderKey
+                documentStore = documentStore,
+                documentTypeRepository = documentTypeRepository,
+                documentOrderKey = documentOrderKey,
+                badgeFunction = badgeFunction
             )
             documentModel.initialize()
             return documentModel

--- a/multipaz-swiftui/src/iosMain/swift/CardBadge.swift
+++ b/multipaz-swiftui/src/iosMain/swift/CardBadge.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import UIKit
+
+/// A badge to be displayed on a card.
+public struct CardBadge: Hashable, Sendable {
+    /// the text to display.
+    public let text: String
+    /// the color of the badge.
+    public let color: Color
+    
+    public init(text: String, color: Color) {
+        self.text = text
+        self.color = color
+    }
+}
+
+/// A view that renders a list of ``CardBadge``s.
+public struct CardBadgesView: View {
+    let badges: [CardBadge]
+    
+    public init(badges: [CardBadge]) {
+        self.badges = badges
+    }
+    
+    public var body: some View {
+        VStack(alignment: .trailing, spacing: 8) {
+            ForEach(badges, id: \.text) { badge in
+                Text(badge.text)
+                    .font(Font.system(.footnote).weight(.bold).smallCaps())
+                    .foregroundColor(badge.color.isLight ? .black : .white)
+                    .shadow(color: .black.opacity(0.4), radius: 1, x: 0, y: 1)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(
+                        Capsule()
+                            .fill(badge.color)
+                            .shadow(color: .black.opacity(0.4), radius: 8, x: 0, y: 4)
+                    )
+            }
+        }
+        .padding(12)
+    }
+}
+
+extension Color {
+    var isLight: Bool {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        // Use UIColor to get components as SwiftUI.Color doesn't provide them easily across platforms/versions
+        UIColor(self).getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
+        return luminance > 0.5
+    }
+}

--- a/multipaz-swiftui/src/iosMain/swift/CardCarousel.swift
+++ b/multipaz-swiftui/src/iosMain/swift/CardCarousel.swift
@@ -2,161 +2,114 @@ import SwiftUI
 import UIKit
 import Combine
 
-// MARK: - Internal Helper Models
-
-private struct CarouselModel: Identifiable, Equatable {
-    let id: String
-    let name: String
-    let image: UIImage
-    
-    static func == (lhs: CarouselModel, rhs: CarouselModel) -> Bool {
-        return lhs.id == rhs.id
-    }
-}
-
-// MARK: - DocumentCarousel
-
-/// A horizontal carousel view that displays a collection of documents.
+/// A horizontal carousel view that displays a collection of cards.
 ///
-/// `DocumentCarousel` provides a highly interactive way to browse, select, and reorder documents.
+/// ``CardCarousel`` provides a highly interactive way to browse, select, and reorder cards.
 /// It features a "cover flow" style layout where the center item is elevated, and side items are scaled down.
 ///
 /// ## Features
 /// - **Snap Scrolling**: Automatically snaps to the nearest card after dragging.
 /// - **Reordering**: Long-press and drag to reorder items (optional).
-/// - **Focus Reporting**: Reports which document is currently centered.
+/// - **Focus Reporting**: Reports which card is currently centered.
 /// - **Custom Overlays**: Supports custom views for selected item information and empty states.
-///
-/// ## Usage Example
-///
-/// ```swift
-/// DocumentCarousel(
-///     documentModel: myDocumentModel,
-///     initialDocumentId: "doc_123",
-///     allowReordering: true,
-///     onDocumentClicked: { docInfo in
-///         print("Tapped on: \(docInfo.document.displayName ?? "Unknown")")
-///     },
-///     onDocumentReordered: { docInfo, oldIndex, newIndex in
-///         print("Moved \(docInfo.document.identifier) from \(oldIndex) to \(newIndex)")
-///     },
-///     selectedDocumentInfo: { docInfo, index, total in
-///         // A view that appears below the active card
-///         VStack {
-///             Text(docInfo?.document.displayName ?? "Loading...")
-///                 .font(.headline)
-///             Text("\(index + 1) of \(total)")
-///                 .font(.caption)
-///         }
-///     },
-///     emptyDocumentContent: {
-///         Text("No Documents Found")
-///     }
-/// )
-/// ```
-public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View {
+public struct CardCarousel<EmptyContent: View, SelectedContent: View>: View {
     
     // MARK: - Properties
     
-    /// The data source containing the list of documents to display.
-    public var documentModel: DocumentModel
+    /// The list of cards to display.
+    public var cardInfos: [CardInfo]
     
-    /// The identifier of the document to focus on immediately upon loading.
-    public var initialDocumentId: String?
+    /// The card to focus on immediately upon loading.
+    public var initialCardInfo: CardInfo?
     
     /// Controls whether the user can reorder cards via long-press and drag.
     /// Defaults to `true`.
     public var allowReordering: Bool
     
-    /// Callback triggered when a document card is tapped.
-    public var onDocumentClicked: (DocumentInfo) -> Void
+    /// Callback triggered when a card is tapped.
+    public var onCardClicked: (CardInfo) -> Void
     
-    /// Callback triggered when a document settles in the center of the screen.
-    public var onDocumentFocused: (DocumentInfo) -> Void
+    /// Callback triggered when a card settles in the center of the screen.
+    public var onCardFocused: (CardInfo) -> Void
     
-    /// Callback triggered when a document has been successfully moved to a new index.
+    /// Callback triggered when a card has been successfully moved to a new index.
     /// - Parameters:
-    ///   - document: The document that was moved.
+    ///   - cardInfo: The card that was moved.
     ///   - oldIndex: The original index before the move.
     ///   - newIndex: The new index after the move.
-    public var onDocumentReordered: (_ document: DocumentInfo, _ oldIndex: Int, _ newIndex: Int) -> Void
+    public var onCardReordered: (_ cardInfo: CardInfo, _ oldIndex: Int, _ newIndex: Int) -> Void
     
-    /// A view builder that constructs the overlay information for the currently selected document.
+    /// A view builder that constructs the overlay information for the currently selected card.
     ///
     /// The closure provides:
-    /// - `DocumentInfo?`: The currently focused document (nil during reordering).
+    /// - `CardInfo?`: The currently focused card (nil during reordering).
     /// - `Int`: The current index.
     /// - `Int`: The total number of items.
-    public var selectedDocumentInfo: (DocumentInfo?, Int, Int) -> SelectedContent
+    public var selectedCardInfo: (CardInfo?, Int, Int) -> SelectedContent
     
-    /// A view builder that constructs the content to display when there are no documents.
-    public var emptyDocumentContent: () -> EmptyContent
+    /// A view builder that constructs the content to display when there are no cards.
+    public var emptyCardContent: () -> EmptyContent
     
     // MARK: - State
     
-    @State private var items: [CarouselModel] = []
+    @State private var items: [CardInfo] = []
     @State private var cardIndex: CGFloat = 0
     @State private var hasInitialized: Bool = false
-    @State private var lastReportedFocusId: String? = nil
+    @State private var lastReportedFocusCard: CardInfo? = nil
     @State private var isReordering: Bool = false
     
     // MARK: - Initializer
     
-    /// Creates a new `DocumentCarousel` instance.
+    /// Creates a new ``CardCarousel`` instance.
     ///
     /// - Parameters:
-    ///   - documentModel: The data model containing document information.
-    ///   - initialDocumentId: An optional ID to scroll to initially.
+    ///   - cardInfos: The cards to display.
+    ///   - initialCardInfo: An optional card to scroll to initially.
     ///   - allowReordering: If `true`, enables long-press to reorder cards. Defaults to `true`.
-    ///   - onDocumentClicked: Action to perform when a card is tapped.
-    ///   - onDocumentFocused: Action to perform when a card becomes the center focus.
-    ///   - onDocumentReordered: Action to perform when the order changes.
-    ///   - selectedDocumentInfo: Builder for the info view below the focused card.
-    ///   - emptyDocumentContent: Builder for the empty state view.
+    ///   - onCardClicked: Action to perform when a card is tapped.
+    ///   - onCardFocused: Action to perform when a card becomes the center focus.
+    ///   - onCardReordered: Action to perform when the order changes.
+    ///   - selectedCardInfo: Builder for the info view below the focused card.
+    ///   - emptyCardContent: Builder for the empty state view.
     public init(
-        documentModel: DocumentModel,
-        initialDocumentId: String? = nil,
+        cardInfos: [CardInfo],
+        initialCardInfo: CardInfo? = nil,
         allowReordering: Bool = true,
-        onDocumentClicked: @escaping (DocumentInfo) -> Void = { _ in },
-        onDocumentFocused: @escaping (DocumentInfo) -> Void = { _ in },
-        onDocumentReordered: @escaping (DocumentInfo, Int, Int) -> Void = { _, _, _ in },
-        @ViewBuilder selectedDocumentInfo: @escaping (DocumentInfo?, Int, Int) -> SelectedContent,
-        @ViewBuilder emptyDocumentContent: @escaping () -> EmptyContent = { EmptyView() }
+        onCardClicked: @escaping (CardInfo) -> Void = { _ in },
+        onCardFocused: @escaping (CardInfo) -> Void = { _ in },
+        onCardReordered: @escaping (CardInfo, Int, Int) -> Void = { _, _, _ in },
+        @ViewBuilder selectedCardInfo: @escaping (CardInfo?, Int, Int) -> SelectedContent,
+        @ViewBuilder emptyCardContent: @escaping () -> EmptyContent = { EmptyView() }
     ) {
-        self.documentModel = documentModel
-        self.initialDocumentId = initialDocumentId
+        self.cardInfos = cardInfos
+        self.initialCardInfo = initialCardInfo
         self.allowReordering = allowReordering
-        self.onDocumentClicked = onDocumentClicked
-        self.onDocumentFocused = onDocumentFocused
-        self.onDocumentReordered = onDocumentReordered
-        self.selectedDocumentInfo = selectedDocumentInfo
-        self.emptyDocumentContent = emptyDocumentContent
+        self.onCardClicked = onCardClicked
+        self.onCardFocused = onCardFocused
+        self.onCardReordered = onCardReordered
+        self.selectedCardInfo = selectedCardInfo
+        self.emptyCardContent = emptyCardContent
     }
     
     // MARK: - Body
     
     public var body: some View {
-        if items.isEmpty && documentModel.documentInfos.isEmpty {
+        if items.isEmpty && cardInfos.isEmpty {
             emptyStateView
         } else {
             VStack(spacing: -10) {
-                CardCarousel(
+                CardCarouselInternal(
                     items: $items,
                     cardIndex: $cardIndex,
                     isReordering: $isReordering,
                     allowReordering: allowReordering,
                     onCarouselItemClick: { item in
-                        if let info = documentModel.documentInfos.first(where: { $0.document.identifier == item.id }) {
-                            onDocumentClicked(info)
-                        }
+                        onCardClicked(item)
                     },
                     onReorder: { oldIndex, newIndex in
                         guard newIndex >= 0 && newIndex < items.count else { return }
                         let movedItem = items[newIndex]
-                        
-                        if let realDoc = documentModel.documentInfos.first(where: { $0.document.identifier == movedItem.id }) {
-                            onDocumentReordered(realDoc, oldIndex, newIndex)
-                        }
+                        onCardReordered(movedItem, oldIndex, newIndex)
                     }
                 )
                 
@@ -169,7 +122,7 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
                     reportFocusChange()
                 }
             }
-            .onChange(of: documentModel.documentInfos) { _, _ in
+            .onChange(of: cardInfos.count) { _, _ in
                 syncItemsFromModel()
                 
                 if !items.isEmpty {
@@ -202,7 +155,7 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
                     )
                     .frame(width: cardWidth, height: cardHeight)
                 
-                emptyDocumentContent()
+                emptyCardContent()
             }
             .frame(width: width, height: geometry.size.height)
         }
@@ -213,7 +166,7 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
         ZStack {
             let totalCount = items.count
             
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                 let dist = CGFloat(index) - cardIndex
                 let absDist = abs(dist)
                 
@@ -222,17 +175,15 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
                     let xOffset = dist * 30
                     
                     if isReordering {
-                        selectedDocumentInfo(nil, index, totalCount)
+                        selectedCardInfo(nil, index, totalCount)
                             .opacity(opacity)
                             .offset(x: xOffset)
                             .allowsHitTesting(false)
                     } else {
-                        if let realDoc = documentModel.documentInfos.first(where: { $0.document.identifier == item.id }) {
-                            selectedDocumentInfo(realDoc, index, totalCount)
-                                .opacity(opacity)
-                                .offset(x: xOffset)
-                                .allowsHitTesting(false)
-                        }
+                        selectedCardInfo(item, index, totalCount)
+                            .opacity(opacity)
+                            .offset(x: xOffset)
+                            .allowsHitTesting(false)
                     }
                 }
             }
@@ -243,20 +194,14 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
     // MARK: - Helpers
     
     private func syncItemsFromModel() {
-        self.items = documentModel.documentInfos.map { info in
-            CarouselModel(
-                id: info.document.identifier,
-                name: info.document.displayName ?? "",
-                image: info.cardArt
-            )
-        }
+        self.items = cardInfos
     }
     
     private func updateInitialIndex() {
         guard !items.isEmpty else { return }
         
-        if let targetId = initialDocumentId,
-           let index = items.firstIndex(where: { $0.id == targetId }) {
+        if let target = initialCardInfo,
+           let index = items.firstIndex(where: { $0.identifier == target.identifier }) {
             cardIndex = CGFloat(index)
         } else {
             if !hasInitialized {
@@ -275,24 +220,22 @@ public struct DocumentCarousel<EmptyContent: View, SelectedContent: View>: View 
         
         let focusedItem = items[index]
         
-        if focusedItem.id != lastReportedFocusId {
-            if let realDoc = documentModel.documentInfos.first(where: { $0.document.identifier == focusedItem.id }) {
-                lastReportedFocusId = focusedItem.id
-                onDocumentFocused(realDoc)
-            }
+        if focusedItem.identifier != lastReportedFocusCard?.identifier {
+            lastReportedFocusCard = focusedItem
+            onCardFocused(focusedItem)
         }
     }
 }
 
 // MARK: - Internal Implementation
 
-private struct CardCarousel: View {
-    @Binding var items: [CarouselModel]
+private struct CardCarouselInternal: View {
+    @Binding var items: [CardInfo]
     @Binding var cardIndex: CGFloat
     @Binding var isReordering: Bool
     
     let allowReordering: Bool
-    let onCarouselItemClick: (CarouselModel) -> Void
+    let onCarouselItemClick: (CardInfo) -> Void
     let onReorder: (Int, Int) -> Void
     
     // Scroll State
@@ -318,7 +261,7 @@ private struct CardCarousel: View {
             let fractionalPart = cardIndex - CGFloat(Int(floor(cardIndex)))
             
             ZStack {
-                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                     let i = CGFloat(index)
                     let offset = i - cardIndex
                     let absOffset = abs(offset)
@@ -586,16 +529,18 @@ private struct CardCarousel: View {
 // MARK: - Carousel Item View
 
 private struct CarouselItem: View {
-    let item: CarouselModel
+    let item: CardInfo
     let overlayAlpha: Double
     
     var body: some View {
-        ZStack {
-            Image(uiImage: item.image)
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: item.cardArt)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .clipped()
+            
+            CardBadgesView(badges: item.badges)
             
             if overlayAlpha > 0 {
                 Color.white.opacity(overlayAlpha)

--- a/multipaz-swiftui/src/iosMain/swift/CardInfo.swift
+++ b/multipaz-swiftui/src/iosMain/swift/CardInfo.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+/// An interface for information about a card to be displayed in a list.
+public protocol CardInfo {
+    /// Unique identifier for the card.
+    var identifier: String { get }
+    /// Card art for the card.
+    var cardArt: UIImage { get }
+    /// Badges for the card.
+    var badges: [CardBadge] { get }
+}

--- a/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
+++ b/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Combine
+import SwiftUI
 
 /// A structure with information about a ``Credential``.
 public struct CredentialInfo: Hashable {
@@ -17,12 +18,18 @@ public struct CredentialInfo: Hashable {
 }
 
 /// A structure with information about a ``Document``.
-public struct DocumentInfo: Hashable {
+public struct DocumentInfo: Hashable, CardInfo {
+    /// A unique identifier for the document.
+    public var identifier: String { document.identifier }
+
     /// A reference to the ``Document`` this information is about.
     public let document: Document
     
     /// Card art for the document.
     public let cardArt: UIImage
+    
+    /// Badges for the document.
+    public let badges: [CardBadge]
     
     /// The credentials for the document.
     public let credentialInfos: [CredentialInfo]
@@ -54,6 +61,9 @@ public class DocumentModel {
     
     let documentTypeRepository: DocumentTypeRepository?
     let documentOrderKey: String
+    let badgeFunction: @Sendable (
+        _ document: Document
+    ) async -> [DocumentBadge]
 
     /**
      * Initialization for ``DocumentModel``.
@@ -62,14 +72,19 @@ public class DocumentModel {
      *   - documentStore: the ``DocumentStore`` to use as a source of truth.
      *   - documentTypeRepository: a ``DocumentTypeRepository`` with information about document types or nil.
      *   - documentOrderKey: the name of the key to use for storing the document order in the ``Tags`` object associated with  ``documentStore``.
+     *   - badgeFunction: a function to return badges for a document.
      */
     public init(
         documentStore: DocumentStore,
         documentTypeRepository: DocumentTypeRepository?,
-        documentOrderKey: String = "org.multipaz.DocumentModel.orderingKey"
+        documentOrderKey: String = "org.multipaz.DocumentModel.orderingKey",
+        badgeFunction: @escaping @Sendable (
+            _ document: Document
+        ) async -> [DocumentBadge] = { document in [] }
     ) async throws {
         self.documentTypeRepository = documentTypeRepository
         self.documentOrderKey = documentOrderKey
+        self.badgeFunction = badgeFunction
         self.documentStore = documentStore
         self.storageData = if let encoded = try await documentStore.getTags().getByteString(key: documentOrderKey) {
             DocumentModelStorageData.fromDataItem(
@@ -173,6 +188,16 @@ public class DocumentModel {
         return DocumentInfo(
             document: document,
             cardArt: document.renderCardArt(),
+            badges: await badgeFunction(document).map { docBadge in
+                CardBadge(
+                    text: docBadge.text,
+                    color: Color(
+                        red: Double(docBadge.color.red)/255.0,
+                        green: Double(docBadge.color.green)/255.0,
+                        blue: Double(docBadge.color.blue)/255.0
+                    )
+                )
+            },
             credentialInfos: credentialInfos
         )
     }

--- a/multipaz-swiftui/src/iosMain/swift/Extensions.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Extensions.swift
@@ -39,3 +39,4 @@ extension Document.Editor: @unchecked Sendable {}
 extension DocumentProvisioningSettings: @unchecked Sendable {}
 extension CredentialMetadata: @unchecked Sendable {}
 extension ProvisioningMetadata: @unchecked Sendable {}
+extension DocumentBadge: @unchecked Sendable {}

--- a/multipaz-swiftui/src/iosMain/swift/SimplePresentmentSourceExt.swift
+++ b/multipaz-swiftui/src/iosMain/swift/SimplePresentmentSourceExt.swift
@@ -33,6 +33,9 @@ extension SimplePresentmentSource.Companion {
             _ preselectedDocuments: [Document],
             _ onDocumentsInFocus: @escaping @Sendable (_ documents: [Document]) -> Void,
         ) async -> CredentialPresentmentSelection?,
+        getBadgesFn: @escaping @Sendable (
+            _ document: Document
+        ) async -> [DocumentBadge] = { document in [] },
         preferSignatureToKeyAgreement: Bool = true,
         domainsMdocSignature: [ String ] = [],
         domainsMdocKeyAgreement: [ String ] = [],
@@ -46,6 +49,7 @@ extension SimplePresentmentSource.Companion {
             eventLogger: eventLogger,
             resolveTrustFn: ResolveTrustHandler(f: resolveTrustFn),
             showConsentPromptFn: ShowConsentPromptHandler(f: showConsentPromptFn),
+            getBadgesFn: GetBadgesHandler(f: getBadgesFn),
             preferSignatureToKeyAgreement: preferSignatureToKeyAgreement,
             domainsMdocSignature: domainsMdocSignature,
             domainsMdocKeyAgreement: domainsMdocKeyAgreement,
@@ -109,6 +113,25 @@ private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
                 preselectedDocuments,
                 { documents in }
             )
+            completionHandler(value, nil)
+        }
+    }
+}
+
+private class GetBadgesHandler: KotlinSuspendFunction1 {
+    let f: @Sendable (
+        _ document: Document
+    ) async -> [DocumentBadge]
+    
+    init(f: @escaping @Sendable (_ document: Document) async -> [DocumentBadge]) {
+        self.f = f
+    }
+
+    func __invoke(p1: Any?, completionHandler: @escaping @Sendable (Any?, (any Error)?) -> Void) {
+        let document = p1 as! Document
+        let f = self.f
+        Task {
+            let value = await f(document)
             completionHandler(value, nil)
         }
     }

--- a/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
+++ b/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIKit
 import Combine
 
-private struct DocumentListScrollOffsetKey: PreferenceKey {
+private struct CardListScrollOffsetKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value += nextValue()
@@ -77,86 +77,86 @@ private struct CardInteractionView: UIViewRepresentable {
     }
 }
 
-/// A vertically scrolling list of documents that mimics a physical wallet experience.
+/// A vertically scrolling list of cards that mimics a physical wallet experience.
 ///
-/// In its default state, documents are displayed as a vertical list of cards. The amount of
+/// In its default state, cards are displayed as a vertical list. The amount of
 /// overlap between cards is configurable. Users can long-press a card to drag and drop it into
 /// a new position.
 ///
 /// When a user taps a card, it enters a "focused" state. The focused card elevates and animates
-/// to the top of the viewport. A dynamic content section (`showDocumentInfo`) fades in immediately
+/// to the top of the viewport. A dynamic content section (`showCardInfo`) fades in immediately
 /// below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
 /// bottom of the screen.
 ///
 /// - Parameters:
-///   - documentModel: The `DocumentModel` providing the reactive flow of documents to display.
-///   - focusedDocument: The currently focused document. When `nil`, the component operates in
-///     standard list mode. When set to a `DocumentInfo`, that document is brought to the top and
+///   - cardInfos: The list of `CardInfo` objects to display.
+///   - focusedCard: The currently focused card. When `nil`, the component operates in
+///     standard list mode. When set to a `CardInfo`, that card is brought to the top and
 ///     detailed information is displayed.
 ///   - unfocusedVisiblePercent: Determines how much of each card is visible when not focused. A
 ///     value of `100` displays cards with standard spacing (no overlap). Lower values cause cards to
 ///     overlap, allowing more cards to fit on screen. Must be between 0 and 100.
-///   - allowDocumentReordering: If `true`, users can long-press and drag cards to reorder them
+///   - allowCardReordering: If `true`, users can long-press and drag cards to reorder them
 ///     when in standard list mode. Defaults to `true`.
 ///   - showStackWhileFocused: If `true`, unfocused cards will collapse into a 3D stack at the bottom
-///     of the screen when a document is focused. If `false`, unfocused cards fade away entirely to maximize
+///     of the screen when a card is focused. If `false`, unfocused cards fade away entirely to maximize
 ///     screen real estate for the detail view. Defaults to `true`.
-///   - showDocumentInfo: A `@ViewBuilder` closure that renders the detailed content below the focused card.
+///   - showCardInfo: A `@ViewBuilder` closure that renders the detailed content below the focused card.
 ///     It is horizontally centered by default.
-///   - emptyDocumentContent: A `@ViewBuilder` closure displayed inside a dashed placeholder card when the
-///     `documentModel` is empty.
-///   - onDocumentReordered: Callback invoked when a drag-and-drop reordering operation completes.
-///     Provides the `DocumentInfo` of the moved card and its new index position in the list.
-///   - onDocumentFocused: Callback invoked when a document is tapped to be focused.
-///   - onDocumentFocusedTapped: Callback invoked when the currently focused document is tapped.
-///   - onDocumentFocusedStackTapped: Callback invoked when the unfocused document stack is tapped while another document is in focus.
-public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: View {
-    public var documentModel: DocumentModel
-    public var focusedDocument: DocumentInfo?
+///   - emptyContent: A `@ViewBuilder` closure displayed inside a dashed placeholder card when the
+///     `cardInfos` list is empty.
+///   - onCardReordered: Callback invoked when a drag-and-drop reordering operation completes.
+///     Provides the `CardInfo` of the moved card and its new index position in the list.
+///   - onCardFocused: Callback invoked when a card is tapped to be focused.
+///   - onCardFocusedTapped: Callback invoked when the currently focused card is tapped.
+///   - onCardFocusedStackTapped: Callback invoked when the unfocused card stack is tapped while another card is in focus.
+public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View {
+    public var cardInfos: [CardInfo]
+    public var focusedCard: CardInfo?
     public var unfocusedVisiblePercent: Int
-    public var allowDocumentReordering: Bool
+    public var allowCardReordering: Bool
     public var showStackWhileFocused: Bool
     
-    @ViewBuilder public var showDocumentInfo: (DocumentInfo) -> SelectedContent
-    @ViewBuilder public var emptyDocumentContent: () -> EmptyContent
-    public var onDocumentReordered: (DocumentInfo, Int) -> Void
-    public var onDocumentFocused: (DocumentInfo) -> Void
-    public var onDocumentFocusedTapped: (DocumentInfo) -> Void
-    public var onDocumentFocusedStackTapped: (DocumentInfo) -> Void
+    @ViewBuilder public var showCardInfo: (CardInfo) -> SelectedContent
+    @ViewBuilder public var emptyContent: () -> EmptyContent
+    public var onCardReordered: (CardInfo, Int) -> Void
+    public var onCardFocused: (CardInfo) -> Void
+    public var onCardFocusedTapped: (CardInfo) -> Void
+    public var onCardFocusedStackTapped: (CardInfo) -> Void
 
-    @State private var displayOrder: [DocumentInfo] = []
+    @State private var displayOrder: [CardInfo] = []
     @State private var scrollOffset: CGFloat = 0
     
-    @State private var draggedDocId: String? = nil
+    @State private var draggedCardIndex: Int? = nil
     @State private var dragCurrentY: CGFloat = 0
     @State private var startDragY: CGFloat = 0
     @State private var isDragging: Bool = false
     @State private var lastDragEndTime: Date = .distantPast
     
     public init(
-        documentModel: DocumentModel,
-        focusedDocument: DocumentInfo?,
+        cardInfos: [CardInfo],
+        focusedCard: CardInfo?,
         unfocusedVisiblePercent: Int = 25,
-        allowDocumentReordering: Bool = true,
+        allowCardReordering: Bool = true,
         showStackWhileFocused: Bool = true,
-        @ViewBuilder showDocumentInfo: @escaping (DocumentInfo) -> SelectedContent = { _ in EmptyView() },
-        @ViewBuilder emptyDocumentContent: @escaping () -> EmptyContent = { EmptyView() },
-        onDocumentReordered: @escaping (DocumentInfo, Int) -> Void = { _, _ in },
-        onDocumentFocused: @escaping (DocumentInfo) -> Void = { _ in },
-        onDocumentFocusedTapped: @escaping (DocumentInfo) -> Void = { _ in },
-        onDocumentFocusedStackTapped: @escaping (DocumentInfo) -> Void = { _ in }
+        @ViewBuilder showCardInfo: @escaping (CardInfo) -> SelectedContent = { _ in EmptyView() },
+        @ViewBuilder emptyContent: @escaping () -> EmptyContent = { EmptyView() },
+        onCardReordered: @escaping (CardInfo, Int) -> Void = { _, _ in },
+        onCardFocused: @escaping (CardInfo) -> Void = { _ in },
+        onCardFocusedTapped: @escaping (CardInfo) -> Void = { _ in },
+        onCardFocusedStackTapped: @escaping (CardInfo) -> Void = { _ in }
     ) {
-        self.documentModel = documentModel
-        self.focusedDocument = focusedDocument
+        self.cardInfos = cardInfos
+        self.focusedCard = focusedCard
         self.unfocusedVisiblePercent = unfocusedVisiblePercent
-        self.allowDocumentReordering = allowDocumentReordering
+        self.allowCardReordering = allowCardReordering
         self.showStackWhileFocused = showStackWhileFocused
-        self.showDocumentInfo = showDocumentInfo
-        self.emptyDocumentContent = emptyDocumentContent
-        self.onDocumentReordered = onDocumentReordered
-        self.onDocumentFocused = onDocumentFocused
-        self.onDocumentFocusedTapped = onDocumentFocusedTapped
-        self.onDocumentFocusedStackTapped = onDocumentFocusedStackTapped
+        self.showCardInfo = showCardInfo
+        self.emptyContent = emptyContent
+        self.onCardReordered = onCardReordered
+        self.onCardFocused = onCardFocused
+        self.onCardFocusedTapped = onCardFocusedTapped
+        self.onCardFocusedStackTapped = onCardFocusedStackTapped
     }
     
     public var body: some View {
@@ -188,13 +188,13 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                 ? frontCardVisibleHeight + CGFloat(maxVisibleStackOffsets) * stackOffset + 16
                 : 16
             
-            if displayOrder.isEmpty && documentModel.documentInfos.isEmpty {
+            if displayOrder.isEmpty && cardInfos.isEmpty {
                 VStack {
                     Spacer().frame(height: paddingTop)
                     ZStack {
                         RoundedRectangle(cornerRadius: 24)
                             .strokeBorder(Color.gray, style: StrokeStyle(lineWidth: 3, dash: [30, 30]))
-                        emptyDocumentContent()
+                        emptyContent()
                     }
                     .frame(width: cardWidth, height: cardHeight)
                     Spacer()
@@ -211,19 +211,19 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                                     .frame(height: totalHeight)
                                     .background(
                                         GeometryReader { geo in
-                                            let minY = geo.frame(in: .named("DocListSpace")).minY
+                                            let minY = geo.frame(in: .named("CardListSpace")).minY
                                             Color.clear.preference(
-                                                key: DocumentListScrollOffsetKey.self,
+                                                key: CardListScrollOffsetKey.self,
                                                 value: minY
                                             )
                                         }
                                     )
                                     .id("TopSpacer")
                                 
-                                if let focusedDoc = focusedDocument {
+                                if let focused = focusedCard {
                                     let detailHeight = max(0, maxHeight - detailBottomPadding)
                                     VStack {
-                                        showDocumentInfo(focusedDoc)
+                                        showCardInfo(focused)
                                     }
                                     .frame(maxWidth: .infinity, alignment: .top)
                                     .padding(.top, paddingTop + cardHeight * 1.05 + 24)
@@ -234,38 +234,42 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                                     .zIndex(50)
                                 }
                                 
-                                ForEach(Array(displayOrder.enumerated()), id: \.element.document.identifier) { index, docInfo in
+                                ForEach(Array(displayOrder.enumerated()), id: \.offset) { index, cardInfo in
                                     let cardState = calculateCardState(
-                                        index: index, docInfo: docInfo, maxHeight: maxHeight, paddingTop: paddingTop,
+                                        index: index, cardInfo: cardInfo, maxHeight: maxHeight, paddingTop: paddingTop,
                                         listStep: listStep, maxStackIndex: maxStackIndex, maxVisibleCardsInStack: maxVisibleCardsInStack,
                                         frontCardVisibleHeight: frontCardVisibleHeight, stackOffset: stackOffset
                                     )
                                     
-                                    Image(uiImage: docInfo.cardArt)
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fill)
-                                        .frame(width: cardWidth, height: cardHeight)
-                                        .clipShape(RoundedRectangle(cornerRadius: 24))
-                                        .contentShape(Rectangle())
-                                        .shadow(color: Color.black.opacity(0.15), radius: cardState.elevation, x: 0, y: cardState.elevation / 2)
+                                    ZStack(alignment: .topTrailing) {
+                                        Image(uiImage: cardInfo.cardArt)
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fill)
+                                            .frame(width: cardWidth, height: cardHeight)
+                                            .clipShape(RoundedRectangle(cornerRadius: 24))
+                                        
+                                        CardBadgesView(badges: cardInfo.badges)
+                                    }
+                                    .contentShape(Rectangle())
+                                    .shadow(color: Color.black.opacity(0.15), radius: cardState.elevation, x: 0, y: cardState.elevation / 2)
                                         .scaleEffect(cardState.scale)
                                         .opacity(cardState.alpha)
                                         .overlay(
                                             CardInteractionView(
-                                                allowReordering: focusedDocument == nil && allowDocumentReordering,
+                                                allowReordering: focusedCard == nil && allowCardReordering,
                                                 onTap: {
                                                     guard !isDragging && Date().timeIntervalSince(lastDragEndTime) > 0.3 else { return }
-                                                    if let focused = focusedDocument {
+                                                    if let focused = focusedCard {
                                                         withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                                                            if docInfo.document.identifier == focused.document.identifier {
-                                                                onDocumentFocusedTapped(focused)
+                                                            if cardInfo.identifier == focused.identifier {
+                                                                onCardFocusedTapped(focused)
                                                             } else {
-                                                                onDocumentFocusedStackTapped(focused)
+                                                                onCardFocusedStackTapped(focused)
                                                             }
                                                         }
                                                     } else {
                                                         withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                                                            onDocumentFocused(docInfo)
+                                                            onCardFocused(cardInfo)
                                                         }
                                                     }
                                                 },
@@ -274,37 +278,38 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                                                     generator.impactOccurred()
                                                     withAnimation(.snappy) {
                                                         isDragging = true
-                                                        draggedDocId = docInfo.document.identifier
+                                                        draggedCardIndex = index
                                                     }
                                                     startDragY = paddingTop + CGFloat(index) * listStep
                                                     dragCurrentY = startDragY
                                                 },
                                                 onDragChanged: { translationY in
-                                                    guard isDragging && draggedDocId == docInfo.document.identifier else { return }
+                                                    guard isDragging, let currentIndex = draggedCardIndex else { return }
                                                     
                                                     dragCurrentY = startDragY + translationY
                                                     let newIndexRaw = Int(round((dragCurrentY - paddingTop) / listStep))
                                                     let newIndex = min(max(newIndexRaw, 0), displayOrder.count - 1)
-                                                    let currentIndex = displayOrder.firstIndex(where: { $0.document.identifier == draggedDocId }) ?? index
 
                                                     if currentIndex != newIndex {
                                                         withAnimation(.snappy) {
                                                             let item = displayOrder.remove(at: currentIndex)
                                                             displayOrder.insert(item, at: newIndex)
+                                                            draggedCardIndex = newIndex
+                                                            // Update startDragY so further translation is relative to new index
+                                                            startDragY = paddingTop + CGFloat(newIndex) * listStep
+                                                            // We don't update dragCurrentY here because it's what we're currently using
                                                         }
                                                         let generator = UIImpactFeedbackGenerator(style: .light)
                                                         generator.impactOccurred()
                                                     }
                                                 },
                                                 onDragEnded: {
-                                                    guard isDragging && draggedDocId == docInfo.document.identifier else { return }
+                                                    guard isDragging, let finalIndex = draggedCardIndex else { return }
                                                     let generator = UIImpactFeedbackGenerator(style: .medium)
                                                     generator.impactOccurred()
-                                                    if let finalIndex = displayOrder.firstIndex(where: { $0.document.identifier == docInfo.document.identifier }) {
-                                                        onDocumentReordered(displayOrder[finalIndex], finalIndex)
-                                                    }
+                                                    onCardReordered(displayOrder[finalIndex], finalIndex)
                                                     withAnimation(.snappy) {
-                                                        draggedDocId = nil
+                                                        draggedCardIndex = nil
                                                         isDragging = false
                                                         lastDragEndTime = Date()
                                                     }
@@ -313,7 +318,7 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                                         )
                                         .offset(x: paddingHorizontal, y: cardState.y)
                                         .zIndex(cardState.zIndex)
-                                        .animation((docInfo.document.identifier == draggedDocId) ? .interactiveSpring() : .spring(response: 0.4, dampingFraction: 0.8), value: cardState.y)
+                                        .animation((index == draggedCardIndex) ? .interactiveSpring() : .spring(response: 0.4, dampingFraction: 0.8), value: cardState.y)
                                         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.scale)
                                         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.elevation)
                                         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.alpha)
@@ -321,9 +326,9 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
                             }
                             .frame(width: maxWidth, height: totalHeight, alignment: .topLeading)
                         }
-                        .coordinateSpace(name: "DocListSpace")
-                        .scrollDisabled(focusedDocument != nil || isDragging)
-                        .onPreferenceChange(DocumentListScrollOffsetKey.self) { value in
+                        .coordinateSpace(name: "CardListSpace")
+                        .scrollDisabled(focusedCard != nil || isDragging)
+                        .onPreferenceChange(CardListScrollOffsetKey.self) { value in
                             if value != -scrollOffset {
                                 scrollOffset = -value
                             }
@@ -333,10 +338,10 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
             }
         }
         .onAppear {
-            if displayOrder.isEmpty { displayOrder = documentModel.documentInfos }
+            if displayOrder.isEmpty { displayOrder = cardInfos }
         }
-        .onChange(of: documentModel.documentInfos) { _, newInfos in
-            if !isDragging { displayOrder = newInfos }
+        .onChange(of: cardInfos.count) { _, _ in
+             if !isDragging { displayOrder = cardInfos }
         }
     }
     
@@ -348,11 +353,11 @@ public struct VerticalDocumentList<EmptyContent: View, SelectedContent: View>: V
         var alpha: Double
     }
     
-    private func calculateCardState(index: Int, docInfo: DocumentInfo, maxHeight: CGFloat, paddingTop: CGFloat, listStep: CGFloat, maxStackIndex: Int, maxVisibleCardsInStack: Int, frontCardVisibleHeight: CGFloat, stackOffset: CGFloat) -> CardState {
-        let isFocused = docInfo.document.identifier == focusedDocument?.document.identifier
-        let isDragged = docInfo.document.identifier == draggedDocId
-        let isAnyFocused = focusedDocument != nil
-        let focusedIndex = displayOrder.firstIndex(where: { $0.document.identifier == focusedDocument?.document.identifier }) ?? 0
+    private func calculateCardState(index: Int, cardInfo: CardInfo, maxHeight: CGFloat, paddingTop: CGFloat, listStep: CGFloat, maxStackIndex: Int, maxVisibleCardsInStack: Int, frontCardVisibleHeight: CGFloat, stackOffset: CGFloat) -> CardState {
+        let isFocused = cardInfo.identifier == focusedCard?.identifier
+        let isDragged = index == draggedCardIndex
+        let isAnyFocused = focusedCard != nil
+        let focusedIndex = displayOrder.firstIndex(where: { $0.identifier == focusedCard?.identifier }) ?? 0
         
         if isAnyFocused {
             if isFocused {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/presentment/DocumentChooserData.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/presentment/DocumentChooserData.android.kt
@@ -3,6 +3,7 @@ package org.multipaz.presentment
 import android.app.PendingIntent
 import android.content.ComponentName
 import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 
 /**
  * Data for configuring a document chooser.
@@ -13,7 +14,6 @@ import org.multipaz.document.Document
  * @property openAppPendingIntentFn a function to create a [PendingIntent] to open the given document when the button is pressed.
  * @property preferredServices a list of services which should be preferred while an activity providing the UI for
  *  [PresentmentModel] is in the foreground. See [PresenmentActivity] in the multipaz-compose library for an example.
- *
  */
 actual data class DocumentChooserData(
     val initiallySelectedDocumentId: String?,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentBadge.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentBadge.kt
@@ -1,0 +1,12 @@
+package org.multipaz.document
+
+/**
+ * A badge to display on a document.
+ *
+ * @param text the text in the badge.
+ * @param color the color of the badge.
+ */
+data class DocumentBadge(
+    val text: String,
+    val color: DocumentBadgeColor
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentBadgeColor.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentBadgeColor.kt
@@ -1,0 +1,14 @@
+package org.multipaz.document
+
+/**
+ * Data type for the color of a badge.
+ *
+ * @property red the red component, between 0 and 255.
+ * @property green the green component, between 0 and 255.
+ * @property blue the blue component, between 0 and 255.
+ */
+data class DocumentBadgeColor(
+    val red: Int,
+    val green: Int,
+    val blue: Int
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 
 /**
  * A model which can be used to drive UI for presentment.
@@ -15,7 +16,7 @@ import org.multipaz.document.Document
  */
 class PresentmentModel {
 
-    private var mutableState = MutableStateFlow<State>(State.Reset(null))
+    private var mutableState = MutableStateFlow<State>(State.Reset)
 
     /**
      * The current state of the model.
@@ -44,6 +45,14 @@ class PresentmentModel {
     val numRequestsServed: StateFlow<Int>
         get() = mutableNumRequestsServed.asStateFlow()
 
+    private var mutableShowDocumentChooser: DocumentChooserData? = null
+
+    /**
+     * Whether to show a document chooser.
+     */
+    val showDocumentChooser: DocumentChooserData?
+        get() = mutableShowDocumentChooser
+
     /**
      * Resets the model.
      *
@@ -62,10 +71,11 @@ class PresentmentModel {
         preselectedDocuments: List<Document>,
         showDocumentChooser: DocumentChooserData? = null,
     ) {
-        mutableState.value = State.Reset(showDocumentChooser)
+        mutableState.value = State.Reset
         mutableSource = source
         mutableDocumentsSelected.value = preselectedDocuments
         mutableNumRequestsServed.value = 0
+        mutableShowDocumentChooser = showDocumentChooser
     }
 
     /**
@@ -144,9 +154,7 @@ class PresentmentModel {
      */
     sealed class State {
         /** The presentment has just started. */
-        data class Reset(
-            val documentChooserData: DocumentChooserData?
-        ): State()
+        data object Reset: State()
 
         /** Connecting to the credential reader. */
         data object Connecting: State()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentSource.kt
@@ -3,6 +3,7 @@ package org.multipaz.presentment
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.eventlogger.EventLogger
@@ -87,4 +88,14 @@ abstract class PresentmentSource(
         requestedClaims: List<RequestedClaim>,
         keyAgreementPossible: List<EcCurve>,
     ): Credential?
+
+    /**
+     * Gets a list of badges for a document.
+     *
+     * This may be used when the UI shows a list of documents to choose from.
+     *
+     * @param document the document to get a list of badges from.
+     * @return the badges.
+     */
+    abstract suspend fun getBadges(document: Document): List<DocumentBadge>
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/SimplePresentmentSource.kt
@@ -4,6 +4,7 @@ import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.crypto.EcCurve
 import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.eventlogger.EventLogger
@@ -54,6 +55,7 @@ class SimplePresentmentSource(
     override val eventLogger: EventLogger? = null,
     private val resolveTrustFn: suspend (requester: Requester) -> TrustMetadata? = { requester -> null },
     private val showConsentPromptFn: ShowConsentPromptFn = ::promptModelRequestConsent,
+    private val getBadgesFn: suspend (document: Document) -> List<DocumentBadge> = { document -> emptyList() },
     val preferSignatureToKeyAgreement: Boolean = true,
     val domainsMdocSignature: List<String> = emptyList(),
     val domainsMdocKeyAgreement: List<String> = emptyList(),
@@ -83,6 +85,10 @@ class SimplePresentmentSource(
             preselectedDocuments,
             onDocumentsInFocus
         )
+    }
+
+    override suspend fun getBadges(document: Document): List<DocumentBadge> {
+        return getBadgesFn(document)
     }
 
     private suspend fun Document.findCredential(domains: List<String>, now: Instant): Credential? {

--- a/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
@@ -10,66 +10,6 @@
 		512DAED62F2A31B30061F72B /* IdentityDocumentProviderExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		51BD5C5E2F22604F0082DE19 /* AdditionalConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */; };
 		51BD5C5F2F22604F0082DE19 /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */; };
-		7B4A4F672F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */; };
-		7B4A4F682F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */; };
-		7B4A4F692F97D8EF003719D6 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */; };
-		7B4A4F6A2F97D8EF003719D6 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F492F97D8EF003719D6 /* Consent.swift */; };
-		7B4A4F6B2F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */; };
-		7B4A4F6C2F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */; };
-		7B4A4F6D2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */; };
-		7B4A4F6E2F97D8EF003719D6 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */; };
-		7B4A4F6F2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */; };
-		7B4A4F702F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */; };
-		7B4A4F712F97D8EF003719D6 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */; };
-		7B4A4F722F97D8EF003719D6 /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */; };
-		7B4A4F732F97D8EF003719D6 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */; };
-		7B4A4F742F97D8EF003719D6 /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */; };
-		7B4A4F752F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */; };
-		7B4A4F762F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */; };
-		7B4A4F772F97D8EF003719D6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */; };
-		7B4A4F782F97D8EF003719D6 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */; };
-		7B4A4F792F97D8EF003719D6 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F632F97D8EF003719D6 /* TagsExt.swift */; };
-		7B4A4F7A2F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */; };
-		7B4A4F7B2F97D8EF003719D6 /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */; };
-		7B4A4F7C2F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */; };
-		7B4A4F7D2F97D8EF003719D6 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */; };
-		7B4A4F7E2F97D8EF003719D6 /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */; };
-		7B4A4F7F2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */; };
-		7B4A4F802F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */; };
-		7B4A4F812F97D8EF003719D6 /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */; };
-		7B4A4F822F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */; };
-		7B4A4F832F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */; };
-		7B4A4F842F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */; };
-		7B4A4F852F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */; };
-		7B4A4F862F97D8EF003719D6 /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */; };
-		7B4A4F872F97D8EF003719D6 /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F492F97D8EF003719D6 /* Consent.swift */; };
-		7B4A4F882F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */; };
-		7B4A4F892F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */; };
-		7B4A4F8A2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */; };
-		7B4A4F8B2F97D8EF003719D6 /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */; };
-		7B4A4F8C2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */; };
-		7B4A4F8D2F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */; };
-		7B4A4F8E2F97D8EF003719D6 /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */; };
-		7B4A4F8F2F97D8EF003719D6 /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */; };
-		7B4A4F902F97D8EF003719D6 /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */; };
-		7B4A4F912F97D8EF003719D6 /* DocumentCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */; };
-		7B4A4F922F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */; };
-		7B4A4F932F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */; };
-		7B4A4F942F97D8EF003719D6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */; };
-		7B4A4F952F97D8EF003719D6 /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */; };
-		7B4A4F962F97D8EF003719D6 /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F632F97D8EF003719D6 /* TagsExt.swift */; };
-		7B4A4F972F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */; };
-		7B4A4F982F97D8EF003719D6 /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */; };
-		7B4A4F992F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */; };
-		7B4A4F9A2F97D8EF003719D6 /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */; };
-		7B4A4F9B2F97D8EF003719D6 /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */; };
-		7B4A4F9C2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */; };
-		7B4A4F9D2F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */; };
-		7B4A4F9E2F97D8EF003719D6 /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */; };
-		7B4A4F9F2F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */; };
-		7B4A4FA02F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */; };
-		7BE862062F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */; };
-		7BE862072F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,36 +41,6 @@
 		512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = IdentityDocumentProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdditionalConfig.xcconfig; path = ../testapp/iosApp/AdditionalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 		51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = DeveloperConfig.xcconfig; path = ../testapp/iosApp/DeveloperConfig.xcconfig; sourceTree = SOURCE_ROOT; };
-		7B4A4F492F97D8EF003719D6 /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
-		7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
-		7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentCarousel.swift; sourceTree = "<group>"; };
-		7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
-		7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExtCardart.swift; sourceTree = "<group>"; };
-		7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
-		7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemCenteredText.swift; sourceTree = "<group>"; };
-		7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemContainer.swift; sourceTree = "<group>"; };
-		7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
-		7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
-		7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
-		7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndText.swift; sourceTree = "<group>"; };
-		7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemList.swift; sourceTree = "<group>"; };
-		7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemText.swift; sourceTree = "<group>"; };
-		7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
-		7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
-		7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
-		7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
-		7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
-		7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
-		7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningView.swift; sourceTree = "<group>"; };
-		7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
-		7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
-		7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
-		7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
-		7B4A4F632F97D8EF003719D6 /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
-		7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalDocumentList.swift; sourceTree = "<group>"; };
-		7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
-		7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultToHumanReadable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -167,6 +77,12 @@
 			path = IdentityDocumentProviderExtension;
 			sourceTree = "<group>";
 		};
+		7BAE03042FA152C1008E2D77 /* swift */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			name = swift;
+			path = "/Users/zeuthen/StudioProjects/multipaz/multipaz-swiftui/src/iosMain/swift";
+			sourceTree = "<absolute>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,7 +106,7 @@
 		51100E5E2F21D4A5006B2ADD = {
 			isa = PBXGroup;
 			children = (
-				7B4A4F662F97D8EF003719D6 /* swift */,
+				7BAE03042FA152C1008E2D77 /* swift */,
 				51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */,
 				51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */,
 				51100E692F21D4A5006B2ADD /* SwiftTestApp */,
@@ -216,44 +132,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		7B4A4F662F97D8EF003719D6 /* swift */ = {
-			isa = PBXGroup;
-			children = (
-				7BE862052F99232A00CCC68B /* DefaultToHumanReadable.swift */,
-				7B4A4F492F97D8EF003719D6 /* Consent.swift */,
-				7B4A4F4A2F97D8EF003719D6 /* ConsentPromptDialog.swift */,
-				7B4A4F4B2F97D8EF003719D6 /* DocumentCarousel.swift */,
-				7B4A4F4C2F97D8EF003719D6 /* DocumentExt.swift */,
-				7B4A4F4D2F97D8EF003719D6 /* DocumentExtCardart.swift */,
-				7B4A4F4E2F97D8EF003719D6 /* DocumentModel.swift */,
-				7B4A4F4F2F97D8EF003719D6 /* Extensions.swift */,
-				7B4A4F502F97D8EF003719D6 /* FloatingItemCenteredText.swift */,
-				7B4A4F512F97D8EF003719D6 /* FloatingItemContainer.swift */,
-				7B4A4F522F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift */,
-				7B4A4F532F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift */,
-				7B4A4F542F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift */,
-				7B4A4F552F97D8EF003719D6 /* FloatingItemHeadingAndText.swift */,
-				7B4A4F562F97D8EF003719D6 /* FloatingItemList.swift */,
-				7B4A4F572F97D8EF003719D6 /* FloatingItemText.swift */,
-				7B4A4F582F97D8EF003719D6 /* MdocProximityQrPresentment.swift */,
-				7B4A4F592F97D8EF003719D6 /* MdocProximityQrSettings.swift */,
-				7B4A4F5A2F97D8EF003719D6 /* PassphraseInputView.swift */,
-				7B4A4F5B2F97D8EF003719D6 /* PassphrasePromptDialog.swift */,
-				7B4A4F5C2F97D8EF003719D6 /* PromptDialogs.swift */,
-				7B4A4F5D2F97D8EF003719D6 /* PromptModelExt.swift */,
-				7B4A4F5E2F97D8EF003719D6 /* ProvisioningView.swift */,
-				7B4A4F5F2F97D8EF003719D6 /* QrCode.swift */,
-				7B4A4F602F97D8EF003719D6 /* RequestAuthorizationView.swift */,
-				7B4A4F612F97D8EF003719D6 /* SimplePresentmentSourceExt.swift */,
-				7B4A4F622F97D8EF003719D6 /* SmartSheet.swift */,
-				7B4A4F632F97D8EF003719D6 /* TagsExt.swift */,
-				7B4A4F642F97D8EF003719D6 /* VerticalDocumentList.swift */,
-				7B4A4F652F97D8EF003719D6 /* X509CertViewer.swift */,
-			);
-			name = swift;
-			path = "/Users/zeuthen/StudioProjects/multipaz/multipaz-swiftui/src/iosMain/swift";
-			sourceTree = "<absolute>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -274,6 +152,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				51100E692F21D4A5006B2ADD /* SwiftTestApp */,
+				7BAE03042FA152C1008E2D77 /* swift */,
 			);
 			name = SwiftTestApp;
 			packageProductDependencies = (
@@ -297,6 +176,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				512DAED02F2A31B30061F72B /* IdentityDocumentProviderExtension */,
+				7BAE03042FA152C1008E2D77 /* swift */,
 			);
 			name = IdentityDocumentProviderExtension;
 			packageProductDependencies = (
@@ -410,36 +290,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B4A4F672F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */,
-				7B4A4F682F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */,
-				7B4A4F692F97D8EF003719D6 /* PromptDialogs.swift in Sources */,
-				7B4A4F6A2F97D8EF003719D6 /* Consent.swift in Sources */,
-				7B4A4F6B2F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */,
-				7B4A4F6C2F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */,
-				7B4A4F6D2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */,
-				7B4A4F6E2F97D8EF003719D6 /* PromptModelExt.swift in Sources */,
-				7B4A4F6F2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */,
-				7B4A4F702F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */,
-				7BE862062F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */,
-				7B4A4F712F97D8EF003719D6 /* DocumentExt.swift in Sources */,
-				7B4A4F722F97D8EF003719D6 /* FloatingItemList.swift in Sources */,
-				7B4A4F732F97D8EF003719D6 /* QrCode.swift in Sources */,
-				7B4A4F742F97D8EF003719D6 /* DocumentCarousel.swift in Sources */,
-				7B4A4F752F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				7B4A4F762F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */,
-				7B4A4F772F97D8EF003719D6 /* Extensions.swift in Sources */,
-				7B4A4F782F97D8EF003719D6 /* X509CertViewer.swift in Sources */,
-				7B4A4F792F97D8EF003719D6 /* TagsExt.swift in Sources */,
-				7B4A4F7A2F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */,
-				7B4A4F7B2F97D8EF003719D6 /* ProvisioningView.swift in Sources */,
-				7B4A4F7C2F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */,
-				7B4A4F7D2F97D8EF003719D6 /* SmartSheet.swift in Sources */,
-				7B4A4F7E2F97D8EF003719D6 /* DocumentModel.swift in Sources */,
-				7B4A4F7F2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */,
-				7B4A4F802F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */,
-				7B4A4F812F97D8EF003719D6 /* FloatingItemText.swift in Sources */,
-				7B4A4F822F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */,
-				7B4A4F832F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,36 +297,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B4A4F842F97D8EF003719D6 /* ConsentPromptDialog.swift in Sources */,
-				7B4A4F852F97D8EF003719D6 /* PassphrasePromptDialog.swift in Sources */,
-				7B4A4F862F97D8EF003719D6 /* PromptDialogs.swift in Sources */,
-				7B4A4F872F97D8EF003719D6 /* Consent.swift in Sources */,
-				7B4A4F882F97D8EF003719D6 /* MdocProximityQrPresentment.swift in Sources */,
-				7B4A4F892F97D8EF003719D6 /* FloatingItemCenteredText.swift in Sources */,
-				7BE862072F99232A00CCC68B /* DefaultToHumanReadable.swift in Sources */,
-				7B4A4F8A2F97D8EF003719D6 /* FloatingItemHeadingAndText.swift in Sources */,
-				7B4A4F8B2F97D8EF003719D6 /* PromptModelExt.swift in Sources */,
-				7B4A4F8C2F97D8EF003719D6 /* PassphraseInputView.swift in Sources */,
-				7B4A4F8D2F97D8EF003719D6 /* FloatingItemHeadingAndDate.swift in Sources */,
-				7B4A4F8E2F97D8EF003719D6 /* DocumentExt.swift in Sources */,
-				7B4A4F8F2F97D8EF003719D6 /* FloatingItemList.swift in Sources */,
-				7B4A4F902F97D8EF003719D6 /* QrCode.swift in Sources */,
-				7B4A4F912F97D8EF003719D6 /* DocumentCarousel.swift in Sources */,
-				7B4A4F922F97D8EF003719D6 /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				7B4A4F932F97D8EF003719D6 /* SimplePresentmentSourceExt.swift in Sources */,
-				7B4A4F942F97D8EF003719D6 /* Extensions.swift in Sources */,
-				7B4A4F952F97D8EF003719D6 /* X509CertViewer.swift in Sources */,
-				7B4A4F962F97D8EF003719D6 /* TagsExt.swift in Sources */,
-				7B4A4F972F97D8EF003719D6 /* VerticalDocumentList.swift in Sources */,
-				7B4A4F982F97D8EF003719D6 /* ProvisioningView.swift in Sources */,
-				7B4A4F992F97D8EF003719D6 /* MdocProximityQrSettings.swift in Sources */,
-				7B4A4F9A2F97D8EF003719D6 /* SmartSheet.swift in Sources */,
-				7B4A4F9B2F97D8EF003719D6 /* DocumentModel.swift in Sources */,
-				7B4A4F9C2F97D8EF003719D6 /* RequestAuthorizationView.swift in Sources */,
-				7B4A4F9D2F97D8EF003719D6 /* FloatingItemContainer.swift in Sources */,
-				7B4A4F9E2F97D8EF003719D6 /* FloatingItemText.swift in Sources */,
-				7B4A4F9F2F97D8EF003719D6 /* DocumentExtCardart.swift in Sources */,
-				7B4A4FA02F97D8EF003719D6 /* FloatingItemHeadingAndContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                 case .aboutScreen: AboutScreen()
                 case .documentStoreScreen: DocumentStoreScreen()
                 case .documentScreen(let documentId): DocumentScreen(documentId: documentId)
-                case .verticalDocumentListScreen: VerticalDocumentListScreen()
+                case .verticalCardListScreen: VerticalCardListScreen()
                 case .credentialScreen(documentId: let documentId, credentialId: let credentialId):
                     CredentialScreen(documentId: documentId, credentialId: credentialId)
                 case .claimsScreen(documentId: let documentId, credentialId: let credentialId):

--- a/samples/SwiftTestApp/SwiftTestApp/Destination.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/Destination.swift
@@ -12,6 +12,6 @@ enum Destination: Hashable {
     case iso18013ProximityPresentmentScreen
     case certificateViewerScreen(certificates: [X509Cert])
     case certificateExamplesScreen
-    case verticalDocumentListScreen
+    case verticalCardListScreen
     case floatingItemListScreen
 }

--- a/samples/SwiftTestApp/SwiftTestApp/DocumentStoreScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/DocumentStoreScreen.swift
@@ -71,17 +71,19 @@ struct DocumentStoreScreen: View {
                     Text("Delete all documents")
                 }
                 
-                DocumentCarousel(
-                    documentModel: viewModel.documentModel,
-                    initialDocumentId: focusedDocumentId,
+                CardCarousel(
+                    cardInfos: viewModel.documentModel.documentInfos,
+                    initialCardInfo: viewModel.documentModel.documentInfos.first { $0.identifier == focusedDocumentId },
                     allowReordering: true,
-                    onDocumentClicked: { documentInfo in
+                    onCardClicked: { cardInfo in
+                        let documentInfo = cardInfo as! DocumentInfo
                         viewModel.path.append(Destination.documentScreen(documentId: documentInfo.document.identifier))
                     },
-                    onDocumentFocused: { documentInfo in
-                        focusedDocumentId = documentInfo.document.identifier
+                    onCardFocused: { cardInfo in
+                        focusedDocumentId = cardInfo.identifier
                     },
-                    onDocumentReordered: { documentInfo, oldPosition, newPosition in
+                    onCardReordered: { cardInfo, oldPosition, newPosition in
+                        let documentInfo = cardInfo as! DocumentInfo
                         Task {
                             do {
                                 try await viewModel.documentModel.setDocumentPosition(
@@ -93,9 +95,9 @@ struct DocumentStoreScreen: View {
                             }
                         }
                     },
-                    selectedDocumentInfo: { documentInfo, documentIdx, numDocuments in
+                    selectedCardInfo: { cardInfo, documentIdx, numDocuments in
                         HStack {
-                            if let documentInfo = documentInfo {
+                            if let documentInfo = cardInfo as? DocumentInfo {
                                 Text("\(documentIdx + 1) of \(numDocuments): " +
                                      (documentInfo.document.displayName ?? "(No displayName)")
                                 )
@@ -108,7 +110,7 @@ struct DocumentStoreScreen: View {
                             }
                         }
                     },
-                    emptyDocumentContent: {
+                    emptyCardContent: {
                         Text("No documents in store")
                             .foregroundStyle(Color.secondary)
                     }

--- a/samples/SwiftTestApp/SwiftTestApp/StartScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/StartScreen.swift
@@ -15,8 +15,8 @@ struct StartScreen: View {
                 Button(action: { viewModel.path.append(Destination.documentStoreScreen) }) {
                     Text("Document Store")
                 }
-                Button(action: { viewModel.path.append(Destination.verticalDocumentListScreen) }) {
-                    Text("Vertical Document List")
+                Button(action: { viewModel.path.append(Destination.verticalCardListScreen) }) {
+                    Text("Vertical Card List")
                 }
                 Button(action: { viewModel.path.append(Destination.consentPromptScreen) }) {
                     Text("Consent Prompt")

--- a/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Multipaz
 
-struct VerticalDocumentListScreen: View {
+struct VerticalCardListScreen: View {
     @Environment(ViewModel.self) private var viewModel
     
     @SceneStorage("focusedDocumentId") private var focusedDocumentId: String?
@@ -15,13 +15,14 @@ struct VerticalDocumentListScreen: View {
             $0.document.identifier == focusedDocumentId
         }
         VStack {
-            VerticalDocumentList(
-                documentModel: viewModel.documentModel,
-                focusedDocument: focusedDocument,
+            VerticalCardList(
+                cardInfos: viewModel.documentModel.documentInfos,
+                focusedCard: focusedDocument,
                 unfocusedVisiblePercent: 25, // Show a bit more of the overlapping cards
-                allowDocumentReordering: true,
+                allowCardReordering: true,
                 showStackWhileFocused: true,
-                showDocumentInfo: { docInfo in
+                showCardInfo: { cardInfo in
+                    let docInfo = cardInfo as! DocumentInfo
                     VStack {
                         Text("\(docInfo.document.displayName ?? "Document") is focused")
                         Spacer()
@@ -38,7 +39,7 @@ struct VerticalDocumentListScreen: View {
                         }
                     }
                 },
-                emptyDocumentContent: {
+                emptyContent: {
                     // This view appears inside the dashed placeholder
                     VStack(spacing: 12) {
                         Image(systemName: "plus.rectangle.on.rectangle")
@@ -52,26 +53,27 @@ struct VerticalDocumentListScreen: View {
                             .foregroundColor(.gray)
                     }
                 },
-                onDocumentReordered: { document, newIndex in
+                onCardReordered: { cardInfo, newIndex in
+                    let document = cardInfo as! DocumentInfo
                     print("User moved \(document.document.displayName ?? "card") to index \(newIndex)")
                     Task {
                         try? await viewModel.documentModel.setDocumentPosition(documentInfo: document, position: newIndex)
                     }
                 },
-                onDocumentFocused: { documentInfo in
-                    focusedDocumentId = documentInfo.document.identifier
+                onCardFocused: { cardInfo in
+                    focusedDocumentId = cardInfo.identifier
                 },
-                onDocumentFocusedTapped: { _ in
+                onCardFocusedTapped: { _ in
                     focusedDocumentShowMoreInfo = true
                 },
-                onDocumentFocusedStackTapped: { _ in
+                onCardFocusedStackTapped: { _ in
                     focusedDocumentId = nil
                 }
             )
         }
         .navigationTitle(focusedDocument != nil
                          ? (focusedDocumentShowMoreInfo ? "Document Focused (more)" : "Document Focused")
-                         : "Vertical Document List"
+                         : "Vertical Card List"
         )
         // Override back button to unfocus...
         .navigationBarBackButtonHidden(true)

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -223,10 +223,25 @@ class ViewModel {
         
         documentModel = try! await DocumentModel(
             documentStore: documentStore,
-            documentTypeRepository: documentTypeRepository
+            documentTypeRepository: documentTypeRepository,
+            badgeFunction: { document in await self.getBadges(document: document) }
         )
     
         isLoading = false
+    }
+    
+    // For testing of the badge rendering, always add a badge with the document name
+    func getBadges(document: Document) async -> [DocumentBadge] {
+        let displayName = document.displayName ?? "Unknown Document"
+        let hash = displayName.hashValue
+        let red = (hash >> 16) & 0xFF
+        let green = (hash >> 8) & 0xFF
+        let blue = hash & 0xFF
+        let badge = DocumentBadge(
+            text: displayName,
+            color: DocumentBadgeColor(red: Int32(red), green: Int32(green), blue: Int32(blue))
+        )
+        return [ badge ]
     }
     
     func addSelfsignedMdoc(

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
@@ -16,6 +16,8 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.multipaz.compose.notifications.NotificationManagerAndroid
 import org.multipaz.compose.prompt.PresentmentActivity
 import org.multipaz.digitalcredentials.getAppOrigin
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.util.Logger
 import java.net.NetworkInterface
@@ -90,7 +92,7 @@ actual object TestAppConfiguration {
 
     fun getPendingIntentForLaunchingQuickAccessWallet(
         source: PresentmentSource,
-        initiallySelectedDocumentId: String?
+        initiallySelectedDocumentId: String?,
     ): PendingIntent {
         return PresentmentActivity.getPendingIntent(
             source = source,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -83,6 +83,8 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.digitalcredentials.DigitalCredentials
 import org.multipaz.digitalcredentials.getDefault
 import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
+import org.multipaz.document.DocumentBadgeColor
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
@@ -99,10 +101,7 @@ import org.multipaz.presentment.uriSchemePresentment
 import org.multipaz.prompt.PromptModel
 import org.multipaz.prompt.promptModelRequestConsent
 import org.multipaz.prompt.promptModelSilentConsent
-import org.multipaz.provisioning.CredentialMetadata
 import org.multipaz.provisioning.DocumentProvisioningHandler
-import org.multipaz.provisioning.DocumentProvisioningSettings
-import org.multipaz.provisioning.ProvisioningMetadata
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.request.Requester
 import org.multipaz.secure_area_test_app.ui.CloudSecureAreaScreen
@@ -151,7 +150,7 @@ import org.multipaz.testapp.ui.TrustEntryRicalEntryScreen
 import org.multipaz.testapp.ui.TrustEntryScreen
 import org.multipaz.testapp.ui.TrustEntryVicalEntryScreen
 import org.multipaz.testapp.ui.TrustManagerScreen
-import org.multipaz.testapp.ui.VerticalDocumentListScreen
+import org.multipaz.testapp.ui.VerticalCardListScreen
 import org.multipaz.trustmanagement.CompositeTrustManager
 import org.multipaz.trustmanagement.ConfigurableTrustManager
 import org.multipaz.trustmanagement.TrustEntryX509Cert
@@ -235,12 +234,13 @@ class App private constructor (val promptModel: PromptModel) {
             documentTypeRepository = documentTypeRepository,
             zkSystemRepository = zkSystemRepository,
             eventLogger = eventLogger,
+            resolveTrustFn = ::resolveTrust,
             showConsentPromptFn = if (settingsModel.presentmentShowConsentPrompt.value) {
                 ::promptModelRequestConsent
             } else {
                 ::promptModelSilentConsent
             },
-            resolveTrustFn = ::resolveTrust,
+            getBadgesFn = ::getBadgesForDocument,
             preferSignatureToKeyAgreement = settingsModel.presentmentPreferSignatureToKeyAgreement.value,
             domainsMdocSignature = if (useAuth) {
                 listOf(TestAppUtils.CREDENTIAL_DOMAIN_MDOC_USER_AUTH, TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE)
@@ -386,7 +386,23 @@ class App private constructor (val promptModel: PromptModel) {
         documentModel = DocumentModel.create(
             documentStore = documentStore,
             documentTypeRepository = documentTypeRepository,
+            badgeFunction = ::getBadgesForDocument
         )
+    }
+
+    // For testing of the badge rendering, always add a badge with the document name
+    suspend fun getBadgesForDocument(document: Document): List<DocumentBadge> {
+        val displayName = document.displayName ?: "Unknown Document"
+        val colorRgb = displayName.hashCode()
+        val badge = DocumentBadge(
+            text = displayName,
+            color = DocumentBadgeColor(
+                red = colorRgb.and(0xff),
+                green = colorRgb.rotateRight(8).and(0xff),
+                blue = colorRgb.rotateRight(16).and(0xff),
+            )
+        )
+        return listOf(badge)
     }
 
     private suspend fun trustManagersInit() {
@@ -1040,9 +1056,9 @@ class App private constructor (val promptModel: PromptModel) {
                             onDigitalCredentialsReregister = { digitalCredentialsReregister() },
                             onClickAbout = { navController.navigate(AboutDestination) },
                             onClickDocumentStore = { navController.navigate(DocumentStoreDestination) },
-                            onClickDocumentListScreen = {
+                            onClickVerticalCardListScreen = {
                                 navController.navigate(
-                                    DocumentListDestination
+                                    VerticalCardListDestination
                                 )
                             },
                             onClickTrustedIssuers = {
@@ -1654,14 +1670,14 @@ class App private constructor (val promptModel: PromptModel) {
                         )
                     }
                 }
-                composable<DocumentListDestination>(
+                composable<VerticalCardListDestination>(
                     enterTransition = { null },
                     exitTransition = { null },
                     popEnterTransition = { null },
                     popExitTransition = { null }
                 ) { backStackEntry ->
-                    // Note: VerticalDocumentListScreen has its own AppBar
-                    VerticalDocumentListScreen(
+                    // Note: VerticalCardListScreen has its own AppBar
+                    VerticalCardListScreen(
                         documentStore = documentStore,
                         documentModel = documentModel,
                         settingsModel = settingsModel,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -145,7 +145,7 @@ data class NfcReaderDestination(
 ): Destination()
 
 @Serializable
-data object DocumentListDestination: Destination()
+data object VerticalCardListDestination: Destination()
 
 @Serializable
 data object EventLogDestination: Destination()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppConfiguration.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppConfiguration.kt
@@ -2,6 +2,8 @@ package org.multipaz.testapp
 
 import io.ktor.client.engine.HttpClientEngineFactory
 import org.jetbrains.compose.resources.DrawableResource
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.storage.Storage
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
@@ -56,7 +56,8 @@ import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
-import org.multipaz.compose.document.DocumentCarousel
+import org.multipaz.compose.cards.CardCarousel
+import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.crypto.AsymmetricKey
@@ -248,17 +249,19 @@ fun DocumentStoreScreen(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         item {
-            DocumentCarousel(
-                documentModel = documentModel,
-                initialDocumentId = settingsModel.currentlyFocusedDocumentId.value,
+            CardCarousel(
+                cardInfos = documentInfos,
+                initialCardInfo = documentInfos.find { it.identifier == settingsModel.currentlyFocusedDocumentId.value },
                 allowReordering = true,
-                onDocumentClicked = { documentInfo ->
+                onCardClicked = { cardInfo ->
+                    val documentInfo = cardInfo as DocumentInfo
                     onViewDocument(documentInfo.document.identifier)
                 },
-                onDocumentFocused = { documentInfo ->
-                    settingsModel.currentlyFocusedDocumentId.value = documentInfo.document.identifier
+                onCardFocused = { cardInfo ->
+                    settingsModel.currentlyFocusedDocumentId.value = cardInfo.identifier
                 },
-                onDocumentReordered = { documentInfo, oldPos, newPos ->
+                onCardReordered = { cardInfo, oldPos, newPos ->
+                    val documentInfo = cardInfo as DocumentInfo
                     coroutineScope.launch {
                         try {
                             documentModel.setDocumentPosition(
@@ -270,8 +273,9 @@ fun DocumentStoreScreen(
                         }
                     }
                 },
-                selectedDocumentInfo = { documentInfo, index, total ->
-                    if (documentInfo != null) {
+                selectedCardInfo = { cardInfo, index, total ->
+                    if (cardInfo != null) {
+                        val documentInfo = cardInfo as DocumentInfo
                         Text(
                             text = "${index + 1} of $total: ${documentInfo.document.displayName ?: "No displayname"}",
                             fontWeight = FontWeight.Bold
@@ -283,7 +287,7 @@ fun DocumentStoreScreen(
                         )
                     }
                 },
-                emptyDocumentContent = {
+                emptyCardContent = {
                     Text(
                         text = "No documents in store",
                         fontWeight = FontWeight.Bold

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -52,7 +52,7 @@ fun StartScreen(
     onClickScreenLock: () -> Unit = {},
     onClickPickersScreen: () -> Unit = {},
     onClickNfcReadersScreen: () -> Unit = {},
-    onClickDocumentListScreen: () -> Unit = {},
+    onClickVerticalCardListScreen: () -> Unit = {},
     onClickQuickAccessWallet: () -> Unit = {},
     onClickEventLog: () -> Unit = {},
     onClickShareSheet: () -> Unit = {},
@@ -133,8 +133,8 @@ fun StartScreen(
                 }
 
                 item {
-                    TextButton(onClick = onClickDocumentListScreen) {
-                        Text("Vertical Document List")
+                    TextButton(onClick = onClickVerticalCardListScreen) {
+                        Text("Vertical Card List")
                     }
                 }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -1,7 +1,6 @@
 package org.multipaz.testapp.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,20 +36,18 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlinx.coroutines.launch
-import org.multipaz.compose.document.VerticalDocumentList
+import org.multipaz.compose.cards.VerticalCardList
 import org.multipaz.compose.document.DocumentModel
+import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.document.DocumentStore
-import org.multipaz.testapp.SettingsDestination
-import org.multipaz.testapp.TestAppConfiguration
 import org.multipaz.testapp.TestAppSettingsModel
 import org.multipaz.util.Logger
 
-private const val TAG = "DocumentListScreen"
+private const val TAG = "VerticalCardListScreen"
 
 private data class VisibilityOption(
     val displayName: String,
@@ -60,7 +56,7 @@ private data class VisibilityOption(
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun VerticalDocumentListScreen(
+fun VerticalCardListScreen(
     documentStore: DocumentStore,
     documentModel: DocumentModel,
     settingsModel: TestAppSettingsModel,
@@ -108,7 +104,7 @@ fun VerticalDocumentListScreen(
                             "Document Focused"
                         }
                     } else {
-                        "Vertical Document List"
+                        "Vertical Card List"
                     }
                     Text(text = text)},
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -194,14 +190,16 @@ fun VerticalDocumentListScreen(
                 (windowInfo.containerSize.height / 3f).toDp()
             }
 
-            VerticalDocumentList(
-                documentModel = documentModel,
-                focusedDocument = focusedDocument,
+            val cardInfos by documentModel.documentInfos.collectAsState()
+            VerticalCardList(
+                cardInfos = cardInfos,
+                focusedCard = focusedDocument,
                 unfocusedVisiblePercent = visibilityOptionsSelected.value.visibilityPercentage,
-                allowDocumentReordering = allowDocumentReordering,
+                allowCardReordering = allowDocumentReordering,
                 showStackWhileFocused = showStackWhileFocused,
                 cardMaxHeight = maxCardHeight,
-                showDocumentInfo = { documentInfo ->
+                showCardInfo = { cardInfo ->
+                    val documentInfo = cardInfo as DocumentInfo
                     Column(
                         modifier = Modifier.fillMaxHeight(),
                         horizontalAlignment = Alignment.CenterHorizontally
@@ -219,20 +217,22 @@ fun VerticalDocumentListScreen(
                         }
                     }
                 },
-                emptyDocumentContent = {
+                emptyContent = {
                     Text("No documents available.")
                 },
-                onDocumentFocused = { documentInfo ->
+                onCardFocused = { cardInfo ->
+                    val documentInfo = cardInfo as DocumentInfo
                     focusedDocumentShowMoreInfo = false
                     focusedDocumentId = documentInfo.document.identifier
                 },
-                onDocumentFocusedTapped = {
+                onCardFocusedTapped = {
                     focusedDocumentShowMoreInfo = true
                 },
-                onDocumentFocusedStackTapped = {
+                onCardFocusedStackTapped = {
                     focusedDocumentId = null
                 },
-                onDocumentReordered = { documentInfo, newIndex ->
+                onCardReordered = { cardInfo, newIndex ->
+                    val documentInfo = cardInfo as DocumentInfo
                     coroutineScope.launch {
                         try {
                             documentModel.setDocumentPosition(

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/TestAppConfiguration.ios.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.app_icon
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.storage.Storage
 import org.multipaz.storage.ios.IosStorage

--- a/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/TestAppConfiguration.wasmJs.kt
+++ b/samples/testapp/src/wasmJsMain/kotlin/org/multipaz/testapp/TestAppConfiguration.wasmJs.kt
@@ -4,6 +4,8 @@ import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.js.Js
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.app_icon
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentBadge
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.util.Platform
 


### PR DESCRIPTION
This introduces `DocumentBadge` which is a construct for showing a badge on top of a document, given a string and a color of the badge.

For display, it is expected that these badges are ephemeral in nature so don't make them part of `Document`. Instead, make `DocumentModel` and `PresentmentSource` provide them at runtime via an application provided callback / lambda. This enables the app to easily put up a "Updated" badge for only a day or two after receiving the PII update.

Also rename `VerticalDocumentList`, `DocumentCarousel` to `VerticalCardList`, `CardCarousel` and introduce an interface `CardInfo` and make `DocumentInfo` implement that. Effectively, this allows apps to easily inject other cards than those coming from a `DocumentModel` / `DocumentStore`.

Fixes #1705.

Test: Manually tested on Android and iOS.
