### PR TITLE
Introduce getAllSelections() on CredentialPresentmentData.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemText.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/items/FloatingItemText.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -17,7 +18,8 @@ import androidx.compose.ui.unit.dp
  * An item showing a text, with smaller secondary text below.
  *
  * @param text text to be shown.
- * @param secondary optional text to show below the main text, in secondary color and smaller font.
+ * @param secondary optional text to show below the main text, in smaller font and [secondaryColor].
+ * @param secondaryColor the color to use for [secondaryColor], defaults to secondary color.
  * @param modifier a [Modifier].
  * @param image optional image, shown to the left of the text.
  * @param trailingContent optional trailing content.
@@ -27,6 +29,7 @@ fun FloatingItemText(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     secondary: String? = null,
+    secondaryColor: Color = MaterialTheme.colorScheme.secondary,
     image: @Composable () -> Unit = {},
     trailingContent: @Composable () -> Unit = {},
 ) {
@@ -60,7 +63,7 @@ fun FloatingItemText(
                             text = secondary,
                             textAlign = TextAlign.Start,
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.secondary
+                            color = secondaryColor
                         )
                     }
                 }
@@ -74,7 +77,8 @@ fun FloatingItemText(
  * An item showing a text, with smaller secondary text below.
  *
  * @param text text to be shown.
- * @param secondary optional text to show below the main text, in secondary color and smaller font.
+ * @param secondary optional text to show below the main text, in smaller font and [secondaryColor].
+ * @param secondaryColor the color to use for [secondaryColor], defaults to secondary color.
  * @param modifier a [Modifier].
  * @param image optional image, shown to the left of the text.
  * @param trailingContent optional trailing content.
@@ -84,6 +88,7 @@ fun FloatingItemText(
     text: String,
     modifier: Modifier = Modifier,
     secondary: String? = null,
+    secondaryColor: Color = MaterialTheme.colorScheme.secondary,
     image: @Composable () -> Unit = {},
     trailingContent: @Composable () -> Unit = {},
 ) {
@@ -91,6 +96,7 @@ fun FloatingItemText(
         text = AnnotatedString(text),
         modifier = modifier,
         secondary = secondary,
+        secondaryColor = secondaryColor,
         image = image,
         trailingContent = trailingContent
     )

--- a/multipaz-swiftui/src/iosMain/swift/FloatingItemText.swift
+++ b/multipaz-swiftui/src/iosMain/swift/FloatingItemText.swift
@@ -10,6 +10,9 @@ public struct FloatingItemText<ImageView: View, TrailingView: View>: View {
     /// An optional secondary string displayed beneath the primary text in a smaller font.
     public var secondary: String?
 
+    /// Color for secondary text.
+    public var secondaryColor: Color
+
     /// A view builder that creates the leading image or icon.
     @ViewBuilder public var image: () -> ImageView
 
@@ -26,11 +29,13 @@ public struct FloatingItemText<ImageView: View, TrailingView: View>: View {
     public init(
         text: AttributedString,
         secondary: String? = nil,
+        secondaryColor: Color = .secondary,
         @ViewBuilder image: @escaping () -> ImageView = { EmptyView() },
         @ViewBuilder trailingContent: @escaping () -> TrailingView = { EmptyView() }
     ) {
         self.text = text
         self.secondary = secondary
+        self.secondaryColor = secondaryColor
         self.image = image
         self.trailingContent = trailingContent
     }
@@ -40,15 +45,17 @@ public struct FloatingItemText<ImageView: View, TrailingView: View>: View {
     /// - Parameters:
     ///   - text: The primary string to display.
     ///   - secondary: An optional secondary string to display below the primary text. Defaults to `nil`.
+    ///   - secondaryColor: Color for secondary text, defaults to `Color.secondary`.
     ///   - image: A view builder that provides a leading image or icon. Defaults to an `EmptyView`.
     ///   - trailingContent: A view builder that provides a trailing view. Defaults to an `EmptyView`.
     public init(
         text: String,
         secondary: String? = nil,
+        secondaryColor: Color = .secondary,
         @ViewBuilder image: @escaping () -> ImageView = { EmptyView() },
         @ViewBuilder trailingContent: @escaping () -> TrailingView = { EmptyView() }
     ) {
-        self.init(text: AttributedString(text), secondary: secondary, image: image, trailingContent: trailingContent)
+        self.init(text: AttributedString(text), secondary: secondary, secondaryColor: secondaryColor, image: image, trailingContent: trailingContent)
     }
 
     public var body: some View {
@@ -64,7 +71,7 @@ public struct FloatingItemText<ImageView: View, TrailingView: View>: View {
                         Text(secondary)
                             .font(.system(size: 13))
                             .multilineTextAlignment(.leading)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(secondaryColor)
                     }
                 } else {
                     Text(text)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentData.kt
@@ -1,5 +1,6 @@
 package org.multipaz.presentment
 
+import org.multipaz.claim.Claim
 import org.multipaz.document.Document
 import org.multipaz.util.Logger
 import org.multipaz.util.generateAllPaths
@@ -146,6 +147,44 @@ data class CredentialPresentmentData(
         }
         Logger.w(TAG, "Error picking combination for pre-selected documents")
         return null
+    }
+
+    /**
+     * Gets all possible selections.
+     *
+     * @return all possible selections from the given options.
+     */
+    fun getAllSelections(): List<CredentialPresentmentSelection> {
+        val allSetSelections = credentialSets.map { set ->
+            val selectionsForSet = mutableListOf<List<CredentialPresentmentSetOptionMemberMatch>>()
+            if (set.optional) {
+                selectionsForSet.add(emptyList())
+            }
+            for (option in set.options) {
+                // We need one match from each member.
+                val memberMatchChoices = option.members.map { it.matches }
+                val paths = memberMatchChoices.map { it.size }.generateAllPaths()
+                for (path in paths) {
+                    val selection = mutableListOf<CredentialPresentmentSetOptionMemberMatch>()
+                    path.forEachIndexed { memberIndex, matchIndex ->
+                        selection.add(memberMatchChoices[memberIndex][matchIndex])
+                    }
+                    selectionsForSet.add(selection)
+                }
+            }
+            selectionsForSet
+        }
+
+        val paths = allSetSelections.map { it.size }.generateAllPaths()
+        val finalSelections = mutableListOf<CredentialPresentmentSelection>()
+        for (path in paths) {
+            val allMatches = mutableListOf<CredentialPresentmentSetOptionMemberMatch>()
+            path.forEachIndexed { setIndex, selectionIndex ->
+                allMatches.addAll(allSetSelections[setIndex][selectionIndex])
+            }
+            finalSelections.add(CredentialPresentmentSelection(allMatches))
+        }
+        return finalSelections
     }
 }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -265,7 +266,20 @@ class ProvisioningModel(
     ): ProvisioningMetadata =
         OpenID4VCI.getMetadata(issuerUrl, httpClient, clientPreferences)
 
-
+    /**
+     * Resets the model to [Idle].
+     *
+     * This is synchronous and waits until the current state is [Idle].
+     */
+    suspend fun reset() {
+        job?.let {
+            if (it.isActive) {
+                it.cancelAndJoin()
+            }
+        }
+        mutableMetadata.emit(null)
+        mutableState.emit(Idle)
+    }
 
     /**
      * Cancel currently-running provisioning session (if any) and sets the state to [Idle].

--- a/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestCredentialSets.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/openid/dcql/TestCredentialSets.kt
@@ -184,6 +184,10 @@ class TestCredentialSets {
         addCredPidReduced1(harness)
         addCredPidReduced2(harness)
         addCredCompanyRewards(harness)
+
+        val queryResult = complexQuery().execute(
+            presentmentSource = harness.presentmentSource
+        )
         assertEquals(
             """
                 credentialSets:
@@ -285,9 +289,176 @@ class TestCredentialSets {
                                       displayName: rewards_number
                                       value: 24601
             """.trimIndent().trim(),
-            complexQuery().execute(
-                presentmentSource = harness.presentmentSource
-            ).prettyPrint().trim()
+            queryResult.prettyPrint().trim()
+        )
+
+        // Also check that getAllSelections() returns all possible selections
+        assertEquals(
+            """
+                selections:
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-other-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-other-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced1
+                        claims:
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced2
+                        claims:
+                          claim:
+                            path: ["postal_code"]
+                            displayName: postal_code
+                            value: 90210
+                          claim:
+                            path: ["locality"]
+                            displayName: locality
+                            value: Beverly Hills
+                          claim:
+                            path: ["region"]
+                            displayName: region
+                            value: Los Angeles Basin
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced1
+                        claims:
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced2
+                        claims:
+                          claim:
+                            path: ["postal_code"]
+                            displayName: postal_code
+                            value: 90210
+                          claim:
+                            path: ["locality"]
+                            displayName: locality
+                            value: Beverly Hills
+                          claim:
+                            path: ["region"]
+                            displayName: region
+                            value: Los Angeles Basin
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+            """.trimIndent().trim(),
+            queryResult.getAllSelections().prettyPrint().trim()
         )
     }
 
@@ -304,6 +475,10 @@ class TestCredentialSets {
         addCredPidReduced1(harness)
         addCredPidReduced2(harness)
         addCredCompanyRewards(harness)
+
+        val queryResult = complexQuery().execute(
+            presentmentSource = harness.presentmentSource
+        )
         assertEquals(
             """
                 credentialSets:
@@ -422,9 +597,221 @@ class TestCredentialSets {
                                       displayName: rewards_number
                                       value: 24601
             """.trimIndent().trim(),
-            complexQuery().execute(
-                presentmentSource = harness.presentmentSource
-            ).prettyPrint().trim()
+            queryResult.prettyPrint().trim()
+        )
+
+        // Also check that getAllSelections() returns all possible selections
+        assertEquals(
+            """
+                selections:
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-max
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Max
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 456
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-max
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Max
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 456
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-other-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-other-pid
+                        claims:
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["address","street_address"]
+                            displayName: address.street_address
+                            value: Sample Street 123
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced1
+                        claims:
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced2
+                        claims:
+                          claim:
+                            path: ["postal_code"]
+                            displayName: postal_code
+                            value: 90210
+                          claim:
+                            path: ["locality"]
+                            displayName: locality
+                            value: Beverly Hills
+                          claim:
+                            path: ["region"]
+                            displayName: region
+                            value: Los Angeles Basin
+                  matches:
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced1
+                        claims:
+                          claim:
+                            path: ["family_name"]
+                            displayName: family_name
+                            value: Mustermann
+                          claim:
+                            path: ["given_name"]
+                            displayName: given_name
+                            value: Erika
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-pid-reduced2
+                        claims:
+                          claim:
+                            path: ["postal_code"]
+                            displayName: postal_code
+                            value: 90210
+                          claim:
+                            path: ["locality"]
+                            displayName: locality
+                            value: Beverly Hills
+                          claim:
+                            path: ["region"]
+                            displayName: region
+                            value: Los Angeles Basin
+                    match:
+                      credential:
+                        type: KeyBoundSdJwtVcCredential
+                        docId: my-reward-card
+                        claims:
+                          claim:
+                            path: ["rewards_number"]
+                            displayName: rewards_number
+                            value: 24601
+            """.trimIndent().trim(),
+            queryResult.getAllSelections().prettyPrint().trim()
         )
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/CredentialPresentmentDataTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/CredentialPresentmentDataTest.kt
@@ -1,0 +1,157 @@
+package org.multipaz.presentment
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.toDataItem
+import org.multipaz.cbor.toDataItemFullDate
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.PhotoID
+import org.multipaz.openid.dcql.DcqlQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CredentialPresentmentDataTest {
+
+    suspend fun addMdl_with_AgeOver_AgeInYears_BirthDate(harness: DocumentStoreTestHarness) {
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "unknown_data_element" to Tstr("Something"),
+                    "given_name" to Tstr("David"),
+                    "age_over_18" to true.toDataItem(),
+                    "age_in_years" to 48.toDataItem(),
+                    "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate(),
+                    "portrait" to byteArrayOf(1, 2, 3).toDataItem()
+                )
+            )
+        )
+    }
+
+    suspend fun addPhotoID_with_AgeOver_AgeInYears_BirthDate(harness: DocumentStoreTestHarness) {
+        harness.provisionMdoc(
+            displayName = "my-photoID",
+            docType = PhotoID.PHOTO_ID_DOCTYPE,
+            data = mapOf(
+                PhotoID.ISO_23220_2_NAMESPACE to listOf(
+                    "unknown_data_element" to Tstr("Something"),
+                    "given_name" to Tstr("David"),
+                    "age_over_18" to true.toDataItem(),
+                    "age_in_years" to 48.toDataItem(),
+                    "birth_date" to LocalDate.parse("1976-03-02").toDataItemFullDate(),
+                    "portrait" to byteArrayOf(1, 2, 3).toDataItem()
+                )
+            )
+        )
+    }
+
+    private fun ageAndPortraitQuery(): DcqlQuery {
+        return DcqlQuery.fromJson(
+            Json.parseToJsonElement(
+                """
+                        {
+                          "credentials": [
+                            {
+                              "id": "mdl",
+                              "format": "mso_mdoc",
+                              "meta": {
+                                "doctype_value": "${DrivingLicense.MDL_DOCTYPE}"
+                              },
+                              "claims": [
+                                {"id": "a", "path": ["${DrivingLicense.MDL_NAMESPACE}", "portrait"]},
+                                {"id": "b", "path": ["${DrivingLicense.MDL_NAMESPACE}", "age_over_18"]},
+                                {"id": "c", "path": ["${DrivingLicense.MDL_NAMESPACE}", "age_in_years"]},
+                                {"id": "d", "path": ["${DrivingLicense.MDL_NAMESPACE}", "birth_date"]}
+                              ],
+                              "claim_sets": [
+                                ["a", "b"],
+                                ["a", "c"],
+                                ["a", "d"]
+                              ]
+                            },
+                            {
+                              "id": "photoid",
+                              "format": "mso_mdoc",
+                              "meta": {
+                                "doctype_value": "${PhotoID.PHOTO_ID_DOCTYPE}"
+                              },
+                              "claims": [
+                                {"id": "a", "path": ["${PhotoID.ISO_23220_2_NAMESPACE}", "portrait"]},
+                                {"id": "b", "path": ["${PhotoID.ISO_23220_2_NAMESPACE}", "age_over_18"]},
+                                {"id": "c", "path": ["${PhotoID.ISO_23220_2_NAMESPACE}", "age_in_years"]},
+                                {"id": "d", "path": ["${PhotoID.ISO_23220_2_NAMESPACE}", "birth_date"]}
+                              ],
+                              "claim_sets": [
+                                ["a", "b"],
+                                ["a", "c"],
+                                ["a", "d"]
+                              ]
+                            }
+                          ],
+                          "credential_sets": [
+                            {
+                              "options": [
+                                [ "mdl" ],
+                                [ "photoid" ]
+                              ]
+                            }
+                          ]
+                        }
+                    """
+            ).jsonObject
+        )
+    }
+
+    @Test
+    fun testGetAllSelections() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        addMdl_with_AgeOver_AgeInYears_BirthDate(harness)
+        addPhotoID_with_AgeOver_AgeInYears_BirthDate(harness)
+
+        val data = ageAndPortraitQuery().execute(presentmentSource = harness.presentmentSource)
+        val selections = data.getAllSelections()
+        assertEquals(
+            """
+                selections:
+                  matches:
+                    match:
+                      credential:
+                        type: MdocCredential
+                        docId: my-mDL
+                        claims:
+                          claim:
+                            nameSpace: org.iso.18013.5.1
+                            dataElement: portrait
+                            displayName: Photo of holder
+                            value: Image (3 bytes)
+                          claim:
+                            nameSpace: org.iso.18013.5.1
+                            dataElement: age_over_18
+                            displayName: Older than 18 years
+                            value: True
+                  matches:
+                    match:
+                      credential:
+                        type: MdocCredential
+                        docId: my-photoID
+                        claims:
+                          claim:
+                            nameSpace: org.iso.23220.1
+                            dataElement: portrait
+                            displayName: Photo of holder
+                            value: Image (3 bytes)
+                          claim:
+                            nameSpace: org.iso.23220.1
+                            dataElement: age_over_18
+                            displayName: Older than 18 years
+                            value: True
+            """.trimIndent() + "\n",
+            selections.prettyPrint()
+        )
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/PrettyPrinter.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/PrettyPrinter.kt
@@ -120,3 +120,36 @@ internal fun CredentialPresentmentData.prettyPrint(): String {
     pp.popIndent()
     return pp.toString()
 }
+
+internal fun CredentialPresentmentSelection.print(pp: PrettyPrinter): String {
+    pp.append("matches:")
+    pp.pushIndent()
+    if (matches.size == 0) {
+        pp.append("<empty>")
+    } else {
+        for (match in matches) {
+            match.print(pp)
+        }
+    }
+    pp.popIndent()
+    return pp.toString()
+}
+internal fun CredentialPresentmentSelection.prettyPrint(): String {
+    val pp = PrettyPrinter()
+    return print(pp)
+}
+
+internal fun List<CredentialPresentmentSelection>.prettyPrint(): String {
+    val pp = PrettyPrinter()
+    pp.append("selections:")
+    pp.pushIndent()
+    if (this.size == 0) {
+        pp.append("<empty>")
+    } else {
+        for (element in this) {
+            element.print(pp)
+        }
+    }
+    pp.popIndent()
+    return pp.toString()
+}

--- a/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
+++ b/samples/SwiftTestApp/SwiftTestApp.xcodeproj/project.pbxproj
@@ -8,70 +8,70 @@
 
 /* Begin PBXBuildFile section */
 		512DAED62F2A31B30061F72B /* IdentityDocumentProviderExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		517BBCDE2FA4C3450057199B /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCE2FA4C3450057199B /* FloatingItemText.swift */; };
-		517BBCDF2FA4C3450057199B /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD22FA4C3450057199B /* PassphrasePromptDialog.swift */; };
-		517BBCE02FA4C3450057199B /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCF2FA4C3450057199B /* MdocProximityQrPresentment.swift */; };
-		517BBCE12FA4C3450057199B /* VerticalCardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDB2FA4C3450057199B /* VerticalCardList.swift */; };
-		517BBCE22FA4C3450057199B /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC62FA4C3450057199B /* Extensions.swift */; };
-		517BBCE32FA4C3450057199B /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC52FA4C3450057199B /* DocumentModel.swift */; };
-		517BBCE42FA4C3450057199B /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCC2FA4C3450057199B /* FloatingItemHeadingAndText.swift */; };
-		517BBCE52FA4C3450057199B /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD42FA4C3450057199B /* PromptModelExt.swift */; };
-		517BBCE62FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCB2FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift */; };
-		517BBCE72FA4C3450057199B /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC92FA4C3450057199B /* FloatingItemHeadingAndContent.swift */; };
-		517BBCE82FA4C3450057199B /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD52FA4C3450057199B /* ProvisioningView.swift */; };
-		517BBCE92FA4C3450057199B /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCD2FA4C3450057199B /* FloatingItemList.swift */; };
-		517BBCEA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift */; };
-		517BBCEB2FA4C3450057199B /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDA2FA4C3450057199B /* TagsExt.swift */; };
-		517BBCEC2FA4C3450057199B /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC42FA4C3450057199B /* DocumentExtCardart.swift */; };
-		517BBCED2FA4C3450057199B /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC82FA4C3450057199B /* FloatingItemContainer.swift */; };
-		517BBCEE2FA4C3450057199B /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDC2FA4C3450057199B /* X509CertViewer.swift */; };
-		517BBCEF2FA4C3450057199B /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC02FA4C3450057199B /* Consent.swift */; };
-		517BBCF02FA4C3450057199B /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD62FA4C3450057199B /* QrCode.swift */; };
-		517BBCF12FA4C3450057199B /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD02FA4C3450057199B /* MdocProximityQrSettings.swift */; };
-		517BBCF22FA4C3450057199B /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC12FA4C3450057199B /* ConsentPromptDialog.swift */; };
-		517BBCF32FA4C3450057199B /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD82FA4C3450057199B /* SimplePresentmentSourceExt.swift */; };
-		517BBCF42FA4C3450057199B /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD32FA4C3450057199B /* PromptDialogs.swift */; };
-		517BBCF52FA4C3450057199B /* CardCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBE2FA4C3450057199B /* CardCarousel.swift */; };
-		517BBCF62FA4C3450057199B /* CardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBF2FA4C3450057199B /* CardInfo.swift */; };
-		517BBCF72FA4C3450057199B /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD72FA4C3450057199B /* RequestAuthorizationView.swift */; };
-		517BBCF82FA4C3450057199B /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC72FA4C3450057199B /* FloatingItemCenteredText.swift */; };
-		517BBCF92FA4C3450057199B /* CardBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBD2FA4C3450057199B /* CardBadge.swift */; };
-		517BBCFA2FA4C3450057199B /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD92FA4C3450057199B /* SmartSheet.swift */; };
-		517BBCFB2FA4C3450057199B /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC32FA4C3450057199B /* DocumentExt.swift */; };
-		517BBCFC2FA4C3450057199B /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD12FA4C3450057199B /* PassphraseInputView.swift */; };
-		517BBCFD2FA4C3450057199B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC22FA4C3450057199B /* DefaultToHumanReadable.swift */; };
-		517BBCFE2FA4C3450057199B /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCE2FA4C3450057199B /* FloatingItemText.swift */; };
-		517BBCFF2FA4C3450057199B /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD22FA4C3450057199B /* PassphrasePromptDialog.swift */; };
-		517BBD002FA4C3450057199B /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCF2FA4C3450057199B /* MdocProximityQrPresentment.swift */; };
-		517BBD012FA4C3450057199B /* VerticalCardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDB2FA4C3450057199B /* VerticalCardList.swift */; };
-		517BBD022FA4C3450057199B /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC62FA4C3450057199B /* Extensions.swift */; };
-		517BBD032FA4C3450057199B /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC52FA4C3450057199B /* DocumentModel.swift */; };
-		517BBD042FA4C3450057199B /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCC2FA4C3450057199B /* FloatingItemHeadingAndText.swift */; };
-		517BBD052FA4C3450057199B /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD42FA4C3450057199B /* PromptModelExt.swift */; };
-		517BBD062FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCB2FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift */; };
-		517BBD072FA4C3450057199B /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC92FA4C3450057199B /* FloatingItemHeadingAndContent.swift */; };
-		517BBD082FA4C3450057199B /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD52FA4C3450057199B /* ProvisioningView.swift */; };
-		517BBD092FA4C3450057199B /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCD2FA4C3450057199B /* FloatingItemList.swift */; };
-		517BBD0A2FA4C3450057199B /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCCA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift */; };
-		517BBD0B2FA4C3450057199B /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDA2FA4C3450057199B /* TagsExt.swift */; };
-		517BBD0C2FA4C3450057199B /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC42FA4C3450057199B /* DocumentExtCardart.swift */; };
-		517BBD0D2FA4C3450057199B /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC82FA4C3450057199B /* FloatingItemContainer.swift */; };
-		517BBD0E2FA4C3450057199B /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCDC2FA4C3450057199B /* X509CertViewer.swift */; };
-		517BBD0F2FA4C3450057199B /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC02FA4C3450057199B /* Consent.swift */; };
-		517BBD102FA4C3450057199B /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD62FA4C3450057199B /* QrCode.swift */; };
-		517BBD112FA4C3450057199B /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD02FA4C3450057199B /* MdocProximityQrSettings.swift */; };
-		517BBD122FA4C3450057199B /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC12FA4C3450057199B /* ConsentPromptDialog.swift */; };
-		517BBD132FA4C3450057199B /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD82FA4C3450057199B /* SimplePresentmentSourceExt.swift */; };
-		517BBD142FA4C3450057199B /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD32FA4C3450057199B /* PromptDialogs.swift */; };
-		517BBD152FA4C3450057199B /* CardCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBE2FA4C3450057199B /* CardCarousel.swift */; };
-		517BBD162FA4C3450057199B /* CardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBF2FA4C3450057199B /* CardInfo.swift */; };
-		517BBD172FA4C3450057199B /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD72FA4C3450057199B /* RequestAuthorizationView.swift */; };
-		517BBD182FA4C3450057199B /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC72FA4C3450057199B /* FloatingItemCenteredText.swift */; };
-		517BBD192FA4C3450057199B /* CardBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCBD2FA4C3450057199B /* CardBadge.swift */; };
-		517BBD1A2FA4C3450057199B /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD92FA4C3450057199B /* SmartSheet.swift */; };
-		517BBD1B2FA4C3450057199B /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC32FA4C3450057199B /* DocumentExt.swift */; };
-		517BBD1C2FA4C3450057199B /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCD12FA4C3450057199B /* PassphraseInputView.swift */; };
-		517BBD1D2FA4C3450057199B /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517BBCC22FA4C3450057199B /* DefaultToHumanReadable.swift */; };
+		5183236B2FA6AB090083253A /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235D2FA6AB080083253A /* MdocProximityQrSettings.swift */; };
+		5183236C2FA6AB090083253A /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323652FA6AB080083253A /* SimplePresentmentSourceExt.swift */; };
+		5183236D2FA6AB090083253A /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234D2FA6AB080083253A /* Consent.swift */; };
+		5183236E2FA6AB090083253A /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323582FA6AB080083253A /* FloatingItemHeadingAndDateTime.swift */; };
+		5183236F2FA6AB090083253A /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323642FA6AB080083253A /* RequestAuthorizationView.swift */; };
+		518323702FA6AB090083253A /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234E2FA6AB080083253A /* ConsentPromptDialog.swift */; };
+		518323712FA6AB090083253A /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234F2FA6AB080083253A /* DefaultToHumanReadable.swift */; };
+		518323722FA6AB090083253A /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323672FA6AB080083253A /* TagsExt.swift */; };
+		518323732FA6AB090083253A /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323692FA6AB080083253A /* X509CertViewer.swift */; };
+		518323742FA6AB090083253A /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235F2FA6AB080083253A /* PassphrasePromptDialog.swift */; };
+		518323752FA6AB090083253A /* VerticalCardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323682FA6AB080083253A /* VerticalCardList.swift */; };
+		518323762FA6AB090083253A /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323512FA6AB080083253A /* DocumentExtCardart.swift */; };
+		518323772FA6AB090083253A /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323602FA6AB080083253A /* PromptDialogs.swift */; };
+		518323782FA6AB090083253A /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323532FA6AB080083253A /* Extensions.swift */; };
+		518323792FA6AB090083253A /* CardBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234A2FA6AB080083253A /* CardBadge.swift */; };
+		5183237A2FA6AB090083253A /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235B2FA6AB080083253A /* FloatingItemText.swift */; };
+		5183237B2FA6AB090083253A /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323502FA6AB080083253A /* DocumentExt.swift */; };
+		5183237C2FA6AB090083253A /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323622FA6AB080083253A /* ProvisioningView.swift */; };
+		5183237D2FA6AB090083253A /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323552FA6AB080083253A /* FloatingItemContainer.swift */; };
+		5183237E2FA6AB090083253A /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323662FA6AB080083253A /* SmartSheet.swift */; };
+		5183237F2FA6AB090083253A /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323542FA6AB080083253A /* FloatingItemCenteredText.swift */; };
+		518323802FA6AB090083253A /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235A2FA6AB080083253A /* FloatingItemList.swift */; };
+		518323812FA6AB090083253A /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235E2FA6AB080083253A /* PassphraseInputView.swift */; };
+		518323822FA6AB090083253A /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323522FA6AB080083253A /* DocumentModel.swift */; };
+		518323832FA6AB090083253A /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235C2FA6AB080083253A /* MdocProximityQrPresentment.swift */; };
+		518323842FA6AB090083253A /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323592FA6AB080083253A /* FloatingItemHeadingAndText.swift */; };
+		518323852FA6AB090083253A /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323632FA6AB080083253A /* QrCode.swift */; };
+		518323862FA6AB090083253A /* CardCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234B2FA6AB080083253A /* CardCarousel.swift */; };
+		518323872FA6AB090083253A /* CardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234C2FA6AB080083253A /* CardInfo.swift */; };
+		518323882FA6AB090083253A /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323562FA6AB080083253A /* FloatingItemHeadingAndContent.swift */; };
+		518323892FA6AB090083253A /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323612FA6AB080083253A /* PromptModelExt.swift */; };
+		5183238A2FA6AB090083253A /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323572FA6AB080083253A /* FloatingItemHeadingAndDate.swift */; };
+		5183238B2FA6AB090083253A /* MdocProximityQrSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235D2FA6AB080083253A /* MdocProximityQrSettings.swift */; };
+		5183238C2FA6AB090083253A /* SimplePresentmentSourceExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323652FA6AB080083253A /* SimplePresentmentSourceExt.swift */; };
+		5183238D2FA6AB090083253A /* Consent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234D2FA6AB080083253A /* Consent.swift */; };
+		5183238E2FA6AB090083253A /* FloatingItemHeadingAndDateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323582FA6AB080083253A /* FloatingItemHeadingAndDateTime.swift */; };
+		5183238F2FA6AB090083253A /* RequestAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323642FA6AB080083253A /* RequestAuthorizationView.swift */; };
+		518323902FA6AB090083253A /* ConsentPromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234E2FA6AB080083253A /* ConsentPromptDialog.swift */; };
+		518323912FA6AB090083253A /* DefaultToHumanReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234F2FA6AB080083253A /* DefaultToHumanReadable.swift */; };
+		518323922FA6AB090083253A /* TagsExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323672FA6AB080083253A /* TagsExt.swift */; };
+		518323932FA6AB090083253A /* X509CertViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323692FA6AB080083253A /* X509CertViewer.swift */; };
+		518323942FA6AB090083253A /* PassphrasePromptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235F2FA6AB080083253A /* PassphrasePromptDialog.swift */; };
+		518323952FA6AB090083253A /* VerticalCardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323682FA6AB080083253A /* VerticalCardList.swift */; };
+		518323962FA6AB090083253A /* DocumentExtCardart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323512FA6AB080083253A /* DocumentExtCardart.swift */; };
+		518323972FA6AB090083253A /* PromptDialogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323602FA6AB080083253A /* PromptDialogs.swift */; };
+		518323982FA6AB090083253A /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323532FA6AB080083253A /* Extensions.swift */; };
+		518323992FA6AB090083253A /* CardBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234A2FA6AB080083253A /* CardBadge.swift */; };
+		5183239A2FA6AB090083253A /* FloatingItemText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235B2FA6AB080083253A /* FloatingItemText.swift */; };
+		5183239B2FA6AB090083253A /* DocumentExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323502FA6AB080083253A /* DocumentExt.swift */; };
+		5183239C2FA6AB090083253A /* ProvisioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323622FA6AB080083253A /* ProvisioningView.swift */; };
+		5183239D2FA6AB090083253A /* FloatingItemContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323552FA6AB080083253A /* FloatingItemContainer.swift */; };
+		5183239E2FA6AB090083253A /* SmartSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323662FA6AB080083253A /* SmartSheet.swift */; };
+		5183239F2FA6AB090083253A /* FloatingItemCenteredText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323542FA6AB080083253A /* FloatingItemCenteredText.swift */; };
+		518323A02FA6AB090083253A /* FloatingItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235A2FA6AB080083253A /* FloatingItemList.swift */; };
+		518323A12FA6AB090083253A /* PassphraseInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235E2FA6AB080083253A /* PassphraseInputView.swift */; };
+		518323A22FA6AB090083253A /* DocumentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323522FA6AB080083253A /* DocumentModel.swift */; };
+		518323A32FA6AB090083253A /* MdocProximityQrPresentment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183235C2FA6AB080083253A /* MdocProximityQrPresentment.swift */; };
+		518323A42FA6AB090083253A /* FloatingItemHeadingAndText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323592FA6AB080083253A /* FloatingItemHeadingAndText.swift */; };
+		518323A52FA6AB090083253A /* QrCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323632FA6AB080083253A /* QrCode.swift */; };
+		518323A62FA6AB090083253A /* CardCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234B2FA6AB080083253A /* CardCarousel.swift */; };
+		518323A72FA6AB090083253A /* CardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183234C2FA6AB080083253A /* CardInfo.swift */; };
+		518323A82FA6AB090083253A /* FloatingItemHeadingAndContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323562FA6AB080083253A /* FloatingItemHeadingAndContent.swift */; };
+		518323A92FA6AB090083253A /* PromptModelExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323612FA6AB080083253A /* PromptModelExt.swift */; };
+		518323AA2FA6AB090083253A /* FloatingItemHeadingAndDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518323572FA6AB080083253A /* FloatingItemHeadingAndDate.swift */; };
 		51BD5C5E2F22604F0082DE19 /* AdditionalConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */; };
 		51BD5C5F2F22604F0082DE19 /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */; };
 /* End PBXBuildFile section */
@@ -103,38 +103,38 @@
 /* Begin PBXFileReference section */
 		51100E672F21D4A5006B2ADD /* SwiftTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		512DAECF2F2A31B30061F72B /* IdentityDocumentProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = IdentityDocumentProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		517BBCBD2FA4C3450057199B /* CardBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBadge.swift; sourceTree = "<group>"; };
-		517BBCBE2FA4C3450057199B /* CardCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCarousel.swift; sourceTree = "<group>"; };
-		517BBCBF2FA4C3450057199B /* CardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardInfo.swift; sourceTree = "<group>"; };
-		517BBCC02FA4C3450057199B /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
-		517BBCC12FA4C3450057199B /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
-		517BBCC22FA4C3450057199B /* DefaultToHumanReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultToHumanReadable.swift; sourceTree = "<group>"; };
-		517BBCC32FA4C3450057199B /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
-		517BBCC42FA4C3450057199B /* DocumentExtCardart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExtCardart.swift; sourceTree = "<group>"; };
-		517BBCC52FA4C3450057199B /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
-		517BBCC62FA4C3450057199B /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		517BBCC72FA4C3450057199B /* FloatingItemCenteredText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemCenteredText.swift; sourceTree = "<group>"; };
-		517BBCC82FA4C3450057199B /* FloatingItemContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemContainer.swift; sourceTree = "<group>"; };
-		517BBCC92FA4C3450057199B /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
-		517BBCCA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
-		517BBCCB2FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
-		517BBCCC2FA4C3450057199B /* FloatingItemHeadingAndText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndText.swift; sourceTree = "<group>"; };
-		517BBCCD2FA4C3450057199B /* FloatingItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemList.swift; sourceTree = "<group>"; };
-		517BBCCE2FA4C3450057199B /* FloatingItemText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemText.swift; sourceTree = "<group>"; };
-		517BBCCF2FA4C3450057199B /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
-		517BBCD02FA4C3450057199B /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
-		517BBCD12FA4C3450057199B /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
-		517BBCD22FA4C3450057199B /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
-		517BBCD32FA4C3450057199B /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
-		517BBCD42FA4C3450057199B /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
-		517BBCD52FA4C3450057199B /* ProvisioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningView.swift; sourceTree = "<group>"; };
-		517BBCD62FA4C3450057199B /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
-		517BBCD72FA4C3450057199B /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
-		517BBCD82FA4C3450057199B /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
-		517BBCD92FA4C3450057199B /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
-		517BBCDA2FA4C3450057199B /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
-		517BBCDB2FA4C3450057199B /* VerticalCardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCardList.swift; sourceTree = "<group>"; };
-		517BBCDC2FA4C3450057199B /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
+		5183234A2FA6AB080083253A /* CardBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBadge.swift; sourceTree = "<group>"; };
+		5183234B2FA6AB080083253A /* CardCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCarousel.swift; sourceTree = "<group>"; };
+		5183234C2FA6AB080083253A /* CardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardInfo.swift; sourceTree = "<group>"; };
+		5183234D2FA6AB080083253A /* Consent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consent.swift; sourceTree = "<group>"; };
+		5183234E2FA6AB080083253A /* ConsentPromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentPromptDialog.swift; sourceTree = "<group>"; };
+		5183234F2FA6AB080083253A /* DefaultToHumanReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultToHumanReadable.swift; sourceTree = "<group>"; };
+		518323502FA6AB080083253A /* DocumentExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExt.swift; sourceTree = "<group>"; };
+		518323512FA6AB080083253A /* DocumentExtCardart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentExtCardart.swift; sourceTree = "<group>"; };
+		518323522FA6AB080083253A /* DocumentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentModel.swift; sourceTree = "<group>"; };
+		518323532FA6AB080083253A /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		518323542FA6AB080083253A /* FloatingItemCenteredText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemCenteredText.swift; sourceTree = "<group>"; };
+		518323552FA6AB080083253A /* FloatingItemContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemContainer.swift; sourceTree = "<group>"; };
+		518323562FA6AB080083253A /* FloatingItemHeadingAndContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndContent.swift; sourceTree = "<group>"; };
+		518323572FA6AB080083253A /* FloatingItemHeadingAndDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDate.swift; sourceTree = "<group>"; };
+		518323582FA6AB080083253A /* FloatingItemHeadingAndDateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndDateTime.swift; sourceTree = "<group>"; };
+		518323592FA6AB080083253A /* FloatingItemHeadingAndText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemHeadingAndText.swift; sourceTree = "<group>"; };
+		5183235A2FA6AB080083253A /* FloatingItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemList.swift; sourceTree = "<group>"; };
+		5183235B2FA6AB080083253A /* FloatingItemText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingItemText.swift; sourceTree = "<group>"; };
+		5183235C2FA6AB080083253A /* MdocProximityQrPresentment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrPresentment.swift; sourceTree = "<group>"; };
+		5183235D2FA6AB080083253A /* MdocProximityQrSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MdocProximityQrSettings.swift; sourceTree = "<group>"; };
+		5183235E2FA6AB080083253A /* PassphraseInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphraseInputView.swift; sourceTree = "<group>"; };
+		5183235F2FA6AB080083253A /* PassphrasePromptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassphrasePromptDialog.swift; sourceTree = "<group>"; };
+		518323602FA6AB080083253A /* PromptDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDialogs.swift; sourceTree = "<group>"; };
+		518323612FA6AB080083253A /* PromptModelExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptModelExt.swift; sourceTree = "<group>"; };
+		518323622FA6AB080083253A /* ProvisioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningView.swift; sourceTree = "<group>"; };
+		518323632FA6AB080083253A /* QrCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCode.swift; sourceTree = "<group>"; };
+		518323642FA6AB080083253A /* RequestAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthorizationView.swift; sourceTree = "<group>"; };
+		518323652FA6AB080083253A /* SimplePresentmentSourceExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePresentmentSourceExt.swift; sourceTree = "<group>"; };
+		518323662FA6AB080083253A /* SmartSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartSheet.swift; sourceTree = "<group>"; };
+		518323672FA6AB080083253A /* TagsExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsExt.swift; sourceTree = "<group>"; };
+		518323682FA6AB080083253A /* VerticalCardList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCardList.swift; sourceTree = "<group>"; };
+		518323692FA6AB080083253A /* X509CertViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = X509CertViewer.swift; sourceTree = "<group>"; };
 		51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdditionalConfig.xcconfig; path = ../testapp/iosApp/AdditionalConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 		51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = DeveloperConfig.xcconfig; path = ../testapp/iosApp/DeveloperConfig.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -196,7 +196,7 @@
 		51100E5E2F21D4A5006B2ADD = {
 			isa = PBXGroup;
 			children = (
-				517BBCDD2FA4C3450057199B /* swift */,
+				5183236A2FA6AB080083253A /* swift */,
 				51BD5C5C2F22604F0082DE19 /* AdditionalConfig.xcconfig */,
 				51BD5C5D2F22604F0082DE19 /* DeveloperConfig.xcconfig */,
 				51100E692F21D4A5006B2ADD /* SwiftTestApp */,
@@ -222,41 +222,41 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		517BBCDD2FA4C3450057199B /* swift */ = {
+		5183236A2FA6AB080083253A /* swift */ = {
 			isa = PBXGroup;
 			children = (
-				517BBCBD2FA4C3450057199B /* CardBadge.swift */,
-				517BBCBE2FA4C3450057199B /* CardCarousel.swift */,
-				517BBCBF2FA4C3450057199B /* CardInfo.swift */,
-				517BBCC02FA4C3450057199B /* Consent.swift */,
-				517BBCC12FA4C3450057199B /* ConsentPromptDialog.swift */,
-				517BBCC22FA4C3450057199B /* DefaultToHumanReadable.swift */,
-				517BBCC32FA4C3450057199B /* DocumentExt.swift */,
-				517BBCC42FA4C3450057199B /* DocumentExtCardart.swift */,
-				517BBCC52FA4C3450057199B /* DocumentModel.swift */,
-				517BBCC62FA4C3450057199B /* Extensions.swift */,
-				517BBCC72FA4C3450057199B /* FloatingItemCenteredText.swift */,
-				517BBCC82FA4C3450057199B /* FloatingItemContainer.swift */,
-				517BBCC92FA4C3450057199B /* FloatingItemHeadingAndContent.swift */,
-				517BBCCA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift */,
-				517BBCCB2FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift */,
-				517BBCCC2FA4C3450057199B /* FloatingItemHeadingAndText.swift */,
-				517BBCCD2FA4C3450057199B /* FloatingItemList.swift */,
-				517BBCCE2FA4C3450057199B /* FloatingItemText.swift */,
-				517BBCCF2FA4C3450057199B /* MdocProximityQrPresentment.swift */,
-				517BBCD02FA4C3450057199B /* MdocProximityQrSettings.swift */,
-				517BBCD12FA4C3450057199B /* PassphraseInputView.swift */,
-				517BBCD22FA4C3450057199B /* PassphrasePromptDialog.swift */,
-				517BBCD32FA4C3450057199B /* PromptDialogs.swift */,
-				517BBCD42FA4C3450057199B /* PromptModelExt.swift */,
-				517BBCD52FA4C3450057199B /* ProvisioningView.swift */,
-				517BBCD62FA4C3450057199B /* QrCode.swift */,
-				517BBCD72FA4C3450057199B /* RequestAuthorizationView.swift */,
-				517BBCD82FA4C3450057199B /* SimplePresentmentSourceExt.swift */,
-				517BBCD92FA4C3450057199B /* SmartSheet.swift */,
-				517BBCDA2FA4C3450057199B /* TagsExt.swift */,
-				517BBCDB2FA4C3450057199B /* VerticalCardList.swift */,
-				517BBCDC2FA4C3450057199B /* X509CertViewer.swift */,
+				5183234A2FA6AB080083253A /* CardBadge.swift */,
+				5183234B2FA6AB080083253A /* CardCarousel.swift */,
+				5183234C2FA6AB080083253A /* CardInfo.swift */,
+				5183234D2FA6AB080083253A /* Consent.swift */,
+				5183234E2FA6AB080083253A /* ConsentPromptDialog.swift */,
+				5183234F2FA6AB080083253A /* DefaultToHumanReadable.swift */,
+				518323502FA6AB080083253A /* DocumentExt.swift */,
+				518323512FA6AB080083253A /* DocumentExtCardart.swift */,
+				518323522FA6AB080083253A /* DocumentModel.swift */,
+				518323532FA6AB080083253A /* Extensions.swift */,
+				518323542FA6AB080083253A /* FloatingItemCenteredText.swift */,
+				518323552FA6AB080083253A /* FloatingItemContainer.swift */,
+				518323562FA6AB080083253A /* FloatingItemHeadingAndContent.swift */,
+				518323572FA6AB080083253A /* FloatingItemHeadingAndDate.swift */,
+				518323582FA6AB080083253A /* FloatingItemHeadingAndDateTime.swift */,
+				518323592FA6AB080083253A /* FloatingItemHeadingAndText.swift */,
+				5183235A2FA6AB080083253A /* FloatingItemList.swift */,
+				5183235B2FA6AB080083253A /* FloatingItemText.swift */,
+				5183235C2FA6AB080083253A /* MdocProximityQrPresentment.swift */,
+				5183235D2FA6AB080083253A /* MdocProximityQrSettings.swift */,
+				5183235E2FA6AB080083253A /* PassphraseInputView.swift */,
+				5183235F2FA6AB080083253A /* PassphrasePromptDialog.swift */,
+				518323602FA6AB080083253A /* PromptDialogs.swift */,
+				518323612FA6AB080083253A /* PromptModelExt.swift */,
+				518323622FA6AB080083253A /* ProvisioningView.swift */,
+				518323632FA6AB080083253A /* QrCode.swift */,
+				518323642FA6AB080083253A /* RequestAuthorizationView.swift */,
+				518323652FA6AB080083253A /* SimplePresentmentSourceExt.swift */,
+				518323662FA6AB080083253A /* SmartSheet.swift */,
+				518323672FA6AB080083253A /* TagsExt.swift */,
+				518323682FA6AB080083253A /* VerticalCardList.swift */,
+				518323692FA6AB080083253A /* X509CertViewer.swift */,
 			);
 			name = swift;
 			path = "/Users/davidz/StudioProjects/multipaz/multipaz-swiftui/src/iosMain/swift";
@@ -418,38 +418,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				517BBCFE2FA4C3450057199B /* FloatingItemText.swift in Sources */,
-				517BBCFF2FA4C3450057199B /* PassphrasePromptDialog.swift in Sources */,
-				517BBD002FA4C3450057199B /* MdocProximityQrPresentment.swift in Sources */,
-				517BBD012FA4C3450057199B /* VerticalCardList.swift in Sources */,
-				517BBD022FA4C3450057199B /* Extensions.swift in Sources */,
-				517BBD032FA4C3450057199B /* DocumentModel.swift in Sources */,
-				517BBD042FA4C3450057199B /* FloatingItemHeadingAndText.swift in Sources */,
-				517BBD052FA4C3450057199B /* PromptModelExt.swift in Sources */,
-				517BBD062FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				517BBD072FA4C3450057199B /* FloatingItemHeadingAndContent.swift in Sources */,
-				517BBD082FA4C3450057199B /* ProvisioningView.swift in Sources */,
-				517BBD092FA4C3450057199B /* FloatingItemList.swift in Sources */,
-				517BBD0A2FA4C3450057199B /* FloatingItemHeadingAndDate.swift in Sources */,
-				517BBD0B2FA4C3450057199B /* TagsExt.swift in Sources */,
-				517BBD0C2FA4C3450057199B /* DocumentExtCardart.swift in Sources */,
-				517BBD0D2FA4C3450057199B /* FloatingItemContainer.swift in Sources */,
-				517BBD0E2FA4C3450057199B /* X509CertViewer.swift in Sources */,
-				517BBD0F2FA4C3450057199B /* Consent.swift in Sources */,
-				517BBD102FA4C3450057199B /* QrCode.swift in Sources */,
-				517BBD112FA4C3450057199B /* MdocProximityQrSettings.swift in Sources */,
-				517BBD122FA4C3450057199B /* ConsentPromptDialog.swift in Sources */,
-				517BBD132FA4C3450057199B /* SimplePresentmentSourceExt.swift in Sources */,
-				517BBD142FA4C3450057199B /* PromptDialogs.swift in Sources */,
-				517BBD152FA4C3450057199B /* CardCarousel.swift in Sources */,
-				517BBD162FA4C3450057199B /* CardInfo.swift in Sources */,
-				517BBD172FA4C3450057199B /* RequestAuthorizationView.swift in Sources */,
-				517BBD182FA4C3450057199B /* FloatingItemCenteredText.swift in Sources */,
-				517BBD192FA4C3450057199B /* CardBadge.swift in Sources */,
-				517BBD1A2FA4C3450057199B /* SmartSheet.swift in Sources */,
-				517BBD1B2FA4C3450057199B /* DocumentExt.swift in Sources */,
-				517BBD1C2FA4C3450057199B /* PassphraseInputView.swift in Sources */,
-				517BBD1D2FA4C3450057199B /* DefaultToHumanReadable.swift in Sources */,
+				5183238B2FA6AB090083253A /* MdocProximityQrSettings.swift in Sources */,
+				5183238C2FA6AB090083253A /* SimplePresentmentSourceExt.swift in Sources */,
+				5183238D2FA6AB090083253A /* Consent.swift in Sources */,
+				5183238E2FA6AB090083253A /* FloatingItemHeadingAndDateTime.swift in Sources */,
+				5183238F2FA6AB090083253A /* RequestAuthorizationView.swift in Sources */,
+				518323902FA6AB090083253A /* ConsentPromptDialog.swift in Sources */,
+				518323912FA6AB090083253A /* DefaultToHumanReadable.swift in Sources */,
+				518323922FA6AB090083253A /* TagsExt.swift in Sources */,
+				518323932FA6AB090083253A /* X509CertViewer.swift in Sources */,
+				518323942FA6AB090083253A /* PassphrasePromptDialog.swift in Sources */,
+				518323952FA6AB090083253A /* VerticalCardList.swift in Sources */,
+				518323962FA6AB090083253A /* DocumentExtCardart.swift in Sources */,
+				518323972FA6AB090083253A /* PromptDialogs.swift in Sources */,
+				518323982FA6AB090083253A /* Extensions.swift in Sources */,
+				518323992FA6AB090083253A /* CardBadge.swift in Sources */,
+				5183239A2FA6AB090083253A /* FloatingItemText.swift in Sources */,
+				5183239B2FA6AB090083253A /* DocumentExt.swift in Sources */,
+				5183239C2FA6AB090083253A /* ProvisioningView.swift in Sources */,
+				5183239D2FA6AB090083253A /* FloatingItemContainer.swift in Sources */,
+				5183239E2FA6AB090083253A /* SmartSheet.swift in Sources */,
+				5183239F2FA6AB090083253A /* FloatingItemCenteredText.swift in Sources */,
+				518323A02FA6AB090083253A /* FloatingItemList.swift in Sources */,
+				518323A12FA6AB090083253A /* PassphraseInputView.swift in Sources */,
+				518323A22FA6AB090083253A /* DocumentModel.swift in Sources */,
+				518323A32FA6AB090083253A /* MdocProximityQrPresentment.swift in Sources */,
+				518323A42FA6AB090083253A /* FloatingItemHeadingAndText.swift in Sources */,
+				518323A52FA6AB090083253A /* QrCode.swift in Sources */,
+				518323A62FA6AB090083253A /* CardCarousel.swift in Sources */,
+				518323A72FA6AB090083253A /* CardInfo.swift in Sources */,
+				518323A82FA6AB090083253A /* FloatingItemHeadingAndContent.swift in Sources */,
+				518323A92FA6AB090083253A /* PromptModelExt.swift in Sources */,
+				518323AA2FA6AB090083253A /* FloatingItemHeadingAndDate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -457,38 +457,38 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				517BBCDE2FA4C3450057199B /* FloatingItemText.swift in Sources */,
-				517BBCDF2FA4C3450057199B /* PassphrasePromptDialog.swift in Sources */,
-				517BBCE02FA4C3450057199B /* MdocProximityQrPresentment.swift in Sources */,
-				517BBCE12FA4C3450057199B /* VerticalCardList.swift in Sources */,
-				517BBCE22FA4C3450057199B /* Extensions.swift in Sources */,
-				517BBCE32FA4C3450057199B /* DocumentModel.swift in Sources */,
-				517BBCE42FA4C3450057199B /* FloatingItemHeadingAndText.swift in Sources */,
-				517BBCE52FA4C3450057199B /* PromptModelExt.swift in Sources */,
-				517BBCE62FA4C3450057199B /* FloatingItemHeadingAndDateTime.swift in Sources */,
-				517BBCE72FA4C3450057199B /* FloatingItemHeadingAndContent.swift in Sources */,
-				517BBCE82FA4C3450057199B /* ProvisioningView.swift in Sources */,
-				517BBCE92FA4C3450057199B /* FloatingItemList.swift in Sources */,
-				517BBCEA2FA4C3450057199B /* FloatingItemHeadingAndDate.swift in Sources */,
-				517BBCEB2FA4C3450057199B /* TagsExt.swift in Sources */,
-				517BBCEC2FA4C3450057199B /* DocumentExtCardart.swift in Sources */,
-				517BBCED2FA4C3450057199B /* FloatingItemContainer.swift in Sources */,
-				517BBCEE2FA4C3450057199B /* X509CertViewer.swift in Sources */,
-				517BBCEF2FA4C3450057199B /* Consent.swift in Sources */,
-				517BBCF02FA4C3450057199B /* QrCode.swift in Sources */,
-				517BBCF12FA4C3450057199B /* MdocProximityQrSettings.swift in Sources */,
-				517BBCF22FA4C3450057199B /* ConsentPromptDialog.swift in Sources */,
-				517BBCF32FA4C3450057199B /* SimplePresentmentSourceExt.swift in Sources */,
-				517BBCF42FA4C3450057199B /* PromptDialogs.swift in Sources */,
-				517BBCF52FA4C3450057199B /* CardCarousel.swift in Sources */,
-				517BBCF62FA4C3450057199B /* CardInfo.swift in Sources */,
-				517BBCF72FA4C3450057199B /* RequestAuthorizationView.swift in Sources */,
-				517BBCF82FA4C3450057199B /* FloatingItemCenteredText.swift in Sources */,
-				517BBCF92FA4C3450057199B /* CardBadge.swift in Sources */,
-				517BBCFA2FA4C3450057199B /* SmartSheet.swift in Sources */,
-				517BBCFB2FA4C3450057199B /* DocumentExt.swift in Sources */,
-				517BBCFC2FA4C3450057199B /* PassphraseInputView.swift in Sources */,
-				517BBCFD2FA4C3450057199B /* DefaultToHumanReadable.swift in Sources */,
+				5183236B2FA6AB090083253A /* MdocProximityQrSettings.swift in Sources */,
+				5183236C2FA6AB090083253A /* SimplePresentmentSourceExt.swift in Sources */,
+				5183236D2FA6AB090083253A /* Consent.swift in Sources */,
+				5183236E2FA6AB090083253A /* FloatingItemHeadingAndDateTime.swift in Sources */,
+				5183236F2FA6AB090083253A /* RequestAuthorizationView.swift in Sources */,
+				518323702FA6AB090083253A /* ConsentPromptDialog.swift in Sources */,
+				518323712FA6AB090083253A /* DefaultToHumanReadable.swift in Sources */,
+				518323722FA6AB090083253A /* TagsExt.swift in Sources */,
+				518323732FA6AB090083253A /* X509CertViewer.swift in Sources */,
+				518323742FA6AB090083253A /* PassphrasePromptDialog.swift in Sources */,
+				518323752FA6AB090083253A /* VerticalCardList.swift in Sources */,
+				518323762FA6AB090083253A /* DocumentExtCardart.swift in Sources */,
+				518323772FA6AB090083253A /* PromptDialogs.swift in Sources */,
+				518323782FA6AB090083253A /* Extensions.swift in Sources */,
+				518323792FA6AB090083253A /* CardBadge.swift in Sources */,
+				5183237A2FA6AB090083253A /* FloatingItemText.swift in Sources */,
+				5183237B2FA6AB090083253A /* DocumentExt.swift in Sources */,
+				5183237C2FA6AB090083253A /* ProvisioningView.swift in Sources */,
+				5183237D2FA6AB090083253A /* FloatingItemContainer.swift in Sources */,
+				5183237E2FA6AB090083253A /* SmartSheet.swift in Sources */,
+				5183237F2FA6AB090083253A /* FloatingItemCenteredText.swift in Sources */,
+				518323802FA6AB090083253A /* FloatingItemList.swift in Sources */,
+				518323812FA6AB090083253A /* PassphraseInputView.swift in Sources */,
+				518323822FA6AB090083253A /* DocumentModel.swift in Sources */,
+				518323832FA6AB090083253A /* MdocProximityQrPresentment.swift in Sources */,
+				518323842FA6AB090083253A /* FloatingItemHeadingAndText.swift in Sources */,
+				518323852FA6AB090083253A /* QrCode.swift in Sources */,
+				518323862FA6AB090083253A /* CardCarousel.swift in Sources */,
+				518323872FA6AB090083253A /* CardInfo.swift in Sources */,
+				518323882FA6AB090083253A /* FloatingItemHeadingAndContent.swift in Sources */,
+				518323892FA6AB090083253A /* PromptModelExt.swift in Sources */,
+				5183238A2FA6AB090083253A /* FloatingItemHeadingAndDate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/SwiftTestApp/SwiftTestApp/FloatingItemListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/FloatingItemListScreen.swift
@@ -12,6 +12,7 @@ struct FloatingItemListScreen: View {
                 FloatingItemList(title: "FloatingItemText") {
                     FloatingItemText(text: "Primary text")
                     FloatingItemText(text: "Primary text", secondary: "Secondary text")
+                    FloatingItemText(text: "Primary text", secondary: "Secondary text, pay attention", secondaryColor: .red)
                     FloatingItemText(text: "Primary text and image", image: { Image(systemName: "star") })
                     FloatingItemText(text: "Primary text and image", secondary: "Secondary text", image: { Image(systemName: "star") })
                     FloatingItemText(

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/FloatingItemListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/FloatingItemListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -43,6 +44,10 @@ fun FloatingItemListScreen(
             FloatingItemList(title = "FloatingItemText") {
                 FloatingItemText(text = "Primary text")
                 FloatingItemText(text = "Primary text", secondary = "Secondary text")
+                FloatingItemText(text = "Primary text",
+                    secondary = "Secondary text, pay attention",
+                    secondaryColor = MaterialTheme.colorScheme.error
+                )
                 FloatingItemText(
                     text = "Primary text and image",
                     image = { Icon(Icons.Outlined.Star, null) })


### PR DESCRIPTION
The `CredentialPresentmentData` is a data structure which describes which credentials can be returned to satisfy a request from a verifier and is used by the consent prompts we have in Compose and SwiftUI. The way this works - see `ShowConsentPromptFn` - is that a `CredentialPresentmentSelection` is returned which represents the particular combination that the user picked in the consent prompt.

For wallet apps with pre-consent, it's helpful to be able to list all possible selections so the wallet can go through and see if any combination of possible credentials satisifies the user's pre-consent settings. Note that these settings may be complex in nature and may be on a per-document or a per-RP or even depending on other external factors such as location or e.g. transaction data.

This PR adds `CredentialPresentmentData.getAllSelections()` which returns all possible combinations. The wallet app logic can then go through each combination and see if it satisifies the mandates for pre-consent as defined by the holder and/or wallet app provider.

Also add a way to set the secondary color for `FloatingItemText` composable and View.

Also make it possible to synchronously reset `ProvisioningModel`.

Test: New unit test and all unit tests pass.
