### PR TITLE
Introduce DocumentAttributeSensitivity.

### DIFF
--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/Aadhaar.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/Aadhaar.kt
@@ -7,6 +7,7 @@ import org.multipaz.documenttype.DocumentType
 import org.multipaz.documenttype.Icon
 import org.multipaz.util.fromBase64Url
 import kotlinx.datetime.LocalDate
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the Aadhaar Document Type.
@@ -26,414 +27,422 @@ object Aadhaar {
         return DocumentType.Builder("Aadhaar")
             .addMdocDocumentType(AADHAAR_DOCTYPE)
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "credential_issuing_date",
-                "Credential issuing date",
-                "Date of credential issuance",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse("2023-01-01").toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "credential_issuing_date",
+                displayName = "Credential issuing date",
+                description = "Date of credential issuance",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse("2023-01-01").toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "enrolment_date",
-                "Enrollment date",
-                "Date of enrollment",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                LocalDate.parse("2023-01-01").toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "enrolment_date",
+                displayName = "Enrollment date",
+                description = "Date of enrollment",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.TODAY,
+                sampleValue = LocalDate.parse("2023-01-01").toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "enrolment_number",
-                "Enrollment number",
-                "Enrollment number",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.NUMBERS,
-                "1234567890".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "enrolment_number",
+                displayName = "Enrollment number",
+                description = "Enrollment number",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = "1234567890".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "is_nri",
-                "Is NRI",
-                "Resident is NRI",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.GLOBE,
-                false.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "is_nri",
+                displayName = "Is NRI",
+                description = "Resident is NRI",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.GLOBE,
+                sampleValue = false.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "resident_image",
-                "Photo",
-                "Photo of the resident",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.ACCOUNT_BOX,
-                SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
+                type = DocumentAttributeType.Picture,
+                identifier = "resident_image",
+                displayName = "Photo",
+                description = "Photo of the resident",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE,
+                icon = Icon.ACCOUNT_BOX,
+                sampleValue = SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_name",
-                "Name",
-                "Resident name",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_name",
+                displayName = "Name",
+                description = "Resident name",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.GIVEN_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_resident_name",
-                "Local name",
-                "Resident name in local language",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_resident_name",
+                displayName = "Local name",
+                description = "Resident name in local language",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.GIVEN_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_above18",
-                "Age above 18",
-                "Age above 18",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                true.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_above18",
+                displayName = "Age above 18",
+                description = "Age above 18",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = true.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_above50",
-                "Age above 50",
-                "Age above 50",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                true.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_above50",
+                displayName = "Age above 50",
+                description = "Age above 50",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = true.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_above60",
-                "Age above 60",
-                "Age above 60",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                true.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_above60",
+                displayName = "Age above 60",
+                description = "Age above 60",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = true.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_above75",
-                "Age above 75",
-                "Age above 75",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                true.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_above75",
+                displayName = "Age above 75",
+                description = "Age above 75",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = true.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "dob",
-                "Date of birth",
-                "Date of birth",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.TODAY,
-                LocalDate.parse("1990-01-01").toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "dob",
+                displayName = "Date of birth",
+                description = "Date of birth",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.TODAY,
+                sampleValue = LocalDate.parse("1990-01-01").toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "gender",
-                "Gender",
-                "Gender",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PERSON,
-                "M".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "gender",
+                displayName = "Gender",
+                description = "Gender",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "M".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "building",
-                "Building",
-                "Building",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Building 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "building",
+                displayName = "Building",
+                description = "Building",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Building 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_building",
-                "Local building",
-                "Local building",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Building 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_building",
+                displayName = "Local building",
+                description = "Local building",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Building 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "locality",
-                "Locality",
-                "Locality",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Locality 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "locality",
+                displayName = "Locality",
+                description = "Locality",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Locality 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_locality",
-                "Local locality",
-                "Local locality",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Locality 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_locality",
+                displayName = "Local locality",
+                description = "Local locality",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Locality 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "street",
-                "Street",
-                "Street",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Street 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "street",
+                displayName = "Street",
+                description = "Street",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Street 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_street",
-                "Local street",
-                "Local street",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Street 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_street",
+                displayName = "Local street",
+                description = "Local street",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Street 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "landmark",
-                "Landmark",
-                "Landmark",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Landmark 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "landmark",
+                displayName = "Landmark",
+                description = "Landmark",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Landmark 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_landmark",
-                "Local landmark",
-                "Local landmark",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Landmark 1".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_landmark",
+                displayName = "Local landmark",
+                description = "Local landmark",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Landmark 1".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "vtc",
-                "VTC",
-                "Village/town/city",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "VTC".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "vtc",
+                displayName = "VTC",
+                description = "Village/town/city",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "VTC".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_vtc",
-                "Local VTC",
-                "Local village/town/city",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "VTC".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_vtc",
+                displayName = "Local VTC",
+                description = "Local village/town/city",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "VTC".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "sub_district",
-                "Sub-district",
-                "Sub-district",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Sub-District".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "sub_district",
+                displayName = "Sub-district",
+                description = "Sub-district",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Sub-District".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_sub_district",
-                "Local Sub-district",
-                "Local Sub-district",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "Sub-District".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_sub_district",
+                displayName = "Local Sub-district",
+                description = "Local Sub-district",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "Sub-District".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "district",
-                "District",
-                "District",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "District".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "district",
+                displayName = "District",
+                description = "District",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "District".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_district",
-                "Local district",
-                "Local district",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "District".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_district",
+                displayName = "Local district",
+                description = "Local district",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "District".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "state",
-                "State",
-                "State",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_STATE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "state",
+                displayName = "State",
+                description = "State",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_STATE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_state",
-                "Local state",
-                "Local state",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_STATE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_state",
+                displayName = "Local state",
+                description = "Local state",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_STATE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "po_name",
-                "PO name",
-                "Post office name",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "PO Name".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "po_name",
+                displayName = "PO name",
+                description = "Post office name",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "PO Name".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_po_name",
-                "Local PO name",
-                "Local post office name",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                "PO Name".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_po_name",
+                displayName = "Local PO name",
+                description = "Local post office name",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "PO Name".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "pincode",
-                "Pincode",
-                "Pincode",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_POSTAL_CODE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "pincode",
+                displayName = "Pincode",
+                description = "Pincode",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_POSTAL_CODE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "address",
-                "Address",
-                "Address",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_ADDRESS.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "address",
+                displayName = "Address",
+                description = "Address",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_ADDRESS.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "local_address",
-                "Local address",
-                "Local address",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_ADDRESS.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "local_address",
+                displayName = "Local address",
+                description = "Local address",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_ADDRESS.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "mobile",
-                "Mobile",
-                "Mobile",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PHONE,
-                "1234567890".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "mobile",
+                displayName = "Mobile",
+                description = "Mobile",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PHONE,
+                sampleValue = "1234567890".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "masked_mobile",
-                "Masked mobile",
-                "Masked mobile",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.PHONE,
-                "XXXXXX7890".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "masked_mobile",
+                displayName = "Masked mobile",
+                description = "Masked mobile",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.PHONE,
+                sampleValue = "XXXXXX7890".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "email",
-                "Email",
-                "Email",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.EMAIL,
-                SampleData.EMAIL_ADDRESS.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "email",
+                displayName = "Email",
+                description = "Email",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.EMAIL,
+                sampleValue = SampleData.EMAIL_ADDRESS.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "masked_email",
-                "Masked email",
-                "Masked email",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.EMAIL,
-                "a***a@example.com".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "masked_email",
+                displayName = "Masked email",
+                description = "Masked email",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.EMAIL,
+                sampleValue = "a***a@example.com".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "masked_uid",
-                "Masked UID",
-                "Masked UID",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.NUMBERS,
-                "XXXXXXXX1234".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "masked_uid",
+                displayName = "Masked UID",
+                description = "Masked UID",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = "XXXXXXXX1234".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "aadhaar_type",
-                "Type",
-                "Type",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.BADGE,
-                "Resident".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "aadhaar_type",
+                displayName = "Type",
+                description = "Type",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                icon = Icon.BADGE,
+                sampleValue = "Resident".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "expires_on",
-                "Expires on",
-                "Expires on",
-                false,
-                AADHAAR_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "expires_on",
+                displayName = "Expires on",
+                description = "Expires on",
+                mandatory = false,
+                mdocNamespace = AADHAAR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
             .addSampleRequest(
                 id = "age_over_18",

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/AgeVerification.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/AgeVerification.kt
@@ -6,6 +6,7 @@ import org.multipaz.documenttype.DocumentType
 import org.multipaz.documenttype.Icon
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the Age Verification document type.
@@ -46,6 +47,7 @@ object AgeVerification {
                     ),
                     mandatory = (age == 18),
                     mdocNamespace = AV_NAMESPACE,
+                    sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                     icon = Icon.TODAY,
                     sampleValue =
                         if (age in ageThresholdsToProvision) {

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
@@ -32,6 +32,7 @@ import org.multipaz.documenttype.Icon
 import org.multipaz.documenttype.IntegerOption
 import org.multipaz.documenttype.StringOption
 import org.multipaz.util.fromBase64Url
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the Driving License
@@ -54,104 +55,110 @@ object DrivingLicense {
              * First the attributes that the mDL and VC Credential Type have in common
              */
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "family_name",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME),
-                true,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                SampleData.FAMILY_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.FAMILY_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "given_name",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAMES),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAMES),
-                true,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAMES),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAMES),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.GIVEN_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "birth_date",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_BIRTH),
-                true,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                LocalDate.parse(SampleData.BIRTH_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "birth_date",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_BIRTH),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.TODAY,
+                sampleValue = LocalDate.parse(SampleData.BIRTH_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "issue_date",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_ISSUE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_ISSUE),
-                true,
-                MDL_NAMESPACE,
-                Icon.DATE_RANGE,
-                LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "issue_date",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_ISSUE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_ISSUE),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.DATE_RANGE,
+                sampleValue = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "expiry_date",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_EXPIRY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_EXPIRY),
-                true,
-                MDL_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "expiry_date",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DATE_OF_EXPIRY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DATE_OF_EXPIRY),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "issuing_country",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_COUNTRY),
-                true,
-                MDL_NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_COUNTRY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "issuing_country",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_COUNTRY),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = SampleData.ISSUING_COUNTRY.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "issuing_authority",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_AUTHORITY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_AUTHORITY),
-                true,
-                MDL_NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_AUTHORITY_MDL.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "issuing_authority",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_AUTHORITY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_AUTHORITY),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = SampleData.ISSUING_AUTHORITY_MDL.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "document_number",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_LICENSE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_LICENSE_NUMBER),
-                true,
-                MDL_NAMESPACE,
-                Icon.NUMBERS,
-                SampleData.DOCUMENT_NUMBER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "document_number",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_LICENSE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_LICENSE_NUMBER),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = SampleData.DOCUMENT_NUMBER.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "portrait",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PHOTO_OF_HOLDER),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PHOTO_OF_HOLDER),
-                true,
-                MDL_NAMESPACE,
-                Icon.ACCOUNT_BOX,
-                SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
+                type = DocumentAttributeType.Picture,
+                identifier = "portrait",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PHOTO_OF_HOLDER),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PHOTO_OF_HOLDER),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE,
+                icon = Icon.ACCOUNT_BOX,
+                sampleValue = SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "driving_privileges",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DRIVING_PRIVILEGES),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DRIVING_PRIVILEGES),
-                true,
-                MDL_NAMESPACE,
-                Icon.DIRECTIONS_CAR,
-                buildCborArray {
+                type = DocumentAttributeType.ComplexType,
+                identifier = "driving_privileges",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DRIVING_PRIVILEGES),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DRIVING_PRIVILEGES),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.DIRECTIONS_CAR,
+                sampleValue = buildCborArray {
                     addCborMap {
                         put("vehicle_category_code", "A")
                         put("issue_date", Tagged(Tagged.FULL_DATE_STRING, Tstr("2018-08-09")))
@@ -165,57 +172,58 @@ object DrivingLicense {
                 }
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.DISTINGUISHING_SIGN_ISO_IEC_18013_1_ANNEX_F),
-                "un_distinguishing_sign",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_UN_DISTINGUISHING_SIGN),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_UN_DISTINGUISHING_SIGN),
-                true,
-                MDL_NAMESPACE,
-                Icon.LANGUAGE,
-                SampleData.UN_DISTINGUISHING_SIGN.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.DISTINGUISHING_SIGN_ISO_IEC_18013_1_ANNEX_F),
+                identifier = "un_distinguishing_sign",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_UN_DISTINGUISHING_SIGN),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_UN_DISTINGUISHING_SIGN),
+                mandatory = true,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.LANGUAGE,
+                sampleValue = SampleData.UN_DISTINGUISHING_SIGN.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "administrative_number",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ADMINISTRATIVE_NUMBER),
-                false,
-                MDL_NAMESPACE,
-                Icon.NUMBERS,
-                SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "administrative_number",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ADMINISTRATIVE_NUMBER),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-                "sex",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SEX),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SEX),
-                false,
-                MDL_NAMESPACE,
-                Icon.EMERGENCY,
-                SampleData.SEX_ISO_5218.toDataItem()
+                type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+                identifier = "sex",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SEX),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SEX),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = SampleData.SEX_ISO_5218.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "height",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HEIGHT),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HEIGHT),
-                false,
-                MDL_NAMESPACE,
-                Icon.EMERGENCY,
-                SampleData.HEIGHT_CM.toDataItem()
+                type = DocumentAttributeType.Number,
+                identifier = "height",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HEIGHT),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HEIGHT),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = SampleData.HEIGHT_CM.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "weight",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_WEIGHT),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_WEIGHT),
-                false,
-                MDL_NAMESPACE,
-                Icon.EMERGENCY,
-                SampleData.WEIGHT_KG.toDataItem()
+                type = DocumentAttributeType.Number,
+                identifier = "weight",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_WEIGHT),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_WEIGHT),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = SampleData.WEIGHT_KG.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("black", "Black"),
@@ -230,16 +238,16 @@ object DrivingLicense {
                         StringOption("unknown", "Unknown")
                     )
                 ),
-                "eye_colour",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_EYE_COLOR),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_EYE_COLOR),
-                false,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                "blue".toDataItem()
+                identifier = "eye_colour",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_EYE_COLOR),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_EYE_COLOR),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "blue".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("bald", "Bald"),
@@ -254,296 +262,308 @@ object DrivingLicense {
                         StringOption("unknown", "Unknown"),
                     )
                 ),
-                "hair_colour",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HAIR_COLOR),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HAIR_COLOR),
-                false,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                "blond".toDataItem()
+                identifier = "hair_colour",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HAIR_COLOR),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HAIR_COLOR),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "blond".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "birth_place",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PLACE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PLACE_OF_BIRTH),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.BIRTH_PLACE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "birth_place",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PLACE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PLACE_OF_BIRTH),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.BIRTH_PLACE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_address",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_ADDRESS),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_ADDRESS),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_ADDRESS.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_address",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_ADDRESS),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_ADDRESS),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_ADDRESS.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "portrait_capture_date",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PORTRAIT_IMAGE_TIMESTAMP),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PORTRAIT_IMAGE_TIMESTAMP),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                LocalDate.parse(SampleData.PORTRAIT_CAPTURE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "portrait_capture_date",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_PORTRAIT_IMAGE_TIMESTAMP),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_PORTRAIT_IMAGE_TIMESTAMP),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.TODAY,
+                sampleValue = LocalDate.parse(SampleData.PORTRAIT_CAPTURE_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "age_in_years",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AGE_IN_YEARS),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AGE_IN_YEARS),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_IN_YEARS.toDataItem()
+                type = DocumentAttributeType.Number,
+                identifier = "age_in_years",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AGE_IN_YEARS),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AGE_IN_YEARS),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_IN_YEARS.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "age_birth_year",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_YEAR_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_YEAR_OF_BIRTH),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_BIRTH_YEAR.toDataItem()
+                type = DocumentAttributeType.Number,
+                identifier = "age_birth_year",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_YEAR_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_YEAR_OF_BIRTH),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_BIRTH_YEAR.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_13",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_13),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_13),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_13.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_13",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_13),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_13),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_13.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_16",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_16),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_16),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_16.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_16",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_16),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_16),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_16.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_18",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_18),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_18),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_18.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_18",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_18),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_18),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_18.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_21",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_21),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_21),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_21.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_21",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_21),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_21),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_21.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_25",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_25),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_25),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_25.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_25",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_25),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_25),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_25.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_60",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_60),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_60),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_60.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_60",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_60),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_60),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_60.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_62",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_62),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_62),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_62.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_62",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_62),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_62),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_62.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_65",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_65),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_65),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_65.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_65",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_65),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_65),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_65.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_68",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_68),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_68),
-                false,
-                MDL_NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_68.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_68",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_OLDER_THAN_68),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_OLDER_THAN_68),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = SampleData.AGE_OVER_68.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "issuing_jurisdiction",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_JURISDICTION),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_JURISDICTION),
-                false,
-                MDL_NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_JURISDICTION.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "issuing_jurisdiction",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ISSUING_JURISDICTION),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ISSUING_JURISDICTION),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = SampleData.ISSUING_JURISDICTION.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "nationality",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_NATIONALITY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_NATIONALITY),
-                false,
-                MDL_NAMESPACE,
-                Icon.LANGUAGE,
-                SampleData.NATIONALITY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "nationality",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_NATIONALITY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_NATIONALITY),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.LANGUAGE,
+                sampleValue = SampleData.NATIONALITY.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_city",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_CITY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_CITY),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_CITY.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_city",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_CITY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_CITY),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_CITY.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_state",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_STATE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_STATE),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_STATE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_state",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_STATE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_STATE),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_STATE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_postal_code",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_POSTAL_CODE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_POSTAL_CODE),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_POSTAL_CODE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_postal_code",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_POSTAL_CODE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_POSTAL_CODE),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_POSTAL_CODE.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "resident_country",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_COUNTRY),
-                false,
-                MDL_NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_COUNTRY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "resident_country",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_COUNTRY),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = SampleData.RESIDENT_COUNTRY.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "family_name_national_character",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME_NATIONAL_CHARACTERS),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME_NATIONAL_CHARACTERS),
-                false,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                SampleData.FAMILY_NAME_NATIONAL_CHARACTER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "family_name_national_character",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME_NATIONAL_CHARACTERS),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME_NATIONAL_CHARACTERS),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.FAMILY_NAME_NATIONAL_CHARACTER.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "given_name_national_character",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAME_NATIONAL_CHARACTERS),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAME_NATIONAL_CHARACTERS),
-                false,
-                MDL_NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAMES_NATIONAL_CHARACTER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "given_name_national_character",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAME_NATIONAL_CHARACTERS),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAME_NATIONAL_CHARACTERS),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.GIVEN_NAMES_NATIONAL_CHARACTER.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "signature_usual_mark",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SIGNATURE_USUAL_MARK),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SIGNATURE_USUAL_MARK),
-                false,
-                MDL_NAMESPACE,
-                Icon.SIGNATURE,
-                SampleData.SIGNATURE_OR_USUAL_MARK_BASE64URL.fromBase64Url().toDataItem()
+                type = DocumentAttributeType.Picture,
+                identifier = "signature_usual_mark",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SIGNATURE_USUAL_MARK),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SIGNATURE_USUAL_MARK),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.SIGNATURE,
+                sampleValue = SampleData.SIGNATURE_OR_USUAL_MARK_BASE64URL.fromBase64Url().toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "domestic_driving_privileges",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DOMESTIC_DRIVING_PRIVILEGES),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DOMESTIC_DRIVING_PRIVILEGES),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.DIRECTIONS_CAR,
-                buildCborArray {}
+                type = DocumentAttributeType.ComplexType,
+                identifier = "domestic_driving_privileges",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_DOMESTIC_DRIVING_PRIVILEGES),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_DOMESTIC_DRIVING_PRIVILEGES),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.DIRECTIONS_CAR,
+                sampleValue = buildCborArray {}
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
-                "name_suffix",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_NAME_SUFFIX),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_NAME_SUFFIX),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "Jr III".toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
+                identifier = "name_suffix",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_NAME_SUFFIX),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_NAME_SUFFIX),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "Jr III".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(
+                type = DocumentAttributeType.IntegerOptions(
                     listOf(
                         IntegerOption(null, "(not set)"),
                         IntegerOption(1, "Donor")
                     )
                 ),
-                "organ_donor",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ORGAN_DONOR),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ORGAN_DONOR),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.EMERGENCY,
-                1.toDataItem()
+                identifier = "organ_donor",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ORGAN_DONOR),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ORGAN_DONOR),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = 1.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(
+                type = DocumentAttributeType.IntegerOptions(
                     listOf(
                         IntegerOption(null, "(not set)"),
                         IntegerOption(1, "Veteran")
                     )
                 ),
-                "veteran",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_VETERAN),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_VETERAN),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.MILITARY_TECH,
-                1.toDataItem()
+                identifier = "veteran",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_VETERAN),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_VETERAN),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.MILITARY_TECH,
+                sampleValue = 1.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("T", "Truncated"),
@@ -551,16 +571,16 @@ object DrivingLicense {
                         StringOption("U", "Unknown whether truncated"),
                     )
                 ),
-                "family_name_truncation",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME_TRUNCATION),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME_TRUNCATION),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "N".toDataItem()
+                identifier = "family_name_truncation",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_FAMILY_NAME_TRUNCATION),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_FAMILY_NAME_TRUNCATION),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "N".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("T", "Truncated"),
@@ -568,46 +588,46 @@ object DrivingLicense {
                         StringOption("U", "Unknown whether truncated"),
                     )
                 ),
-                "given_name_truncation",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAME_TRUNCATION),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAME_TRUNCATION),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "N".toDataItem()
+                identifier = "given_name_truncation",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_GIVEN_NAME_TRUNCATION),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_GIVEN_NAME_TRUNCATION),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "N".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "aka_family_name",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_FAMILY_NAME),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "Musstermensch".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "aka_family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_FAMILY_NAME),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "Musstermensch".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "aka_given_name",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_GIVEN_NAME),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_GIVEN_NAME),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "Erica".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "aka_given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_GIVEN_NAME),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_GIVEN_NAME),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "Erica".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
-                "aka_suffix",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_SUFFIX),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_SUFFIX),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.PERSON,
-                "Ica".toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.AAMVA_NAME_SUFFIX),
+                identifier = "aka_suffix",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_ALIAS_SUFFIX),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_ALIAS_SUFFIX),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "Ica".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(
+                type = DocumentAttributeType.IntegerOptions(
                     listOf(
                         IntegerOption(null, "(not set)"),
                         IntegerOption(0, "Up to 31 kg (up to 70 lbs.)"),
@@ -622,16 +642,16 @@ object DrivingLicense {
                         IntegerOption(9, "146+ kg (321+ lbs.)"),
                     )
                 ),
-                "weight_range",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_WEIGHT_RANGE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_WEIGHT_RANGE),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.EMERGENCY,
-                3.toDataItem()
+                identifier = "weight_range",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_WEIGHT_RANGE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_WEIGHT_RANGE),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = 3.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("AI", "Alaskan or American Indian"),
@@ -643,153 +663,158 @@ object DrivingLicense {
                         StringOption("W", "White")
                     )
                 ),
-                "race_ethnicity",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RACE_ETHNICITY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RACE_ETHNICITY),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.EMERGENCY,
-                "W".toDataItem()
+                identifier = "race_ethnicity",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RACE_ETHNICITY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RACE_ETHNICITY),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = "W".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption(null, "(not set)"),
                         StringOption("F", "Fully compliant"),
                         StringOption("N", "Non-compliant"),
                     )
                 ),
-                "DHS_compliance",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_COMPLIANCE_TYPE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_COMPLIANCE_TYPE),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.STARS,
-                "F".toDataItem()
+                identifier = "DHS_compliance",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_COMPLIANCE_TYPE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_COMPLIANCE_TYPE),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.STARS,
+                sampleValue = "F".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(
+                type = DocumentAttributeType.IntegerOptions(
                     listOf(
                         IntegerOption(null, "(not set)"),
                         IntegerOption(1, "Temporary lawful status")
                     )
                 ),
-                "DHS_temporary_lawful_status",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_LIMITED_DURATION_DOCUMENT_INDICATOR),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_LIMITED_DURATION_DOCUMENT_INDICATOR),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.STARS,
-                1.toDataItem()
+                identifier = "DHS_temporary_lawful_status",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_LIMITED_DURATION_DOCUMENT_INDICATOR),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_LIMITED_DURATION_DOCUMENT_INDICATOR),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.STARS,
+                sampleValue = 1.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(
+                type = DocumentAttributeType.IntegerOptions(
                     listOf(
                         IntegerOption(null, "(not set)"),
                         IntegerOption(1, "Driver's license"),
                         IntegerOption(2, "Identification card")
                     )
                 ),
-                "EDL_credential",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_EDL_INDICATOR),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_EDL_INDICATOR),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.DIRECTIONS_CAR,
-                1.toDataItem()
+                identifier = "EDL_credential",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_EDL_INDICATOR),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_EDL_INDICATOR),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.DIRECTIONS_CAR,
+                sampleValue = 1.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "resident_county",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_COUNTY),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_COUNTY),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.PLACE,
-                "037".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_county",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_RESIDENT_COUNTY),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_RESIDENT_COUNTY),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValue = "037".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "hazmat_endorsement_expiration_date",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HAZMAT_ENDORSEMENT_EXPIRATION_DATE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HAZMAT_ENDORSEMENT_EXPIRATION_DATE),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "hazmat_endorsement_expiration_date",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_HAZMAT_ENDORSEMENT_EXPIRATION_DATE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_HAZMAT_ENDORSEMENT_EXPIRATION_DATE),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-                "sex",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SEX),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SEX),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.EMERGENCY,
-                SampleData.SEX_ISO_5218.toDataItem()
+                type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+                identifier = "sex",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_SEX),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_SEX),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValue = SampleData.SEX_ISO_5218.toDataItem()
             )
             /*
              * Then the attributes that exist only in the mDL Credential Type and not in the VC Credential Type
              */
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "biometric_template_face",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_FACE),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_FACE),
-                false,
-                MDL_NAMESPACE,
-                Icon.FACE,
-                Simple.NULL
+                type = DocumentAttributeType.Picture,
+                identifier = "biometric_template_face",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_FACE),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_FACE),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.FACE,
+                sampleValue = Simple.NULL
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "biometric_template_finger",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_FINGERPRINT),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_FINGERPRINT),
-                false,
-                MDL_NAMESPACE,
-                Icon.FINGERPRINT,
-                Simple.NULL
+                type = DocumentAttributeType.Picture,
+                identifier = "biometric_template_finger",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_FINGERPRINT),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_FINGERPRINT),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.FINGERPRINT,
+                sampleValue = Simple.NULL
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "biometric_template_signature_sign",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_SIGNATURE_SIGN),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_SIGNATURE_SIGN),
-                false,
-                MDL_NAMESPACE,
-                Icon.SIGNATURE,
-                Simple.NULL
+                type = DocumentAttributeType.Picture,
+                identifier = "biometric_template_signature_sign",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_SIGNATURE_SIGN),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_SIGNATURE_SIGN),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.SIGNATURE,
+                sampleValue = Simple.NULL
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "biometric_template_iris",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_IRIS),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_IRIS),
-                false,
-                MDL_NAMESPACE,
-                Icon.EYE_TRACKING,
-                Simple.NULL
+                type = DocumentAttributeType.Picture,
+                identifier = "biometric_template_iris",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_BIOMETRIC_TEMPLATE_IRIS),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_BIOMETRIC_TEMPLATE_IRIS),
+                mandatory = false,
+                mdocNamespace = MDL_NAMESPACE,
+                icon = Icon.EYE_TRACKING,
+                sampleValue = Simple.NULL
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "audit_information",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AUDIT_INFORMATION),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AUDIT_INFORMATION),
-                false,
-                AAMVA_NAMESPACE,
-                Icon.STARS,
-                "".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "audit_information",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AUDIT_INFORMATION),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AUDIT_INFORMATION),
+                mandatory = false,
+                mdocNamespace = AAMVA_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.STARS,
+                sampleValue = "".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "aamva_version",
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AAMVA_VERSION_NUMBER),
-                getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AAMVA_VERSION_NUMBER),
-                true,
-                AAMVA_NAMESPACE,
-                Icon.NUMBERS,
-                1.toDataItem()
+                type = DocumentAttributeType.Number,
+                identifier = "aamva_version",
+                displayName = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_ATTRIBUTE_AAMVA_VERSION_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.DRIVING_LICENSE_DESCRIPTION_AAMVA_VERSION_NUMBER),
+                mandatory = true,
+                mdocNamespace = AAMVA_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.NUMBERS,
+                sampleValue = 1.toDataItem()
             )
             .addSampleRequest(
                 id = "us-transportation",

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.buildJsonObject
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the EU Personal ID Document Type.
@@ -90,6 +91,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_AGE_IN_YEARS),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValueMdoc = SampleData.AGE_IN_YEARS.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.AGE_IN_YEARS)
@@ -101,6 +103,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_YEAR_OF_BIRTH),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValueMdoc = SampleData.AGE_BIRTH_YEAR.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.AGE_BIRTH_YEAR)
@@ -110,6 +113,7 @@ object EUPersonalID {
                 identifier = "age_equal_or_over",
                 displayName = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_ATTRIBUTE_OLDER_THAN_AGE_ATTESTATIONS),
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_OLDER_THAN_AGE_ATTESTATIONS),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValue = buildJsonObject {
                     put("18", JsonPrimitive(SampleData.AGE_OVER_18))
@@ -124,6 +128,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_OLDER_THAN_18),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValueMdoc = SampleData.AGE_OVER_18.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.AGE_OVER_18)
@@ -136,6 +141,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_OLDER_THAN_21),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValueMdoc = SampleData.AGE_OVER_21.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.AGE_OVER_21)
@@ -359,6 +365,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_DATE_OF_ISSUE),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
                 icon = Icon.DATE_RANGE,
                 sampleValueMdoc = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate(),
                 sampleValueJson = JsonPrimitive(SampleData.ISSUE_DATE)
@@ -371,6 +378,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_DATE_OF_EXPIRY),
                 mandatory = true,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
                 icon = Icon.CALENDAR_CLOCK,
                 sampleValueMdoc = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate(),
                 sampleValueJson = JsonPrimitive(SampleData.EXPIRY_DATE)
@@ -382,6 +390,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_ISSUING_AUTHORITY),
                 mandatory = true,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
                 icon = Icon.ACCOUNT_BALANCE,
                 sampleValueMdoc = SampleData.ISSUING_AUTHORITY_EU_PID.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.ISSUING_AUTHORITY_EU_PID)
@@ -415,6 +424,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_ISSUING_JURISDICTION),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
                 icon = Icon.ACCOUNT_BALANCE,
                 sampleValueMdoc = SampleData.ISSUING_JURISDICTION.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.ISSUING_JURISDICTION)
@@ -426,6 +436,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_ISSUING_COUNTRY),
                 mandatory = true,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
                 icon = Icon.ACCOUNT_BALANCE,
                 sampleValueMdoc = SampleData.ISSUING_COUNTRY.toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.ISSUING_COUNTRY)
@@ -438,6 +449,7 @@ object EUPersonalID {
                 description = getLocalizedString(GeneratedStringKeys.EU_PERSONAL_ID_DESCRIPTION_PHOTO_OF_HOLDER),
                 mandatory = false,
                 mdocNamespace = EUPID_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE,
                 icon = Icon.ACCOUNT_BOX,
                 sampleValueMdoc = SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem(),
                 sampleValueJson = JsonPrimitive(SampleData.PORTRAIT_BASE64URL)

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PhotoID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PhotoID.kt
@@ -11,6 +11,7 @@ import org.multipaz.cbor.buildCborMap
 import org.multipaz.documenttype.knowntypes.DrivingLicense.MDL_NAMESPACE
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * PhotoID according to ISO/IEC 23220-4 Annex C.
@@ -35,44 +36,44 @@ object PhotoID {
         // Data elements from ISO/IEC 23220-4 Table C.1 — PhotoID data elements defined by ISO/IEC TS 23220-2
         //
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "family_name",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            SampleData.FAMILY_NAME.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "family_name",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = SampleData.FAMILY_NAME.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "family_name_viz",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME_VIZ),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME_VIZ),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            SampleData.FAMILY_NAME.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "family_name_viz",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME_VIZ),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME_VIZ),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = SampleData.FAMILY_NAME.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "given_name",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAMES),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAMES),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            SampleData.GIVEN_NAME.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "given_name",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAMES),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAMES),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = SampleData.GIVEN_NAME.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "given_name_viz",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAME_VIZ),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAME_VIZ),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            SampleData.GIVEN_NAME.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "given_name_viz",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAME_VIZ),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAME_VIZ),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = SampleData.GIVEN_NAME.toDataItem()
         )
         // Note, this is more complicated than mDL and EU PID, according to ISO/IEC 23220-2
         // clause "6.3.1.1.3 Date of birth as either uncertain or approximate, or both"
@@ -88,76 +89,82 @@ object PhotoID {
         // NOTE "approximate mask" is not intended to be used for calculation.
         //
         addMdocAttribute(
-            DocumentAttributeType.Date,   // TODO: this is a more complex type
+            type = DocumentAttributeType.Date,   identifier = // TODO: this is a more complex type
             "birth_date",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_BIRTH),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_BIRTH),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.TODAY,
-            buildCborMap {
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_BIRTH),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_BIRTH),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.TODAY,
+            sampleValue = buildCborMap {
                 put("birth_date", LocalDate.parse(SampleData.BIRTH_DATE).toDataItemFullDate())
             }
         )
         addMdocAttribute(
-            DocumentAttributeType.Picture,
-            "portrait",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PHOTO_OF_HOLDER),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PHOTO_OF_HOLDER),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.ACCOUNT_BOX,
-            SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
+            type = DocumentAttributeType.Picture,
+            identifier = "portrait",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PHOTO_OF_HOLDER),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PHOTO_OF_HOLDER),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE,
+            icon = Icon.ACCOUNT_BOX,
+            sampleValue = SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.Date,
-            "issue_date",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_ISSUE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_ISSUE),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.DATE_RANGE,
-            LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+            type = DocumentAttributeType.Date,
+            identifier = "issue_date",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_ISSUE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_ISSUE),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.VALIDITY,
+            icon = Icon.DATE_RANGE,
+            sampleValue = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
         )
         addMdocAttribute(
-            DocumentAttributeType.Date,
-            "expiry_date",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_EXPIRY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_EXPIRY),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.CALENDAR_CLOCK,
-            LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+            type = DocumentAttributeType.Date,
+            identifier = "expiry_date",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DATE_OF_EXPIRY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DATE_OF_EXPIRY),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.VALIDITY,
+            icon = Icon.CALENDAR_CLOCK,
+            sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "issuing_authority_unicode",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_AUTHORITY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_AUTHORITY),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.ACCOUNT_BALANCE,
-            SampleData.ISSUING_AUTHORITY_PHOTO_ID.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "issuing_authority_unicode",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_AUTHORITY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_AUTHORITY),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.ISSUER,
+            icon = Icon.ACCOUNT_BALANCE,
+            sampleValue = SampleData.ISSUING_AUTHORITY_PHOTO_ID.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-            "issuing_country",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_COUNTRY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_COUNTRY),
-            true,
-            ISO_23220_2_NAMESPACE,
-            Icon.ACCOUNT_BALANCE,
-            SampleData.ISSUING_COUNTRY.toDataItem()
+            type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+            identifier = "issuing_country",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_COUNTRY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_COUNTRY),
+            mandatory = true,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.ISSUER,
+            icon = Icon.ACCOUNT_BALANCE,
+            sampleValue = SampleData.ISSUING_COUNTRY.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.Number,
-            "age_in_years",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_AGE_IN_YEARS),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_AGE_IN_YEARS),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.TODAY,
-            SampleData.AGE_IN_YEARS.toDataItem()
+            type = DocumentAttributeType.Number,
+            identifier = "age_in_years",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_AGE_IN_YEARS),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_AGE_IN_YEARS),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+            icon = Icon.TODAY,
+            sampleValue = SampleData.AGE_IN_YEARS.toDataItem()
         )
         // If we provision all 99 age_over_NN claims the MSO will be 3886 bytes which exceeds the Longfellow-ZK
         // MSO size limit of ~ 2200 bytes. With these 13 claims, the MSO is 764 bytes which is more manageable.
@@ -170,6 +177,7 @@ object PhotoID {
                 description = "Indication whether the document holder is as old or older than $age",
                 mandatory = (age == 18),
                 mdocNamespace = ISO_23220_2_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
                 icon = Icon.TODAY,
                 sampleValue = if (age in ageThresholdsToProvision) {
                     (SampleData.AGE_IN_YEARS >= age).toDataItem()
@@ -179,451 +187,453 @@ object PhotoID {
             )
         }
         addMdocAttribute(
-            DocumentAttributeType.Number,
-            "age_birth_year",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_YEAR_OF_BIRTH),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_YEAR_OF_BIRTH),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.TODAY,
-            SampleData.AGE_BIRTH_YEAR.toDataItem()
+            type = DocumentAttributeType.Number,
+            identifier = "age_birth_year",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_YEAR_OF_BIRTH),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_YEAR_OF_BIRTH),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+            icon = Icon.TODAY,
+            sampleValue = SampleData.AGE_BIRTH_YEAR.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.Date,
-            "portrait_capture_date",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PORTRAIT_CAPTURE_DATE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PORTRAIT_CAPTURE_DATE),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.TODAY,
-            LocalDate.parse(SampleData.PORTRAIT_CAPTURE_DATE).toDataItemFullDate()
+            type = DocumentAttributeType.Date,
+            identifier = "portrait_capture_date",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PORTRAIT_CAPTURE_DATE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PORTRAIT_CAPTURE_DATE),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.TODAY,
+            sampleValue = LocalDate.parse(SampleData.PORTRAIT_CAPTURE_DATE).toDataItemFullDate()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "birthplace",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PLACE_OF_BIRTH),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PLACE_OF_BIRTH),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            SampleData.BIRTH_PLACE.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "birthplace",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PLACE_OF_BIRTH),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PLACE_OF_BIRTH),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.BIRTH_PLACE.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "name_at_birth",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_NAME_AT_BIRTH),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_NAME_AT_BIRTH),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "name_at_birth",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_NAME_AT_BIRTH),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_NAME_AT_BIRTH),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_address",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_ADDRESS),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_ADDRESS),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_ADDRESS.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_address",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_ADDRESS),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_ADDRESS),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_ADDRESS.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_city",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_CITY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_CITY),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_CITY.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_city",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_CITY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_CITY),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_CITY.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_postal_code",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_POSTAL_CODE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_POSTAL_CODE),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_POSTAL_CODE.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_postal_code",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_POSTAL_CODE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_POSTAL_CODE),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_POSTAL_CODE.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-            "resident_country",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_COUNTRY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_COUNTRY),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_COUNTRY.toDataItem()
+            type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+            identifier = "resident_country",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_COUNTRY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_COUNTRY),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_COUNTRY.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_city_latin1",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_CITY_LATIN1),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_CITY_LATIN1),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PLACE,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "resident_city_latin1",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_CITY_LATIN1),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_CITY_LATIN1),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-            "sex",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_SEX),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_SEX),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.EMERGENCY,
-            SampleData.SEX_ISO_5218.toDataItem()
+            type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+            identifier = "sex",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_SEX),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_SEX),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.EMERGENCY,
+            sampleValue = SampleData.SEX_ISO_5218.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-            "nationality",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_NATIONALITY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_NATIONALITY),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.LANGUAGE,
-            SampleData.NATIONALITY.toDataItem()
+            type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+            identifier = "nationality",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_NATIONALITY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_NATIONALITY),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.LANGUAGE,
+            sampleValue = SampleData.NATIONALITY.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "document_number",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DOCUMENT_NUMBER),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DOCUMENT_NUMBER),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.NUMBERS,
-            SampleData.DOCUMENT_NUMBER.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "document_number",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DOCUMENT_NUMBER),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DOCUMENT_NUMBER),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = SampleData.DOCUMENT_NUMBER.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "issuing_subdivision",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_SUBDIVISION),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_SUBDIVISION),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.ACCOUNT_BALANCE,
-            SampleData.ISSUING_JURISDICTION.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "issuing_subdivision",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ISSUING_SUBDIVISION),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ISSUING_SUBDIVISION),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            sensitivity = DocumentAttributeSensitivity.ISSUER,
+            icon = Icon.ACCOUNT_BALANCE,
+            sampleValue = SampleData.ISSUING_JURISDICTION.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "family_name_latin1",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME_LATIN1),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME_LATIN1),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "family_name_latin1",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_FAMILY_NAME_LATIN1),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_FAMILY_NAME_LATIN1),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "given_name_latin1",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAMES_LATIN1),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAMES_LATIN1),
-            false,
-            ISO_23220_2_NAMESPACE,
-            Icon.PERSON,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "given_name_latin1",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_GIVEN_NAMES_LATIN1),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_GIVEN_NAMES_LATIN1),
+            mandatory = false,
+            mdocNamespace = ISO_23220_2_NAMESPACE,
+            icon = Icon.PERSON,
+            sampleValue = null
         )
 
         // Data elements from ISO/IEC 23220-4 Table C.2 — Data elements specifically defined for PhotoID
         //
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "person_id",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PERSON_ID),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PERSON_ID),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.NUMBERS,
-            SampleData.PERSON_ID.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "person_id",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_PERSON_ID),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_PERSON_ID),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = SampleData.PERSON_ID.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-            "birth_country",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_COUNTRY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_COUNTRY),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            null
+            type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+            identifier = "birth_country",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_COUNTRY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_COUNTRY),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "birth_state",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_STATE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_STATE),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "birth_state",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_STATE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_STATE),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "birth_city",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_CITY),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_CITY),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "birth_city",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_BIRTH_CITY),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_BIRTH_CITY),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "administrative_number",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ADMINISTRATIVE_NUMBER),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.NUMBERS,
-            SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "administrative_number",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_ADMINISTRATIVE_NUMBER),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_street",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_STREET),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_STREET),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_STREET.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_street",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_STREET),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_STREET),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_STREET.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_house_number",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_HOUSE_NUMBER),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_HOUSE_NUMBER),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_HOUSE_NUMBER.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_house_number",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_HOUSE_NUMBER),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_HOUSE_NUMBER),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_HOUSE_NUMBER.toDataItem()
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "travel_document_type",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_TYPE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_TYPE),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "travel_document_type",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_TYPE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_TYPE),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "travel_document_number",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_NUMBER),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_NUMBER),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "travel_document_number",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_NUMBER),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_NUMBER),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "travel_document_mrz",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_MRZ),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_MRZ),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "travel_document_mrz",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_TRAVEL_DOCUMENT_MRZ),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_TRAVEL_DOCUMENT_MRZ),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "resident_state",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_STATE),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_STATE),
-            false,
-            PHOTO_ID_NAMESPACE,
-            Icon.PLACE,
-            SampleData.RESIDENT_STATE.toDataItem()
+            type = DocumentAttributeType.String,
+            identifier = "resident_state",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_RESIDENT_STATE),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_RESIDENT_STATE),
+            mandatory = false,
+            mdocNamespace = PHOTO_ID_NAMESPACE,
+            icon = Icon.PLACE,
+            sampleValue = SampleData.RESIDENT_STATE.toDataItem()
         )
 
 
         // Data elements from ISO/IEC 23220-4 Table C.3 — Data elements defined by ICAO 9303 part 10
         //
         addMdocAttribute(
-            DocumentAttributeType.String,
-            "version",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DTC_VC_VERSION),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DTC_VC_VERSION),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.String,
+            identifier = "version",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_DTC_VC_VERSION),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_DTC_VC_VERSION),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "sod",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_SOD),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_SOD),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "sod",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_SOD),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_SOD),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg1",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG1),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG1),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg1",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG1),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG1),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg2",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG2),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG2),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg2",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG2),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG2),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg3",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG3),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG3),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg3",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG3),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG3),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg4",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG4),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG4),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg4",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG4),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG4),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg5",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG5),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG5),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg5",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG5),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG5),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg6",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG6),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG6),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg6",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG6),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG6),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg7",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG7),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG7),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg7",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG7),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG7),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg8",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG8),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG8),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg8",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG8),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG8),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg9",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG9),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG9),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg9",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG9),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG9),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg10",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG10),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG10),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg10",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG10),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG10),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg11",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG11),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG11),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg11",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG11),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG11),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg12",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG12),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG12),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg12",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG12),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG12),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg13",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG13),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG13),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg13",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG13),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG13),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg14",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG14),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG14),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg14",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG14),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG14),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg15",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG15),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG15),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg15",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG15),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG15),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
         addMdocAttribute(
-            DocumentAttributeType.Blob,
-            "dg16",
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG16),
-            getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG16),
-            false,
-            DTC_NAMESPACE,
-            Icon.NUMBERS,
-            null
+            type = DocumentAttributeType.Blob,
+            identifier = "dg16",
+            displayName = getLocalizedString(GeneratedStringKeys.PHOTO_ID_ATTRIBUTE_EMRTD_DG16),
+            description = getLocalizedString(GeneratedStringKeys.PHOTO_ID_DESCRIPTION_EMRTD_DG16),
+            mandatory = false,
+            mdocNamespace = DTC_NAMESPACE,
+            icon = Icon.NUMBERS,
+            sampleValue = null
         )
 
         // Finally for the sample requests.

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/VaccinationDocument.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/VaccinationDocument.kt
@@ -20,6 +20,7 @@ import org.multipaz.documenttype.DocumentAttributeType
 import org.multipaz.documenttype.DocumentType
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the Vaccination
@@ -38,148 +39,149 @@ object VaccinationDocument {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_VACCINATION_DOCUMENT))
             .addMdocDocumentType("org.micov.1")
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "1D47_vaccinated",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_YELLOW_FEVER_VACCINATED),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_YELLOW_FEVER_VACCINATED),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Boolean,
+                identifier = "1D47_vaccinated",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_YELLOW_FEVER_VACCINATED),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_YELLOW_FEVER_VACCINATED),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Boolean,
-                "RA01_vaccinated",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_VACCINATED),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_VACCINATED),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Boolean,
+                identifier = "RA01_vaccinated",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_VACCINATED),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_VACCINATED),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "RA01_test",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_TEST),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_TEST),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "RA01_test",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_TEST),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_TEST),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "safeEntry_Leisure",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_SAFE_ENTRY_LEISURE),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_SAFE_ENTRY_LEISURE),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "safeEntry_Leisure",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_SAFE_ENTRY_LEISURE),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_SAFE_ENTRY_LEISURE),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "fac",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FACIAL_IMAGE),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FACIAL_IMAGE),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Picture,
+                identifier = "fac",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FACIAL_IMAGE),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FACIAL_IMAGE),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "fni",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FAMILY_NAME_INITIAL),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FAMILY_NAME_INITIAL),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.String,
+                identifier = "fni",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FAMILY_NAME_INITIAL),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FAMILY_NAME_INITIAL),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "gni",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_GIVEN_NAME_INITIAL),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_GIVEN_NAME_INITIAL),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.String,
+                identifier = "gni",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_GIVEN_NAME_INITIAL),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_GIVEN_NAME_INITIAL),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "by",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_YEAR),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_YEAR),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Number,
+                identifier = "by",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_YEAR),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_YEAR),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "bm",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_MONTH),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_MONTH),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Number,
+                identifier = "bm",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_MONTH),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_MONTH),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Number,
-                "bd",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_DAY),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_DAY),
-                false,
-                MICOV_ATT_NAMESPACE
+                type = DocumentAttributeType.Number,
+                identifier = "bd",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_BIRTH_DAY),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_BIRTH_DAY),
+                mandatory = false,
+                mdocNamespace = MICOV_ATT_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "fn",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FAMILY_NAME),
-                true,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.String,
+                identifier = "fn",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_FAMILY_NAME),
+                mandatory = true,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "gn",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_GIVEN_NAME),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_GIVEN_NAME),
-                true,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.String,
+                identifier = "gn",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_GIVEN_NAME),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_GIVEN_NAME),
+                mandatory = true,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "dob",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_DATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_DATE_OF_BIRTH),
-                true,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.Date,
+                identifier = "dob",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_DATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_DATE_OF_BIRTH),
+                mandatory = true,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-                "sex",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_SEX),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_SEX),
-                false,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+                identifier = "sex",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_SEX),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_SEX),
+                mandatory = false,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "v_RA01_1",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_FIRST_VACCINATION),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_FIRST_VACCINATION),
-                false,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "v_RA01_1",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_FIRST_VACCINATION),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_FIRST_VACCINATION),
+                mandatory = false,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "v_RA01_2",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_SECOND_VACCINATION),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_SECOND_VACCINATION),
-                false,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "v_RA01_2",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_COVID19_SECOND_VACCINATION),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_COVID19_SECOND_VACCINATION),
+                mandatory = false,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "pid_PPN",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_ID_WITH_PASSPORT_NUMBER),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_ID_WITH_PASSPORT_NUMBER),
-                false,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "pid_PPN",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_ID_WITH_PASSPORT_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_ID_WITH_PASSPORT_NUMBER),
+                mandatory = false,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "pid_DL",
-                getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_ID_WITH_DRIVERS_LICENSE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_ID_WITH_DRIVERS_LICENSE_NUMBER),
-                false,
-                MICOV_VTR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "pid_DL",
+                displayName = getLocalizedString(GeneratedStringKeys.VACCINATION_ATTRIBUTE_ID_WITH_DRIVERS_LICENSE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.VACCINATION_DESCRIPTION_ID_WITH_DRIVERS_LICENSE_NUMBER),
+                mandatory = false,
+                mdocNamespace = MICOV_VTR_NAMESPACE
             )
             .build()
     }

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/VehicleRegistration.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/VehicleRegistration.kt
@@ -20,6 +20,7 @@ import org.multipaz.documenttype.DocumentAttributeType
 import org.multipaz.documenttype.DocumentType
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the Vehicle Registration
@@ -38,44 +39,45 @@ object VehicleRegistration {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_VEHICLE_REGISTRATION))
             .addMdocDocumentType("nl.rdw.mekb.1")
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "registration_info",
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_REGISTRATION_INFO),
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_REGISTRATION_INFO),
-                true,
-                MVR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "registration_info",
+                displayName = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_REGISTRATION_INFO),
+                description = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_REGISTRATION_INFO),
+                mandatory = true,
+                mdocNamespace = MVR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "issue_date",
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_ISSUE_DATE),
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_ISSUE_DATE),
-                true,
-                MVR_NAMESPACE
+                type = DocumentAttributeType.Date,
+                identifier = "issue_date",
+                displayName = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_ISSUE_DATE),
+                description = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_ISSUE_DATE),
+                mandatory = true,
+                mdocNamespace = MVR_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "registration_holder",
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_REGISTRATION_HOLDER),
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_REGISTRATION_HOLDER),
-                true,
-                MVR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "registration_holder",
+                displayName = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_REGISTRATION_HOLDER),
+                description = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_REGISTRATION_HOLDER),
+                mandatory = true,
+                mdocNamespace = MVR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.ComplexType,
-                "basic_vehicle_info",
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_BASIC_VEHICLE_INFO),
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_BASIC_VEHICLE_INFO),
-                true,
-                MVR_NAMESPACE
+                type = DocumentAttributeType.ComplexType,
+                identifier = "basic_vehicle_info",
+                displayName = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_BASIC_VEHICLE_INFO),
+                description = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_BASIC_VEHICLE_INFO),
+                mandatory = true,
+                mdocNamespace = MVR_NAMESPACE
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "vin",
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_VIN),
-                getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_VIN),
-                true,
-                MVR_NAMESPACE
+                type = DocumentAttributeType.String,
+                identifier = "vin",
+                displayName = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_ATTRIBUTE_VIN),
+                description = getLocalizedString(GeneratedStringKeys.VEHICLE_REGISTRATION_DESCRIPTION_VIN),
+                mandatory = true,
+                mdocNamespace = MVR_NAMESPACE
             )
             .build()
     }

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DigitalPaymentCredential.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DigitalPaymentCredential.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.LocalDate
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
 import org.multipaz.documenttype.knowntypes.SampleData
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Example Payment SCA credential profile for card-based digital payments.
@@ -32,64 +33,67 @@ object DigitalPaymentCredential {
             .addMdocDocumentType(CARD_DOCTYPE)
 
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "issuer_name",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_ISSUER_NAME),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_ISSUER_NAME),
-                true,
-                CARD_NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                "Utopia Bank".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "issuer_name",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_ISSUER_NAME),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_ISSUER_NAME),
+                mandatory = true,
+                mdocNamespace = CARD_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = "Utopia Bank".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "payment_instrument_id",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_PAYMENT_INSTRUMENT_ID),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_PAYMENT_INSTRUMENT_ID),
-                false,
-                CARD_NAMESPACE,
-                Icon.NUMBERS,
-                "pi-77AABBCC".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "payment_instrument_id",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_PAYMENT_INSTRUMENT_ID),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_PAYMENT_INSTRUMENT_ID),
+                mandatory = false,
+                mdocNamespace = CARD_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = "pi-77AABBCC".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "masked_account_reference",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_MASKED_ACCOUNT_REFERENCE),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_MASKED_ACCOUNT_REFERENCE),
-                true,
-                CARD_NAMESPACE,
-                Icon.NUMBERS,
-                "****1234".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "masked_account_reference",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_MASKED_ACCOUNT_REFERENCE),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_MASKED_ACCOUNT_REFERENCE),
+                mandatory = true,
+                mdocNamespace = CARD_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = "****1234".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "holder_name",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_HOLDER_NAME),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_HOLDER_NAME),
-                true,
-                CARD_NAMESPACE,
-                Icon.PERSON,
-                "${SampleData.GIVEN_NAME} ${SampleData.FAMILY_NAME}".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "holder_name",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_HOLDER_NAME),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_HOLDER_NAME),
+                mandatory = true,
+                mdocNamespace = CARD_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = "${SampleData.GIVEN_NAME} ${SampleData.FAMILY_NAME}".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "issue_date",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_ISSUE_DATE),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_ISSUE_DATE),
-                true,
-                CARD_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "issue_date",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_ISSUE_DATE),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_ISSUE_DATE),
+                mandatory = true,
+                mdocNamespace = CARD_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "expiry_date",
-                getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_EXPIRY_DATE),
-                getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_EXPIRY_DATE),
-                true,
-                CARD_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "expiry_date",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_ATTRIBUTE_EXPIRY_DATE),
+                description = getLocalizedString(GeneratedStringKeys.PAYMENT_DESCRIPTION_EXPIRY_DATE),
+                mandatory = true,
+                mdocNamespace = CARD_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
 
             .addSampleRequest(

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/EUCertificateOfResidence.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/EUCertificateOfResidence.kt
@@ -10,6 +10,7 @@ import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
 import org.multipaz.documenttype.knowntypes.Options
 import org.multipaz.documenttype.knowntypes.SampleData
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the EU Certificate of Residency (COR) document.
@@ -32,234 +33,241 @@ object EUCertificateOfResidence {
             .addMdocDocumentType(DOCTYPE)
             .addJsonDocumentType(type = VCT, keyBound = true)
             .addAttribute(
-                DocumentAttributeType.String,
-                "family_name",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_FAMILY_NAME),
-                true,
-                NAMESPACE,
-                Icon.PERSON,
-                SampleData.FAMILY_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_FAMILY_NAME),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValueMdoc = SampleData.FAMILY_NAME.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "given_name",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_GIVEN_NAMES),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_GIVEN_NAMES),
-                true,
-                NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_GIVEN_NAMES),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_GIVEN_NAMES),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValueMdoc = SampleData.GIVEN_NAME.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.Date,
-                "birth_date",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_BIRTH),
-                true,
-                NAMESPACE,
-                Icon.TODAY,
-                LocalDate.parse(SampleData.BIRTH_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "birth_date",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_BIRTH),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.TODAY,
+                sampleValueMdoc = LocalDate.parse(SampleData.BIRTH_DATE).toDataItemFullDate()
             )
             .addAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_18",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_OLDER_THAN_18),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_OLDER_THAN_18),
-                false,
-                NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_18.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_18",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_OLDER_THAN_18),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_OLDER_THAN_18),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValueMdoc = SampleData.AGE_OVER_18.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.Boolean,
-                "age_over_21",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_OLDER_THAN_21),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_OLDER_THAN_21),
-                false,
-                NAMESPACE,
-                Icon.TODAY,
-                SampleData.AGE_OVER_21.toDataItem()
+                type = DocumentAttributeType.Boolean,
+                identifier = "age_over_21",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_OLDER_THAN_21),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_OLDER_THAN_21),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValueMdoc = SampleData.AGE_OVER_21.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.Date,
-                "arrival_date",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_ARRIVAL),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_ARRIVAL),
-                false,
-                NAMESPACE,
-                Icon.DATE_RANGE,
-                LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "arrival_date",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_ARRIVAL),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_ARRIVAL),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.DATE_RANGE,
+                sampleValueMdoc = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_address",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_ADDRESS),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_ADDRESS),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_ADDRESS.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_address",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_ADDRESS),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_ADDRESS),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_ADDRESS.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "resident_country",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_COUNTRY),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_COUNTRY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "resident_country",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_COUNTRY),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_COUNTRY.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_state",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_STATE),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_STATE),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_STATE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_state",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_STATE),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_STATE),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_STATE.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_city",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_CITY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_CITY),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_CITY.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_city",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_CITY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_CITY),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_CITY.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_postal_code",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_POSTAL_CODE),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_POSTAL_CODE),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_POSTAL_CODE.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_postal_code",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_POSTAL_CODE),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_POSTAL_CODE),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_POSTAL_CODE.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_street",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_STREET),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_STREET),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_STREET.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_street",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_STREET),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_STREET),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_STREET.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "resident_house_number",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_HOUSE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_HOUSE_NUMBER),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_HOUSE_NUMBER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "resident_house_number",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_RESIDENT_HOUSE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_RESIDENT_HOUSE_NUMBER),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_HOUSE_NUMBER.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "birth_place",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_PLACE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_PLACE_OF_BIRTH),
-                false,
-                NAMESPACE,
-                Icon.PLACE,
-                SampleData.RESIDENT_CITY.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "birth_place",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_PLACE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_PLACE_OF_BIRTH),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.PLACE,
+                sampleValueMdoc = SampleData.RESIDENT_CITY.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-                "gender",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_GENDER),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_GENDER),
-                false,
-                NAMESPACE,
-                Icon.EMERGENCY,
-                SampleData.SEX_ISO_5218.toDataItem()
+                type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+                identifier = "gender",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_GENDER),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_GENDER),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.EMERGENCY,
+                sampleValueMdoc = SampleData.SEX_ISO_5218.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "nationality",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_NATIONALITY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_NATIONALITY),
-                true,
-                NAMESPACE,
-                Icon.LANGUAGE,
-                SampleData.NATIONALITY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "nationality",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_NATIONALITY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_NATIONALITY),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.LANGUAGE,
+                sampleValueMdoc = SampleData.NATIONALITY.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.Date,
-                "issuance_date",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_ISSUE),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_ISSUE),
-                true,
-                NAMESPACE,
-                Icon.DATE_RANGE,
-                LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "issuance_date",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_ISSUE),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_ISSUE),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.DATE_RANGE,
+                sampleValueMdoc = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
             )
             .addAttribute(
-                DocumentAttributeType.Date,
-                "expiry_date",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_EXPIRY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_EXPIRY),
-                true,
-                NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "expiry_date",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DATE_OF_EXPIRY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DATE_OF_EXPIRY),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValueMdoc = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "issuing_authority",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_AUTHORITY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_AUTHORITY),
-                true,
-                NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_AUTHORITY_EU_PID.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "issuing_authority",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_AUTHORITY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_AUTHORITY),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValueMdoc = SampleData.ISSUING_AUTHORITY_EU_PID.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "document_number",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DOCUMENT_NUMBER),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DOCUMENT_NUMBER),
-                false,
-                NAMESPACE,
-                Icon.NUMBERS,
-                SampleData.DOCUMENT_NUMBER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "document_number",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_DOCUMENT_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_DOCUMENT_NUMBER),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValueMdoc = SampleData.DOCUMENT_NUMBER.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "administrative_number",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ADMINISTRATIVE_NUMBER),
-                false,
-                NAMESPACE,
-                Icon.NUMBERS,
-                SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "administrative_number",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ADMINISTRATIVE_NUMBER),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValueMdoc = SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.String,
-                "issuing_jurisdiction",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_JURISDICTION),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_JURISDICTION),
-                false,
-                NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_JURISDICTION.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "issuing_jurisdiction",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_JURISDICTION),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_JURISDICTION),
+                mandatory = false,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValueMdoc = SampleData.ISSUING_JURISDICTION.toDataItem()
             )
             .addAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "issuing_country",
-                getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_COUNTRY),
-                true,
-                NAMESPACE,
-                Icon.ACCOUNT_BALANCE,
-                SampleData.ISSUING_COUNTRY.toDataItem()
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "issuing_country",
+                displayName = getLocalizedString(GeneratedStringKeys.COR_ATTRIBUTE_ISSUING_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.COR_DESCRIPTION_ISSUING_COUNTRY),
+                mandatory = true,
+                mdocNamespace = NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValueMdoc = SampleData.ISSUING_COUNTRY.toDataItem()
             )
             .addSampleRequest(
                 id = "age_over_18",

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/GermanPersonalID.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/GermanPersonalID.kt
@@ -9,6 +9,7 @@ import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
 import org.multipaz.documenttype.knowntypes.Options
 import org.multipaz.documenttype.knowntypes.SampleData
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 /**
  * Object containing the metadata of the German ID Document Type.
@@ -29,239 +30,252 @@ object GermanPersonalID {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_GERMAN_PERSONAL_ID))
             .addJsonDocumentType(type = EUPID_VCT, keyBound = true)
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "family_name",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_FAMILY_NAME),
-                Icon.PERSON,
-                JsonPrimitive(SampleData.FAMILY_NAME)
+                type = DocumentAttributeType.String,
+                identifier = "family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_FAMILY_NAME),
+                icon = Icon.PERSON,
+                sampleValue = JsonPrimitive(SampleData.FAMILY_NAME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "given_name",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_GIVEN_NAMES),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_GIVEN_NAMES),
-                Icon.PERSON,
-                JsonPrimitive(SampleData.GIVEN_NAME)
+                type = DocumentAttributeType.String,
+                identifier = "given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_GIVEN_NAMES),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_GIVEN_NAMES),
+                icon = Icon.PERSON,
+                sampleValue = JsonPrimitive(SampleData.GIVEN_NAME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Date,
-                "birthdate",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_BIRTH),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.BIRTH_DATE)
+                type = DocumentAttributeType.Date,
+                identifier = "birthdate",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_BIRTH),
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_DATE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Number,
-                "age_in_years",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_AGE_IN_YEARS),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_AGE_IN_YEARS),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_IN_YEARS)
+                type = DocumentAttributeType.Number,
+                identifier = "age_in_years",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_AGE_IN_YEARS),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_AGE_IN_YEARS),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_IN_YEARS)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Number,
-                "age_birth_year",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_YEAR_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_YEAR_OF_BIRTH),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_BIRTH_YEAR)
+                type = DocumentAttributeType.Number,
+                identifier = "age_birth_year",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_YEAR_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_YEAR_OF_BIRTH),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_BIRTH_YEAR)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "12",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_12),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_12),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER)
+                type = DocumentAttributeType.Boolean,
+                identifier = "12",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_12),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_12),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "14",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_14),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_14),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER)
+                type = DocumentAttributeType.Boolean,
+                identifier = "14",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_14),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_14),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "16",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_16),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_16),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER_16)
+                type = DocumentAttributeType.Boolean,
+                identifier = "16",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_16),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_16),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER_16)
             )
             // TODO: nest in age_equal_or_over object
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "18",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_18),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_18),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER_18)
+                type = DocumentAttributeType.Boolean,
+                identifier = "18",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_18),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_18),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER_18)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "21",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_21),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_21),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER_21)
+                type = DocumentAttributeType.Boolean,
+                identifier = "21",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_21),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_21),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER_21)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "65",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_65),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_65),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.AGE_OVER_65)
+                type = DocumentAttributeType.Boolean,
+                identifier = "65",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_OLDER_THAN_65),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_OLDER_THAN_65),
+                sensitivity = DocumentAttributeSensitivity.AGE_INFORMATION,
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.AGE_OVER_65)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "birth_family_name",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_FAMILY_NAME_AT_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_FAMILY_NAME_AT_BIRTH),
-                Icon.PERSON,
-                JsonPrimitive(SampleData.FAMILY_NAME_BIRTH)
+                type = DocumentAttributeType.String,
+                identifier = "birth_family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_FAMILY_NAME_AT_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_FAMILY_NAME_AT_BIRTH),
+                icon = Icon.PERSON,
+                sampleValue = JsonPrimitive(SampleData.FAMILY_NAME_BIRTH)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "birth_place",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_PLACE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_PLACE_OF_BIRTH),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.BIRTH_PLACE)
+                type = DocumentAttributeType.String,
+                identifier = "birth_place",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_PLACE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_PLACE_OF_BIRTH),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_PLACE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "birth_country",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_COUNTRY_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_COUNTRY_OF_BIRTH),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.BIRTH_COUNTRY)
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "birth_country",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_COUNTRY_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_COUNTRY_OF_BIRTH),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_COUNTRY)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "birth_state",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_STATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_STATE_OF_BIRTH),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.BIRTH_STATE)
+                type = DocumentAttributeType.String,
+                identifier = "birth_state",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_STATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_STATE_OF_BIRTH),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_STATE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "birth_city",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_CITY_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_CITY_OF_BIRTH),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.BIRTH_CITY)
+                type = DocumentAttributeType.String,
+                identifier = "birth_city",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_CITY_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_CITY_OF_BIRTH),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_CITY)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "street_address",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_ADDRESS),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_ADDRESS),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.RESIDENT_ADDRESS)
+                type = DocumentAttributeType.String,
+                identifier = "street_address",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_ADDRESS),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_ADDRESS),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.RESIDENT_ADDRESS)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "locality",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_CITY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_CITY),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.RESIDENT_CITY)
+                type = DocumentAttributeType.String,
+                identifier = "locality",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_CITY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_CITY),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.RESIDENT_CITY)
             )
             .addJsonAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "country",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_COUNTRY),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.RESIDENT_COUNTRY)
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "country",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_COUNTRY),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.RESIDENT_COUNTRY)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "postal_code",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_POSTAL_CODE),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_POSTAL_CODE),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.RESIDENT_POSTAL_CODE)
+                type = DocumentAttributeType.String,
+                identifier = "postal_code",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_RESIDENT_POSTAL_CODE),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_RESIDENT_POSTAL_CODE),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.RESIDENT_POSTAL_CODE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
-                "gender",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_GENDER),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_GENDER),
-                Icon.EMERGENCY,
-                JsonPrimitive(SampleData.SEX_ISO_5218)
+                type = DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
+                identifier = "gender",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_GENDER),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_GENDER),
+                icon = Icon.EMERGENCY,
+                sampleValue = JsonPrimitive(SampleData.SEX_ISO_5218)
             )
             .addJsonAttribute(
-                DocumentAttributeType.ComplexType,
-                "nationalities",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_NATIONALITY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_NATIONALITY),
-                Icon.LANGUAGE,
-                buildJsonArray {
+                type = DocumentAttributeType.ComplexType,
+                identifier = "nationalities",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_NATIONALITY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_NATIONALITY),
+                icon = Icon.LANGUAGE,
+                sampleValue = buildJsonArray {
                     add(JsonPrimitive(SampleData.NATIONALITY))
                 }
             )
             .addJsonAttribute(
-                DocumentAttributeType.Date,
-                "issuance_date",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_ISSUE),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_ISSUE),
-                Icon.DATE_RANGE,
-                JsonPrimitive(SampleData.ISSUE_DATE)
+                type = DocumentAttributeType.Date,
+                identifier = "issuance_date",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_ISSUE),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_ISSUE),
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.DATE_RANGE,
+                sampleValue = JsonPrimitive(SampleData.ISSUE_DATE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Date,
-                "expiry_date",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_EXPIRY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_EXPIRY),
-                Icon.CALENDAR_CLOCK,
-                JsonPrimitive(SampleData.EXPIRY_DATE)
+                type = DocumentAttributeType.Date,
+                identifier = "expiry_date",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DATE_OF_EXPIRY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DATE_OF_EXPIRY),
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = JsonPrimitive(SampleData.EXPIRY_DATE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "issuing_authority",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_AUTHORITY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_AUTHORITY),
-                Icon.ACCOUNT_BALANCE,
-                JsonPrimitive(SampleData.ISSUING_AUTHORITY_EU_PID)
+                type = DocumentAttributeType.String,
+                identifier = "issuing_authority",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_AUTHORITY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_AUTHORITY),
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = JsonPrimitive(SampleData.ISSUING_AUTHORITY_EU_PID)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "document_number",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DOCUMENT_NUMBER),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DOCUMENT_NUMBER),
-                Icon.NUMBERS,
-                JsonPrimitive(SampleData.DOCUMENT_NUMBER)
+                type = DocumentAttributeType.String,
+                identifier = "document_number",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_DOCUMENT_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_DOCUMENT_NUMBER),
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive(SampleData.DOCUMENT_NUMBER)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "administrative_number",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ADMINISTRATIVE_NUMBER),
-                Icon.NUMBERS,
-                JsonPrimitive(SampleData.ADMINISTRATIVE_NUMBER)
+                type = DocumentAttributeType.String,
+                identifier = "administrative_number",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ADMINISTRATIVE_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ADMINISTRATIVE_NUMBER),
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive(SampleData.ADMINISTRATIVE_NUMBER)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "issuing_jurisdiction",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_JURISDICTION),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_JURISDICTION),
-                Icon.ACCOUNT_BALANCE,
-                JsonPrimitive(SampleData.ISSUING_JURISDICTION)
+                type = DocumentAttributeType.String,
+                identifier = "issuing_jurisdiction",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_JURISDICTION),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_JURISDICTION),
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = JsonPrimitive(SampleData.ISSUING_JURISDICTION)
             )
             .addJsonAttribute(
-                DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
-                "issuing_country",
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_COUNTRY),
-                getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_COUNTRY),
-                Icon.ACCOUNT_BALANCE,
-                JsonPrimitive(SampleData.ISSUING_COUNTRY)
+                type = DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
+                identifier = "issuing_country",
+                displayName = getLocalizedString(GeneratedStringKeys.GERMAN_ID_ATTRIBUTE_ISSUING_COUNTRY),
+                description = getLocalizedString(GeneratedStringKeys.GERMAN_ID_DESCRIPTION_ISSUING_COUNTRY),
+                sensitivity = DocumentAttributeSensitivity.ISSUER,
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = JsonPrimitive(SampleData.ISSUING_COUNTRY)
             )
             .addSampleRequest(
                 id = "age_over_18",

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/Loyalty.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/Loyalty.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.LocalDate
 import org.multipaz.doctypes.localization.LocalizedStrings
 import org.multipaz.doctypes.localization.GeneratedStringKeys
 import org.multipaz.documenttype.knowntypes.SampleData
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 
 object Loyalty {
     const val LOYALTY_DOCTYPE = "org.multipaz.loyalty.1"
@@ -26,76 +27,79 @@ object Loyalty {
             // Core holder data relevant for a loyalty card
             //
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "family_name",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_FAMILY_NAME),
-                true,
-                LOYALTY_NAMESPACE,
-                Icon.PERSON,
-                SampleData.FAMILY_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_FAMILY_NAME),
+                mandatory = true,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.FAMILY_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "given_name",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_GIVEN_NAMES),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_GIVEN_NAMES),
-                true,
-                LOYALTY_NAMESPACE,
-                Icon.PERSON,
-                SampleData.GIVEN_NAME.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_GIVEN_NAMES),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_GIVEN_NAMES),
+                mandatory = true,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                icon = Icon.PERSON,
+                sampleValue = SampleData.GIVEN_NAME.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Picture,
-                "portrait",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_PHOTO_OF_HOLDER),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_PHOTO_OF_HOLDER),
-                true,
-                LOYALTY_NAMESPACE,
-                Icon.ACCOUNT_BOX,
-                SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
+                type = DocumentAttributeType.Picture,
+                identifier = "portrait",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_PHOTO_OF_HOLDER),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_PHOTO_OF_HOLDER),
+                mandatory = true,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.PORTRAIT_IMAGE,
+                icon = Icon.ACCOUNT_BOX,
+                sampleValue = SampleData.PORTRAIT_BASE64URL.fromBase64Url().toDataItem()
             )
             // Then the LoyaltyID specific data elements.
             //
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "membership_number",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_MEMBERSHIP_ID),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_MEMBERSHIP_ID),
-                false,
-                LOYALTY_NAMESPACE,
-                Icon.NUMBERS,
-                SampleData.PERSON_ID.toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "membership_number",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_MEMBERSHIP_ID),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_MEMBERSHIP_ID),
+                mandatory = false,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                icon = Icon.NUMBERS,
+                sampleValue = SampleData.PERSON_ID.toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.String,
-                "tier",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_TIER),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_TIER),
-                false,
-                LOYALTY_NAMESPACE,
-                Icon.STARS,
-                "basic".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "tier",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_TIER),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_TIER),
+                mandatory = false,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                icon = Icon.STARS,
+                sampleValue = "basic".toDataItem()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "issue_date",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_DATE_OF_ISSUE),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_DATE_OF_ISSUE),
-                true,
-                LOYALTY_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "issue_date",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_DATE_OF_ISSUE),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_DATE_OF_ISSUE),
+                mandatory = true,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.ISSUE_DATE).toDataItemFullDate()
             )
             .addMdocAttribute(
-                DocumentAttributeType.Date,
-                "expiry_date",
-                getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_DATE_OF_EXPIRY),
-                getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_DATE_OF_EXPIRY),
-                true,
-                LOYALTY_NAMESPACE,
-                Icon.CALENDAR_CLOCK,
-                LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
+                type = DocumentAttributeType.Date,
+                identifier = "expiry_date",
+                displayName = getLocalizedString(GeneratedStringKeys.LOYALTY_ATTRIBUTE_DATE_OF_EXPIRY),
+                description = getLocalizedString(GeneratedStringKeys.LOYALTY_DESCRIPTION_DATE_OF_EXPIRY),
+                mandatory = true,
+                mdocNamespace = LOYALTY_NAMESPACE,
+                sensitivity = DocumentAttributeSensitivity.VALIDITY,
+                icon = Icon.CALENDAR_CLOCK,
+                sampleValue = LocalDate.parse(SampleData.EXPIRY_DATE).toDataItemFullDate()
             )
             // Finally for the sample requests.
             //

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaBoardingPass.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaBoardingPass.kt
@@ -28,44 +28,44 @@ object UtopiaBoardingPass {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_BOARDING_PASS)).apply {
             addMdocDocumentType(BOARDING_PASS_DOCTYPE)
             addMdocAttribute(
-                DocumentAttributeType.String,
-                "passenger_name",
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_PASSENGER_NAME),
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_PASSENGER_NAME),
-                true,
-                BOARDING_PASS_NS,
-                Icon.PERSON,
-                "Erika Mustermann".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "passenger_name",
+                displayName = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_PASSENGER_NAME),
+                description = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_PASSENGER_NAME),
+                mandatory = true,
+                mdocNamespace = BOARDING_PASS_NS,
+                icon = Icon.PERSON,
+                sampleValue = "Erika Mustermann".toDataItem()
             )
             addMdocAttribute(
-                DocumentAttributeType.String,
-                "flight_number",
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_FLIGHT_NUMBER),
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_FLIGHT_NUMBER),
-                true,
-                BOARDING_PASS_NS,
-                Icon.AIRPORT_SHUTTLE,
-                "United 815".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "flight_number",
+                displayName = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_FLIGHT_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_FLIGHT_NUMBER),
+                mandatory = true,
+                mdocNamespace = BOARDING_PASS_NS,
+                icon = Icon.AIRPORT_SHUTTLE,
+                sampleValue = "United 815".toDataItem()
             )
             addMdocAttribute(
-                DocumentAttributeType.String,
-                "seat_number",
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_SEAT_NUMBER),
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_SEAT_NUMBER),
-                true,
-                BOARDING_PASS_NS,
-                Icon.DIRECTIONS,
-                "12A".toDataItem()
+                type = DocumentAttributeType.String,
+                identifier = "seat_number",
+                displayName = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_SEAT_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_SEAT_NUMBER),
+                mandatory = true,
+                mdocNamespace = BOARDING_PASS_NS,
+                icon = Icon.DIRECTIONS,
+                sampleValue = "12A".toDataItem()
             )
             addMdocAttribute(
-                DocumentAttributeType.DateTime,
-                "departure_time",
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_DEPARTURE_TIME),
-                getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_DEPARTURE_TIME),
-                true,
-                BOARDING_PASS_NS,
-                Icon.TODAY,
-                Clock.System.now().toDataItemDateTimeString()
+                type = DocumentAttributeType.DateTime,
+                identifier = "departure_time",
+                displayName = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_ATTRIBUTE_DEPARTURE_TIME),
+                description = getLocalizedString(GeneratedStringKeys.BOARDING_PASS_DESCRIPTION_DEPARTURE_TIME),
+                mandatory = true,
+                mdocNamespace = BOARDING_PASS_NS,
+                icon = Icon.TODAY,
+                sampleValue = Clock.System.now().toDataItemDateTimeString()
             )
         }.build()
     }

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaMovieTicket.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaMovieTicket.kt
@@ -24,28 +24,28 @@ object UtopiaMovieTicket {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_MOVIE_TICKET))
             .addJsonDocumentType(type = MOVIE_TICKET_VCT, keyBound = false)
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "ticket_id",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_TICKET_NUMBER),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_TICKET_NUMBER),
-                Icon.NUMBERS,
-                JsonPrimitive(SampleData.TICKET_NUMBER)
+                type = DocumentAttributeType.String,
+                identifier = "ticket_id",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_TICKET_NUMBER),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_TICKET_NUMBER),
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive(SampleData.TICKET_NUMBER)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "cinema",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_CINEMA_THEATER),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_CINEMA_THEATER),
-                Icon.PLACE,
-                JsonPrimitive(SampleData.CINEMA)
+                type = DocumentAttributeType.String,
+                identifier = "cinema",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_CINEMA_THEATER),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_CINEMA_THEATER),
+                icon = Icon.PLACE,
+                sampleValue = JsonPrimitive(SampleData.CINEMA)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "movie",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_MOVIE_TITLE),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_MOVIE_TITLE),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.MOVIE)
+                type = DocumentAttributeType.String,
+                identifier = "movie",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_MOVIE_TITLE),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_MOVIE_TITLE),
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.MOVIE)
             )
             .addJsonAttribute(
                 type = DocumentAttributeType.DateTime,
@@ -56,7 +56,7 @@ object UtopiaMovieTicket {
                 sampleValue = JsonPrimitive(SampleData.MOVIE_DATE_TIME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.StringOptions(
+                type = DocumentAttributeType.StringOptions(
                     listOf(
                         StringOption("NR", "NR - Not Rated"),
                         StringOption("G", "G – General Audiences"),
@@ -66,42 +66,42 @@ object UtopiaMovieTicket {
                         StringOption("NC-17", "NC-17 – Adults Only"),
                     )
                 ),
-                "movie_rating",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_AGE_RATING_CODE),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_AGE_RATING_CODE),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.MOVIE_RATING)
+                identifier = "movie_rating",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_AGE_RATING_CODE),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_AGE_RATING_CODE),
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.MOVIE_RATING)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "theater_id",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_THEATER),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_THEATER),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.THEATRE_NAME)
+                type = DocumentAttributeType.String,
+                identifier = "theater_id",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_THEATER),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_THEATER),
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.THEATRE_NAME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "seat_id",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_SEAT),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_SEAT),
-                Icon.NUMBERS,
-                JsonPrimitive(SampleData.THEATRE_SEAT)
+                type = DocumentAttributeType.String,
+                identifier = "seat_id",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_SEAT),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_SEAT),
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive(SampleData.THEATRE_SEAT)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Boolean,
-                "parking_option",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_PARKING),
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_PARKING),
-                Icon.DIRECTIONS_CAR,
-                JsonPrimitive(SampleData.CINEMA_PARKING)
+                type = DocumentAttributeType.Boolean,
+                identifier = "parking_option",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_PARKING),
+                description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_PARKING),
+                icon = Icon.DIRECTIONS_CAR,
+                sampleValue = JsonPrimitive(SampleData.CINEMA_PARKING)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Picture,
-                "poster",
-                getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_MOVIE_POSTER),
+                type = DocumentAttributeType.Picture,
+                identifier = "poster",
+                displayName = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_ATTRIBUTE_MOVIE_POSTER),
                 description = getLocalizedString(GeneratedStringKeys.MOVIE_TICKET_DESCRIPTION_MOVIE_POSTER),
-                Icon.IMAGE
+                icon = Icon.IMAGE
             )
             .addSampleRequest(
                 id = "is_parking_prepaid",

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaNaturalization.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/UtopiaNaturalization.kt
@@ -23,36 +23,36 @@ object UtopiaNaturalization {
         return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_NATURALIZATION_CERTIFICATE))
             .addJsonDocumentType(type = VCT, keyBound = true)
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "family_name",
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_FAMILY_NAME),
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_FAMILY_NAME),
-                Icon.PERSON,
-                JsonPrimitive(SampleData.FAMILY_NAME)
+                type = DocumentAttributeType.String,
+                identifier = "family_name",
+                displayName = getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_FAMILY_NAME),
+                description = getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_FAMILY_NAME),
+                icon = Icon.PERSON,
+                sampleValue = JsonPrimitive(SampleData.FAMILY_NAME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.String,
-                "given_name",
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_GIVEN_NAMES),
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_GIVEN_NAMES),
-                Icon.PERSON,
-                JsonPrimitive(SampleData.GIVEN_NAME)
+                type = DocumentAttributeType.String,
+                identifier = "given_name",
+                displayName = getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_GIVEN_NAMES),
+                description = getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_GIVEN_NAMES),
+                icon = Icon.PERSON,
+                sampleValue = JsonPrimitive(SampleData.GIVEN_NAME)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Date,
-                "birth_date",
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_DATE_OF_BIRTH),
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_DATE_OF_BIRTH),
-                Icon.TODAY,
-                JsonPrimitive(SampleData.BIRTH_DATE)
+                type = DocumentAttributeType.Date,
+                identifier = "birth_date",
+                displayName = getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_DATE_OF_BIRTH),
+                description = getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_DATE_OF_BIRTH),
+                icon = Icon.TODAY,
+                sampleValue = JsonPrimitive(SampleData.BIRTH_DATE)
             )
             .addJsonAttribute(
-                DocumentAttributeType.Date,
-                "naturalization_date",
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_DATE_OF_NATURALIZATION),
-                getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_DATE_OF_NATURALIZATION),
-                Icon.DATE_RANGE,
-                JsonPrimitive(SampleData.ISSUE_DATE)
+                type = DocumentAttributeType.Date,
+                identifier = "naturalization_date",
+                displayName = getLocalizedString(GeneratedStringKeys.NATURALIZATION_ATTRIBUTE_DATE_OF_NATURALIZATION),
+                description = getLocalizedString(GeneratedStringKeys.NATURALIZATION_DESCRIPTION_DATE_OF_NATURALIZATION),
+                icon = Icon.DATE_RANGE,
+                sampleValue = JsonPrimitive(SampleData.ISSUE_DATE)
             )
             .addSampleRequest(
                 id = "full",

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentAttribute.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentAttribute.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.JsonElement
  * @property identifier the identifier of this attribute.
  * @property displayName the name suitable for display of the attribute.
  * @property description a description of the attribute.
+ * @property sensitivity the sensitivity of the attribute.
  * @property icon the icon for the attribute, if available.
  * @property sampleValueMdoc a sample value for the attribute for ISO mdoc credentials, if available.
  * @property sampleValueJson a sample value for the attribute for JSON-based credentials, if available.
@@ -37,6 +38,7 @@ data class DocumentAttribute(
     val identifier: String,
     val displayName: String,
     val description: String,
+    val sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
     val icon: Icon? = null,
     val sampleValueMdoc: DataItem? = null,
     val sampleValueJson: JsonElement? = null,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentAttributeSensitivity.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentAttributeSensitivity.kt
@@ -1,0 +1,44 @@
+package org.multipaz.documenttype
+
+/**
+ * Attribute sensitivity classification.
+ *
+ * These values are ordered in terms of sensitivity, ranging from [VALIDITY] being the least sensitive and [PII]
+ * being the highest. New values may be added in the future so applications should be careful serializing these
+ * values to storage or transmitting them to other applications.
+ *
+ * These levels should always be considered in context (including whether a presentment is proximity or online), and
+ * is not an indication of risk by themselves. For example for presentment of a credential to a website level
+ * [PORTRAIT_IMAGE] should be considered risky whereas for proximity presentment it's not.
+ */
+enum class DocumentAttributeSensitivity {
+    /**
+     * The attribute conveys information about the validity of the underlying document or credential.
+     */
+    VALIDITY,
+
+    /**
+     * The attribute conveys information about the issuer of the document.
+     */
+    ISSUER,
+
+    /**
+     * The attribute conveys information about the subject's age, e.g. `age_over_21` or `age_in_years`. This does
+     * not include e.g. a subject's birthdate since this can reliably identify an individual.
+     */
+    AGE_INFORMATION,
+
+    /**
+     * The holder's portrait image, used to prove that the individual presenting a credential is the authorized holder.
+     */
+    PORTRAIT_IMAGE,
+
+    // TODO: when we add support for holder-device-binding we want to add a new sensitivity-level for this
+    //  data element (which will hold a boolean/enum) which will likely sit between ISSUER and AGE_INFORMATION.
+
+    /**
+     * The attribute contains Personally Identifiable Information about the subject, for example name, street address,
+     * or birthdate.
+     */
+    PII,
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -127,6 +127,7 @@ class DocumentType private constructor(
          * @param description a description of the attribute.
          * @param mandatory indication whether the ISO mdoc attribute is mandatory.
          * @param mdocNamespace the namespace of the ISO mdoc attribute.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValueMdoc a sample value for the attribute for ISO mdoc credentials, if available.
          * @param sampleValueJson a sample value for the attribute for JSON-based credentials, if available.
@@ -138,12 +139,31 @@ class DocumentType private constructor(
             description: String,
             mandatory: Boolean,
             mdocNamespace: String,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValueMdoc: DataItem? = null,
             sampleValueJson: JsonElement? = null,
         ) = apply {
-            addMdocAttribute(type, identifier, displayName, description, mandatory, mdocNamespace, icon, sampleValueMdoc)
-            addJsonAttribute(type, identifier, displayName, description, icon, sampleValueJson)
+            addMdocAttribute(
+                type = type,
+                identifier = identifier,
+                displayName = displayName,
+                description = description,
+                mandatory = mandatory,
+                mdocNamespace = mdocNamespace,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValueMdoc
+            )
+            addJsonAttribute(
+                type = type,
+                identifier = identifier,
+                displayName = displayName,
+                description = description,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValueJson
+            )
         }
 
         /**
@@ -157,6 +177,7 @@ class DocumentType private constructor(
          * @param description a description of the attribute.
          * @param mandatory indication whether the ISO mdoc attribute is mandatory.
          * @param mdocNamespace the namespace of the ISO mdoc attribute.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValueMdoc a sample value for the attribute for ISO mdoc credentials, if available.
          * @param sampleValueJson a sample value for the attribute for JSON-based credentials, if available.
@@ -169,21 +190,31 @@ class DocumentType private constructor(
             description: String,
             mandatory: Boolean,
             mdocNamespace: String,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValueMdoc: DataItem? = null,
             sampleValueJson: JsonElement? = null,
         ) = apply {
             addMdocAttribute(
-                type,
-                mdocIdentifier,
-                displayName,
-                description,
-                mandatory,
-                mdocNamespace,
-                icon,
-                sampleValueMdoc
+                type = type,
+                identifier = mdocIdentifier,
+                displayName = displayName,
+                description = description,
+                mandatory = mandatory,
+                mdocNamespace = mdocNamespace,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValueMdoc
             )
-            addJsonAttribute(type, jsonIdentifier, displayName, description, icon, sampleValueJson)
+            addJsonAttribute(
+                type = type,
+                identifier = jsonIdentifier,
+                displayName = displayName,
+                description = description,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValueJson
+            )
         }
 
         /**
@@ -195,6 +226,7 @@ class DocumentType private constructor(
          * @param description a description of the attribute.
          * @param mandatory indication whether the ISO mdoc attribute is mandatory.
          * @param mdocNamespace the namespace of the ISO mdoc attribute.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValue a sample value for the attribute, if available.
          */
@@ -205,18 +237,20 @@ class DocumentType private constructor(
             description: String,
             mandatory: Boolean,
             mdocNamespace: String,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValue: DataItem? = null
         ) = apply {
             mdocBuilder?.addDataElement(
-                mdocNamespace,
-                type,
-                identifier,
-                displayName,
-                description,
-                mandatory,
-                icon,
-                sampleValue
+                namespace = mdocNamespace,
+                type = type,
+                identifier = identifier,
+                displayName = displayName,
+                description = description,
+                mandatory = mandatory,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValue
             ) ?: throw Exception("The ISO mdoc Document Type was not initialized")
         }
 
@@ -228,6 +262,7 @@ class DocumentType private constructor(
          * `age_equal_or_over.18`.
          * @param displayName a name suitable for display of the attribute.
          * @param description a description of the attribute.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValue a sample value for the attribute, if available.
          */
@@ -236,6 +271,7 @@ class DocumentType private constructor(
             identifier: String,
             displayName: String,
             description: String,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValue: JsonElement? = null
         ) = apply {
@@ -252,6 +288,7 @@ class DocumentType private constructor(
                         identifier = splits[1],
                         displayName = displayName,
                         description = description,
+                        sensitivity = sensitivity,
                         icon = icon,
                         sampleValue = sampleValue
                     ) ?: throw Exception("The JSON Document Type was not initialized")
@@ -346,8 +383,6 @@ class DocumentType private constructor(
             mdocBuilder?.build(),
             jsonBuilder?.build())
     }
-
-    // TODO: also add createSdJwtVCWithSampleData()
 
     /**
      * Adds a [MdocCredential] to a [Document] with sample data for the document type.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/JsonDocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/JsonDocumentType.kt
@@ -98,6 +98,7 @@ class JsonDocumentType private constructor(
             identifier: String,
             displayName: String,
             description: String,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValue: JsonElement? = null
         ) {
@@ -109,6 +110,7 @@ class JsonDocumentType private constructor(
                     identifier = identifier,
                     displayName = displayName,
                     description = description,
+                    sensitivity = sensitivity,
                     icon = icon,
                     sampleValueMdoc = null,
                     sampleValueJson = sampleValue,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDocumentType.kt
@@ -46,6 +46,7 @@ class MdocDocumentType private constructor(
          * @param displayName the name suitable for display of the attribute.
          * @param description a description of the attribute.
          * @param mandatory indication whether the ISO mdoc attribute is mandatory.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValue a sample value for the attribute, if available.
          * @return the builder.
@@ -57,6 +58,7 @@ class MdocDocumentType private constructor(
             displayName: String,
             description: String,
             mandatory: Boolean,
+            sensitivity: DocumentAttributeSensitivity = DocumentAttributeSensitivity.PII,
             icon: Icon? = null,
             sampleValue: DataItem? = null,
         ) = apply {
@@ -64,13 +66,14 @@ class MdocDocumentType private constructor(
                 namespaces[namespace] = MdocNamespace.Builder(namespace)
             }
             namespaces[namespace]!!.addDataElement(
-                type,
-                identifier,
-                displayName,
-                description,
-                mandatory,
-                icon,
-                sampleValue
+                type = type,
+                identifier = identifier,
+                displayName = displayName,
+                description = description,
+                mandatory = mandatory,
+                sensitivity = sensitivity,
+                icon = icon,
+                sampleValue = sampleValue
             )
         }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocNamespace.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocNamespace.kt
@@ -47,6 +47,7 @@ class MdocNamespace private constructor(
          * @param displayName the name suitable for display of the attribute.
          * @param description a description of the attribute.
          * @param mandatory indication whether the mdoc attribute is mandatory.
+         * @param sensitivity the sensitivity of the attribute.
          * @param icon the icon, if available.
          * @param sampleValue a sample value for the attribute, if available.
          */
@@ -56,6 +57,7 @@ class MdocNamespace private constructor(
             displayName: String,
             description: String,
             mandatory: Boolean,
+            sensitivity: DocumentAttributeSensitivity,
             icon: Icon?,
             sampleValue: DataItem?,
         ) = apply {
@@ -65,6 +67,7 @@ class MdocNamespace private constructor(
                     identifier = identifier,
                     displayName = displayName,
                     description = description,
+                    sensitivity = sensitivity,
                     icon = icon,
                     sampleValueMdoc = sampleValue,
                     sampleValueJson = null,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSelection.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSelection.kt
@@ -1,5 +1,7 @@
 package org.multipaz.presentment
 
+import org.multipaz.documenttype.DocumentAttributeSensitivity
+
 /**
  * A selection of credentials and claims in a [CredentialPresentmentData].
  *
@@ -12,4 +14,28 @@ package org.multipaz.presentment
  */
 data class CredentialPresentmentSelection(
     val matches: List<CredentialPresentmentSetOptionMemberMatch>,
-)
+) {
+
+    /**
+     * Returns the highest sensitivity level of the claims in all the credentials in this object.
+     *
+     * @return The highest sensitivity level or `null` if one or more of the claims are unknown.
+     */
+    fun getMaxSensitivity(): DocumentAttributeSensitivity? {
+        var maxSensitivity: DocumentAttributeSensitivity? = null
+        matches.forEach { match ->
+            match.claims.forEach { (_, claim) ->
+                claim.attribute?.let { attribute ->
+                    if (maxSensitivity == null) {
+                        maxSensitivity = attribute.sensitivity
+                    } else {
+                        if (attribute.sensitivity > maxSensitivity!!) {
+                            maxSensitivity = attribute.sensitivity
+                        }
+                    }
+                } ?: return null
+            }
+        }
+        return maxSensitivity
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPrivacyPreservingAgeRequest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestPrivacyPreservingAgeRequest.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.multipaz.datetime.formatLocalized
+import org.multipaz.documenttype.DocumentAttributeSensitivity
 import org.multipaz.presentment.DocumentStoreTestHarness
 import org.multipaz.presentment.prettyPrint
 import kotlin.test.Test
@@ -23,10 +24,12 @@ class TestPrivacyPreservingAgeRequest {
                 docType = "org.iso.18013.5.1.mDL",
                 data = mapOf(
                     "org.iso.18013.5.1" to listOf(
+                        "unknown_data_element" to Tstr("Something"),
                         "given_name" to Tstr("David"),
                         "age_over_18" to true.toDataItem(),
                         "age_in_years" to 48.toDataItem(),
-                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate()
+                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate(),
+                        "portrait" to byteArrayOf(1, 2, 3).toDataItem()
                     )
                 )
             )
@@ -38,9 +41,11 @@ class TestPrivacyPreservingAgeRequest {
                 docType = "org.iso.18013.5.1.mDL",
                 data = mapOf(
                     "org.iso.18013.5.1" to listOf(
+                        "unknown_data_element" to Tstr("Something"),
                         "given_name" to Tstr("David"),
                         "age_in_years" to 48.toDataItem(),
-                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate()
+                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate(),
+                        "portrait" to byteArrayOf(1, 2, 3).toDataItem()
                     )
                 )
             )
@@ -52,8 +57,10 @@ class TestPrivacyPreservingAgeRequest {
                 docType = "org.iso.18013.5.1.mDL",
                 data = mapOf(
                     "org.iso.18013.5.1" to listOf(
+                        "unknown_data_element" to Tstr("Something"),
                         "given_name" to Tstr("David"),
-                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate()
+                        "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate(),
+                        "portrait" to byteArrayOf(1, 2, 3).toDataItem()
                     )
                 )
             )
@@ -71,7 +78,7 @@ class TestPrivacyPreservingAgeRequest {
             )
         }
 
-        private fun ageMdlQuery(): DcqlQuery {
+        private fun ageAndNameMdlQuery(): DcqlQuery {
             return DcqlQuery.fromJson(
                 Json.parseToJsonElement(
                     """
@@ -101,6 +108,98 @@ class TestPrivacyPreservingAgeRequest {
                 ).jsonObject
             )
         }
+    }
+
+    private fun ageAndPortraitMdlQuery(): DcqlQuery {
+        return DcqlQuery.fromJson(
+            Json.parseToJsonElement(
+                """
+                        {
+                          "credentials": [
+                            {
+                              "id": "my_credential",
+                              "format": "mso_mdoc",
+                              "meta": {
+                                "doctype_value": "org.iso.18013.5.1.mDL"
+                              },
+                              "claims": [
+                                {"id": "a", "path": ["org.iso.18013.5.1", "portrait"]},
+                                {"id": "b", "path": ["org.iso.18013.5.1", "age_over_18"]},
+                                {"id": "c", "path": ["org.iso.18013.5.1", "age_in_years"]},
+                                {"id": "d", "path": ["org.iso.18013.5.1", "birth_date"]}
+                              ],
+                              "claim_sets": [
+                                ["a", "b"],
+                                ["a", "c"],
+                                ["a", "d"]
+                              ]
+                            }
+                          ]
+                        }
+                    """
+            ).jsonObject
+        )
+    }
+
+    private fun ageMdlQuery(): DcqlQuery {
+        return DcqlQuery.fromJson(
+            Json.parseToJsonElement(
+                """
+                        {
+                          "credentials": [
+                            {
+                              "id": "my_credential",
+                              "format": "mso_mdoc",
+                              "meta": {
+                                "doctype_value": "org.iso.18013.5.1.mDL"
+                              },
+                              "claims": [
+                                {"id": "b", "path": ["org.iso.18013.5.1", "age_over_18"]},
+                                {"id": "c", "path": ["org.iso.18013.5.1", "age_in_years"]},
+                                {"id": "d", "path": ["org.iso.18013.5.1", "birth_date"]}
+                              ],
+                              "claim_sets": [
+                                ["b"],
+                                ["c"],
+                                ["d"]
+                              ]
+                            }
+                          ]
+                        }
+                    """
+            ).jsonObject
+        )
+    }
+
+    private fun ageMdlAndUnknownDataElementQuery(): DcqlQuery {
+        return DcqlQuery.fromJson(
+            Json.parseToJsonElement(
+                """
+                        {
+                          "credentials": [
+                            {
+                              "id": "my_credential",
+                              "format": "mso_mdoc",
+                              "meta": {
+                                "doctype_value": "org.iso.18013.5.1.mDL"
+                              },
+                              "claims": [
+                                {"id": "a", "path": ["org.iso.18013.5.1", "unknown_data_element"]},
+                                {"id": "b", "path": ["org.iso.18013.5.1", "age_over_18"]},
+                                {"id": "c", "path": ["org.iso.18013.5.1", "age_in_years"]},
+                                {"id": "d", "path": ["org.iso.18013.5.1", "birth_date"]}
+                              ],
+                              "claim_sets": [
+                                ["a", "b"],
+                                ["a", "c"],
+                                ["a", "d"]
+                              ]
+                            }
+                          ]
+                        }
+                    """
+            ).jsonObject
+        )
     }
 
     @Test
@@ -134,7 +233,7 @@ class TestPrivacyPreservingAgeRequest {
                                       displayName: Older than 18 years
                                       value: True
             """.trimIndent().trim(),
-            ageMdlQuery().execute(
+            ageAndNameMdlQuery().execute(
                 presentmentSource = harness.presentmentSource
             ).prettyPrint().trim()
         )
@@ -171,7 +270,7 @@ class TestPrivacyPreservingAgeRequest {
                                       displayName: Age in years
                                       value: 48
             """.trimIndent().trim(),
-            ageMdlQuery().execute(
+            ageAndNameMdlQuery().execute(
                 presentmentSource = harness.presentmentSource
             ).prettyPrint().trim()
         )
@@ -182,7 +281,7 @@ class TestPrivacyPreservingAgeRequest {
         val harness = DocumentStoreTestHarness()
         harness.initialize()
         addMdl_with_BirthDate(harness)
-        val result = ageMdlQuery().execute(
+        val result = ageAndNameMdlQuery().execute(
             presentmentSource = harness.presentmentSource
         ).prettyPrint().trim()
 
@@ -224,11 +323,66 @@ class TestPrivacyPreservingAgeRequest {
         harness.initialize()
         addMdl_with_OnlyName(harness)
         val e = assertFailsWith(DcqlCredentialQueryException::class) {
-            ageMdlQuery().execute(
+            ageAndNameMdlQuery().execute(
                 presentmentSource = harness.presentmentSource
             )
         }
         assertEquals("No matches for credential query with id my_credential", e.message)
     }
 
+    @Test
+    fun testGetMaxSensitivity_AgeInformation() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        addMdl_with_AgeInYears_BirthDate(harness)
+
+        val request = ageMdlQuery().execute(
+            presentmentSource = harness.presentmentSource
+        ).select(preselectedDocuments = emptyList())
+
+        // This should return AGE_INFORMATION b/c age_in_years is classified as AGE_IN_YEARS
+        assertEquals(DocumentAttributeSensitivity.AGE_INFORMATION, request.getMaxSensitivity())
+    }
+
+    @Test
+    fun testGetMaxSensitivity_PortraitImage() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        addMdl_with_AgeInYears_BirthDate(harness)
+
+        val request = ageAndPortraitMdlQuery().execute(
+            presentmentSource = harness.presentmentSource
+        ).select(preselectedDocuments = emptyList())
+
+        // This should return PORTRAIT_IMAGE b/c portrait is classified as PORTRAIT_IMAGE
+        assertEquals(DocumentAttributeSensitivity.PORTRAIT_IMAGE, request.getMaxSensitivity())
+    }
+
+    @Test
+    fun testGetMaxSensitivity_PII() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        addMdl_with_BirthDate(harness)
+
+        val request = ageMdlQuery().execute(
+            presentmentSource = harness.presentmentSource
+        ).select(preselectedDocuments = emptyList())
+
+        // This should return PII b/c birth_date is classified as PII
+        assertEquals(DocumentAttributeSensitivity.PII, request.getMaxSensitivity())
+    }
+
+    @Test
+    fun testGetMaxSensitivity_Unknown() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        addMdl_with_BirthDate(harness)
+
+        val request = ageMdlAndUnknownDataElementQuery().execute(
+            presentmentSource = harness.presentmentSource
+        ).select(preselectedDocuments = emptyList())
+
+        // This should return `null` b/c there is no DocumentAttribute for unknown_data_element and thus no sensitivity.
+        assertEquals(null, request.getMaxSensitivity())
+    }
 }


### PR DESCRIPTION
This adds the `DocumentAttributeSensitivity` enum which is used to express how sensitive a particular attribute is.

Use this attribute in all document types and also introduce `getMaxSensitivity()` method on `CredentialPresentmentSelection` (which represents a selection of credential w/ claims to return) which returns the maximum sensitivity of the claims to be returned. Also add tests for this for `getMaxSensitivity()`.

This PR also updates the known doctypes to use parameter names, making it easier to figure out what's going on.

Test: New unit tests and all unit tests pass.
