### PR TITLE
Expose permanently denied permissions state

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.android.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.compose.runtime.Composable
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
 @OptIn(ExperimentalPermissionsApi::class)
@@ -14,6 +15,12 @@ private class AccompanistBluetoothPermissionState(
 
     override val isGranted: Boolean
         get() = multiplePermissionsState.allPermissionsGranted
+
+    override val isPermanentlyDenied: Boolean
+        get() = multiplePermissionsState.permissions.any { perm ->
+            val status = perm.status
+            status is PermissionStatus.Denied && !status.shouldShowRationale
+        }
 
     override suspend fun launchPermissionRequest() {
         multiplePermissionsState.launchMultiplePermissionRequest()

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.android.kt
@@ -16,6 +16,12 @@ private class AccompanistCameraPermissionState(
     override val isGranted: Boolean
         get() = permissionsState.status == PermissionStatus.Granted
 
+    override val isPermanentlyDenied: Boolean
+        get() {
+            val status = permissionsState.status
+            return status is PermissionStatus.Denied && !status.shouldShowRationale
+        }
+
     override suspend fun launchPermissionRequest() {
         permissionsState.launchPermissionRequest()
     }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.android.kt
@@ -16,6 +16,12 @@ private class AccompanistNotificationPermissionState(
     override val isGranted: Boolean
         get() = permissionsState.status == PermissionStatus.Granted
 
+    override val isPermanentlyDenied: Boolean
+        get() {
+            val status = permissionsState.status
+            return status is PermissionStatus.Denied && !status.shouldShowRationale
+        }
+
     override suspend fun launchPermissionRequest() {
         permissionsState.launchPermissionRequest()
     }
@@ -37,6 +43,9 @@ actual fun rememberNotificationPermissionState(): PermissionState {
         return object: PermissionState {
             override val isGranted: Boolean
                 get() = true
+
+            override val isPermanentlyDenied: Boolean
+                get() = false
 
             override suspend fun launchPermissionRequest() {
                 throw IllegalStateException("Permission is already granted")

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/permissions/PermissionState.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/permissions/PermissionState.kt
@@ -11,6 +11,18 @@ interface PermissionState {
     val isGranted: Boolean
 
     /**
+     * Whether the permission has been permanently denied by the user.
+     *
+     * When `true`, calling [launchPermissionRequest] will not show a system dialog.
+     * The user must be directed to the app settings screen to grant the permission manually.
+     *
+     * On Android this means the user has denied the permission and the system will no longer
+     * offer the permission dialog (e.g. the user selected "Don't ask again").
+     * On iOS this means the system authorization status is denied or restricted.
+     */
+    val isPermanentlyDenied: Boolean
+
+    /**
      * Requests the permission.
      */
     suspend fun launchPermissionRequest()

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.ios.kt
@@ -33,6 +33,12 @@ private class IosBluetoothPermissionState(
     override val isGranted: Boolean
         get() = (CBManager.authorization == CBManagerAuthorizationAllowedAlways)
 
+    override val isPermanentlyDenied: Boolean
+        get() {
+            val auth = CBManager.authorization
+            return auth == CBManagerAuthorizationDenied || auth == CBManagerAuthorizationRestricted
+        }
+
     override suspend fun launchPermissionRequest() {
         CBCentralManager(object : NSObject(), CBCentralManagerDelegateProtocol {
             override fun centralManagerDidUpdateState(central: CBCentralManager) {

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.ios.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
 import platform.AVFoundation.AVAuthorizationStatusAuthorized
+import platform.AVFoundation.AVAuthorizationStatusDenied
+import platform.AVFoundation.AVAuthorizationStatusRestricted
 import platform.AVFoundation.AVCaptureDevice
 import platform.AVFoundation.AVMediaTypeVideo
 import platform.AVFoundation.authorizationStatusForMediaType
@@ -17,10 +19,15 @@ import platform.AVFoundation.requestAccessForMediaType
 
 private class IosCameraPermissionState(
     val hasPermission: Boolean,
+    val authorizationStatus: Long,
     val recomposeCounter: MutableIntState
 ): PermissionState {
     override val isGranted: Boolean
         get() = hasPermission
+
+    override val isPermanentlyDenied: Boolean
+        get() = authorizationStatus == AVAuthorizationStatusDenied ||
+            authorizationStatus == AVAuthorizationStatusRestricted
 
     override suspend fun launchPermissionRequest() {
         AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
@@ -48,5 +55,5 @@ actual fun rememberCameraPermissionState(): PermissionState {
         }
     }
 
-    return IosCameraPermissionState(hasPermission, recomposeCounter)
+    return IosCameraPermissionState(hasPermission, authzStatus, recomposeCounter)
 }

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.ios.kt
@@ -17,11 +17,13 @@ import platform.UserNotifications.UNAuthorizationOptionSound
 
 import platform.UserNotifications.UNUserNotificationCenter
 import platform.UserNotifications.UNAuthorizationStatusAuthorized
+import platform.UserNotifications.UNAuthorizationStatusDenied
 import kotlin.coroutines.resume
 
 private class IosNotificationPermissionState(
     val center: UNUserNotificationCenter,
     val hasPermission: Boolean,
+    val authorizationStatus: Long,
     val recomposeCounter: MutableIntState
 ): PermissionState {
     companion object {
@@ -33,6 +35,9 @@ private class IosNotificationPermissionState(
 
     override val isGranted: Boolean
         get() = hasPermission
+
+    override val isPermanentlyDenied: Boolean
+        get() = authorizationStatus == UNAuthorizationStatusDenied
 
     override suspend fun launchPermissionRequest() {
         center.requestAuthorizationWithOptions(NOTIFICATION_PERMISSIONS) { isGranted, _ ->
@@ -49,10 +54,11 @@ actual fun rememberNotificationPermissionState(): PermissionState {
     val recomposeCounter = remember { mutableIntStateOf(0) }
     LaunchedEffect(recomposeCounter.value) {}
 
-    val hasPermission = runBlocking {
-        suspendCancellableCoroutine<Boolean> { continuation ->
+    val (hasPermission, authorizationStatus) = runBlocking {
+        suspendCancellableCoroutine<Pair<Boolean, Long>> { continuation ->
             center.getNotificationSettingsWithCompletionHandler { settings ->
-                continuation.resume(settings?.authorizationStatus == UNAuthorizationStatusAuthorized)
+                val status = settings?.authorizationStatus ?: -1L
+                continuation.resume(Pair(status == UNAuthorizationStatusAuthorized, status))
             }
         }
     }
@@ -68,5 +74,5 @@ actual fun rememberNotificationPermissionState(): PermissionState {
         }
     }
 
-    return IosNotificationPermissionState(center, hasPermission, recomposeCounter)
+    return IosNotificationPermissionState(center, hasPermission, authorizationStatus, recomposeCounter)
 }

--- a/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.web.kt
+++ b/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothPermissionState.web.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 
 private class WebBluetoothPermissionState: PermissionState {
     override val isGranted = true  // TODO
+    override val isPermanentlyDenied = false
     override suspend fun launchPermissionRequest() {
         TODO()
     }

--- a/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.web.kt
+++ b/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberCameraPermissionState.web.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 
 private class WebCameraPermissionState: PermissionState {
     override val isGranted = true  // TODO
+    override val isPermanentlyDenied = false
     override suspend fun launchPermissionRequest() {
         TODO()
     }

--- a/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.web.kt
+++ b/multipaz-compose/src/webMain/kotlin/org/multipaz/compose/permissions/rememberNotificationPermissionState.web.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 
 private class WebNotificationPermissionState: PermissionState {
     override val isGranted = true  // TODO
+    override val isPermanentlyDenied = false
     override suspend fun launchPermissionRequest() {
         TODO()
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -59,10 +59,14 @@ fun IsoMdocProximitySharingScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         if (!blePermissionState.isGranted) {
-            Button(
-                onClick = { coroutineScope.launch { blePermissionState.launchPermissionRequest() } }
-            ) {
-                Text("Request BLE permissions")
+            if (blePermissionState.isPermanentlyDenied) {
+                Text("BLE permissions have been permanently denied. Please enable them in your device settings.")
+            } else {
+                Button(
+                    onClick = { coroutineScope.launch { blePermissionState.launchPermissionRequest() } }
+                ) {
+                    Text("Request BLE permissions")
+                }
             }
         } else if (!bleEnabledState.isEnabled) {
             Column(

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NotificationsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NotificationsScreen.kt
@@ -45,14 +45,18 @@ fun NotificationsScreen(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Button(
-                onClick = {
-                    coroutineScope.launch {
-                        notificationPermissionState.launchPermissionRequest()
+            if (notificationPermissionState.isPermanentlyDenied) {
+                Text("Notification permission has been permanently denied. Please enable it in your device settings.")
+            } else {
+                Button(
+                    onClick = {
+                        coroutineScope.launch {
+                            notificationPermissionState.launchPermissionRequest()
+                        }
                     }
+                ) {
+                    Text("Request Notification permission")
                 }
-            ) {
-                Text("Request Notification permission")
             }
         }
     } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ScanQrCodeDialog.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ScanQrCodeDialog.kt
@@ -65,14 +65,18 @@ fun ScanQrCodeDialog(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        Button(
-                            onClick = {
-                                coroutineScope.launch {
-                                    cameraPermissionState.launchPermissionRequest()
+                        if (cameraPermissionState.isPermanentlyDenied) {
+                            Text("Camera permission has been permanently denied. Please enable it in your device settings.")
+                        } else {
+                            Button(
+                                onClick = {
+                                    coroutineScope.launch {
+                                        cameraPermissionState.launchPermissionRequest()
+                                    }
                                 }
+                            ) {
+                                Text("Request Camera permission")
                             }
-                        ) {
-                            Text("Request Camera permission")
                         }
                     }
                 } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -93,14 +93,22 @@ fun StartScreen(
                 }
                 if (!documentInfos.isEmpty()) {
                     if (!blePermissionState.isGranted) {
-                        WarningCard(
-                            modifier = Modifier.padding(8.dp).clickable() {
-                                coroutineScope.launch {
-                                    blePermissionState.launchPermissionRequest()
-                                }
+                        if (blePermissionState.isPermanentlyDenied) {
+                            WarningCard(
+                                modifier = Modifier.padding(8.dp)
+                            ) {
+                                Text("BLE permissions have been permanently denied. Please enable them in your device settings.")
                             }
-                        ) {
-                            Text("Proximity presentment require BLE permissions to be granted. Click to fix.")
+                        } else {
+                            WarningCard(
+                                modifier = Modifier.padding(8.dp).clickable() {
+                                    coroutineScope.launch {
+                                        blePermissionState.launchPermissionRequest()
+                                    }
+                                }
+                            ) {
+                                Text("Proximity presentment require BLE permissions to be granted. Click to fix.")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Updated remember permission states to expose whether the permission is permanently denied or not.
Updated relevant locations in testapp to validate.

By exposing this, the application can decide whether it wants to take additional actions after it can no longer show the system permissions prompt anymore. This could have the app navigate to the app's system settings, or just show a different string (like what I've done here for testapp). 

I can't seem to get the testapp to build on main, as it appears there is some unrelated breakage. Marking as draft until this is resolved and I can verify functionality.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR