### PR TITLE
Add event for credential provisioning.

### DIFF
--- a/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
+++ b/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
@@ -726,13 +726,17 @@ class CborSymbolProcessor(
                         }
                     }
                 }
-                line("return $baseName(")
-                withIndent {
-                    constructorParameters.forEach { parameter ->
-                        line("$parameter,")
+                if (classDeclaration.classKind == ClassKind.OBJECT) {
+                    line ("return $baseName")
+                } else {
+                    line("return $baseName(")
+                    withIndent {
+                        constructorParameters.forEach { parameter ->
+                            line("$parameter,")
+                        }
                     }
+                    line(")")
                 }
-                line(")")
             }
 
             if (hadMergedMap) {

--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -199,10 +199,10 @@
     <string name="trust_entry_editor_test_only_vical">This VICAL is for testing only</string>
     <string name="trust_entry_editor_test_only_rical">This RICAL is for testing only</string>
 
-    <!-- AndroidPromptModel -->
-    <string name="key_unlock_default_title">Verify it\'s you</string>
+    <!-- DefaultToHumanReadable.kt -->
+    <string name="key_unlock_default_title">Verify it's you</string>
     <string name="key_unlock_default_subtitle">Authentication is required</string>
-    <string name="key_unlock_present_title">Verify it\'s you to share the document</string>
+    <string name="key_unlock_present_title">Verify it's you to share the document</string>
     <string name="key_unlock_present_bio_subtitle">Authentication is required</string>
     <string name="key_unlock_present_passphrase_subtitle">Enter the passphrase associated with the document</string>
     <string name="aks_unlock_present_pin_subtitle">Enter the PIN associated with the document</string>

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventPresentment.kt
@@ -4,7 +4,7 @@ import org.multipaz.cbor.DataItem
 import kotlin.time.Instant
 
 /**
- * Base class for events recorded in the [EventLogger] related to credential presentment.
+ * Base class for events recorded in [EventLogger] related to credential presentment.
  *
  * @property presentmentData a [EventPresentmentData] with details about the presentment.
  */

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioning.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioning.kt
@@ -1,0 +1,43 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.provisioning.Display
+import kotlin.time.Instant
+
+/**
+ * An event recorded when a document is provisioned.
+ *
+ * @property identifier the event identifier.
+ * @property timestamp the time the event was recorded.
+ * @property appData application-specific data.
+ * @property issuerData information about the issuer.
+ * @property initialProvisioning whether this was the first time the document was provisioned.
+ * @property documentId the unique identifier of the document.
+ * @property documentName the name of the document, if available.
+ * @property display display information for the document.
+ * @property credentialsFetched the credentials fetched, keyed by credential configuration ID.
+ */
+data class EventProvisioning(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    val issuerData: EventProvisioningIssuerData,
+    val initialProvisioning: Boolean,
+    val documentId: String,
+    val documentName: String?,
+    val display: Display?,
+    val credentialsFetched: Map<String, List<EventProvisioningCredentialData>>
+): Event(identifier, timestamp, appData) {
+
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        issuerData = this.issuerData,
+        initialProvisioning = this.initialProvisioning,
+        documentId = this.documentId,
+        documentName = this.documentName,
+        display = this.display,
+        credentialsFetched = this.credentialsFetched,
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningCredentialData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningCredentialData.kt
@@ -1,0 +1,16 @@
+package org.multipaz.eventlogger
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
+
+/**
+ * Data for a credential fetched during provisioning.
+ *
+ * @property issuerProvidedData the raw data provided by the issuer.
+ */
+@CborSerializable
+data class EventProvisioningCredentialData(
+    val issuerProvidedData: ByteString,
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningIssuerData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningIssuerData.kt
@@ -1,0 +1,16 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.provisioning.Display
+
+/**
+ * Base class for data about the issuer in a provisioning event.
+ *
+ * @property display display information about the issuer.
+ */
+@CborSerializable
+sealed class EventProvisioningIssuerData(
+    open val display: Display
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningIssuerDataOpenID4VCI.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventProvisioningIssuerDataOpenID4VCI.kt
@@ -1,0 +1,15 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.provisioning.Display
+
+/**
+ * Issuer data for provisioning via OpenID4VCI.
+ *
+ * @property url the URL of the issuer.
+ * @property credentialId the identifier of the credential.
+ */
+data class EventProvisioningIssuerDataOpenID4VCI(
+    override val display: Display,
+    val url: String,
+    val credentialId: String,
+): EventProvisioningIssuerData(display)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/CredentialMetadata.kt
@@ -1,8 +1,11 @@
 package org.multipaz.provisioning
 
+import org.multipaz.cbor.annotation.CborSerializable
+
 /**
  * Metadata for a particular type of credential that an issuer can provision.
  */
+@CborSerializable
 data class CredentialMetadata(
     /** Credential name and visual representation of that credential in the wallet. */
     val display: Display,
@@ -12,4 +15,6 @@ data class CredentialMetadata(
     val keyBindingType: KeyBindingType,
     /** Maximum number of credentials that can be requested in a single request */
     val maxBatchSize: Int
-)
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Display.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/Display.kt
@@ -1,13 +1,20 @@
 package org.multipaz.provisioning
 
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
 
 /**
- * Describes something in the user-facing manner.
+ * Describes something in a user-facing manner.
  *
- * [logo] image bytes in PNG or JPEG format.
+ * This is used to describe both issuers and credentials.
+ *
+ * @property text User-visible text.
+ * @property logo Image bytes in PNG or JPEG format.
  */
-class Display(
+@CborSerializable
+data class Display(
     val text: String,
     val logo: ByteString?
-)
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/KeyBindingType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/KeyBindingType.kt
@@ -1,5 +1,6 @@
 package org.multipaz.provisioning
 
+import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.crypto.Algorithm
 import org.multipaz.securearea.KeyAttestation
 
@@ -7,6 +8,7 @@ import org.multipaz.securearea.KeyAttestation
  * Type of [KeyBindingInfo] that credential issuer expects in [ProvisioningClient.obtainCredentials]
  * call.
  */
+@CborSerializable
 sealed class KeyBindingType {
     /**
      * No key binding, [KeyBindingInfo.Keyless] should be used.
@@ -30,4 +32,6 @@ sealed class KeyBindingType {
     data class Attestation(
         val algorithm: Algorithm
     ): KeyBindingType()
+
+    companion object
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -21,7 +21,10 @@ import org.multipaz.credential.Credential
 import org.multipaz.credential.SecureAreaBoundCredential
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.document.Document
-import org.multipaz.webtoken.buildJwt
+import org.multipaz.eventlogger.EventLogger
+import org.multipaz.eventlogger.EventProvisioning
+import org.multipaz.eventlogger.EventProvisioningCredentialData
+import org.multipaz.eventlogger.EventProvisioningIssuerDataOpenID4VCI
 import org.multipaz.prompt.PromptModel
 import org.multipaz.provisioning.openid4vci.OpenID4VCI
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
@@ -32,6 +35,7 @@ import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
 import org.multipaz.securearea.SecureAreaProvider
 import org.multipaz.util.Logger
+import org.multipaz.webtoken.buildJwt
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
@@ -52,12 +56,14 @@ private const val TAG = "ProvisioningModel"
  * @param authorizationSecureArea secure area that is used to store session authorization keys
  *  during provisioning; when credentials are refreshed, it is important that the [SecureArea]
  *  used during refresh is the same that was used during the initial provisioning
+ * @param eventLogger an [EventLogger] for logging events or `null`.
  */
 class ProvisioningModel(
     private val documentProvisioningHandler: AbstractDocumentProvisioningHandler,
     private val httpClient: HttpClient,
     private val promptModel: PromptModel,
-    private val authorizationSecureArea: SecureArea
+    private val authorizationSecureArea: SecureArea,
+    private val eventLogger: EventLogger? = null
 ) {
     private var mutableState = MutableStateFlow<State>(Idle)
     private var mutableMetadata = MutableStateFlow<ProvisioningMetadata?>(null)
@@ -169,6 +175,7 @@ class ProvisioningModel(
                 provisioningClient = provisioningClient,
                 targetDocument = document,
                 documentProvisioningHandler = documentProvisioningHandler,
+                eventLogger = eventLogger
             ).second
         }
         return numCredentialsFetched.await()
@@ -215,6 +222,7 @@ class ProvisioningModel(
                     provisioningClient = provisioningClient,
                     targetDocument = targetDocument,
                     documentProvisioningHandler = documentProvisioningHandler,
+                    eventLogger = eventLogger,
                     onRequestingCredentials = {
                         mutableState.emit(RequestingCredentials)
                     }
@@ -379,6 +387,7 @@ private suspend fun requestCredentials(
     provisioningClient: ProvisioningClient,
     targetDocument: Document?,
     documentProvisioningHandler: AbstractDocumentProvisioningHandler,
+    eventLogger: EventLogger?,
     onRequestingCredentials: suspend () -> Unit = {},
 ): Pair<Document, Int> {
     val issuerMetadata = provisioningClient.getMetadata()
@@ -458,12 +467,30 @@ private suspend fun requestCredentials(
                 if (credentialData.size != 1) {
                     throw IllegalStateException("Only a single keyless credential is expected to be issued")
                 }
-                pendingCredential.certify(credentialData.first().issuerData)
+                val issuerData = credentialData.first().issuerData
+                pendingCredential.certify(issuerData)
 
                 documentProvisioningHandler.updateDocument(
                     document = document,
                     display = credentials.display,
                     documentAuthorizationData = provisioningClient.getAuthorizationData()
+                )
+
+                eventLogger?.addEvent(
+                    EventProvisioning(
+                        issuerData = EventProvisioningIssuerDataOpenID4VCI(
+                            display = issuerMetadata.display,
+                            url = issuerMetadata.url,
+                            credentialId = credentialData.first().credentialId
+                        ),
+                        initialProvisioning = (targetDocument == null),
+                        documentId = document.identifier,
+                        documentName = document.displayName,
+                        display = credentials.display,
+                        credentialsFetched = mapOf(
+                            pendingCredential.domain to listOf(EventProvisioningCredentialData(issuerData))
+                        )
+                    )
                 )
 
                 // Modify pendingCredentials so this now certified credential isn't removed on error
@@ -486,6 +513,7 @@ private suspend fun requestCredentials(
                 // Credential minting can happen offline, we can get any number of new credentials
                 // here, some might have been created as pending in the previous calls to this
                 // method.
+                val credentialsFetched = mutableMapOf<String, MutableList<EventProvisioningCredentialData>>()
                 for ((credentialId, credentialData) in credentialData) {
                     val pendingCredential = document.lookupCredential(credentialId)
                     if (pendingCredential == null) {
@@ -494,12 +522,44 @@ private suspend fun requestCredentials(
                         Logger.e(TAG, "Credential '$credentialId' is already certified")
                     } else {
                         pendingCredential.certify(credentialData)
+                        val domainList = credentialsFetched.getOrPut(key = pendingCredential.domain) { mutableListOf() }
+                        domainList.add(EventProvisioningCredentialData(credentialData))
                     }
                 }
                 documentProvisioningHandler.updateDocument(
                     document = document,
                     display = credentials.display,
                     documentAuthorizationData = provisioningClient.getAuthorizationData()
+                )
+
+                eventLogger?.addEvent(
+                    EventProvisioning(
+                        issuerData = EventProvisioningIssuerDataOpenID4VCI(
+                            display = issuerMetadata.display,
+                            url = issuerMetadata.url,
+                            credentialId = credentialData.first().credentialId
+                        ),
+                        initialProvisioning = (targetDocument == null),
+                        documentId = document.identifier,
+                        documentName = document.displayName,
+                        display = credentials.display,
+                        credentialsFetched = credentialsFetched
+                    )
+                )
+            } else {
+                eventLogger?.addEvent(
+                    EventProvisioning(
+                        issuerData = EventProvisioningIssuerDataOpenID4VCI(
+                            display = issuerMetadata.display,
+                            url = issuerMetadata.url,
+                            credentialId = issuerMetadata.credentials.entries.first().key
+                        ),
+                        initialProvisioning = (targetDocument == null),
+                        documentId = document.identifier,
+                        documentName = document.displayName,
+                        display = null,
+                        credentialsFetched = emptyMap()
+                    )
                 )
             }
         }
@@ -514,6 +574,7 @@ private suspend fun requestCredentials(
         }
         throw err
     }
+
     return Pair(document, numCredentialsFetched)
 }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -299,6 +299,7 @@ class App private constructor (val promptModel: PromptModel) {
             val initFuncs = listOf<Pair<suspend () -> Unit, String>>(
                 Pair(TestAppConfiguration::init, "TestAppConfiguration::init"),
                 Pair(::settingsInit, "settingsInit"),
+                Pair(::eventLoggerInit, "eventLoggerInit"),
                 Pair(::platformCryptoInit, "platformCryptoInit"),
                 Pair(::platformExternalNfcTagReadersInit, "platformExternalNfcTagReadersInit"),
                 Pair(::documentTypeRepositoryInit, "documentTypeRepositoryInit"),
@@ -313,7 +314,6 @@ class App private constructor (val promptModel: PromptModel) {
                 Pair(::zkSystemRepositoryInit, "zkSystemRepositoryInit"),
                 Pair(::observeModeInit, "observeModeInit"),
                 Pair(::digitalCredentialsInit, "digitalCredentialsInit"),
-                Pair(::eventLoggerInit, "eventLoggerInit"),
             )
 
             val begin = Clock.System.now()
@@ -415,7 +415,8 @@ class App private constructor (val promptModel: PromptModel) {
                 followRedirects = false
             },
             promptModel = promptModel,
-            authorizationSecureArea = secureArea
+            authorizationSecureArea = secureArea,
+            eventLogger = eventLogger
         )
         provisioningSupport = ProvisioningSupport(
             storage = TestAppConfiguration.storage,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -50,6 +50,8 @@ import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
 import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
 import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
+import org.multipaz.eventlogger.EventProvisioning
+import org.multipaz.eventlogger.EventSimple
 import org.multipaz.eventlogger.SimpleEventLogger
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -156,7 +158,8 @@ fun EventLoggerScreen(
                     }
 
                     else -> {
-                        currentEvents.forEach { event ->
+                        // Show the newest events first
+                        currentEvents.reversed().forEach { event ->
                             EventItem(
                                 modifier = Modifier
                                     .clickable { onEventClicked(event) },
@@ -184,8 +187,84 @@ private fun EventItem(
 ) {
     // Right now the all events are presentment events. This will change in the future as we add
     // support for logging other events
-    val presentmentData = (event as EventPresentment).presentmentData
+    when (event) {
+        is EventPresentment -> {
+            EventItemPresentment(
+                event = event,
+                imageLoader = imageLoader,
+                documentModel = documentModel,
+                imageSize = imageSize,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
+        is EventProvisioning -> {
+            EventItemProvisioning(
+                event = event,
+                imageLoader = imageLoader,
+                documentModel = documentModel,
+                imageSize = imageSize,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
+        is EventSimple -> {
+            FloatingItemCenteredText(
+                text = "EventSimple w/ ${event.appData.size} bytes of data"
+            )
+        }
+    }
+}
 
+@Composable
+private fun EventItemProvisioning(
+    event: EventProvisioning,
+    imageLoader: ImageLoader,
+    documentModel: DocumentModel,
+    imageSize: Dp = 40.dp,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val docInfo = event.documentId.let { documentId ->
+        documentModel.documentInfos.collectAsState().value.find {
+            it.document.identifier == documentId
+        }
+    }
+
+    val eventType = if (event.initialProvisioning) {
+        "Document provisioning"
+    } else {
+        "Credential refresh"
+    }
+
+    val eventDateTimeString = event.timestamp.toLocalDateTime(timeZone = timeZone).formatLocalized()
+    val text = "$eventDateTimeString • $eventType"
+
+    FloatingItemText(
+        modifier = modifier,
+        image = {
+            docInfo?.cardArt?.let {
+                Image(
+                    modifier = modifier.size(imageSize),
+                    bitmap = it,
+                    contentDescription = null
+                )
+            } ?: Spacer(modifier = Modifier.size(imageSize))
+        },
+        text = docInfo?.document?.displayName ?: event.documentName ?: "Unknown document",
+        secondary = text,
+    )
+}
+
+@Composable
+private fun EventItemPresentment(
+    event: EventPresentment,
+    imageLoader: ImageLoader,
+    documentModel: DocumentModel,
+    imageSize: Dp = 40.dp,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
     val sharingType = when (event) {
         is EventPresentmentDigitalCredentialsMdocApi -> getSharingType(event.origin)
         is EventPresentmentDigitalCredentialsOpenID4VP -> getSharingType(event.origin)
@@ -194,7 +273,7 @@ private fun EventItem(
         is EventPresentmentUriSchemeOpenID4VP ->getSharingType(event.origin)
     }
 
-    val firstDoc = presentmentData.requestedDocuments.firstOrNull()
+    val firstDoc = event.presentmentData.requestedDocuments.firstOrNull()
     val firstDocInfo = firstDoc?.let { requestedDocument ->
         documentModel.documentInfos.collectAsState().value.find {
             it.document.identifier == requestedDocument.documentId

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -59,6 +59,7 @@ import org.multipaz.compose.decodeImage
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.eventlogger.SimpleEventLoggerModel
 import org.multipaz.compose.getOutlinedImageVector
+import org.multipaz.compose.items.FloatingItemCenteredText
 import org.multipaz.compose.items.FloatingItemHeadingAndText
 import org.multipaz.compose.items.FloatingItemList
 import org.multipaz.compose.rememberUiBoundCoroutineScope
@@ -76,6 +77,9 @@ import org.multipaz.eventlogger.EventPresentmentDigitalCredentialsOpenID4VP
 import org.multipaz.eventlogger.EventPresentmentIso18013AnnexA
 import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
+import org.multipaz.eventlogger.EventProvisioning
+import org.multipaz.eventlogger.EventProvisioningIssuerDataOpenID4VCI
+import org.multipaz.eventlogger.EventSimple
 import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.toDataItem
 import org.multipaz.prompt.PromptModel
@@ -243,15 +247,138 @@ private fun EventViewer(
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
     modifier: Modifier = Modifier
 ) {
+    when (event) {
+        is EventPresentment -> {
+            EventViewerPresentment(
+                event = event,
+                documentTypeRepository = documentTypeRepository,
+                documentModel = documentModel,
+                imageLoader = imageLoader,
+                onViewCertificateChain = onViewCertificateChain,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
+        is EventProvisioning -> {
+            EventViewerProvisioning(
+                event = event,
+                documentTypeRepository = documentTypeRepository,
+                documentModel = documentModel,
+                imageLoader = imageLoader,
+                onViewCertificateChain = onViewCertificateChain,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
+        is EventSimple -> {
+           FloatingItemList(title = "EventSimple") {
+               FloatingItemCenteredText(text = "${event.data.size} bytes of data")
+           }
+        }
+    }
+}
+
+@Composable
+private fun EventViewerProvisioning(
+    event: EventProvisioning,
+    documentTypeRepository: DocumentTypeRepository,
+    documentModel: DocumentModel,
+    imageLoader: ImageLoader,
+    onViewCertificateChain: (certChain: X509CertChain) -> Unit,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val docInfo = documentModel.documentInfos.collectAsState().value.find {
+        it.document.identifier == event.documentId
+    }
+
+    val imageSize = 80.dp
+    event.issuerData.display.logo?.let {
+        val bitmap = remember { decodeImage(it.toByteArray()) }
+        Image(
+            modifier = Modifier.size(imageSize),
+            bitmap = bitmap,
+            contentDescription = null
+        )
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (docInfo != null) {
+            Image(
+                modifier = Modifier.height(80.dp),
+                bitmap = docInfo.cardArt,
+                contentDescription = null
+            )
+        }
+        Text(
+            text = docInfo?.document?.displayName ?: "Unknown document",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+
+        val eventDateTime = event.timestamp.toLocalDateTime(timeZone = timeZone)
+        val eventDateTimeString = eventDateTime.formatLocalized(
+            dateStyle = FormatStyle.LONG,
+            timeStyle = FormatStyle.LONG
+        )
+
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp)
+        ) {
+            FloatingItemHeadingAndText(
+                heading = "Date and time",
+                text = eventDateTimeString
+            )
+            FloatingItemHeadingAndText(
+                heading = "Issuer name",
+                text = event.issuerData.display.text
+            )
+            when (event.issuerData) {
+                is EventProvisioningIssuerDataOpenID4VCI -> {
+                    FloatingItemHeadingAndText(
+                        heading = "OpenID4VCI server",
+                        text = (event.issuerData as EventProvisioningIssuerDataOpenID4VCI).url
+                    )
+                }
+            }
+            FloatingItemHeadingAndText(
+                heading = "Type",
+                text = if (event.initialProvisioning) "Initial provisioning" else "Credential refresh"
+            )
+            var numCredentials = 0
+            event.credentialsFetched.forEach { (domain, credentials) -> numCredentials += credentials.size }
+            FloatingItemHeadingAndText(
+                heading = "Credentials",
+                text = if (numCredentials == 1) {
+                    "1 credential downloaded"
+                } else {
+                    "$numCredentials credentials downloaded"
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun EventViewerPresentment(
+    event: EventPresentment,
+    documentTypeRepository: DocumentTypeRepository,
+    documentModel: DocumentModel,
+    imageLoader: ImageLoader,
+    onViewCertificateChain: (certChain: X509CertChain) -> Unit,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
     val eventDateTime = event.timestamp.toLocalDateTime(timeZone = timeZone)
     val eventDateTimeString = eventDateTime.formatLocalized(
         dateStyle = FormatStyle.LONG,
         timeStyle = FormatStyle.LONG
     )
-
-    // Right now the all events are presentment events. This will change in the future as we add
-    // support for logging other events
-    val presentmentData = (event as EventPresentment).presentmentData
 
     val protocol = when (event) {
         is EventPresentmentDigitalCredentialsMdocApi -> "W3C DC API w/ ISO/IEC 18013-7:2025 Annex C"
@@ -267,14 +394,14 @@ private fun EventViewer(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val imageSize = 80.dp
-        presentmentData.trustMetadata?.displayIcon?.let {
+        event.presentmentData.trustMetadata?.displayIcon?.let {
             val bitmap = remember { decodeImage(it.toByteArray()) }
             Image(
                 modifier = Modifier.size(imageSize),
                 bitmap = bitmap,
                 contentDescription = null
             )
-        } ?: presentmentData.trustMetadata?.displayIconUrl?.let {
+        } ?: event.presentmentData.trustMetadata?.displayIconUrl?.let {
             AsyncImage(
                 modifier = Modifier.size(imageSize),
                 model = it,
@@ -285,7 +412,7 @@ private fun EventViewer(
         }
 
         Text(
-            text = presentmentData.requesterName ?: "Unknown requester",
+            text = event.presentmentData.requesterName ?: "Unknown requester",
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
@@ -333,7 +460,7 @@ private fun EventViewer(
                 text =  protocol
             )
 
-            if (presentmentData.trustMetadata != null) {
+            if (event.presentmentData.trustMetadata != null) {
                 FloatingItemHeadingAndText(
                     heading = "Requester trusted",
                     text =  "Yes, in trust list"
@@ -349,7 +476,7 @@ private fun EventViewer(
                 )
             }
 
-            presentmentData.requesterCertChain?.let {
+            event.presentmentData.requesterCertChain?.let {
                 FloatingItemHeadingAndText(
                     heading = "Requester certificate",
                     text = "Click to view",
@@ -364,7 +491,7 @@ private fun EventViewer(
                 )
             }
 
-            presentmentData.trustMetadata?.privacyPolicyUrl?.let {
+            event.presentmentData.trustMetadata?.privacyPolicyUrl?.let {
                 FloatingItemHeadingAndText(
                     heading = "Requester privacy policy",
                     text = AnnotatedString.fromMarkdown(
@@ -374,7 +501,7 @@ private fun EventViewer(
             }
         }
 
-        presentmentData.requestedDocuments.forEach { requestedDocument ->
+        event.presentmentData.requestedDocuments.forEach { requestedDocument ->
             val info = documentModel.documentInfos.collectAsState().value.find {
                 it.document.identifier == requestedDocument.documentId
             }


### PR DESCRIPTION
This adds `EventProvisioning` which is logged when interacting with a provisioning server, including serializing the data structures needed for proper event analysis. This includes adding CborSerializable to a couple of existing types:

- org.multipaz.provisioning.Display
- org.multipaz.provisioning.KeyBindingType
- org.multipaz.provisioning.CredentialMetadata

This can be used by passing an `EventLogger` when constructing a `ProvisioningModel`, similar to how `PresentmentSource` also has an optional `EventLogger`.

This PR also fixes the following other small problems

- Add support for objects in multipaz-cbor-rpc.
- Removes a superfluous apostrophe in a string used in the biometric prompt.

Test: Manually tested