### PR TITLE
Add an SD-JWT DPC based on emvco spec.

### DIFF
--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/Main.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/server/Main.kt
@@ -2,6 +2,7 @@ package org.multipaz.openid4vci.server
 
 import org.multipaz.openid4vci.credential.CredentialFactoryAgeVerification
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredential
+import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredentialSdJwt
 import org.multipaz.openid4vci.credential.CredentialFactoryMdl
 import org.multipaz.openid4vci.credential.CredentialFactoryMdocPid
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
@@ -46,6 +47,7 @@ class Main {
                             CredentialFactoryAgeVerification(),
                             CredentialFactoryUtopiaLoyalty(),
                             CredentialFactoryDigitalPaymentCredential(),
+                            CredentialFactoryDigitalPaymentCredentialSdJwt(),
                         )
                     )
                     credentialFactoryRegistry.initialize()

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredentialSdJwt.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredentialSdJwt.kt
@@ -1,0 +1,187 @@
+package org.multipaz.openid4vci.credential
+
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.toDataItemFullDate
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.openid4vci.util.CredentialId
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.revocation.RevocationStatus
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.server.common.getBaseUrl
+import org.multipaz.utopia.knowntypes.DigitalPaymentCredentialSdJwt
+import kotlin.math.max
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+
+/** [CredentialFactory] for [DigitalPaymentCredentialSdJwt] credentials in EMVCo DPC SD-JWT format. */
+class CredentialFactoryDigitalPaymentCredentialSdJwt : CredentialFactory {
+    override val configurationId: String
+        get() = "payment_sca_sd_jwt"
+
+    override val scope: String
+        get() = "payment"
+
+    override val format
+        get() = FORMAT
+
+    override val requireKeyAttestation: Boolean
+        get() = true
+
+    override val proofSigningAlgorithms: List<String>
+        get() = CredentialFactory.DEFAULT_PROOF_SIGNING_ALGORITHMS
+
+    override val cryptographicBindingMethods: List<String>
+        get() = listOf("jwk")
+
+    override val name: String
+        get() = "Payment card"
+
+    override val logo: String
+        get() = "card_payment_sca_v2.png"
+
+    override suspend fun mint(
+        systemOfRecordData: DataItem,
+        authenticationKey: EcPublicKey?,
+        credentialId: CredentialId
+    ): MintedCredential {
+        check(authenticationKey != null)
+        val issuer = BackendEnvironment.getBaseUrl()
+
+        val records = systemOfRecordData["records"]
+        if (!records.hasKey("payment")) {
+            throw IllegalArgumentException("No payment card for this person")
+        }
+        val paymentData = records["payment"].asMap.values.firstOrNull() ?: buildCborMap {}
+
+        val accountNumber = if (paymentData.hasKey("account_number")) {
+            paymentData["account_number"].asTstr
+        } else {
+            "01234567"
+        }
+        val maskedLength = max(0, accountNumber.length - 4)
+        val lastFour = accountNumber.substring(maskedLength)
+
+        val network = if (paymentData.hasKey("network")) {
+            paymentData["network"].asTstr
+        } else {
+            "multipaz"
+        }
+
+        val now = Clock.System.now()
+        val timeSigned = now
+        val validFrom = now
+        val validUntil = validFrom + 30.days
+
+        val baseUrl = BackendEnvironment.getBaseUrl()
+        val revocationStatus = RevocationStatus.StatusList(
+            idx = credentialId.index,
+            uri = "$baseUrl/status_list/${credentialId.bucket}",
+            certificate = null
+        )
+
+        val claimsObj = buildJsonObject {
+            put("credential_id", "urn:multipaz:cred:${credentialId.bucket}:${credentialId.index}")
+            put("network", network)
+            put("last_four", lastFour)
+        }
+
+        val sdJwt = SdJwt.create(
+            issuerKey = getSigningKey(),
+            kbKey = authenticationKey,
+            claims = claimsObj,
+            nonSdClaims = buildJsonObject {
+                put("iss", issuer)
+                put("vct", DigitalPaymentCredentialSdJwt.CARD_VCT)
+                put("iat", timeSigned.epochSeconds)
+                put("nbf", validFrom.epochSeconds)
+                put("exp", validUntil.epochSeconds)
+                put("status", revocationStatus.toJson())
+            }
+        )
+
+        return MintedCredential(
+            credential = sdJwt.compactSerialization,
+            creation = validFrom,
+            expiration = validUntil
+        )
+    }
+
+    override suspend fun display(systemOfRecordData: DataItem): CredentialDisplay =
+        CredentialDisplay.create(
+            extractData(systemOfRecordData),
+            "credential_payment"
+        )
+
+    private fun extractData(systemOfRecordData: DataItem): DataItem {
+        val records = systemOfRecordData["records"]
+        val paymentData = records["payment"].asMap.values.firstOrNull() ?: buildCborMap {}
+
+        val instanceTitle = if (paymentData.hasKey("instance_title")) {
+            paymentData["instance_title"].asTstr
+        } else {
+            "Pay Card"
+        }
+        val issuerName = if (paymentData.hasKey("issuer_name")) {
+            paymentData["issuer_name"].asTstr
+        } else {
+            "Bank of Utopia"
+        }
+        val holderName = if (paymentData.hasKey("holder_name")) {
+            paymentData["holder_name"].asTstr
+        } else {
+            "Utopia User"
+        }
+        val issueDate = if (paymentData.hasKey("issue_date")) {
+            paymentData["issue_date"]
+        } else {
+            LocalDate.parse("2026-01-01").toDataItemFullDate()
+        }
+        val expiryDate = if (paymentData.hasKey("expiry_date")) {
+            paymentData["expiry_date"]
+        } else {
+            LocalDate.parse("2031-01-01").toDataItemFullDate()
+        }
+        val accountNumber = if (paymentData.hasKey("account_number")) {
+            paymentData["account_number"].asTstr
+        } else {
+            "01234567"
+        }
+
+        val maskedLength = max(0, accountNumber.length - 4)
+        val lastFour = accountNumber.substring(maskedLength)
+        val maskedAccountReference = lastFour.padStart(accountNumber.length, '*')
+
+        val expiryShort = formatExpiryMonthYear(expiryDate.asDateString.toString())
+
+        return buildCborMap {
+            put("instance_title", instanceTitle)
+            put("issuer_name", issuerName)
+            put("holder_name", holderName)
+            put("given_name", "Utopia")
+            put("account_number", accountNumber)
+            put("issue_date", issueDate)
+            put("expiry_date", expiryDate)
+            put("masked_account_reference", maskedAccountReference)
+            put("expiry_short", expiryShort)
+        }
+    }
+
+    private fun formatExpiryMonthYear(isoDate: String): String {
+        // Convert YYYY-MM-DD to MM/YY for payment-card display.
+        if (isoDate.length >= 10 && isoDate[4] == '-' && isoDate[7] == '-') {
+            return "${isoDate.substring(5, 7)}/${isoDate.substring(2, 4)}"
+        }
+        return isoDate
+    }
+
+    companion object {
+        private val FORMAT = CredentialFormat.SdJwt(DigitalPaymentCredentialSdJwt.CARD_VCT)
+    }
+}

--- a/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -39,6 +39,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.X509Cert
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredential
+import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredentialSdJwt
 import org.multipaz.openid4vci.credential.CredentialFactoryMdl
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
 import org.multipaz.openid4vci.credential.CredentialFactoryUtopiaNaturalization
@@ -95,7 +96,8 @@ class ProvisioningClientTest {
             listOf(
                 CredentialFactoryMdl(),
                 CredentialFactoryUtopiaNaturalization(),
-                CredentialFactoryDigitalPaymentCredential()
+                CredentialFactoryDigitalPaymentCredential(),
+                CredentialFactoryDigitalPaymentCredentialSdJwt()
             )
         )
         credentalFactoryRegistry.initialize()
@@ -156,6 +158,18 @@ class ProvisioningClientTest {
     fun authorizationCodeWithPaymentCredential() {
         runWithAuthorizationCode(
             offer = OFFER_PAYMENT,
+            serverArgs = arrayOf(
+                "-param", "base_url=http://localhost",
+                "-param", "database_engine=ephemeral",
+                "-param", "use_scopes=true"
+            )
+        )
+    }
+
+    @Test
+    fun authorizationCodeWithPaymentCredentialSdJwt() {
+        runWithAuthorizationCode(
+            offer = OFFER_PAYMENT_SD_JWT,
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -524,6 +538,7 @@ class ProvisioningClientTest {
         const val OFFER_MDL = "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%22%2C%22credential_configuration_ids%22%3A%5B%22mDL%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%7D%7D%7D"
         const val OFFER_NATURALIZATION = "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%22%2C%22credential_configuration_ids%22%3A%5B%22utopia_naturalization%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%7D%7D%7D"
         const val OFFER_PAYMENT = "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%22%2C%22credential_configuration_ids%22%3A%5B%22payment_sca_mdoc%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%7D%7D%7D"
+        const val OFFER_PAYMENT_SD_JWT = "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Flocalhost%22%2C%22credential_configuration_ids%22%3A%5B%22payment_sca_sd_jwt%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%7D%7D%7D"
 
         val testClientPreferences = OpenID4VCIClientPreferences(
             clientId = "urn:uuid:418745b8-78a3-4810-88df-7898aff3ffb4",

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DigitalPaymentCredentialSdJwt.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DigitalPaymentCredentialSdJwt.kt
@@ -1,0 +1,74 @@
+package org.multipaz.utopia.knowntypes
+
+import kotlinx.serialization.json.JsonPrimitive
+import org.multipaz.documenttype.DocumentAttributeType
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.Icon
+import org.multipaz.utopia.localization.GeneratedStringKeys
+import org.multipaz.utopia.localization.LocalizedStrings
+
+/**
+ * EMVCo Digital Payment Credential (DPC) profile for SD-JWT digital payments.
+ *
+ * Compliant with the EMVCo DPC Card Credential JSON Schema (urn:emvco:dpc:card:1).
+ */
+object DigitalPaymentCredentialSdJwt {
+    const val CARD_VCT = "urn:emvco:dpc:card:1"
+
+    /**
+     * Creates the Digital Payment Credential SD-JWT document type definition with localized labels.
+     *
+     * @param locale BCP-47 language tag used to resolve localized strings.
+     */
+    fun getDocumentType(locale: String = LocalizedStrings.getCurrentLocale()): DocumentType {
+        fun getLocalizedString(key: String) = LocalizedStrings.getString(key, locale)
+
+        return DocumentType.Builder(getLocalizedString(GeneratedStringKeys.DOCUMENT_DISPLAY_NAME_PAYMENT_CARD))
+            .addJsonDocumentType(type = CARD_VCT, keyBound = true)
+            .addJsonAttribute(
+                type = DocumentAttributeType.String,
+                identifier = "credential_id",
+                displayName = "Credential ID",
+                description = "Unique identifier of this specific credential instance.",
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive("urn:uuid:9f2b7a2e-3b74-4a0d-9b1a-0e6a91f5d2c8")
+            )
+            .addJsonAttribute(
+                type = DocumentAttributeType.String,
+                identifier = "network",
+                displayName = "Card Network",
+                description = "Payment network or scheme associated with the credential.",
+                icon = Icon.ACCOUNT_BALANCE,
+                sampleValue = JsonPrimitive("multipaz")
+            )
+            .addJsonAttribute(
+                type = DocumentAttributeType.String,
+                identifier = "last_four",
+                displayName = "Last Four Digits",
+                description = "The last four digits of the PAN for display and recognition.",
+                icon = Icon.NUMBERS,
+                sampleValue = JsonPrimitive("1513")
+            )
+            .addSampleRequest(
+                id = "payment_sca_minimal",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_REQUEST_PAYMENT_SCA_MINIMAL),
+                jsonClaims = listOf(
+                    "credential_id",
+                    "network",
+                    "last_four"
+                )
+            )
+            .addSampleRequest(
+                id = "payment_sca_full",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_REQUEST_PAYMENT_SCA_ALL),
+                jsonClaims = listOf()
+            )
+            .addSampleRequest(
+                id = "payment_transaction",
+                displayName = getLocalizedString(GeneratedStringKeys.PAYMENT_REQUEST_PAYMENT_SCA_ALL),
+                jsonClaims = listOf(),
+                cannedTransactionData = listOf(PaymentTransaction.sampleData)
+            )
+            .build()
+    }
+}

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DocumentTypeRepositoryExt.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/DocumentTypeRepositoryExt.kt
@@ -11,6 +11,7 @@ import org.multipaz.documenttype.DocumentTypeRepository
  */
 fun DocumentTypeRepository.addUtopiaTypes(locale: String = LocalizedStrings.getCurrentLocale()) {
     addDocumentType(DigitalPaymentCredential.getDocumentType(locale))
+    addDocumentType(DigitalPaymentCredentialSdJwt.getDocumentType(locale))
     addDocumentType(EUCertificateOfResidence.getDocumentType(locale))
     addDocumentType(GermanPersonalID.getDocumentType(locale))
     addDocumentType(Loyalty.getDocumentType(locale))


### PR DESCRIPTION
Adds support for issuing EMVCo SD-JWT Digital Payment Credentials (`urn:emvco:dpc:card:1`) via OpenID4VCI.
## Key Changes
- **Profile Definition**: Added `DigitalPaymentCredentialSdJwt` containing the strictly required selectively disclosable EMVCo claims (`credential_id`, `network`, `last_four`).
- **Credential Factory**: Implemented `CredentialFactoryDigitalPaymentCredentialSdJwt` to mint cards using System of Record payment data.
- **Ecosystem Registration**: Registered the factory and known types to enable automatic offer advertising on the server UI.
- **Integration Tests**: Added `authorizationCodeWithPaymentCredentialSdJwt` to verify end-to-end issuance.