### PR TITLE
VerticalCardList: Hoist state into a separate object.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -26,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
@@ -51,6 +53,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import kotlinx.coroutines.yield
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -65,6 +68,69 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 
 /**
+ * State object for [VerticalCardList].
+ *
+ * Use [rememberVerticalCardListState] to create an instance.
+ *
+ * @param scrollState the scroll state for the list.
+ */
+@Stable
+class VerticalCardListState(
+    val scrollState: ScrollState
+) {
+    /**
+     * The current display order of the cards, tracked by identifier.
+     */
+    var displayOrderIdentifiers by mutableStateOf<List<String>>(emptyList())
+        internal set
+
+    /**
+     * The identifier of the card currently being dragged, if any.
+     */
+    var draggedCardIdentifier by mutableStateOf<String?>(null)
+        internal set
+
+    /**
+     * The current Y position of the dragged card.
+     */
+    var dragCurrentY by mutableFloatStateOf(0f)
+        internal set
+
+    /**
+     * Whether a drag operation just ended.
+     */
+    var dragJustEnded by mutableStateOf(false)
+        internal set
+
+    /**
+     * The identifier of the last focused card, used to preserve animations across navigation.
+     */
+    var lastFocusedCardIdentifier by mutableStateOf<String?>(null)
+        internal set
+
+    /**
+     * Whether to animate spatial transitions (like sliding cards) when entering this screen.
+     * This should typically be set to true only when navigating directly between two list states.
+     */
+    var animateListTransitions by mutableStateOf(false)
+}
+
+/**
+ * Creates and remembers a [VerticalCardListState].
+ *
+ * @param scrollState the scroll state for the list.
+ * @return a [VerticalCardListState] instance.
+ */
+@Composable
+fun rememberVerticalCardListState(
+    scrollState: ScrollState = rememberScrollState()
+): VerticalCardListState {
+    return remember(scrollState) {
+        VerticalCardListState(scrollState)
+    }
+}
+
+/**
  * A vertically scrolling list of cards that mimics a physical wallet experience.
  *
  * In its default state, cards are displayed as a vertical list. The amount of
@@ -75,6 +141,19 @@ import kotlin.math.roundToInt
  * to the top of the viewport. A dynamic content section ([showCardInfo]) fades in immediately
  * below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
  * bottom of the screen.
+ *
+ * This composable uses [VerticalCardListState] to store state and this state object uses
+ * [CardInfo.identifier] as the identifiers, meaning it's allowable to pass ephemeral [CardInfo]
+ * instances into this composable as long as they keep using the same stable identifiers. This
+ * in turn means that it works directly with [DocumentModel] in the following way:
+ *
+ * ```
+ * val cardInfos by documentModel.documentInfos.collectAsState()
+ * VerticalCardList(
+ *   cardInfos = cardInfos,
+ *   [...]
+ * )
+ * ```
  *
  * @param modifier The modifier to be applied to the list container.
  * @param cardInfos The list of [CardInfo] objects to display.
@@ -90,6 +169,7 @@ import kotlin.math.roundToInt
  * of the screen when a card is focused. If false, unfocused cards fade away entirely to maximize
  * screen real estate for the detail view. Defaults to true.
  * @param cardMaxHeight An optional max height constraint for the cards. Useful for foldables and wide screens.
+ * @param state The state object to be used to control or observe the list's state.
  * @param showCardInfo A composable slot that renders the detailed content below the focused card.
  * It is horizontally centered by default.
  * @param emptyContent A composable slot displayed inside a dashed placeholder card when the
@@ -111,6 +191,7 @@ fun VerticalCardList(
     allowCardReordering: Boolean = true,
     showStackWhileFocused: Boolean = true,
     cardMaxHeight: Dp = Dp.Unspecified,
+    state: VerticalCardListState = rememberVerticalCardListState(),
     showCardInfo: @Composable (CardInfo) -> Unit = {},
     emptyContent: @Composable () -> Unit = { },
     onCardReordered: (cardInfo: CardInfo, newPosition: Int) -> Unit = { _, _ -> },
@@ -122,27 +203,55 @@ fun VerticalCardList(
         throw IllegalArgumentException("unfocusedVisiblePercent must be between 0 and 100")
     }
 
-    val scrollState = rememberScrollState()
-    val haptic = LocalHapticFeedback.current
+    // Sync cardInfos with state.displayOrderIdentifiers
+    val currentCardIdentifiers = cardInfos.map { it.identifier }
+    if (state.draggedCardIdentifier == null && state.displayOrderIdentifiers != currentCardIdentifiers) {
+        state.displayOrderIdentifiers = currentCardIdentifiers
+    }
 
-    // Local state to handle visual reordering without waiting for DB updates
-    var displayOrder by remember(cardInfos) { mutableStateOf(cardInfos) }
+    // Resolve CardInfo objects based on the current display order
+    val displayOrder = remember(state.displayOrderIdentifiers, cardInfos) {
+        state.displayOrderIdentifiers.mapNotNull { id -> cardInfos.find { it.identifier == id } }
+    }
 
-    // Drag tracking state
-    var draggedCard by remember { mutableStateOf<CardInfo?>(null) }
-    var dragCurrentY by remember { mutableFloatStateOf(0f) }
-    var dragJustEnded by remember { mutableStateOf(false) }
+    // To preserve animations across navigation, we use an internal focused card identifier state
+    // initialized from the state's last focused card identifier ONLY if we are animating a list transition.
+    var internalFocusedCardIdentifier by remember(state) {
+        mutableStateOf(if (state.animateListTransitions) state.lastFocusedCardIdentifier else focusedCard?.identifier)
+    }
 
-    // Automatically reset the block on clicks after a short delay
-    LaunchedEffect(dragJustEnded) {
-        if (dragJustEnded) {
-            delay(300)
-            dragJustEnded = false
+    // We use LaunchedEffect to detect when this screen enters the composition or focusedCard changes.
+    LaunchedEffect(focusedCard?.identifier) {
+        if (state.animateListTransitions && state.lastFocusedCardIdentifier != focusedCard?.identifier) {
+            // We are transitioning from another list state, and the focus changed.
+            // Snap to the global state so we can animate from it.
+            internalFocusedCardIdentifier = state.lastFocusedCardIdentifier
+            // Yield to allow Compose to render the snapshot before we change it
+            yield()
+            // The next frame will animate to our intended state
+            state.lastFocusedCardIdentifier = focusedCard?.identifier
+            internalFocusedCardIdentifier = focusedCard?.identifier
+        } else if (internalFocusedCardIdentifier != focusedCard?.identifier || state.lastFocusedCardIdentifier != focusedCard?.identifier) {
+            // Normal forward navigation without transition animation, or local state change
+            internalFocusedCardIdentifier = focusedCard?.identifier
+            state.lastFocusedCardIdentifier = focusedCard?.identifier
         }
     }
 
-    val isAnyFocused = focusedCard != null
-    val focusedIndex = displayOrder.indexOfFirst { it.identifier == focusedCard?.identifier }.coerceAtLeast(0)
+    val internalFocusedCard = cardInfos.find { it.identifier == internalFocusedCardIdentifier }
+
+    val haptic = LocalHapticFeedback.current
+
+    // Automatically reset the block on clicks after a short delay
+    LaunchedEffect(state.dragJustEnded) {
+        if (state.dragJustEnded) {
+            delay(300)
+            state.dragJustEnded = false
+        }
+    }
+
+    val isAnyFocused = internalFocusedCardIdentifier != null
+    val focusedIndex = state.displayOrderIdentifiers.indexOf(internalFocusedCardIdentifier).coerceAtLeast(0)
 
     // A nested scroll connection to intercept and consume the overscroll effect cleanly
     val overscrollConsumer = remember {
@@ -236,11 +345,11 @@ fun VerticalCardList(
             cardHeightPx * (unfocusedVisiblePercent / 100f)
         }
 
-        val totalHeightPx = paddingTopPx + (max(0, displayOrder.size - 1) * listStepPx) + cardHeightPx + paddingTopPx
+        val totalHeightPx = paddingTopPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingTopPx
         val totalHeightDp = with(density) { totalHeightPx.toDp() }
 
         // --- Stack Math ---
-        val maxStackIndex = max(0, displayOrder.size - 2)
+        val maxStackIndex = max(0, state.displayOrderIdentifiers.size - 2)
         val maxVisibleCardsInStack = 5
         val maxVisibleStackOffsets = min(maxStackIndex, maxVisibleCardsInStack - 1)
 
@@ -260,7 +369,7 @@ fun VerticalCardList(
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(overscrollConsumer)
-                .verticalScroll(scrollState, enabled = !isAnyFocused)
+                .verticalScroll(state.scrollState, enabled = !isAnyFocused)
         ) {
             Spacer(
                 modifier = Modifier
@@ -275,7 +384,7 @@ fun VerticalCardList(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(with(density) { maxHeightPx.toDp() })
-                    .offset { IntOffset(0, scrollState.value) }
+                    .offset { IntOffset(0, state.scrollState.value) }
                     .zIndex(50f)
             ) {
                 val topOffsetDp = with(density) { (paddingTopPx + cardHeightPx * 1.05f + 24.dp.toPx()).toDp() }
@@ -286,8 +395,8 @@ fun VerticalCardList(
                         .padding(top = topOffsetDp, bottom = detailBottomPaddingDp),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    if (focusedCard != null) {
-                        showCardInfo(focusedCard)
+                    if (internalFocusedCard != null) {
+                        showCardInfo(internalFocusedCard)
                     }
                 }
             }
@@ -295,10 +404,10 @@ fun VerticalCardList(
             // Iterate over displayOrder so dragged positions instantly update visually
             displayOrder.forEachIndexed { index, cardInfo ->
                 // key block prevents the layout from destroying gesture state when cards swap indices
-                key(cardInfo) {
-                    val isFocused = cardInfo == focusedCard
-                    val isDragged = cardInfo == draggedCard
-                    val viewportTop = scrollState.value.toFloat()
+                key(cardInfo.identifier) {
+                    val isFocused = cardInfo.identifier == internalFocusedCardIdentifier
+                    val isDragged = cardInfo.identifier == state.draggedCardIdentifier
+                    val viewportTop = state.scrollState.value.toFloat()
 
                     val targetY: Float
                     val targetScale: Float
@@ -325,11 +434,11 @@ fun VerticalCardList(
                             targetElevation = 12f
                             targetZIndex = stackIndex.toFloat()
 
-                            targetAlpha = if (!showStackWhileFocused || distanceToFront >= maxVisibleCardsInStack) 0f else 1f
+                            targetAlpha = if (!showStackWhileFocused) 0f else if (distanceToFront >= maxVisibleCardsInStack) 0f else 1f
                         }
                     } else {
                         // In list mode, the dragged card directly tracks the finger ignoring layout positioning
-                        targetY = if (isDragged) dragCurrentY else paddingTopPx + index * listStepPx
+                        targetY = if (isDragged) state.dragCurrentY else paddingTopPx + index * listStepPx
                         targetScale = if (isDragged) 1.05f else 1f
                         targetElevation = if (isDragged) 24f else 12f
                         targetZIndex = if (isDragged) 100f else index.toFloat()
@@ -365,57 +474,60 @@ fun VerticalCardList(
                                 if (!isAnyFocused && allowCardReordering) {
                                     detectDragGesturesAfterLongPress(
                                         onDragStart = { _ ->
-                                            draggedCard = cardInfo
-                                            val currentIndex = displayOrder.indexOfFirst { it.identifier == cardInfo.identifier }
-                                            dragCurrentY = paddingTopPx + currentIndex * listStepPx
+                                            state.draggedCardIdentifier = cardInfo.identifier
+                                            val currentIndex = state.displayOrderIdentifiers.indexOf(cardInfo.identifier)
+                                            state.dragCurrentY = paddingTopPx + currentIndex * listStepPx
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         },
                                         onDrag = { change, dragAmount ->
                                             change.consume()
-                                            dragCurrentY += dragAmount.y
+                                            state.dragCurrentY += dragAmount.y
 
                                             // Calculate what index the card *should* be at based on physical height
-                                            val newIndex = ((dragCurrentY - paddingTopPx) / listStepPx)
+                                            val newIndex = ((state.dragCurrentY - paddingTopPx) / listStepPx)
                                                 .roundToInt()
-                                                .coerceIn(0, displayOrder.lastIndex)
+                                                .coerceIn(0, state.displayOrderIdentifiers.lastIndex)
 
-                                            val currentIndex = displayOrder.indexOfFirst { it.identifier == cardInfo.identifier }
+                                            val currentIndex = state.displayOrderIdentifiers.indexOf(cardInfo.identifier)
 
                                             if (currentIndex != -1 && newIndex != currentIndex) {
                                                 // Swap the items visually in the local state
-                                                val newOrder = displayOrder.toMutableList()
+                                                val newOrder = state.displayOrderIdentifiers.toMutableList()
                                                 val item = newOrder.removeAt(currentIndex)
                                                 newOrder.add(newIndex, item)
-                                                displayOrder = newOrder
+                                                state.displayOrderIdentifiers = newOrder
 
                                                 haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
                                             }
                                         },
                                         onDragEnd = {
-                                            dragJustEnded = true
-                                            if (draggedCard != null) {
-                                                val finalIndex = displayOrder.indexOfFirst { it.identifier == draggedCard?.identifier }
-                                                val finalCard = draggedCard!!
+                                            state.dragJustEnded = true
+                                            val draggedCardIdentifier = state.draggedCardIdentifier
+                                            if (draggedCardIdentifier != null) {
+                                                val finalIndex = state.displayOrderIdentifiers.indexOf(draggedCardIdentifier)
+                                                val finalCard = cardInfos.find { it.identifier == draggedCardIdentifier }
 
                                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                draggedCard = null
+                                                state.draggedCardIdentifier = null
 
-                                                onCardReordered(finalCard, finalIndex)
+                                                if (finalCard != null) {
+                                                    onCardReordered(finalCard, finalIndex)
+                                                }
                                             }
                                         },
                                         onDragCancel = {
-                                            dragJustEnded = true
-                                            draggedCard = null
+                                            state.dragJustEnded = true
+                                            state.draggedCardIdentifier = null
                                         }
                                     )
                                 }
                             }
                             .clickable {
                                 // Block clicks if a drag is occurring, or ended in the last 300ms
-                                if (dragJustEnded || draggedCard != null) return@clickable
+                                if (state.dragJustEnded || state.draggedCardIdentifier != null) return@clickable
 
                                 if (isAnyFocused) {
-                                    focusedCard.let {
+                                    internalFocusedCard?.let {
                                         if (isFocused) {
                                             // The user tapped the card that is currently focused
                                             onCardFocusedTapped(it)

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -1,5 +1,9 @@
 package org.multipaz.testapp
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,6 +27,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -68,6 +74,7 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.certext.MultipazExtension
 import org.multipaz.certext.fromCbor
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.cards.rememberVerticalCardListState
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.compose.provisioning.ProvisioningBottomSheet
@@ -1020,8 +1027,10 @@ class App private constructor (val promptModel: PromptModel) {
         }
 
         snackbarHostState = remember { SnackbarHostState() }
+        val verticalCardListState = rememberVerticalCardListState()
 
         val provisioningIssuerUrl = remember { mutableStateOf<String?>(null) }
+
         val currentBranding = Branding.Current.collectAsState().value
         currentBranding.theme {
             PromptDialogs(
@@ -1059,7 +1068,7 @@ class App private constructor (val promptModel: PromptModel) {
                             onClickDocumentStore = { navController.navigate(DocumentStoreDestination) },
                             onClickVerticalCardListScreen = {
                                 navController.navigate(
-                                    VerticalCardListDestination
+                                    VerticalCardListDestination()
                                 )
                             },
                             onClickTrustedIssuers = {
@@ -1229,6 +1238,13 @@ class App private constructor (val promptModel: PromptModel) {
                             },
                             onDocumentDeleted = {
                                 navController.navigateUp()
+                            },
+                            onOpenInVerticalCardList = { documentId ->
+                                navController.navigate(
+                                    VerticalCardListDestination(
+                                        focusedDocumentId = documentId,
+                                    )
+                                )
                             }
                         )
                     }
@@ -1672,18 +1688,61 @@ class App private constructor (val promptModel: PromptModel) {
                     }
                 }
                 composable<VerticalCardListDestination>(
-                    enterTransition = { null },
-                    exitTransition = { null },
-                    popEnterTransition = { null },
-                    popExitTransition = { null }
+                    enterTransition = {
+                        if (initialState.destination.route?.contains("VerticalCardListDestination") == true) EnterTransition.None else null
+                    },
+                    exitTransition = {
+                        if (targetState.destination.route?.contains("VerticalCardListDestination") == true) ExitTransition.None else null
+                    },
+                    popEnterTransition = {
+                        if (initialState.destination.route?.contains("VerticalCardListDestination") == true) EnterTransition.None else null
+                    },
+                    popExitTransition = {
+                        if (targetState.destination.route?.contains("VerticalCardListDestination") == true) ExitTransition.None else null
+                    }
                 ) { backStackEntry ->
+                    val destination = backStackEntry.toRoute<VerticalCardListDestination>()
+                    val overrideAnim = backStackEntry.savedStateHandle.get<Boolean>("animateListTransitions")
+                    verticalCardListState.animateListTransitions = overrideAnim ?: destination.animateListTransitions
+
                     // Note: VerticalCardListScreen has its own AppBar
                     VerticalCardListScreen(
                         documentStore = documentStore,
                         documentModel = documentModel,
                         settingsModel = settingsModel,
+                        focusedDocumentId = destination.focusedDocumentId,
+                        state = verticalCardListState,
+                        onDocumentFocused = { documentId ->
+                            navController.navigate(VerticalCardListDestination(documentId, animateListTransitions = true))
+                        },
+                        onDocumentUnfocused = {
+                            val previousEntry = navController.previousBackStackEntry
+                            if (previousEntry?.destination?.route?.contains("VerticalCardListDestination") == true) {
+                                previousEntry.savedStateHandle["animateListTransitions"] = true
+                            }
+                            navController.navigateUp()
+                        },
                         onViewDocument = { documentId ->
                             navController.navigate(DocumentViewerDestination(documentId))
+                        },
+                        onFocusDocumentFollowing = { documentId ->
+                            coroutineScope.launch {
+                                val documents = documentStore.listDocuments()
+                                var nextDocument = documents.first()
+                                documents.forEachIndexed { index, document ->
+                                    if (document.identifier == documentId) {
+                                        if (index < documents.size - 1) {
+                                            nextDocument = documents[index + 1]
+                                            return@forEachIndexed
+                                        }
+                                    }
+                                }
+                                navController.navigateUp()
+                                navController.navigate(VerticalCardListDestination(
+                                    focusedDocumentId = nextDocument.identifier,
+                                    animateListTransitions = false
+                                ))
+                            }
                         },
                         onBackPressed = {
                             navController.navigateUp()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -145,7 +145,10 @@ data class NfcReaderDestination(
 ): Destination()
 
 @Serializable
-data object VerticalCardListDestination: Destination()
+data class VerticalCardListDestination(
+    val focusedDocumentId: String? = null,
+    val animateListTransitions: Boolean = false
+): Destination()
 
 @Serializable
 data object EventLogDestination: Destination()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentViewerScreen.kt
@@ -43,7 +43,8 @@ fun DocumentViewerScreen(
     onViewCredential: (documentId: String, credentialId: String) -> Unit,
     onProvisionMore: (document: Document, authorizationData: ByteString) -> Unit,
     onDeleteAllCredentials: (document: Document) -> Unit,
-    onDocumentDeleted: () -> Unit
+    onDocumentDeleted: () -> Unit,
+    onOpenInVerticalCardList: (documentId: String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val documentInfos = documentModel.documentInfos.collectAsState().value
@@ -99,6 +100,24 @@ fun DocumentViewerScreen(
                     keyText = "Document Name",
                     valueText = document.displayName ?: "(displayName not set)"
                 )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Button(
+                        modifier = Modifier.weight(1.0f),
+                        onClick = {
+                            onOpenInVerticalCardList(documentId)
+                        },
+                    ) {
+                        Text(
+                            modifier = Modifier.padding(vertical = 8.dp),
+                            text = "Open in Vertical Card List"
+                        )
+                    }
+                }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -22,12 +22,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -36,16 +36,17 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
-import androidx.navigationevent.NavigationEventInfo
-import androidx.navigationevent.compose.NavigationBackHandler
-import androidx.navigationevent.compose.rememberNavigationEventState
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.multipaz.compose.cards.VerticalCardList
+import org.multipaz.compose.cards.VerticalCardListState
+import org.multipaz.compose.cards.rememberVerticalCardListState
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.document.DocumentStore
 import org.multipaz.testapp.TestAppSettingsModel
 import org.multipaz.util.Logger
+import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "VerticalCardListScreen"
 
@@ -60,49 +61,22 @@ fun VerticalCardListScreen(
     documentStore: DocumentStore,
     documentModel: DocumentModel,
     settingsModel: TestAppSettingsModel,
+    focusedDocumentId: String?,
+    state: VerticalCardListState = rememberVerticalCardListState(),
+    onDocumentFocused: (documentId: String) -> Unit,
+    onDocumentUnfocused: () -> Unit,
     onViewDocument: (documentId: String) -> Unit,
+    onFocusDocumentFollowing: (documentId: String) -> Unit,
     onBackPressed: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    var showStackWhileFocused by remember { mutableStateOf(true) }
-    var allowDocumentReordering by remember { mutableStateOf(true) }
-    val visibilityOptions = listOf(
-        VisibilityOption("25%", 25),
-        VisibilityOption("50%", 50),
-        VisibilityOption("75%", 75),
-        VisibilityOption("100%", 100),
-    )
-    val visibilityOptionsExpanded = remember { mutableStateOf(false) }
-    val visibilityOptionsSelected = remember { mutableStateOf(visibilityOptions[0]) }
-    var focusedDocumentShowMoreInfo by rememberSaveable { mutableStateOf(false) }
-    var focusedDocumentId by rememberSaveable { mutableStateOf<String?>(null) }
-    val focusedDocument = documentModel.documentInfos.collectAsState().value.find { documentInfo ->
-        documentInfo.document.identifier == focusedDocumentId
-    }
-
-    // This hooks the back handler so we can close the focused document instead of going back.
-    NavigationBackHandler(
-        state = rememberNavigationEventState(NavigationEventInfo.None),
-        isBackEnabled = focusedDocumentId != null,
-        onBackCompleted = {
-            if (focusedDocumentShowMoreInfo) {
-                focusedDocumentShowMoreInfo = false
-            } else {
-                focusedDocumentId = null
-            }
-        }
-    )
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     val text = if (focusedDocumentId != null) {
-                        if (focusedDocumentShowMoreInfo) {
-                            "Document Focused (more)"
-                        } else {
-                            "Document Focused"
-                        }
+                        "Vertical Card List (doc focused)"
                     } else {
                         "Vertical Card List"
                     }
@@ -112,16 +86,7 @@ fun VerticalCardListScreen(
                 ),
                 navigationIcon = {
                     IconButton(onClick = {
-                        // Unfocus focused document instead of going back, like the back handler above
-                        if (focusedDocumentId != null) {
-                            if (focusedDocumentShowMoreInfo) {
-                                focusedDocumentShowMoreInfo = false
-                            } else {
-                                focusedDocumentId = null
-                            }
-                        } else {
-                            onBackPressed()
-                        }
+                        onBackPressed()
                     }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -143,47 +108,6 @@ fun VerticalCardListScreen(
                 ),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            ComboBox(
-                headline = "Card visibility",
-                options = visibilityOptions,
-                comboBoxSelected = visibilityOptionsSelected,
-                comboBoxExpanded = visibilityOptionsExpanded,
-                getDisplayName = { it.displayName },
-                onSelected = { index, value ->
-                    visibilityOptionsSelected.value = visibilityOptions[index]
-                }
-            )
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
-                    checked = showStackWhileFocused,
-                    onCheckedChange = { value ->
-                        showStackWhileFocused = value
-                    },
-                )
-                Text(
-                    text = "Show stack while focused",
-                )
-            }
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
-                    checked = allowDocumentReordering,
-                    onCheckedChange = { value ->
-                        allowDocumentReordering = value
-                    },
-                )
-                Text(
-                    text = "Allow document reordering",
-                )
-            }
-
             val windowInfo = LocalWindowInfo.current
             val density = LocalDensity.current
             val maxCardHeight = with(density) {
@@ -191,13 +115,15 @@ fun VerticalCardListScreen(
             }
 
             val cardInfos by documentModel.documentInfos.collectAsState()
+            val focusedCard = cardInfos.find { it.document.identifier == focusedDocumentId }
             VerticalCardList(
                 cardInfos = cardInfos,
-                focusedCard = focusedDocument,
-                unfocusedVisiblePercent = visibilityOptionsSelected.value.visibilityPercentage,
-                allowCardReordering = allowDocumentReordering,
-                showStackWhileFocused = showStackWhileFocused,
+                focusedCard = focusedCard,
+                unfocusedVisiblePercent = 25,
+                allowCardReordering = true,
+                showStackWhileFocused = true,
                 cardMaxHeight = maxCardHeight,
+                state = state,
                 showCardInfo = { cardInfo ->
                     val documentInfo = cardInfo as DocumentInfo
                     Column(
@@ -205,15 +131,16 @@ fun VerticalCardListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text("${documentInfo.document.displayName} is focused")
+                        Button(onClick = {
+                            onFocusDocumentFollowing(documentInfo.document.identifier)
+                        }) {
+                            Text("Next document")
+                        }
                         Spacer(modifier = Modifier.weight(1.0f))
-                        if (!focusedDocumentShowMoreInfo) {
-                            Text("Tap card for more info!")
-                        } else {
-                            Button(onClick = {
-                                onViewDocument(documentInfo.document.identifier)
-                            }) {
-                                Text("Even more info")
-                            }
+                        Button(onClick = {
+                            onViewDocument(documentInfo.document.identifier)
+                        }) {
+                            Text("Document Info")
                         }
                     }
                 },
@@ -222,14 +149,13 @@ fun VerticalCardListScreen(
                 },
                 onCardFocused = { cardInfo ->
                     val documentInfo = cardInfo as DocumentInfo
-                    focusedDocumentShowMoreInfo = false
-                    focusedDocumentId = documentInfo.document.identifier
+                    onDocumentFocused(documentInfo.document.identifier)
                 },
                 onCardFocusedTapped = {
-                    focusedDocumentShowMoreInfo = true
+                    onDocumentUnfocused()
                 },
                 onCardFocusedStackTapped = {
-                    focusedDocumentId = null
+                    onDocumentUnfocused()
                 },
                 onCardReordered = { cardInfo, newIndex ->
                     val documentInfo = cardInfo as DocumentInfo


### PR DESCRIPTION
Proper navigation for an app will usually dictate that there's a destination for showing the vertical card list w/o focused document as one destination object and if focused, as a separate destination object. To support this, hoist the state of `VerticalCardList` into a separate object, `VerticalCardListState`.

For testing, use this in TestApp's `VerticalCardListScreen`.

Test: Manually tested in TestApp and also with Multipaz Wallet.
