### PR TITLE
NFCv2: New NFC engagement protocol.

### DIFF
--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -15,6 +15,12 @@ with the following changes
   system errors (like `OutOfMemoryError`). Catching it prevents the environment from terminating
   when it absolutely needs to, leading to corrupted state and unpredictable behavior.
 
+- **Don't throw `Error`:** The `java.lang.Error` (or `kotlin.Error` which is type-aliased for 
+  when running on the JVM) class represents serious, unrecoverable problems that an application
+  should generally not attempt to catch. Unlike standard exceptions, these typically indicate
+  failures at the Java Virtual Machine (JVM) level or catastrophic system conditions. Use
+  `IllegalStateException` or similar instead.
+
 - **Avoid catching generic `Exception`:** Catching all exceptions acts as a black hole for
   standard developer bugs (like `NullPointerException` or `IllegalArgumentException`). This
   makes debugging extremely difficult because the application fails silently.

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -149,7 +149,7 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
 
             val documents = selectionInfo.documentIds.map {
                 settings.source.documentStore.lookupForCredmanId(it)
-                    ?: throw Error("No registered document for document ID $it")
+                    ?: throw IllegalStateException("No registered document for document ID $it")
             }
             // Find request matching the protocol for the selected entry...
             val requestForSelectedEntry = json["requests"]!!.jsonArray.find {

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
@@ -17,8 +17,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlin.concurrent.Volatile
-import kotlin.time.Clock
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
@@ -27,17 +25,14 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
-import org.multipaz.mdoc.nfc.MdocNfcEngagementHelper
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
+import org.multipaz.mdoc.nfc.MdocNfcV2EngagementHelper
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
-import org.multipaz.mdoc.transport.advertise
-import org.multipaz.mdoc.transport.waitForConnection
+import org.multipaz.mdoc.transport.NfcHybridTransportMdoc
 import org.multipaz.nfc.CommandApdu
-import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.ResponseApdu
 import org.multipaz.presentment.Iso18013Presentment
 import org.multipaz.presentment.PresentmentCanceledException
@@ -45,21 +40,19 @@ import org.multipaz.presentment.PresentmentModel
 import org.multipaz.presentment.PresentmentSource
 import org.multipaz.prompt.PromptModel
 import org.multipaz.util.Logger
-import org.multipaz.util.UUID
+import kotlin.concurrent.Volatile
+import kotlin.time.Clock
 import kotlin.time.Duration
 
 /**
- * Base class for implementing NFC engagement according to ISO/IEC 18013-5:2021.
+ * Base class for implementing NFCv2 engagement according to ISO/IEC 18013 Second Edition.
  *
  * Applications should subclass this and include the appropriate stanzas in its manifest
- * for binding to the NDEF Type 4 tag AID (D2760000850101).
- *
- * See `ComposeWallet` in [Multipaz Samples](https://github.com/openwallet-foundation/multipaz-samples)
- * for an example.
+ * for binding to the appropriate AID (A0000002480401).
  */
-abstract class MdocNdefService: HostApduService() {
+abstract class MdocNfcV2Service: HostApduService() {
     companion object {
-        private const val TAG = "MdocNdefService"
+        private const val TAG = "MdocNfcV2Service"
     }
 
     private fun vibrate(pattern: List<Int>) {
@@ -76,33 +69,28 @@ abstract class MdocNdefService: HostApduService() {
         vibrate(listOf(0, 100, 50, 100))
     }
 
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-
-    override fun onDestroy() {
-        Logger.i(TAG, "onDestroy")
-        super.onDestroy()
-        serviceScope.cancel()
-        engagementJob = null
-        channel.close()
-    }
-
-    // A job started when the reader has selected us and used for establishing
-    // NFC engagement. Runs until NFC engagement completes successfully or fails.
-    private var engagementJob: Job? = null
+    // A job started when onCreate is called and used for dispatching APDUs and onDeactivated events
+    // to a suspend-world. Runs until onDestroy is called.
+    private var dispatchJob: Job? = null
 
     // A job started when the reader has selected us and used for listening for
     // a signal from the UI that it wants to cancel.
     private var listenForCancellationFromUiJob: Job? = null
+
+    // A job started when we're waiting for a connection on the non-NFC transport.
+    private var waitForTransportJob: Job? = null
 
     // A job started after NFC engagement completes successfully and
     // runs until the remote reader disconnects.
     private var transactionJob: Job? = null
 
     @Volatile
-    private var engagement: MdocNfcEngagementHelper? = null
+    private var engagement: MdocNfcV2EngagementHelper? = null
 
     // Channel used for bouncing data from processCommandApdu() and onDeactivated() to engagementJob coroutine.
-    private val channel = Channel<Data>(Channel.UNLIMITED)
+    private val dispatchChannel = Channel<Data>(Channel.UNLIMITED)
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private sealed class Data
 
@@ -124,12 +112,6 @@ abstract class MdocNdefService: HostApduService() {
      * @property useNegotiatedHandover if `true` NFC negotiated handover will be used, otherwise NFC static handover.
      * @property negotiatedHandoverPreferredOrder a list of the preferred order for which kind of
      *   [org.multipaz.mdoc.transport.MdocTransport] to create when using NFC negotiated handover.
-     * @property staticHandoverBleCentralClientModeEnabled `true` if mdoc BLE Central Client mode should be offered
-     *   when using NFC static handover.
-     * @property staticHandoverBlePeripheralServerModeEnabled `true` if mdoc BLE Peripheral Server mode should be
-     *   offered when using NFC static handover.
-     * @property staticHandoverNfcDataTransferEnabled `true` if NFC data transfer should be offered when using NFC
-     *   static handover
      * @property transportOptions the [MdocTransportOptions] to use for newly created connections.
      */
     data class Settings(
@@ -142,10 +124,6 @@ abstract class MdocNdefService: HostApduService() {
         val useNegotiatedHandover: Boolean,
         val negotiatedHandoverPreferredOrder: List<String>,
 
-        val staticHandoverBleCentralClientModeEnabled: Boolean,
-        val staticHandoverBlePeripheralServerModeEnabled: Boolean,
-        val staticHandoverNfcDataTransferEnabled: Boolean,
-
         val transportOptions: MdocTransportOptions,
     )
 
@@ -154,8 +132,8 @@ abstract class MdocNdefService: HostApduService() {
      *
      * Note that this is called after the NFC tap has been detected but before any messages are sent. As such
      * it's of paramount importance that this completes quickly because the NFC tag reader only stays in the
-     * field for so long. Every millisecond literally counts and it's very likely the application is cold-
-     * starting so be mindful of doing expensive initializations here.
+     * field for so long. Every millisecond literally counts, and it's very likely the application is cold-starting
+     * so be mindful of doing expensive initializations here.
      *
      * @return a [Settings] object.
      */
@@ -167,15 +145,12 @@ abstract class MdocNdefService: HostApduService() {
 
         initializeApplication(applicationContext)
 
-        engagement = null
-        transactionJob = null
-
         // Start a coroutine on an I/O thread for handling incoming APDUs and deactivation events
         // from the OS in processCommandApdu() and onDeactivated() overrides. This is so we can
         // use suspend functions.
         //
-        engagementJob = serviceScope.launch(Dispatchers.IO) {
-            for (data in channel) {
+        dispatchJob = serviceScope.launch(Dispatchers.IO) {
+            for (data in dispatchChannel) {
                 try {
                     when (data) {
                         is CommandApduData -> {
@@ -198,7 +173,7 @@ abstract class MdocNdefService: HostApduService() {
                             throw e
                         }
                         // Only the current sub-task (APDU processing) was aborted, keep the loop alive for the next tap.
-                        Logger.i(TAG, "engagementJob: APDU processing cancelled (likely due to deactivation)")
+                        Logger.i(TAG, "dispatchJob: APDU processing cancelled (likely due to deactivation)")
                     } else {
                         Logger.e(TAG, "Error processing data from channel", e)
                     }
@@ -207,10 +182,20 @@ abstract class MdocNdefService: HostApduService() {
         }
     }
 
+    override fun onDestroy() {
+        Logger.i(TAG, "onDestroy")
+        super.onDestroy()
+        serviceScope.cancel()
+        dispatchJob = null
+        dispatchChannel.close()
+    }
+
     @Volatile
     private var engagementStarted = false
     @Volatile
     private var engagementComplete = false
+    @Volatile
+    private var hybridTransport: NfcHybridTransportMdoc? = null
 
     private suspend fun startEngagement() {
         Logger.i(TAG, "startEngagement")
@@ -233,77 +218,24 @@ abstract class MdocNdefService: HostApduService() {
                     cancelEngagementJobs()
                     transactionJob?.cancel()
                     transactionJob = null
+                    waitForTransportJob?.cancel()
+                    waitForTransportJob = null
                 }
             }
         }
 
         settings.presentmentModel?.setConnecting()
 
-        fun negotiatedHandoverPicker(connectionMethods: List<MdocConnectionMethod>): MdocConnectionMethod {
-            Logger.i(TAG, "Negotiated Handover available methods: $connectionMethods")
-            for (prefix in settings.negotiatedHandoverPreferredOrder) {
-                for (connectionMethod in connectionMethods) {
-                    if (connectionMethod.toString().startsWith(prefix)) {
-                        Logger.i(TAG, "Using method $connectionMethod")
-                        return connectionMethod
-                    }
-                }
-            }
-            Logger.i(TAG, "Using method ${connectionMethods.first()}")
-            return connectionMethods.first()
-        }
-
-        val negotiatedHandoverPicker: ((connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod)? =
-            if (settings.useNegotiatedHandover) {
-                { connectionMethods -> negotiatedHandoverPicker(connectionMethods) }
-            } else {
-                null
-            }
-
-        var staticHandoverConnectionMethods: List<MdocConnectionMethod>? = null
-        if (!settings.useNegotiatedHandover) {
-            staticHandoverConnectionMethods = mutableListOf<MdocConnectionMethod>()
-            val bleUuid = UUID.randomUUID()
-            if (settings.staticHandoverBleCentralClientModeEnabled) {
-                staticHandoverConnectionMethods.add(
-                    MdocConnectionMethodBle(
-                        supportsPeripheralServerMode = false,
-                        supportsCentralClientMode = true,
-                        peripheralServerModeUuid = null,
-                        centralClientModeUuid = bleUuid,
-                    )
-                )
-            }
-            if (settings.staticHandoverBlePeripheralServerModeEnabled) {
-                staticHandoverConnectionMethods.add(
-                    MdocConnectionMethodBle(
-                        supportsPeripheralServerMode = true,
-                        supportsCentralClientMode = false,
-                        peripheralServerModeUuid = bleUuid,
-                        centralClientModeUuid = null,
-                    )
-                )
-            }
-            if (settings.staticHandoverNfcDataTransferEnabled) {
-                staticHandoverConnectionMethods.add(
-                    MdocConnectionMethodNfc(
-                        commandDataFieldMaxLength = 0xffff,
-                        responseDataFieldMaxLength = 0x10000
-                    )
-                )
-            }
-        }
-
         // TODO: Listen on methods _before_ starting the engagement helper so we can send the PSM
         //   for mdoc Peripheral Server mode when using NFC Static Handover.
         //
-        engagement = MdocNfcEngagementHelper(
+        engagement = MdocNfcV2EngagementHelper(
             eDeviceKey = eDeviceKey.publicKey,
-            onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
-                // OK, we're done with engagement and we're communicating with a bona fide ISO/IEC 18013-5:2021 reader.
-                // Start the activity and also launch a new job for handling the transaction...
+            onHandoverComplete = { connectionMethod, encodedDeviceEngagement, handover ->
+                // OK, we're done with engagement and we're communicating with a bona fide ISO/IEC 18013-5 Second
+                // Edition reader capable of NFCv2. Start the activity and also launch a new job for handling the
+                // transaction...
                 //
-                //engagementComplete = true
                 vibrateSuccess()
 
                 if (settings.activityClass != null) {
@@ -317,20 +249,33 @@ abstract class MdocNdefService: HostApduService() {
                     applicationContext.startActivity(intent)
                 }
 
+                hybridTransport = NfcHybridTransportMdoc(
+                    sendMessageViaNfc = { message ->
+                        engagement?.let {
+                            it.sendMessage(message)
+                            true
+                        } ?: false
+                    }
+                )
+
                 // We launch transactionJob in a new detached scope so it survives both
                 // NFC deactivation (the reader moving away) and the Service's onDestroy
                 // (as the transaction may continue over BLE and wait for UI consent).
                 transactionJob = CoroutineScope(Dispatchers.IO + settings.promptModel).launch {
+                    hybridTransport!!.open(eDeviceKey.publicKey)
                     val duration = Clock.System.now() - timeStarted
                     startTransaction(
                         settings = settings,
-                        connectionMethods = connectionMethods,
+                        connectionMethod = connectionMethod,
                         encodedDeviceEngagement = encodedDeviceEngagement,
                         handover = handover,
                         eDeviceKey = eDeviceKey,
                         engagementDuration = duration
                     )
                 }
+            },
+            onMessageReceived = { message ->
+                hybridTransport?.onMessageReceivedViaNfc(message)
             },
             onError = { error ->
                 // Engagement failed. This can happen if a NDEF tag reader - for example another unlocked
@@ -341,34 +286,61 @@ abstract class MdocNdefService: HostApduService() {
                 settings.presentmentModel?.setCompleted(error)
                 Logger.w(TAG, "Engagement failed. Maybe this wasn't an ISO mdoc reader.", error)
             },
-            staticHandoverMethods = staticHandoverConnectionMethods,
-            negotiatedHandoverPicker = negotiatedHandoverPicker
+            negotiatedHandoverPicker = { connectionMethods ->
+                if (settings.useNegotiatedHandover) {
+                    for (prefix in settings.negotiatedHandoverPreferredOrder) {
+                        for (connectionMethod in connectionMethods) {
+                            if (connectionMethod.toString().startsWith(prefix)) {
+                                return@MdocNfcV2EngagementHelper connectionMethod
+                            }
+                        }
+                    }
+                    return@MdocNfcV2EngagementHelper connectionMethods.first()
+                } else {
+                    connectionMethods.find { it is MdocConnectionMethodNfcV2 }!!
+                }
+            }
         )
     }
 
     private suspend fun startTransaction(
         settings: Settings,
-        connectionMethods: List<MdocConnectionMethod>,
+        connectionMethod: MdocConnectionMethod,
         encodedDeviceEngagement: ByteString,
         handover: DataItem,
         eDeviceKey: EcPrivateKey,
         engagementDuration: Duration,
     ) {
-        Logger.i(TAG, "startEngagement - advertising and waiting for connection")
-        val transports = connectionMethods.advertise(
-            role = MdocRole.MDOC,
-            transportFactory = MdocTransportFactory.Default,
-            options = settings.transportOptions,
-        )
-        val transport = transports.waitForConnection(
-            eSenderKey = eDeviceKey.publicKey,
-        )
+        val transactionJobContext = currentCoroutineContext()
 
-        val context = currentCoroutineContext()
-        val monitorJob = CoroutineScope(context).launch {
-            transport.state.collect { state ->
-                if (state == MdocTransport.State.FAILED || state == MdocTransport.State.CLOSED) {
-                    context.cancel(CancellationException("Transport $state"))
+        if (connectionMethod is MdocConnectionMethodNfcV2) {
+            hybridTransport?.setExpectTransport(false)
+            // Nothing to do
+        } else {
+            hybridTransport?.setExpectTransport(true)
+            // Wait for the non-NFC transport in a coroutine so we are not blocking
+            // initiating presentment....
+            waitForTransportJob = serviceScope.launch(Dispatchers.IO) {
+                try {
+                    val transport = MdocTransportFactory.Default.createTransport(
+                        connectionMethod = connectionMethod,
+                        role = MdocRole.MDOC,
+                        options = settings.transportOptions
+                    )
+                    transport.open(eSenderKey = eDeviceKey.publicKey)
+
+                    // Monitor the secondary transport
+                    launch {
+                        transport.state.collect { state ->
+                            if (state == MdocTransport.State.FAILED || state == MdocTransport.State.CLOSED) {
+                                transactionJobContext.cancel(CancellationException("Secondary transport $state"))
+                            }
+                        }
+                    }
+
+                    hybridTransport?.setTransport(transport)
+                } catch (e: Exception) {
+                    Logger.w(TAG, "Error opening non-NFC transport", e)
                 }
             }
         }
@@ -376,7 +348,7 @@ abstract class MdocNdefService: HostApduService() {
         try {
             settings.presentmentModel?.setConnecting()
             Iso18013Presentment(
-                transport = transport,
+                transport = hybridTransport!!,
                 eDeviceKey = eDeviceKey,
                 deviceEngagement = Cbor.decode(encodedDeviceEngagement.toByteArray()),
                 handover = handover,
@@ -398,57 +370,31 @@ abstract class MdocNdefService: HostApduService() {
                 settings.presentmentModel?.setCompleted(e)
             }
         } finally {
-            monitorJob.cancel()
             listenForCancellationFromUiJob?.cancel()
             listenForCancellationFromUiJob = null
         }
     }
 
     private fun cancelEngagementJobs() {
-        engagementJob?.cancel()
-        engagementJob = null
         listenForCancellationFromUiJob?.cancel()
         listenForCancellationFromUiJob = null
     }
 
-    private var numApdusReceived = 0
-    private var firstCommandApdu: CommandApdu? = null
-
     // Called by coroutine running in I/O thread, see onCreate() for details
     private suspend fun processCommandApdu(commandApdu: CommandApdu): ResponseApdu? {
-        // Recent Android versions seems to want a super-fast response to the SELECT APPLICATION
-        // command otherwise it may pick the Wallet Role owner instead. Observed this when using
-        // Multipaz Test App on an iOS device to read from Multipaz Test App on an Android
-        // device in the foregroup where Google Wallet is the Wallet Role Owner and has registered
-        // for NDEF AID.
-        //
-        if (numApdusReceived == 0) {
-            numApdusReceived = 1
-            firstCommandApdu = commandApdu
-            return ResponseApdu(status = Nfc.RESPONSE_STATUS_SUCCESS)
-        }
-
+        // TODO: maybe need replay and super-fast response as in mdocReaderNfcHandover.kt function processCommandApdu()
         if (!engagementStarted) {
             engagementStarted = true
             startEngagement()
         }
-
         try {
             engagement?.let {
-                // Replay the first APDU
-                if (numApdusReceived++ == 1) {
-                    val responseApdu = it.processApdu(firstCommandApdu!!)
-                    if (responseApdu != ResponseApdu(status = Nfc.RESPONSE_STATUS_SUCCESS)) {
-                        Logger.w(TAG, "Expected response 9000 to SELECT APPLICATION, " +
-                                " got $responseApdu")
-                    }
-                }
                 val responseApdu = it.processApdu(commandApdu)
                 return responseApdu
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            Logger.e(TAG, "Error processing APDU in MdocNfcEngagementHelper", e)
+            Logger.e(TAG, "Error processing APDU in MdocNfcV2EngagementHelper", e)
         }
         return null
     }
@@ -457,19 +403,21 @@ abstract class MdocNdefService: HostApduService() {
     private suspend fun processDeactivated(reason: Int) {
         try {
             engagement?.processDeactivated(reason)
+            hybridTransport?.onNfcDeactivated(reason)
 
             // Android might reuse this service for the next tap. That is, we can't rely on onDestroy()
-            // firing right after this, then onCreate(). So reset everything so next time processCommandApdu()
-            // is called we're ready to go with a new engagement...
+            // firing right after this, then onCreate(). So reset everything so next time the OS calls
+            // processCommandApdu() we'll start processing a new engagement.
+            //
             engagement = null
             engagementStarted = false
             engagementComplete = false
-            numApdusReceived = 0
+            hybridTransport = null
 
             cancelEngagementJobs()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            Logger.e(TAG, "Error processing deactivation event in MdocNfcEngagementHelper", e)
+            Logger.e(TAG, "Error processing deactivation event in MdocNfcV2EngagementHelper", e)
         }
     }
 
@@ -478,7 +426,7 @@ abstract class MdocNdefService: HostApduService() {
         // Bounce the APDU to processCommandApdu() above via the coroutine in I/O thread set up in onCreate()
         val commandApdu = CommandApdu.decode(encodedCommandApdu)
         if (!engagementComplete) {
-            val unused = channel.trySend(CommandApduData(commandApdu))
+            val unused = dispatchChannel.trySend(CommandApduData(commandApdu))
         } else {
             Logger.w(TAG, "Engagement complete but received APDU $commandApdu")
         }
@@ -488,10 +436,10 @@ abstract class MdocNdefService: HostApduService() {
     // Called by OS when NFC tag reader deactivates
     override fun onDeactivated(reason: Int) {
         Logger.i(TAG, "onDeactivated: reason=$reason")
-        // Important: we must call this here to unblock engagementJob if it is suspended in
+        // Important: we must call this here to unblock dispatchJob if it is suspended in
         // engagement.processApdu() waiting for a response to send back to the reader.
         engagement?.processDeactivated(reason)
         // Bounce the event to processDeactivated() above via the coroutine in I/O thread set up in onCreate()
-        val unused = channel.trySend(DeactivatedData(reason))
+        val unused = dispatchChannel.trySend(DeactivatedData(reason))
     }
 }

--- a/multipaz-dcapi/src/iosMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentialsExt.ios.kt
+++ b/multipaz-dcapi/src/iosMain/kotlin/org/multipaz/digitalcredentials/DigitalCredentialsExt.ios.kt
@@ -117,7 +117,7 @@ private suspend fun updateOsCredentialManagerUnlocked(
             SwiftBridge.docRegGetAll { docIds, error ->
                 if (error != null) {
                     continuation.resumeWithException(
-                        Error("Error getting registered document ids", error.toKotlinError())
+                        IllegalStateException("Error getting registered document ids", error.toKotlinError())
                     )
                 } else {
                     continuation.resume((docIds as List<String>).toSet())
@@ -152,7 +152,7 @@ private suspend fun updateOsCredentialManagerUnlocked(
                             continuation.resume(true)
                         } else {
                             continuation.resumeWithException(
-                                Error("Credential registration failed", error.toKotlinError())
+                                IllegalStateException("Credential registration failed", error.toKotlinError())
                             )
                         }
                     } else {
@@ -175,7 +175,7 @@ private suspend fun updateOsCredentialManagerUnlocked(
                 // Matching on the error like this is a little bit of a hack but it does work...
                 if (error != null) {
                     continuation.resumeWithException(
-                        Error("Credential registration failed", error.toKotlinError())
+                        IllegalStateException("Credential registration failed", error.toKotlinError())
                     )
                 } else {
                     Logger.i(TAG, "Unregistered document with docId $docId")

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -186,7 +186,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onScanResult failed", error))
+                onError(IllegalStateException("onScanResult failed", error))
             }
         }
 
@@ -194,13 +194,13 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             Logger.d(TAG, "onScanFailed: errorCode=$errorCode")
             try {
                 if (waitFor?.state == WaitState.PERIPHERAL_DISCOVERED) {
-                    resumeWaitWithException(Error("BLE scan failed with error code $errorCode"))
+                    resumeWaitWithException(IllegalStateException("BLE scan failed with error code $errorCode"))
                 } else {
                     Logger.w(TAG, "onScanFailed but not waiting")
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onScanFailed failed", error))
+                onError(IllegalStateException("onScanFailed failed", error))
             }
         }
     }
@@ -224,7 +224,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                             // See connectToPeripheral() for retries based on this exception
                             resumeWaitWithException(ConnectionFailedException("Failed to connect to peripheral"))
                         } else {
-                            throw Error("Peripheral unexpectedly disconnected")
+                            throw IllegalStateException("Peripheral unexpectedly disconnected")
                         }
                     }
 
@@ -234,7 +234,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onConnectionStateChange failed", error))
+                onError(IllegalStateException("onConnectionStateChange failed", error))
             }
         }
 
@@ -243,10 +243,10 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             try {
                 if (waitFor?.state == WaitState.REQUEST_MTU) {
                     if (status != BluetoothGatt.GATT_SUCCESS) {
-                        resumeWaitWithException(Error("Expected GATT_SUCCESS but got $status"))
+                        resumeWaitWithException(IllegalStateException("Expected GATT_SUCCESS but got $status"))
                     } else {
                         if (mtu < 22) {
-                            resumeWaitWithException(Error("Unexpected MTU size $mtu"))
+                            resumeWaitWithException(IllegalStateException("Unexpected MTU size $mtu"))
                         } else {
                             maxCharacteristicSize = min(mtu - 3, 512)
                             Logger.i(
@@ -261,7 +261,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onMtuChanged failed", error))
+                onError(IllegalStateException("onMtuChanged failed", error))
             }
         }
 
@@ -270,7 +270,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             try {
                 if (waitFor?.state == WaitState.PERIPHERAL_DISCOVER_SERVICES) {
                     if (status != BluetoothGatt.GATT_SUCCESS) {
-                        resumeWaitWithException(Error("Expected GATT_SUCCESS but got $status"))
+                        resumeWaitWithException(IllegalStateException("Expected GATT_SUCCESS but got $status"))
                     } else {
                         resumeWait()
                     }
@@ -279,7 +279,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onServicesDiscovered failed", error))
+                onError(IllegalStateException("onServicesDiscovered failed", error))
             }
         }
 
@@ -298,12 +298,12 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                     if (waitFor?.state == WaitState.GET_L2CAP_PSM) {
                         if (status != BluetoothGatt.GATT_SUCCESS) {
                             resumeWaitWithException(
-                                Error("onCharacteristicRead: Expected GATT_SUCCESS but got $status")
+                                IllegalStateException("onCharacteristicRead: Expected GATT_SUCCESS but got $status")
                             )
                         } else {
                             if (value.size != 4) {
                                 resumeWaitWithException(
-                                    Error("onCharacteristicRead: Expected four bytes for PSM, got ${value.size}")
+                                    IllegalStateException("onCharacteristicRead: Expected four bytes for PSM, got ${value.size}")
                                 )
                             }
                             _l2capPsm = value.getUInt32(0).toInt()
@@ -318,14 +318,14 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                     if (waitFor?.state == WaitState.GET_READER_IDENT) {
                         if (status != BluetoothGatt.GATT_SUCCESS) {
                             resumeWaitWithException(
-                                Error("onCharacteristicRead: Expected GATT_SUCCESS but got $status")
+                                IllegalStateException("onCharacteristicRead: Expected GATT_SUCCESS but got $status")
                             )
                         }
                         if (expectedIdentValue contentEquals value) {
                             resumeWait()
                         } else {
                             resumeWaitWithException(
-                                Error(
+                                IllegalStateException(
                                     "onCharacteristicRead: Expected ${expectedIdentValue!!.toHex()} " +
                                             "for ident, got ${value.toHex()} instead"
                                 )
@@ -337,7 +337,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onCharacteristicRead failed", error))
+                onError(IllegalStateException("onCharacteristicRead failed", error))
             }
         }
 
@@ -360,7 +360,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             Logger.d(TAG, "onCharacteristicWrite: characteristic=${characteristic?.uuid ?: ""} status=$status")
             if (waitFor?.state == WaitState.CHARACTERISTIC_WRITE_COMPLETED) {
                 if (status != BluetoothGatt.GATT_SUCCESS) {
-                    resumeWaitWithException(Error("onCharacteristicWrite: Expected GATT_SUCCESS but got $status"))
+                    resumeWaitWithException(IllegalStateException("onCharacteristicWrite: Expected GATT_SUCCESS but got $status"))
                 } else {
                     resumeWait()
                 }
@@ -377,7 +377,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             Logger.d(TAG, "onDescriptorWrite: descriptor=${descriptor?.uuid ?: ""} status=$status")
             if (waitFor?.state == WaitState.WRITE_TO_DESCRIPTOR) {
                 if (status != BluetoothGatt.GATT_SUCCESS) {
-                    resumeWaitWithException(Error("Expected GATT_SUCCESS but got $status"))
+                    resumeWaitWithException(IllegalStateException("Expected GATT_SUCCESS but got $status"))
                 } else {
                     resumeWait()
                 }
@@ -408,7 +408,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 }
             } catch (error: Exception) {
                 if (error is CancellationException) throw error
-                onError(Error("onCharacteristicChanged failed", error))
+                onError(IllegalStateException("onCharacteristicChanged failed", error))
             }
         }
 
@@ -429,7 +429,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
 
     private fun handleIncomingData(chunk: ByteArray) {
         if (chunk.size < 1) {
-            throw Error("Invalid data length ${chunk.size} for Server2Client characteristic")
+            throw IllegalStateException("Invalid data length ${chunk.size} for Server2Client characteristic")
         }
         incomingMessage.append(chunk, 1, chunk.size)
         when {
@@ -454,7 +454,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             }
 
             else -> {
-                throw Error(
+                throw IllegalStateException(
                     "Invalid first byte ${chunk[0]} in Server2Client data chunk, " +
                             "expected 0 or 1"
                 )
@@ -553,7 +553,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
         }
         service = gatt!!.getService(uuid.toJavaUuid())
         if (service == null) {
-            throw Error("No service with the given UUID")
+            throw IllegalStateException("No service with the given UUID")
         }
     }
 
@@ -561,22 +561,22 @@ internal class BleCentralManagerAndroid : BleCentralManager {
         check(device != null && gatt != null && service != null)
         characteristicState = service!!.getCharacteristic(stateCharacteristicUuid.toJavaUuid())
         if (characteristicState == null) {
-            throw Error("State characteristic not found")
+            throw IllegalStateException("State characteristic not found")
         }
         characteristicClient2Server =
             service!!.getCharacteristic(client2ServerCharacteristicUuid.toJavaUuid())
         if (characteristicClient2Server == null) {
-            throw Error("Client2Server characteristic not found")
+            throw IllegalStateException("Client2Server characteristic not found")
         }
         characteristicServer2Client =
             service!!.getCharacteristic(server2ClientCharacteristicUuid.toJavaUuid())
         if (characteristicServer2Client == null) {
-            throw Error("Server2Client characteristic not found")
+            throw IllegalStateException("Server2Client characteristic not found")
         }
         if (identCharacteristicUuid != null) {
             characteristicIdent = service!!.getCharacteristic(identCharacteristicUuid!!.toJavaUuid())
             if (characteristicIdent == null) {
-                throw Error("Ident characteristic not found")
+                throw IllegalStateException("Ident characteristic not found")
             }
         }
         if (l2capCharacteristicUuid != null) {
@@ -618,10 +618,10 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             val clientCharacteristicConfigUuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 
             if (!gatt!!.setCharacteristicNotification(characteristic, true)) {
-                throw Error("Error setting notification")
+                throw IllegalStateException("Error setting notification")
             }
             val descriptor = characteristic.getDescriptor(clientCharacteristicConfigUuid.toJavaUuid())
-                ?: throw Error("Error getting clientCharacteristicConfig descriptor")
+                ?: throw IllegalStateException("Error getting clientCharacteristicConfig descriptor")
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 val rc = gatt!!.writeDescriptor(
@@ -629,14 +629,14 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                     BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
                 )
                 if (rc != BluetoothStatusCodes.SUCCESS) {
-                    throw Error("Error writing to clientCharacteristicConfig descriptor rc=$rc")
+                    throw IllegalStateException("Error writing to clientCharacteristicConfig descriptor rc=$rc")
                 }
             } else {
                 @Suppress("DEPRECATION")
                 descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
                 @Suppress("DEPRECATION")
                 if (!gatt!!.writeDescriptor(descriptor)) {
-                    throw Error("Error writing to clientCharacteristicConfig descriptor")
+                    throw IllegalStateException("Error writing to clientCharacteristicConfig descriptor")
                 }
             }
         }
@@ -661,14 +661,14 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                     BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
                 )
                 if (rc != BluetoothStatusCodes.SUCCESS) {
-                    throw Error("Error writing to characteristic ${characteristic.uuid}, rc=$rc")
+                    throw IllegalStateException("Error writing to characteristic ${characteristic.uuid}, rc=$rc")
                 }
             } else {
                 @Suppress("DEPRECATION")
                 characteristic.setValue(value)
                 @Suppress("DEPRECATION")
                 if (!gatt!!.writeCharacteristic(characteristic)) {
-                    throw Error("Error writing to characteristic ${characteristic.uuid}")
+                    throw IllegalStateException("Error writing to characteristic ${characteristic.uuid}")
                 }
             }
         }
@@ -766,7 +766,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            onError(Error("Reading from L2CAP socket failed", e))
+            onError(IllegalStateException("Reading from L2CAP socket failed", e))
         }
     }
 

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -185,7 +185,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     resumeWait()
                 } else {
-                    resumeWaitWithException(Error("onServiceAdded: Expected GATT_SUCCESS got $status"))
+                    resumeWaitWithException(IllegalStateException("onServiceAdded: Expected GATT_SUCCESS got $status"))
                 }
             } else {
                 Logger.w(TAG, "onServiceAdded but not waiting")
@@ -204,7 +204,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                     "$offset ${characteristic.uuid}")
             if (characteristic == identCharacteristic) {
                 if (identValue == null) {
-                    onError(Error("Received request for ident before it's set.."))
+                    onError(IllegalStateException("Received request for ident before it's set.."))
                 } else {
                     gattServer!!.sendResponse(
                         device,
@@ -293,7 +293,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                     handleIncomingData(value)
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
-                    onError(Error("Error processing incoming data", e))
+                    onError(IllegalStateException("Error processing incoming data", e))
                 }
             }
         }
@@ -330,7 +330,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
             Logger.d(TAG, "onNotificationSent $status for ${device.address}")
             if (waitFor?.state == WaitState.CHARACTERISTIC_WRITE_COMPLETED) {
                 if (status != BluetoothGatt.GATT_SUCCESS) {
-                    resumeWaitWithException(Error("onNotificationSent: Expected GATT_SUCCESS but got $status"))
+                    resumeWaitWithException(IllegalStateException("onNotificationSent: Expected GATT_SUCCESS but got $status"))
                 } else {
                     resumeWait()
                 }
@@ -351,7 +351,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
 
         override fun onStartFailure(errorCode: Int) {
             if (waitFor?.state == WaitState.START_ADVERTISING) {
-                resumeWaitWithException(Error("Started advertising failed with $errorCode"))
+                resumeWaitWithException(IllegalStateException("Started advertising failed with $errorCode"))
             } else {
                 Logger.w(TAG, "Unexpected AdvertiseCallback.onStartFailure() callback")
             }
@@ -362,7 +362,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
 
     private fun handleIncomingData(chunk: ByteArray) {
         if (chunk.size < 1) {
-            throw Error("Invalid data length ${chunk.size} for Client2Server characteristic")
+            throw IllegalStateException("Invalid data length ${chunk.size} for Client2Server characteristic")
         }
         incomingMessage.append(chunk, 1, chunk.size)
         when {
@@ -383,7 +383,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
             }
 
             else -> {
-                throw Error("Invalid first byte ${chunk[0]} in Client2Server data chunk, " +
+                throw IllegalStateException("Invalid first byte ${chunk[0]} in Client2Server data chunk, " +
                         "expected 0 or 1")
             }
         }
@@ -475,7 +475,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
 
         advertiser = bluetoothManager.adapter.bluetoothLeAdvertiser
         if (advertiser == null) {
-            throw Error("Advertiser not available, is Bluetooth off?")
+            throw IllegalStateException("Advertiser not available, is Bluetooth off?")
         }
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
@@ -543,7 +543,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                     false,
                     value)
                 if (rc != BluetoothStatusCodes.SUCCESS) {
-                    throw Error("Error notifyCharacteristicChanged on characteristic ${characteristic.uuid} rc=$rc")
+                    throw IllegalStateException("Error notifyCharacteristicChanged on characteristic ${characteristic.uuid} rc=$rc")
                 }
             } else {
                 @Suppress("DEPRECATION")
@@ -554,7 +554,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
                         characteristic,
                         false)
                 ) {
-                    throw Error("Error notifyCharacteristicChanged on characteristic ${characteristic.uuid}")
+                    throw IllegalStateException("Error notifyCharacteristicChanged on characteristic ${characteristic.uuid}")
                 }
             }
         }
@@ -641,7 +641,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
             if (l2capNotUsed) {
                 Logger.d(TAG, "Ignoring error since l2capNotUsed is true", e)
             } else {
-                onError(Error("Accepting/reading from L2CAP socket failed", e))
+                onError(IllegalStateException("Accepting/reading from L2CAP socket failed", e))
             }
         }
     }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcIsoTagAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcIsoTagAndroid.kt
@@ -3,7 +3,9 @@ package org.multipaz.nfc
 import android.nfc.TagLostException
 import android.nfc.tech.IsoDep
 import kotlinx.coroutines.withContext
+import org.multipaz.util.Logger
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Clock
 
 class NfcIsoTagAndroid(
     private val tag: IsoDep,
@@ -33,6 +35,8 @@ class NfcIsoTagAndroid(
         // Because transceive() blocks the calling thread, we want to ensure this runs in the
         // context such as Dispatchers.IO where it's allowed to do so.
         //
+        val t0 = Clock.System.now()
+        Logger.i(TAG, "Sending APDU of ${encodedCommand.size} bytes")
         val responseApduData = withContext(context) {
             try {
                 tag.transceive(encodedCommand)
@@ -40,6 +44,9 @@ class NfcIsoTagAndroid(
                 throw NfcTagLostException("Tag was lost", e)
             }
         }
+        val duration = Clock.System.now() - t0
+        Logger.i(TAG, "Sent APDU of ${encodedCommand.size} and received APDU of ${responseApduData.size} bytes " +
+        "in ${duration.inWholeMilliseconds} msec")
         return ResponseApdu.decode(responseApduData)
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/claim/Claim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/claim/Claim.kt
@@ -230,7 +230,7 @@ private fun jsonFindMatchingClaimValue(
                     it.identifier == pathComponent.jsonPrimitive.content
                 }
             } else {
-                throw Error("Can only select from object or array of objects")
+                throw IllegalStateException("Can only select from object or array of objects")
             }
         } else if (pathComponent.isNumber) {
             currentObject = currentObject!!.jsonArray[pathComponent.jsonPrimitive.int]

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
@@ -80,6 +80,10 @@ abstract class MdocConnectionMethod {
                 MdocConnectionMethodHttp.METHOD_TYPE -> return MdocConnectionMethodHttp.fromDeviceEngagement(
                     encodedDeviceRetrievalMethod
                 )
+
+                MdocConnectionMethodNfcV2.METHOD_TYPE -> return MdocConnectionMethodNfcV2.fromDeviceEngagement(
+                    encodedDeviceRetrievalMethod
+                )
             }
             Logger.w(TAG, "Unsupported ConnectionMethod type $type in DeviceEngagement")
             return null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfc.kt
@@ -14,6 +14,7 @@ import org.multipaz.util.ByteDataReader
 import org.multipaz.util.appendByteString
 import org.multipaz.util.appendUInt16
 import org.multipaz.util.appendUInt8
+
 /**
  * Connection method for NFC.
  *

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfcV2.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfcV2.kt
@@ -1,0 +1,76 @@
+package org.multipaz.mdoc.connectionmethod
+
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.addCborMap
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.nfc.NdefRecord
+import org.multipaz.util.Logger
+
+/**
+ * Connection method for NFCv2.
+ *
+ * The [apduResponseMaxSize] parameter is used to tell the mdoc that it needs to send its responses in APDUs no
+ * larger than this size and this value must be smaller or equal to 65536, the maximum size of an Extended APDU.
+ * Since this class is usually not used in an environment where a 64 KiB buffer is a showstopper we default to the
+ * maximum size.
+ *
+ * @property apduResponseMaxSize the maximum length of the response data field.
+ */
+data class MdocConnectionMethodNfcV2(
+    val apduResponseMaxSize: Long = 65536L
+): MdocConnectionMethod() {
+    override fun toString(): String =
+        "nfcv2:apdu_response_max_size=$apduResponseMaxSize"
+
+    override fun toDeviceEngagement(): ByteArray {
+        return Cbor.encode(
+            buildCborArray {
+                add(METHOD_TYPE)
+                add(METHOD_MAX_VERSION)
+                addCborMap {
+                    put(OPTION_KEY_APDU_RESPONSE_MAX_LENGTH, apduResponseMaxSize)
+                }
+            }
+        )
+    }
+
+    override fun toNdefRecord(
+        auxiliaryReferences: List<String>,
+        role: MdocRole,
+        skipUuids: Boolean
+    ): Pair<NdefRecord, NdefRecord>? {
+        Logger.w(TAG, "MdocConnectionMethodNfcV2 should never appear in a NDEF record")
+        return null
+    }
+
+    companion object {
+        private const val TAG = "MdocConnectionMethodNfcV2"
+
+        /**
+         * The device retrieval method type for NFC according to ISO/IEC 18013-5 Second Edition
+         */
+        const val METHOD_TYPE = 5L
+
+        /**
+         * The supported version of the device retrieval method type for NFC.
+         */
+        const val METHOD_MAX_VERSION = 1L
+
+        private const val OPTION_KEY_APDU_RESPONSE_MAX_LENGTH = 0L
+
+        internal fun fromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethodNfcV2? {
+            val array = Cbor.decode(encodedDeviceRetrievalMethod)
+            val type = array[0].asNumber
+            val version = array[1].asNumber
+            require(type == METHOD_TYPE)
+            if (version > METHOD_MAX_VERSION) {
+                return null
+            }
+            val map = array[2]
+            return MdocConnectionMethodNfcV2(
+                map[OPTION_KEY_APDU_RESPONSE_MAX_LENGTH].asNumber
+            )
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
@@ -51,7 +51,7 @@ class MdocNfcEngagementHelper(
         connectionMethods: List<MdocConnectionMethod>,
         encodedDeviceEngagement: ByteString,
         handover: DataItem) -> Unit,
-    val onError: (error: Throwable) -> Unit,
+    val onError: (error: Exception) -> Unit,
     val staticHandoverMethods: List<MdocConnectionMethod>? = null,
     val negotiatedHandoverPicker: ((connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod)? = null,
 ) {
@@ -93,7 +93,7 @@ class MdocNfcEngagementHelper(
     private fun raiseError(errorMessage: String, cause: Throwable? = null) {
         check(!raisedError && !raisedHandoverComplete)
         raisedError = true
-        onError(Error(errorMessage, cause))
+        onError(IllegalStateException(errorMessage, cause))
     }
 
     private fun raiseHandoverComplete(
@@ -217,7 +217,7 @@ class MdocNfcEngagementHelper(
     private suspend fun ndefTransactHandleServiceSelect(message: NdefMessage): NdefMessage {
         check(message.records.size == 1) { "Expected just a single record for service select" }
         val serviceSelectRecord = ServiceSelectRecord.fromNdefRecord(message.records[0])
-            ?: throw Error("Service Select record not found")
+            ?: throw IllegalStateException("Service Select record not found")
         check(serviceSelectRecord.serviceName == Nfc.SERVICE_NAME_CONNECTION_HANDOVER) {
             "Expected service ${Nfc.SERVICE_NAME_CONNECTION_HANDOVER} found ${serviceSelectRecord.serviceName}"
         }
@@ -234,7 +234,7 @@ class MdocNfcEngagementHelper(
     private suspend fun ndefTransactHandleHandoverRequest(message: NdefMessage): NdefMessage {
         // Handover Request Record must be the first record in Handover Request Message..
         val hrRecord = HandoverRequestRecord.fromNdefRecord(message.records[0])
-            ?: throw Error("Handover Request Record not the first in message")
+            ?: throw IllegalStateException("Handover Request Record not the first in message")
         check(hrRecord.version == 0x15) {
             "Expected Connection Handover version 1.5, got ${byteArrayOf(hrRecord.version.toByte()).toHex()}"
         }
@@ -246,7 +246,7 @@ class MdocNfcEngagementHelper(
             }
         }
         if (availableConnectionMethods.isEmpty()) {
-            throw Error("No supported connection methods found in Handover Request method")
+            throw IllegalStateException("No supported connection methods found in Handover Request method")
         }
         val disambiguatedConnectionMethods = MdocConnectionMethod.disambiguate(
             availableConnectionMethods,
@@ -334,10 +334,10 @@ class MdocNfcEngagementHelper(
 
     private suspend fun ndefTransact(message: NdefMessage): NdefMessage {
         return when (negotiatedHandoverState) {
-            NegotiatedHandoverState.NOT_STARTED -> throw Error("Unexpected message - Negotiated Handover not started")
+            NegotiatedHandoverState.NOT_STARTED -> throw IllegalStateException("Unexpected message - Negotiated Handover not started")
             NegotiatedHandoverState.EXPECT_SERVICE_SELECT -> ndefTransactHandleServiceSelect(message)
             NegotiatedHandoverState.EXPECT_HANDOVER_REQUEST_MESSAGE -> ndefTransactHandleHandoverRequest(message)
-            NegotiatedHandoverState.EXPECT_HANDOVER_SELECT_MESSAGE -> throw Error("Negotiated Handover is complete")
+            NegotiatedHandoverState.EXPECT_HANDOVER_SELECT_MESSAGE -> throw IllegalStateException("Negotiated Handover is complete")
         }
     }
 
@@ -453,7 +453,7 @@ class MdocNfcEngagementHelper(
      *
      * @param reason the reason.
      */
-    suspend fun processDeactivated(reason: Int) {
+    fun processDeactivated(reason: Int) {
         if (raisedHandoverComplete || raisedError) {
             return
         } else {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelper.kt
@@ -1,0 +1,321 @@
+package org.multipaz.mdoc.nfc
+
+import io.ktor.utils.io.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.ByteStringBuilder
+import kotlinx.io.bytestring.append
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
+import org.multipaz.mdoc.engagement.buildDeviceEngagement
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.transport.encapsulateInDo53
+import org.multipaz.mdoc.transport.extractFromDo53
+import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.Nfc
+import org.multipaz.nfc.ResponseApdu
+import org.multipaz.util.Logger
+import org.multipaz.util.toHex
+import kotlin.math.min
+
+/**
+ * Helper used for NFC engagement on the mdoc side.
+ *
+ * This implements NFC engagement v2 according to ISO/IEC 18013 Second Edition
+ *
+ * APDUs received from the NFC tag reader should be passed to the [processApdu] method.
+ *
+ * The [apduCommandMaxSize] parameter is used to tell the mdoc reader that it needs to send its commands in APDUs no
+ * larger than this size and this value must be smaller or equal to 65536, the maximum size of an Extended APDU.
+ * Since this class is usually not used in an environment where a 64 KiB buffer is a showstopper we default to the
+ * maximum size.
+ *
+ * @param eDeviceKey EDeviceKey as per ISO/IEC 18013-5:2021.
+ * @param onHandoverComplete the function to call when handover is complete.
+ * @param onMessageReceived the function to call when a data message has been received over NFC.
+ * @param onError the function to call if an error occurs.
+ * @param negotiatedHandoverPicker a function to choose one of the connection methods from the mdoc reader. This
+ * always contain a [MdocConnectionMethodNfcV2] instance and contains others if the mdoc reader is capable of data
+ * transfer over e.g. BLE or Wifi Aware. If the mdoc only supports data transfer over NFC, it should return the element
+ * for [MdocConnectionMethodNfcV2].
+ * @param apduCommandMaxSize the maximum length of the command data field.
+ */
+class MdocNfcV2EngagementHelper(
+    val eDeviceKey: EcPublicKey,
+    val onHandoverComplete: (
+        connectionMethod: MdocConnectionMethod,
+        encodedDeviceEngagement: ByteString,
+        handover: DataItem) -> Unit,
+    val onMessageReceived: suspend (ByteString) -> Unit,
+    val onError: (error: Exception) -> Unit,
+    val negotiatedHandoverPicker: (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod,
+    val apduCommandMaxSize: Long = 65536L,
+) {
+    companion object {
+        private const val TAG = "MdocNfcV2EngagementHelper"
+    }
+
+    private enum class HandoverState {
+        NOT_STARTED,
+        EXPECT_HANDOVER_REQUEST_MESSAGE,
+        EXPECT_PAYLOAD_MESSAGES,
+    }
+
+    private var handoverState = HandoverState.NOT_STARTED
+
+    private var inError = false
+
+    private fun raiseError(errorMessage: String, cause: Exception? = null) {
+        inError = true
+        onError(IllegalStateException(errorMessage, cause))
+    }
+
+    private suspend fun processSelectApplication(command: CommandApdu): ResponseApdu {
+        val requestedApplicationId = command.payload
+        if (requestedApplicationId != Nfc.MDOC_NFC_ENGAGEMENT_V2_AID) {
+            raiseError(
+                "SelectApplication: Expected Engagement v2 AID but got " +
+                        requestedApplicationId.toByteArray().toHex()
+            )
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+        }
+        handoverState = HandoverState.EXPECT_HANDOVER_REQUEST_MESSAGE
+
+        val nfcV2SelectApplicationPayload = buildCborMap {
+            put(0, apduCommandMaxSize)
+        }
+        return ResponseApdu(
+            status = Nfc.RESPONSE_STATUS_SUCCESS,
+            payload = ByteString(Cbor.encode(nfcV2SelectApplicationPayload))
+        )
+    }
+
+    private suspend fun nfcV2TransactHandleHandoverRequest(message: ByteString): ByteString {
+        val nfcV2HandoverRequest = Cbor.decode(message.toByteArray())
+        Logger.iCbor(TAG, "Received nfcV2HandoverRequest", nfcV2HandoverRequest)
+
+        // ReaderEngagement is at key 0
+        val readerEngagementDataItem = nfcV2HandoverRequest.get(0)
+
+        // DeviceRetrievalMethods is at key 2
+        val availableConnectionMethods = readerEngagementDataItem.get(2).asArray.mapNotNull {
+            val cm = MdocConnectionMethod.fromDeviceEngagement(Cbor.encode(it))
+            if (cm == null) {
+                Logger.iCbor(TAG, "Unknown data retrieval method", it)
+            }
+            cm
+        }
+
+        // The reader *MUST* always include MdocConnectionMethodNfcV2, check this
+        if (availableConnectionMethods.find { it is MdocConnectionMethodNfcV2 } == null) {
+            throw IllegalStateException(
+                "No DeviceRetrievalMethodNfcV2DataTransfer element in DeviceRetrievalMethods in ReaderEngagement"
+            )
+        }
+
+        val disambiguatedConnectionMethods = MdocConnectionMethod.disambiguate(
+            availableConnectionMethods,
+            MdocRole.MDOC
+        )
+
+        val selectedMethod = negotiatedHandoverPicker(disambiguatedConnectionMethods)
+
+        val deviceEngagement = buildDeviceEngagement(eDeviceKey = eDeviceKey) {
+            addConnectionMethod(selectedMethod)
+        }.toDataItem()
+        val encodedDeviceEngagement = Cbor.encode(deviceEngagement)
+
+        val nfcV2HandoverSelect = buildCborMap {
+            put(0, deviceEngagement)
+        }
+        val encodedNfcV2HandoverSelect = Cbor.encode(nfcV2HandoverSelect)
+
+        val handover = buildCborArray {
+            add(encodedNfcV2HandoverSelect)    // Handover Select message
+            add(message.toByteArray())           // Handover Request message
+        }
+
+        handoverState = HandoverState.EXPECT_PAYLOAD_MESSAGES
+
+        onHandoverComplete(
+            selectedMethod,
+            ByteString(encodedDeviceEngagement),
+            handover
+        )
+
+        return ByteString(encodedNfcV2HandoverSelect)
+    }
+
+    private val queueForPayloadReply = Channel<ByteString>(Channel.UNLIMITED)
+
+    /**
+     * Function for sending data via NFC.
+     *
+     * This data will be queued up and returned to the mdoc reader as a reply.
+     *
+     * @param message the data to send.
+     */
+    suspend fun sendMessage(message: ByteString) {
+        try {
+            queueForPayloadReply.send(message)
+        } catch (e: Throwable) {
+            Logger.w(TAG, "Ignoring failure sending message of ${message.size} over NFC", e)
+        }
+    }
+
+    private suspend fun nfcV2TransactHandlePayloadMessages(message: ByteString): ByteString {
+        onMessageReceived(message)
+        val responsePayloadMessage = queueForPayloadReply.receive()
+        return responsePayloadMessage
+    }
+
+    private suspend fun nfcV2Transact(message: ByteString): ByteString {
+        return when (handoverState) {
+            HandoverState.NOT_STARTED -> throw IllegalStateException("Unexpected message - Negotiated Handover not started")
+            HandoverState.EXPECT_HANDOVER_REQUEST_MESSAGE -> nfcV2TransactHandleHandoverRequest(message)
+            HandoverState.EXPECT_PAYLOAD_MESSAGES -> nfcV2TransactHandlePayloadMessages(message)
+        }
+    }
+
+    private var leReceived = 0
+
+    private var currentIncomingEncapsulatedMessage = ByteStringBuilder()
+    private val outgoingChunks = mutableListOf<ByteString>()
+    private var outgoingChunksRemainingBytesAvailable = 0
+
+    private fun getNextOutgoingChunkResponse(): ResponseApdu {
+        val chunk = outgoingChunks.removeAt(0)
+        outgoingChunksRemainingBytesAvailable -= chunk.size
+
+        /* Following excerpts are from ISO/IEC 18013-5:2021 clause 8.3.3.1.2 Data retrieval using
+         * near field communication (NFC)
+         */
+        val isLastChunk = outgoingChunks.isEmpty()
+        if (isLastChunk) {
+            /* If Le ≥ the number of available bytes, the mdoc shall include all
+             * available bytes in the response and set the status words to ’90 00’.
+             */
+            return ResponseApdu(
+                status = Nfc.RESPONSE_STATUS_SUCCESS,
+                payload = chunk
+            )
+        } else {
+            if (outgoingChunksRemainingBytesAvailable <= leReceived + 255) {
+                /* If Le < the number of available bytes ≤ Le + 255, the mdoc shall
+                 * include as many bytes in the response as indicated by Le and shall
+                 * set the status words to ’61 XX’, where XX is the number of available
+                 * bytes remaining. The mdoc reader shall respond with a GET RESPONSE
+                 * command where Le is set to XX.
+                 */
+                val numBytesRemaining = outgoingChunksRemainingBytesAvailable - leReceived
+                return ResponseApdu(
+                    status = Nfc.RESPONSE_STATUS_CHAINING_RESPONSE_BYTES_STILL_AVAILABLE + numBytesRemaining.and(0xff),
+                    payload = chunk
+                )
+            } else {
+                /* If the number of available bytes > Le + 255, the mdoc shall include
+                 * as many bytes in the response as indicated by Le and shall set the
+                 * status words to ’61 00’. The mdoc reader shall respond with a GET
+                 * RESPONSE command where Le is set to the maximum length of the
+                 * response data field that is supported by both the mdoc and the mdoc
+                 * reader.
+                 */
+                return ResponseApdu(
+                    status = Nfc.RESPONSE_STATUS_CHAINING_RESPONSE_BYTES_STILL_AVAILABLE,
+                    payload = chunk
+                )
+            }
+        }
+    }
+
+    private suspend fun processEnvelope(command: CommandApdu): ResponseApdu {
+        Logger.i(TAG, "processEnvelope")
+        currentIncomingEncapsulatedMessage.append(command.payload)
+        if (command.cla == Nfc.CLA_CHAIN_LAST) {
+
+            // For the last ENVELOPE command in a chain, Le shall be set to the maximum length
+            // of the response data field that is supported by both the mdoc and the mdoc reader.
+            //
+            // We'll need this for later.
+            if (leReceived == 0) {
+                leReceived = command.le
+                Logger.i(TAG, "LE in last ENVELOPE is $leReceived")
+            }
+
+            // No more data coming.
+            val message = extractFromDo53(currentIncomingEncapsulatedMessage.toByteString())
+            currentIncomingEncapsulatedMessage = ByteStringBuilder()
+
+            val responseMessage = nfcV2Transact(message)
+
+            val encapsulatedMessage = encapsulateInDo53(responseMessage)
+            val maxChunkSize = leReceived
+            val offsets = 0 until encapsulatedMessage.size step maxChunkSize
+            for (offset in offsets) {
+                val chunkSize = min(maxChunkSize, encapsulatedMessage.size - offset)
+                val chunk = encapsulatedMessage.substring(offset, offset + chunkSize)
+                outgoingChunks.add(chunk)
+            }
+            outgoingChunksRemainingBytesAvailable += encapsulatedMessage.size
+
+            val chunkResponse = getNextOutgoingChunkResponse()
+            return chunkResponse
+        } else if (command.cla == Nfc.CLA_CHAIN_NOT_LAST) {
+            // More data is coming
+            check(command.le == 0) { "Expected LE 0 for non-last ENVELOPE, got ${command.le}" }
+            Logger.i(TAG, "processEnvelope: returning SUCCESS")
+            return ResponseApdu(status = Nfc.RESPONSE_STATUS_SUCCESS)
+        } else {
+            throw IllegalStateException("Expected CLA 0x00 or 0x10 for ENVELOPE, got ${command.cla}")
+        }
+    }
+
+    private fun processGetResponse(command: CommandApdu): ResponseApdu {
+        Logger.i(TAG, "processGetResponse")
+        val chunkResponse = getNextOutgoingChunkResponse()
+        return chunkResponse
+    }
+
+    /**
+     * Process APDUs received from the remote NFC tag reader.
+     *
+     * @param command The command received.
+     * @return the response.
+     */
+    suspend fun processApdu(command: CommandApdu): ResponseApdu {
+        if (inError) {
+            Logger.w(TAG, "processApdu: Already in error state, responding to APDU with status 6f00")
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
+        }
+        try {
+            when (command.ins) {
+                Nfc.INS_SELECT -> {
+                    when (command.p1) {
+                        Nfc.INS_SELECT_P1_APPLICATION -> return processSelectApplication(command)
+                    }
+                }
+                Nfc.INS_ENVELOPE -> return processEnvelope(command)
+                Nfc.INS_GET_RESPONSE -> return processGetResponse(command)
+            }
+            raiseError("Command APDU $command not supported, returning 6d00")
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
+            raiseError("Error processing APDU: ${error.message}", error)
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
+        }
+    }
+
+    /**
+     * Must be called when the session is deactivated, e.g. when the NFC tag reader leaves the field.
+     */
+    fun processDeactivated(reason: Int) {
+        queueForPayloadReply.cancel(CancellationException("The session was deactivated"))
+    }
+}
+

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/ScanMdocReaderResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/ScanMdocReaderResult.kt
@@ -11,11 +11,13 @@ import kotlin.time.Duration
  * @property transport The [MdocTransport] which to hand over to.
  * @property encodedDeviceEngagement the device engagement that was used.
  * @property handover the handover that was used.
+ * @property type the type of handover.
  * @property processingDuration the amount of time spent exchanging APDUs to set up the handover.
  */
 data class ScanMdocReaderResult(
     val transport: MdocTransport,
     val encodedDeviceEngagement: ByteString,
     val handover: DataItem,
+    val type: MdocHandoverType,
     val processingDuration: Duration
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
@@ -18,14 +18,38 @@ import org.multipaz.nfc.TnepStatusRecord
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.ByteStringBuilder
+import kotlinx.io.bytestring.append
 import kotlinx.io.bytestring.decodeToString
 import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborArray
+import org.multipaz.cbor.putCborMap
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
+import org.multipaz.mdoc.engagement.DeviceEngagement
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.transport.encapsulateInDo53
+import org.multipaz.mdoc.transport.extractFromDo53
+import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.ResponseApdu
 import org.multipaz.util.getUInt16
+import org.multipaz.util.toHex
+import kotlin.math.min
 
 const private val TAG = "mdocReaderNfcHandover"
+
+/**
+ * The type of handover which occurred.
+ */
+enum class MdocHandoverType {
+    /** Static handover according to ISO/IEC 18013-5:2021 */
+    STATIC_HANDOVER,
+    /** Negotiated handover according to ISO/IEC 18013-5:2021 */
+    NEGOTIATED_HANDOVER,
+    /** Handover according to ISO/IEC 18013-5 Second Edition */
+    V2_HANDOVER
+}
 
 /**
  * The result of a successful NFC handover operation
@@ -33,11 +57,22 @@ const private val TAG = "mdocReaderNfcHandover"
  * @property connectionMethods the possible connection methods for the mdoc reader to connect to.
  * @property encodedDeviceEngagement the bytes of DeviceEngagement.
  * @property handover the handover value.
+ * @property type the type of NFC handover which occurred.
  */
 data class MdocReaderNfcHandoverResult(
     val connectionMethods: List<MdocConnectionMethod>,
     val encodedDeviceEngagement: ByteString,
     val handover: DataItem,
+    val type: MdocHandoverType,
+)
+
+/**
+ * Options for when performing handover as a mdoc reader.
+ *
+ * @property useNfcV2 if `true`, will attempt to use NFCv2 handover from ISO 18013-5 Second Edition.
+ */
+data class MdocReaderNfcHandoverOptions(
+    val useNfcV2: Boolean = false
 )
 
 /**
@@ -46,15 +81,39 @@ data class MdocReaderNfcHandoverResult(
  * @param tag the [NfcIsoTag] representing a NFC connection to the mdoc.
  * @param negotiatedHandoverConnectionMethods the connection methods to offer if the remote mdoc is using NFC
  * negotiated handover.
+ * @param options a [MdocReaderNfcHandoverOptions]
  * @return a [MdocReaderNfcHandoverResult] if the handover was successful or `null` if the tag isn't an NDEF tag.
  * @throws Throwable if an error occurs during handover.
  */
 suspend fun mdocReaderNfcHandover(
     tag: NfcIsoTag,
     negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
+    options: MdocReaderNfcHandoverOptions = MdocReaderNfcHandoverOptions()
 ): MdocReaderNfcHandoverResult? {
+    // First try the new engagement method, if requested...
+    if (options.useNfcV2) {
+        val selectApplicationResponse = try {
+            tag.selectApplication(Nfc.MDOC_NFC_ENGAGEMENT_V2_AID)
+        } catch (e: NfcCommandFailedException) {
+            if (e.status == Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND) {
+                Logger.i(TAG, "Selecting NFCv2 AID returned FILE_NOT_FOUND")
+            }
+            null
+        }
+        if (selectApplicationResponse != null) {
+            Logger.i(TAG, "Successfully selected NFCv2 AID")
+            Logger.i(TAG, "payload: ${selectApplicationResponse.payload.toByteArray().toHex()}")
+            val payload = Cbor.decode(selectApplicationResponse.payload.toByteArray())
+            val mdocNfcMaxCommandApduSize = payload.get(0).asNumber.toInt()
+            Logger.i(TAG, "mdoc indicates APDU max command length is $mdocNfcMaxCommandApduSize")
+            return mdocReaderNfcV2Handover(tag, mdocNfcMaxCommandApduSize, negotiatedHandoverConnectionMethods)
+        }
+    }
+
+    // Fall back to NDEF...
     try {
         tag.selectApplication(Nfc.NDEF_APPLICATION_ID)
+        Logger.i(TAG, "Successfully selected NDEF AID")
     } catch (e: NfcCommandFailedException) {
         // This is returned by Android when locked phone is being tapped by an mdoc reader. Once unlocked the
         // user will be shown UI to convey another tap should happen. So since we're the mdoc reader, we
@@ -65,6 +124,7 @@ suspend fun mdocReaderNfcHandover(
             return null
         }
     }
+
     tag.selectFile(Nfc.NDEF_CAPABILITY_CONTAINER_FILE_ID)
     // CC file is 15 bytes long
     val ccFile = tag.readBinary(0, 15)
@@ -96,6 +156,7 @@ suspend fun mdocReaderNfcHandover(
             connectionMethods = disambiguatedConnectionMethods,
             encodedDeviceEngagement = ByteString(encodedDeviceEngagement),
             handover = handover,
+            type = MdocHandoverType.STATIC_HANDOVER
         )
     }
 
@@ -150,6 +211,67 @@ suspend fun mdocReaderNfcHandover(
         ),
         encodedDeviceEngagement = ByteString(encodedDeviceEngagement),
         handover = handover,
+        type = MdocHandoverType.NEGOTIATED_HANDOVER
+    )
+}
+
+private suspend fun mdocReaderNfcV2Handover(
+    tag: NfcIsoTag,
+    mdocNfcMaxCommandApduSize: Int,
+    negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
+): MdocReaderNfcHandoverResult? {
+    // Send Handover Request message, the resulting NDEF message is Handover Response
+    //
+    val combinedNegotiatedHandoverConnectionMethods = listOf(MdocConnectionMethodNfcV2()) +
+            MdocConnectionMethod.combine(negotiatedHandoverConnectionMethods)
+
+
+    val nfcV2HandoverRequest = buildCborMap {
+        // ReaderEngagement is at key 0
+        putCborMap(0) {
+            // DeviceRetrievalMethods is at key 2
+            putCborArray(2) {
+                for (method in combinedNegotiatedHandoverConnectionMethods) {
+                    val encodedDeviceRetrievalMethod = method.toDeviceEngagement()
+                    add(Cbor.decode(encodedDeviceRetrievalMethod))
+                }
+            }
+        }
+    }
+    val encodedNfcV2HandoverRequest = Cbor.encode(nfcV2HandoverRequest)
+
+    val encodedNfcV2HandoverSelect = tag.nfcV2Transact(
+        message = ByteString(encodedNfcV2HandoverRequest),
+        commandDataFieldMaxLength = tag.maxTransceiveLength,
+        responseDataFieldMaxLength = tag.maxTransceiveLength
+    ).toByteArray()
+
+    Logger.i(TAG, "Handover complete")
+
+    val nfcV2HandoverSelect = Cbor.decode(encodedNfcV2HandoverSelect)
+
+    val deviceEngagementDataItem = nfcV2HandoverSelect.get(0)
+    val encodedDeviceEngagement = Cbor.encode(deviceEngagementDataItem)
+
+    val deviceEngagement = DeviceEngagement.fromDataItem(deviceEngagementDataItem)
+
+    check(deviceEngagement.connectionMethods.size == 1) {
+        "Expected exactly one Device Retrieval methods in engagement, found ${deviceEngagement.connectionMethods.size}"
+    }
+
+    val handover = buildCborArray {
+        add(encodedNfcV2HandoverSelect) // Handover Select message
+        add(encodedNfcV2HandoverRequest)  // Handover Request message
+    }
+
+    return MdocReaderNfcHandoverResult(
+        connectionMethods = MdocConnectionMethod.disambiguate(
+            deviceEngagement.connectionMethods,
+            MdocRole.MDOC_READER
+        ),
+        encodedDeviceEngagement = ByteString(encodedDeviceEngagement),
+        handover = handover,
+        type = MdocHandoverType.V2_HANDOVER
     )
 }
 
@@ -224,10 +346,114 @@ private fun parseHandoverSelectMessage(
         }
     }
     if (!hasHandoverSelectRecord) {
-        throw Error("Handover Select record not found")
+        throw IllegalStateException("Handover Select record not found")
     }
     if (encodedDeviceEngagement == null) {
-        throw Error("DeviceEngagement record not found")
+        throw IllegalStateException("DeviceEngagement record not found")
     }
     return Pair(encodedDeviceEngagement.toByteArray(), connectionMethods)
+}
+
+
+internal suspend fun NfcIsoTag.nfcV2Transact(
+    message: ByteString,
+    commandDataFieldMaxLength: Int,
+    responseDataFieldMaxLength: Int,
+    onMessageSent: (suspend () -> Unit)? = null
+): ByteString {
+    val encMessage = encapsulateInDo53(message)
+
+    val maxChunkSize = commandDataFieldMaxLength
+    val offsets = 0 until encMessage.size step maxChunkSize
+    var lastEnvelopeResponse: ResponseApdu? = null
+    for (offset in offsets) {
+        val moreDataComing = (offset != offsets.last)
+        val size = min(maxChunkSize, encMessage.size - offset)
+        val le = if (!moreDataComing) {
+            responseDataFieldMaxLength
+        } else {
+            0
+        }
+        val response = transceive(
+            CommandApdu(
+                cla = if (moreDataComing) Nfc.CLA_CHAIN_NOT_LAST else Nfc.CLA_CHAIN_LAST,
+                ins = Nfc.INS_ENVELOPE,
+                p1 = 0x00,
+                p2 = 0x00,
+                payload = ByteString(encMessage.toByteArray(), offset, offset + size),
+                le = le
+            )
+        )
+        if (response.status != Nfc.RESPONSE_STATUS_SUCCESS && response.status.and(0xff00) != 0x6100) {
+            throw NfcCommandFailedException("Unexpected ENVELOPE status ${response.statusHexString}", response.status)
+        }
+        lastEnvelopeResponse = response
+    }
+    Logger.i(TAG, "Successfully sent message, waiting for response")
+
+    if (onMessageSent != null) {
+        onMessageSent()
+    }
+
+    check(lastEnvelopeResponse != null)
+    val encapsulatedMessageBuilder = ByteStringBuilder()
+    encapsulatedMessageBuilder.append(lastEnvelopeResponse.payload)
+    if (lastEnvelopeResponse.status == Nfc.RESPONSE_STATUS_SUCCESS) {
+        // Woohoo, entire response fits
+        Logger.i(TAG, "Entire response fits")
+    } else {
+        // More bytes are coming, have to use GET RESPONSE to get the rest
+
+        var leForGetResponse = responseDataFieldMaxLength
+        if (lastEnvelopeResponse.status.and(0xff) != 0) {
+            leForGetResponse = lastEnvelopeResponse.status.and(0xff)
+        }
+        while (true) {
+            Logger.i(TAG, "Sending GET RESPONSE")
+            val response = transceive(
+                CommandApdu(
+                    cla = 0x00,
+                    ins = Nfc.INS_GET_RESPONSE,
+                    p1 = 0x00,
+                    p2 = 0x00,
+                    payload = ByteString(),
+                    le = leForGetResponse
+                )
+            )
+            encapsulatedMessageBuilder.append(response.payload)
+            if (response.status == Nfc.RESPONSE_STATUS_SUCCESS) {
+                /* If Le ≥ the number of available bytes, the mdoc shall include
+                 * all available bytes in the response and set the status words
+                 * to ’90 00’.
+                 */
+                break
+            } else if (response.status == 0x6100) {
+                /* If the number of available bytes > Le + 255, the mdoc shall
+                 * include as many bytes in the response as indicated by Le and
+                 * shall set the status words to ’61 00’. The mdoc reader shall
+                 * respond with a GET RESPONSE command where Le is set to the
+                 * maximum length of the response data field that is supported
+                 * by both the mdoc and the mdoc reader.
+                 */
+                leForGetResponse = responseDataFieldMaxLength
+            } else if (response.status.and(0xff00) == 0x6100) {
+                /* If Le < the number of available bytes ≤ Le + 255, the
+                 * mdoc shall include as many bytes in the response as
+                 * indicated by Le and shall set the status words to ’61 XX’,
+                 * where XX is the number of available bytes remaining. The
+                 * mdoc reader shall respond with a GET RESPONSE command where
+                 * Le is set to XX.
+                 */
+                leForGetResponse = response.status.and(0xff)
+            } else {
+                throw NfcCommandFailedException(
+                    "Unexpected GET RESPONSE status ${response.statusHexString}",
+                    response.status
+                )
+            }
+        }
+    }
+    val encapsulatedMessage = encapsulatedMessageBuilder.toByteString()
+    val extractedMessage = extractFromDo53(encapsulatedMessage)
+    return extractedMessage
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanMdocReader.kt
@@ -1,21 +1,20 @@
 package org.multipaz.mdoc.nfc
 
 import kotlinx.coroutines.Dispatchers
-import org.multipaz.cbor.DataItem
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
 import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
 import org.multipaz.mdoc.transport.NfcTransportMdocReader
 import org.multipaz.prompt.PromptDismissedException
 import org.multipaz.util.Logger
-import kotlinx.io.bytestring.ByteString
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NfcScanOptions
 import org.multipaz.nfc.NfcTagReader
+import org.multipaz.mdoc.transport.NfcHybridTransportMdocReader
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
-import kotlin.time.Duration
 
 private const val TAG = "scanMdocReader"
 
@@ -30,6 +29,7 @@ private const val TAG = "scanMdocReader"
  *   platforms supports not showing a dialog, use [org.multipaz.nfc.nfcTagScanningSupportedWithoutDialog] to check at
  *   runtime if the platform supports this.
  * @param options the [MdocTransportOptions] used to create new [MdocTransport] instances.
+ * @param handoverOptions the [MdocReaderNfcHandoverOptions] used to control handover behavior.
  * @param transportFactory the factory used to create [MdocTransport] instances.
  * @param selectConnectionMethod used to choose a connection method if the remote mdoc is using NFC static handover.
  * @param negotiatedHandoverConnectionMethods the connection methods to offer if the remote mdoc is using NFC
@@ -41,6 +41,7 @@ private const val TAG = "scanMdocReader"
 suspend fun NfcTagReader.scanMdocReader(
     message: String?,
     options: MdocTransportOptions,
+    handoverOptions: MdocReaderNfcHandoverOptions,
     transportFactory: MdocTransportFactory = MdocTransportFactory.Default,
     selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?,
     negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
@@ -72,6 +73,7 @@ suspend fun NfcTagReader.scanMdocReader(
                 val handoverResult = mdocReaderNfcHandover(
                     tag = tag,
                     negotiatedHandoverConnectionMethods = negotiatedHandoverTransports.map { it.connectionMethod },
+                    options = handoverOptions
                 )
                 if (handoverResult == null) {
                     return@tagInteractionFunc null
@@ -99,25 +101,42 @@ suspend fun NfcTagReader.scanMdocReader(
                 }
                 transportsToClose.clear()
                 if (transport == null) {
-                    transport = transportFactory.createTransport(
-                        connectionMethod,
-                        MdocRole.MDOC_READER,
-                        options
+                    // For NFCv2, it's possible the mdoc only supports NFC in which case there is
+                    // no transport to create
+                    if (connectionMethod !is MdocConnectionMethodNfcV2) {
+                        transport = transportFactory.createTransport(
+                            connectionMethod,
+                            MdocRole.MDOC_READER,
+                            options
+                        )
+                    }
+                }
+
+                if (handoverResult.type == MdocHandoverType.V2_HANDOVER) {
+                    ScanMdocReaderResult(
+                        transport = NfcHybridTransportMdocReader(
+                            nfcTag = tag,
+                            negotiatedTransport = transport
+                        ),
+                        encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
+                        handover = handoverResult.handover,
+                        type = handoverResult.type,
+                        processingDuration = Clock.System.now() - t0
+                    )
+                } else {
+                    if (transport is NfcTransportMdocReader) {
+                        transport.setTag(tag)
+                    } else {
+                        tag.close()
+                    }
+                    ScanMdocReaderResult(
+                        transport = transport!!,
+                        encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
+                        handover = handoverResult.handover,
+                        type = handoverResult.type,
+                        processingDuration = Clock.System.now() - t0
                     )
                 }
-
-                if (transport is NfcTransportMdocReader) {
-                    transport.setTag(tag)
-                } else {
-                    tag.close()
-                }
-
-                ScanMdocReaderResult(
-                    transport = transport,
-                    encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
-                    handover = handoverResult.handover,
-                    processingDuration = Clock.System.now() - t0
-                )
             },
             options = nfcScanOptions,
             context = context

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +15,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 import kotlin.time.Instant
 import org.multipaz.crypto.EcPublicKey
@@ -34,7 +38,9 @@ internal class BleTransportCentralMdoc(
         private const val TAG = "BleTransportCentralMdoc"
     }
 
+    private val transportScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mutex = Mutex()
+    @Volatile
     private var currentJob: Job? = null
 
     private val _state = MutableStateFlow<State>(State.IDLE)
@@ -62,7 +68,7 @@ internal class BleTransportCentralMdoc(
         )
         centralManager.setCallbacks(
             onError = { error ->
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -70,7 +76,7 @@ internal class BleTransportCentralMdoc(
                 }
             },
             onClosed = {
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }
@@ -91,44 +97,46 @@ internal class BleTransportCentralMdoc(
         var timeScanningStarted: Instant
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        _state.value = State.SCANNING
-                        centralManager.waitForPowerOn()
-                        timeScanningStarted = Clock.System.now()
-                        centralManager.waitForPeripheralWithUuid(uuid)
-                        _scanningTime = Clock.System.now() - timeScanningStarted
-                        _state.value = State.CONNECTING
-                        if (psm != null) {
-                            // If the PSM is known at engagement-time we can bypass the entire GATT server
-                            // and just connect directly.
-                            Logger.i(TAG, "Connecting directly to PSM $psm")
-                            centralManager.connectL2cap(psm)
-                        } else {
-                            centralManager.connectToPeripheral()
-                            centralManager.requestMtu()
-                            centralManager.peripheralDiscoverServices(uuid)
-                            centralManager.peripheralDiscoverCharacteristics()
-                            centralManager.checkReaderIdentMatches(eSenderKey)
-                            if (centralManager.l2capPsm != null) {
-                                centralManager.connectL2cap(centralManager.l2capPsm!!)
-                            } else {
-                                centralManager.subscribeToCharacteristics()
-                                centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
-                            }
-                        }
-                        _state.value = State.CONNECTED
+            _state.value = State.SCANNING
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                centralManager.waitForPowerOn()
+                timeScanningStarted = Clock.System.now()
+                centralManager.waitForPeripheralWithUuid(uuid)
+                _scanningTime = Clock.System.now() - timeScanningStarted
+                mutex.withLock { _state.value = State.CONNECTING }
+                if (psm != null) {
+                    // If the PSM is known at engagement-time we can bypass the entire GATT server
+                    // and just connect directly.
+                    Logger.i(TAG, "Connecting directly to PSM $psm")
+                    centralManager.connectL2cap(psm)
+                } else {
+                    centralManager.connectToPeripheral()
+                    centralManager.requestMtu()
+                    centralManager.peripheralDiscoverServices(uuid)
+                    centralManager.peripheralDiscoverCharacteristics()
+                    centralManager.checkReaderIdentMatches(eSenderKey)
+                    if (centralManager.l2capPsm != null) {
+                        centralManager.connectL2cap(centralManager.l2capPsm!!)
+                    } else {
+                        centralManager.subscribeToCharacteristics()
+                        centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
                     }
                 }
-            } catch (error: Exception) {
-                error.unwrapCancellationException().let {
-                    failTransport(it)
-                    throw it.wrapUnlessCancellationException("Failed while opening transport")
-                }
-            } finally {
-                currentJob = null
+                mutex.withLock { _state.value = State.CONNECTED }
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while opening transport")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -158,24 +166,26 @@ internal class BleTransportCentralMdoc(
             if (message.isEmpty() && centralManager.usingL2cap) {
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (message.isEmpty()) {
-                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                        } else {
-                            centralManager.sendMessage(message)
-                        }
-                    }
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (message.isEmpty()) {
+                    centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                } else {
+                    centralManager.sendMessage(message)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while sending message")
-                }
-            } finally {
-                currentJob = null
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while sending message")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -195,11 +205,12 @@ internal class BleTransportCentralMdoc(
         _state.value = State.CLOSED
     }
 
-    override suspend fun close() {
+    override suspend fun close() = withContext(NonCancellable) {
         currentJob?.cancel("close() was called")
+        transportScope.cancel("Transport closed")
         mutex.withLock {
             if (_state.value == State.FAILED || _state.value == State.CLOSED) {
-                return
+                return@withContext
             }
             closeWithoutDelay()
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +15,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -31,7 +35,9 @@ internal class BleTransportCentralMdocReader(
         private const val TAG = "BleTransportCentralMdocReader"
     }
 
+    private val transportScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mutex = Mutex()
+    @Volatile
     private var currentJob: Job? = null
 
     private val _state = MutableStateFlow<State>(State.IDLE)
@@ -64,7 +70,7 @@ internal class BleTransportCentralMdocReader(
         )
         peripheralManager.setCallbacks(
             onError = { error ->
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -72,7 +78,7 @@ internal class BleTransportCentralMdocReader(
                 }
             },
             onClosed = {
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }
@@ -84,22 +90,24 @@ internal class BleTransportCentralMdocReader(
     override suspend fun advertise() {
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        peripheralManager.waitForPowerOn()
-                        peripheralManager.advertiseService(uuid)
-                        _state.value = State.ADVERTISING
-                    }
-                }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while advertising")
-                }
-            } finally {
-                currentJob = null
+            _state.value = State.ADVERTISING
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                peripheralManager.waitForPowerOn()
+                peripheralManager.advertiseService(uuid)
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while advertising")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -107,35 +115,39 @@ internal class BleTransportCentralMdocReader(
         get() = null
 
     override suspend fun open(eSenderKey: EcPublicKey) {
-        mutex.withLock {
+        val wasAdvertising = mutex.withLock {
             check(_state.value == State.IDLE || _state.value == State.ADVERTISING) {
                 "Expected state IDLE or ADVERTISING, got ${_state.value}"
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (_state.value != State.ADVERTISING) {
-                            // Start advertising if we aren't already...
-                            _state.value = State.ADVERTISING
-                            peripheralManager.waitForPowerOn()
-                            peripheralManager.advertiseService(uuid)
-                        }
-                        peripheralManager.setESenderKey(eSenderKey)
-                        // Note: It's not really possible to know someone is connecting to use until they're _actually_
-                        // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
-                        // to go into State.CONNECTING...
-                        peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
-                        _state.value = State.CONNECTED
-                    }
+            val advertising = _state.value == State.ADVERTISING
+            _state.value = State.ADVERTISING
+            advertising
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (!wasAdvertising) {
+                    // Start advertising if we aren't already...
+                    peripheralManager.waitForPowerOn()
+                    peripheralManager.advertiseService(uuid)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while opening transport")
-                }
-            } finally {
-                currentJob = null
+                peripheralManager.setESenderKey(eSenderKey)
+                // Note: It's not really possible to know someone is connecting to use until they're _actually_
+                // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
+                // to go into State.CONNECTING...
+                peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
+                mutex.withLock { _state.value = State.CONNECTED }
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while opening transport")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -165,24 +177,26 @@ internal class BleTransportCentralMdocReader(
             if (message.isEmpty() && peripheralManager.usingL2cap) {
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (message.isEmpty()) {
-                            peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                        } else {
-                            peripheralManager.sendMessage(message)
-                        }
-                    }
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (message.isEmpty()) {
+                    peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                } else {
+                    peripheralManager.sendMessage(message)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while sending message")
-                }
-            } finally {
-                currentJob = null
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while sending message")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -202,11 +216,12 @@ internal class BleTransportCentralMdocReader(
         _state.value = State.CLOSED
     }
 
-    override suspend fun close() {
+    override suspend fun close() = withContext(NonCancellable) {
         currentJob?.cancel("close() was called")
+        transportScope.cancel("Transport closed")
         mutex.withLock {
             if (_state.value == State.FAILED || _state.value == State.CLOSED) {
-                return
+                return@withContext
             }
             peripheralManager.close()
             _state.value = State.CLOSED

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +15,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -31,7 +35,9 @@ internal class BleTransportPeripheralMdoc(
         private const val TAG = "BleTransportPeripheralMdoc"
     }
 
+    private val transportScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mutex = Mutex()
+    @Volatile
     private var currentJob: Job? = null
 
     private val _state = MutableStateFlow<State>(State.IDLE)
@@ -64,7 +70,7 @@ internal class BleTransportPeripheralMdoc(
         )
         peripheralManager.setCallbacks(
             onError = { error ->
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -73,7 +79,7 @@ internal class BleTransportPeripheralMdoc(
             },
             onClosed = {
                 Logger.w(TAG, "BlePeripheralManager close")
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }
@@ -85,22 +91,24 @@ internal class BleTransportPeripheralMdoc(
     override suspend fun advertise() {
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        peripheralManager.waitForPowerOn()
-                        peripheralManager.advertiseService(uuid)
-                        _state.value = State.ADVERTISING
-                    }
-                }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while advertising")
-                }
-            } finally {
-                currentJob = null
+            _state.value = State.ADVERTISING
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                peripheralManager.waitForPowerOn()
+                peripheralManager.advertiseService(uuid)
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while advertising")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -108,35 +116,39 @@ internal class BleTransportPeripheralMdoc(
         get() = null
 
     override suspend fun open(eSenderKey: EcPublicKey) {
-        mutex.withLock {
+        val wasAdvertising = mutex.withLock {
             check(_state.value == State.IDLE || _state.value == State.ADVERTISING) {
                 "Expected state IDLE or ADVERTISING, got ${_state.value}"
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (_state.value != State.ADVERTISING) {
-                            // Start advertising if we aren't already...
-                            _state.value = State.ADVERTISING
-                            peripheralManager.waitForPowerOn()
-                            peripheralManager.advertiseService(uuid)
-                        }
-                        peripheralManager.setESenderKey(eSenderKey)
-                        // Note: It's not really possible to know someone is connecting to us until they're _actually_
-                        // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
-                        // to go into State.CONNECTING...
-                        peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
-                        _state.value = State.CONNECTED
-                    }
+            val advertising = _state.value == State.ADVERTISING
+            _state.value = State.ADVERTISING
+            advertising
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (!wasAdvertising) {
+                    // Start advertising if we aren't already...
+                    peripheralManager.waitForPowerOn()
+                    peripheralManager.advertiseService(uuid)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while opening transport")
-                }
-            } finally {
-                currentJob = null
+                peripheralManager.setESenderKey(eSenderKey)
+                // Note: It's not really possible to know someone is connecting to us until they're _actually_
+                // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
+                // to go into State.CONNECTING...
+                peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
+                mutex.withLock { _state.value = State.CONNECTED }
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while opening transport")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -166,24 +178,26 @@ internal class BleTransportPeripheralMdoc(
             if (message.isEmpty() && peripheralManager.usingL2cap) {
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (message.isEmpty()) {
-                            peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                        } else {
-                            peripheralManager.sendMessage(message)
-                        }
-                    }
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (message.isEmpty()) {
+                    peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                } else {
+                    peripheralManager.sendMessage(message)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while sending message")
-                }
-            } finally {
-                currentJob = null
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while sending message")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -203,11 +217,12 @@ internal class BleTransportPeripheralMdoc(
         _state.value = State.CLOSED
     }
 
-    override suspend fun close() {
+    override suspend fun close() = withContext(NonCancellable) {
         currentJob?.cancel("close() was called")
+        transportScope.cancel("Transport closed")
         mutex.withLock {
             if (_state.value == State.FAILED || _state.value == State.CLOSED) {
-                return
+                return@withContext
             }
             peripheralManager.close()
             _state.value = State.CLOSED

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,7 +15,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 import kotlin.time.Clock
+import kotlin.time.Instant
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -33,7 +38,9 @@ internal class BleTransportPeripheralMdocReader(
         private const val TAG = "BleTransportPeripheralMdocReader"
     }
 
+    private val transportScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mutex = Mutex()
+    @Volatile
     private var currentJob: Job? = null
 
     private val _state = MutableStateFlow<State>(State.IDLE)
@@ -61,7 +68,7 @@ internal class BleTransportPeripheralMdocReader(
         )
         centralManager.setCallbacks(
             onError = { error ->
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
@@ -70,7 +77,7 @@ internal class BleTransportPeripheralMdocReader(
             },
             onClosed = {
                 Logger.w(TAG, "BleCentralManager close")
-                CoroutineScope(Dispatchers.Default).launch {
+                transportScope.launch {
                     mutex.withLock {
                         closeWithoutDelay()
                     }
@@ -88,46 +95,49 @@ internal class BleTransportPeripheralMdocReader(
         get() = _scanningTime
 
     override suspend fun open(eSenderKey: EcPublicKey) {
+        var timeScanningStarted: Instant? = null
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        _state.value = State.SCANNING
-                        centralManager.waitForPowerOn()
-                        val timeScanningStarted = Clock.System.now()
-                        centralManager.waitForPeripheralWithUuid(uuid)
-                        _scanningTime = Clock.System.now() - timeScanningStarted
-                        _state.value = State.CONNECTING
-                        if (psm != null) {
-                            // If the PSM is known at engagement-time we can bypass the entire GATT server
-                            // and just connect directly.
-                            centralManager.connectL2cap(psm)
-                        } else {
-                            centralManager.connectToPeripheral()
-                            centralManager.requestMtu()
-                            centralManager.peripheralDiscoverServices(uuid)
-                            centralManager.peripheralDiscoverCharacteristics()
-                            // NOTE: ident characteristic isn't used when the mdoc is the GATT server so we don't call
-                            // centralManager.checkReaderIdentMatches(eSenderKey)
-                            if (centralManager.l2capPsm != null) {
-                                centralManager.connectL2cap(centralManager.l2capPsm!!)
-                            } else {
-                                centralManager.subscribeToCharacteristics()
-                                centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
-                            }
-                        }
-                        _state.value = State.CONNECTED
+            _state.value = State.SCANNING
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                centralManager.waitForPowerOn()
+                timeScanningStarted = Clock.System.now()
+                centralManager.waitForPeripheralWithUuid(uuid)
+                _scanningTime = Clock.System.now() - timeScanningStarted!!
+                mutex.withLock { _state.value = State.CONNECTING }
+                if (psm != null) {
+                    // If the PSM is known at engagement-time we can bypass the entire GATT server
+                    // and just connect directly.
+                    centralManager.connectL2cap(psm)
+                } else {
+                    centralManager.connectToPeripheral()
+                    centralManager.requestMtu()
+                    centralManager.peripheralDiscoverServices(uuid)
+                    centralManager.peripheralDiscoverCharacteristics()
+                    // NOTE: ident characteristic isn't used when the mdoc is the GATT server so we don't call
+                    // centralManager.checkReaderIdentMatches(eSenderKey)
+                    if (centralManager.l2capPsm != null) {
+                        centralManager.connectL2cap(centralManager.l2capPsm!!)
+                    } else {
+                        centralManager.subscribeToCharacteristics()
+                        centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
                     }
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while opening transport")
-                }
-            } finally {
-                currentJob = null
+                mutex.withLock { _state.value = State.CONNECTED }
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while opening transport")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -157,24 +167,26 @@ internal class BleTransportPeripheralMdocReader(
             if (message.isEmpty() && centralManager.usingL2cap) {
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
-            try {
-                coroutineScope {
-                    currentJob = launch {
-                        if (message.isEmpty()) {
-                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                        } else {
-                            centralManager.sendMessage(message)
-                        }
-                    }
+        }
+        try {
+            coroutineScope {
+                currentJob = coroutineContext[Job]
+                if (message.isEmpty()) {
+                    centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                } else {
+                    centralManager.sendMessage(message)
                 }
-            } catch (error: Exception) {
-                throw error.unwrapCancellationException().let {
-                    failTransport(it)
-                    it.wrapUnlessCancellationException("Failed while sending message")
-                }
-            } finally {
-                currentJob = null
             }
+        } catch (error: Exception) {
+            val unwrapped = error.unwrapCancellationException()
+            if (unwrapped is CancellationException) {
+                throw unwrapped
+            } else {
+                mutex.withLock { failTransport(unwrapped) }
+                throw unwrapped.wrapUnlessCancellationException("Failed while sending message")
+            }
+        } finally {
+            currentJob = null
         }
     }
 
@@ -189,16 +201,17 @@ internal class BleTransportPeripheralMdocReader(
     }
 
     private fun closeWithoutDelay() {
-        check(mutex.isLocked) { "failTransport called without holding lock" }
+        check(mutex.isLocked) { "closeWithoutDelay called without holding lock" }
         centralManager.close()
         _state.value = State.CLOSED
     }
 
-    override suspend fun close() {
+    override suspend fun close() = withContext(NonCancellable) {
         currentJob?.cancel("close() was called")
+        transportScope.cancel("Transport closed")
         mutex.withLock {
             if (_state.value == State.FAILED || _state.value == State.CLOSED) {
-                return
+                return@withContext
             }
             centralManager.close()
             _state.value = State.CLOSED

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
@@ -35,7 +35,8 @@ import kotlin.time.Duration
  * the state to [State.CLOSED] except if it's already in [State.FAILED].
  *
  * [MdocTransport] instances are thread-safe and methods and properties can be called from
- * any thread or coroutine.
+ * any thread or coroutine. To avoid resource leaks it's important that [close] is always
+ * called with the application is done using the [MdocTransport], even if it fails.
  */
 abstract class MdocTransport {
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdoc.kt
@@ -1,0 +1,263 @@
+package org.multipaz.mdoc.transport
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.ResponseApdu
+import org.multipaz.util.Logger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+
+/**
+ * Hybrid transport for using NFCv2.
+ *
+ * @param sendMessageViaNfc a function to send a message via NFC, returns false if the NFC connection is no longer up.
+ * be on NFC
+ */
+class NfcHybridTransportMdoc(
+    private val sendMessageViaNfc: suspend (message: ByteString) -> Boolean,
+): MdocTransport() {
+    companion object {
+        private const val TAG = "NfcHybridTransportMdoc"
+    }
+
+    private val _state = MutableStateFlow<State>(State.IDLE)
+    override val state: StateFlow<State> = _state.asStateFlow()
+
+    private var expectTransport: Boolean = false
+
+    override val role: MdocRole
+        get() = MdocRole.MDOC
+
+    override val connectionMethod: MdocConnectionMethod
+        get() {
+            throw IllegalStateException("Should not be called")
+        }
+
+    override val scanningTime: Duration?
+        get() = null
+
+    override suspend fun advertise() {}
+
+    private var transport: MdocTransport? = null
+    private var transportMessageBacklog = mutableListOf<ByteString>()
+    private var transportListenMessageJob: Job? = null
+
+    /**
+     * Sets whether a [setTransport] is expected to be called.
+     *
+     * @param expectTransport `true` if it's expected that [setTransport] will be called, `false` if not.
+     */
+    suspend fun setExpectTransport(expectTransport: Boolean) {
+        this.expectTransport = expectTransport
+    }
+
+    /**
+     * Called when a message has been received via NFC.
+     *
+     * @param message the message that was received.
+     */
+    suspend fun onMessageReceivedViaNfc(message: ByteString) {
+        Logger.i(TAG, "Received message over NFC of length ${message.size}")
+        conveyMessage(message, true)
+    }
+
+    /**
+     * Called when a deactivation event on NFC has occurred.
+     *
+     * @param reason the reason for the deactivation event.
+     */
+    suspend fun onNfcDeactivated(reason: Int) {
+        if (!expectTransport) {
+            mutex.withLock {
+                failTransport(MdocTransportException(
+                    "NFC deactivated with reason $reason and not expecting a Transport. Failing this transport"
+                ))
+            }
+        }
+    }
+
+    /**
+     * Called when the negotiated transport is connected.
+     *
+     * @param transport the negotiated transport which connected.
+     */
+    suspend fun setTransport(transport: MdocTransport) {
+        this.transport = transport
+        val backlog = mutex.withLock { transportMessageBacklog.map { it.toByteArray() } }
+        Logger.i(TAG, "Connected to transport, sending backlog of ${backlog.size} messages")
+        backlog.forEachIndexed { idx, message ->
+            transport.sendMessage(message)
+            Logger.i(TAG, "Sending message over Transport of length ${message.size} (backlog index $idx)")
+            numSentViaTransport += 1
+        }
+
+        transportListenMessageJob = CoroutineScope(Dispatchers.Default).launch {
+            try {
+                while (true) {
+                        val message = transport.waitForMessage()
+                        Logger.i(TAG, "Received message over Transport of length ${message.size}")
+                        conveyMessage(ByteString(message), false)
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.e(TAG, "Caught exception while waiting for message on transport", e)
+            }
+        }
+    }
+
+    override suspend fun open(eSenderKey: EcPublicKey) {
+        mutex.withLock {
+            check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
+            _state.value = State.CONNECTED
+        }
+    }
+
+    private val mutex = Mutex()
+    private val writingQueue = Channel<ByteString>(Channel.UNLIMITED)
+    private val incomingMessages = Channel<ByteString>(Channel.UNLIMITED)
+    private var incomingMessagesNumViaNfc = 0
+    private var incomingMessagesNumViaTransport = 0
+    private var incomingMessagesNumConveyed = 0
+
+    private var numSent = 0
+    private var numSentViaNfc = 0
+    private var numSentViaTransport = 0
+    private var nfcDisconnected = false
+
+    /**
+     * Statistics about the [NfcHybridTransportMdoc].
+     */
+    val stats: NfcHybridTransportStats
+        get() = NfcHybridTransportStats(
+            numSent = numSent,
+            numSentViaNfc = numSentViaNfc,
+            numSentViaTransport = numSentViaTransport,
+            numReceived = incomingMessagesNumConveyed,
+            numReceivedFirstOnNfc = incomingMessagesNumViaNfc,
+            numReceivedFirstOnTransport = incomingMessagesNumViaTransport,
+            nfcDisconnectedDuringTransaction = nfcDisconnected
+        )
+
+    private suspend fun conveyMessage(message: ByteString, fromNfc: Boolean) {
+        val shouldConveyMessage = mutex.withLock {
+            val shouldConvey = if (fromNfc) {
+                incomingMessagesNumViaNfc++ == incomingMessagesNumConveyed
+            } else {
+                incomingMessagesNumViaTransport++ == incomingMessagesNumConveyed
+            }
+            if (shouldConvey) {
+                incomingMessagesNumConveyed += 1
+            }
+            shouldConvey
+        }
+        val (conveyanceName, otherName) = if (fromNfc) Pair("NFC", "Transport") else Pair("Transport", "NFC")
+        if (shouldConveyMessage) {
+            Logger.i(TAG, "Conveying message of ${message.size} bytes received via " +
+                    "$conveyanceName (not yet received via $otherName)")
+            incomingMessages.send(message)
+        } else {
+            Logger.i(TAG, "Not conveying message of ${message.size} bytes received via " +
+                    "$conveyanceName (already received via $otherName)")
+        }
+    }
+
+    override suspend fun sendMessage(message: ByteArray) {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+        }
+        val messageBs = ByteString(message)
+        writingQueue.send(messageBs)
+        if (sendMessageViaNfc(messageBs)) {
+            Logger.i(TAG, "Sending message over NFC of length ${messageBs.size}")
+            numSentViaNfc += 1
+        } else {
+            if (expectTransport) {
+                Logger.i(TAG, "Error sending message over NFC of length ${messageBs.size} - " +
+                        "NFC is disconnected, continuing on non-NFC transport")
+                nfcDisconnected = true
+            } else {
+                val e = MdocTransportException("Error sending on NFC and no non-NFC transport is expected")
+                mutex.lock {
+                    failTransport(e)
+                }
+                throw e
+            }
+        }
+
+        val toSend = mutex.withLock {
+            if (transport == null) {
+                transportMessageBacklog.add(messageBs)
+                null
+            } else {
+                message
+            }
+        }
+        toSend?.let {
+            transport?.sendMessage(it)
+            Logger.i(TAG, "Sending message over Transport of length ${toSend.size}")
+            numSentViaTransport += 1
+        }
+    }
+
+    override suspend fun waitForMessage(): ByteArray {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+        }
+        try {
+            return incomingMessages.receive().toByteArray()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            if (_state.value == State.CLOSED) {
+                throw MdocTransportClosedException("Transport was closed while waiting for message")
+            } else {
+                mutex.withLock {
+                    failTransport(error)
+                }
+                throw MdocTransportException("Failed while waiting for message", error)
+            }
+        }
+    }
+
+    override suspend fun close() {
+        mutex.withLock {
+            if (_state.value == State.CLOSED) {
+                return
+            }
+            incomingMessages.close()
+            transportListenMessageJob?.cancel()
+            transportListenMessageJob = null
+            transport?.close()
+            transport = null
+            if (_state.value != State.FAILED) {
+                _state.value = State.CLOSED
+            }
+        }
+    }
+
+    private var inError = false
+
+    private fun failTransport(error: Throwable) {
+        check(mutex.isLocked) { "failTransport called without holding lock" }
+        inError = true
+        if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+            return
+        }
+        Logger.w(TAG, "Failing transport with error", error)
+        incomingMessages.close(error)
+        _state.value = State.FAILED
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdocReader.kt
@@ -1,0 +1,288 @@
+package org.multipaz.mdoc.transport
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
+import org.multipaz.mdoc.nfc.nfcV2Transact
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.nfc.NfcIsoTag
+import org.multipaz.util.Logger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+
+/**
+ * Hybrid transport for ISO 18013-5 Second Edition NFCv2 engagement on the reader side.
+ *
+ * @param nfcTag the [NfcIsoTag] that was used for NFCv2 engagement and which is used to send data over.
+ * @param negotiatedTransport the [MdocTransport] that was negotiated between reader and holder or `null` if only NFC
+ * data exchange is supported.
+ */
+class NfcHybridTransportMdocReader(
+    private val nfcTag: NfcIsoTag,
+    private val negotiatedTransport: MdocTransport?
+): MdocTransport() {
+    companion object {
+        private const val TAG = "NfcHybridTransportMdocReader"
+    }
+
+    private var numSent = 0
+    private var numSentViaNfc = 0
+    private var numSentViaTransport = 0
+
+    /**
+     * Statistics about the [NfcHybridTransportMdocReader].
+     */
+    val stats: NfcHybridTransportStats
+        get() = NfcHybridTransportStats(
+            numSent = numSent,
+            numSentViaNfc = numSentViaNfc,
+            numSentViaTransport = numSentViaTransport,
+            numReceived = incomingMessagesNumConveyed,
+            numReceivedFirstOnNfc = incomingMessagesNumViaNfc,
+            numReceivedFirstOnTransport = incomingMessagesNumViaTransport,
+            nfcDisconnectedDuringTransaction = nfcNotAvailable
+        )
+
+    private val _state = MutableStateFlow<State>(State.IDLE)
+    override val state: StateFlow<State> = _state.asStateFlow()
+
+    override val role: MdocRole
+        get() = MdocRole.MDOC_READER
+
+    override val connectionMethod: MdocConnectionMethod
+        get() = negotiatedTransport?.connectionMethod
+            ?: MdocConnectionMethodNfcV2()
+
+    override val scanningTime: Duration?
+        get() = null
+
+    override suspend fun advertise() {
+    }
+
+    private val mutex = Mutex()
+    private var ioJob: Job? = null
+    private val writingQueue = Channel<ByteString>(Channel.UNLIMITED)
+    private val incomingMessages = Channel<ByteString>(Channel.UNLIMITED)
+
+    // Counts how many messages was sent via NFC
+    private var sentMessagesNumViaNfc: Int = 0
+
+    // Counts how many total messages we received via NFC
+    private var incomingMessagesNumViaNfc = 0
+
+    // Counts how many total messages we received via Transport
+    private var incomingMessagesNumViaTransport = 0
+
+    // Counts how many total messages received via either NFC or Transport
+    private var incomingMessagesNumConveyed = 0
+
+    // Number of messages where we received them first on NFC
+    private var incomingMessagesNumConveyedWasViaNfc = 0
+
+    // Number of messages where we received them first on Transport
+    private var incomingMessagesNumConveyedWasViaTransport = 0
+
+    private var nfcNotAvailable = false
+
+    private var negotiatedTransportOpenJob: Job? = null
+    private val negotiatedTransportPendingOutgoingMessages = mutableListOf<ByteString>()
+
+    private suspend fun conveyMessage(message: ByteString, fromNfc: Boolean) {
+        val shouldConveyMessage = mutex.withLock {
+            val shouldConvey = if (fromNfc) {
+                incomingMessagesNumViaNfc++ == incomingMessagesNumConveyed
+            } else {
+                incomingMessagesNumViaTransport++ == incomingMessagesNumConveyed
+            }
+            if (shouldConvey) {
+                incomingMessagesNumConveyed += 1
+            }
+            shouldConvey
+        }
+        val (conveyanceName, otherName) = if (fromNfc) Pair("NFC", "Transport") else Pair("Transport", "NFC")
+        if (shouldConveyMessage) {
+            Logger.i(TAG, "Conveying message of ${message.size} bytes received via " +
+                    "$conveyanceName (not yet received via $otherName)")
+            if (fromNfc) {
+                incomingMessagesNumConveyedWasViaNfc += 1
+            }
+            incomingMessages.send(message)
+        } else {
+            Logger.i(TAG, "Not conveying message of ${message.size} bytes received via " +
+                    "$conveyanceName (already received via $otherName)")
+        }
+    }
+
+
+    override suspend fun open(eSenderKey: EcPublicKey) {
+        mutex.withLock {
+            check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
+            _state.value = State.CONNECTED
+        }
+
+        if (negotiatedTransport != null) {
+            negotiatedTransportOpenJob = CoroutineScope(Dispatchers.Default).launch {
+                try {
+                    negotiatedTransport.open(eSenderKey)
+                    negotiatedTransportOpenJob = null
+                    Logger.i(
+                        TAG, "Connected to negotiated transport, sending " +
+                                "${negotiatedTransportPendingOutgoingMessages.size} pending messages"
+                    )
+                    negotiatedTransportPendingOutgoingMessages.forEachIndexed { idx, message ->
+                        negotiatedTransport.sendMessage(message.toByteArray())
+                        Logger.i(TAG, "Sending message over Transport of length ${message.size} (backlog index $idx)")
+                        numSentViaTransport += 1
+                    }
+
+                    while (true) {
+                        val message = negotiatedTransport.waitForMessage()
+                        Logger.i(TAG, "Received message over Transport of length ${message.size}")
+                        conveyMessage(ByteString(message), false)
+                    }
+                } catch (e: Throwable) {
+                    mutex.withLock {
+                        failTransport(e)
+                    }
+                }
+            }
+        }
+
+        // This job is canceled in close()
+        ioJob = CoroutineScope(Dispatchers.Default).launch {
+            try {
+                while (true) {
+                    Logger.i(TAG, "Waiting for message to send over NFC")
+                    val messageToSend = writingQueue.receive()
+                    numSentViaNfc += 1
+                    Logger.i(TAG, "Sending message over NFC of length ${messageToSend.size}")
+                    val responseMessage = nfcTag.nfcV2Transact(
+                        message = messageToSend,
+                        commandDataFieldMaxLength = 65530, // TODO
+                        responseDataFieldMaxLength = 65530, // TODO
+                        onMessageSent = {
+                            sentMessagesNumViaNfc += 1
+                        }
+                    )
+                    Logger.i(TAG, "Received message over NFC of length ${responseMessage.size}")
+                    conveyMessage(responseMessage, true)
+                }
+            } catch (e: Throwable) {
+                if (negotiatedTransport != null) {
+                    Logger.w(TAG, "Error while transacting on NFC - continuing on non-NFC transport", e)
+                    nfcNotAvailable = true
+                } else {
+                    mutex.withLock {
+                        failTransport(e)
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun sendMessage(message: ByteArray) {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+        }
+        if (!nfcNotAvailable) {
+            writingQueue.send(ByteString(message))
+        }
+
+        if (negotiatedTransport != null) {
+            if (negotiatedTransport.state.value == State.CONNECTED) {
+                try {
+                    negotiatedTransport.sendMessage(message)
+                    Logger.i(TAG, "Sending message over Transport of length ${message.size}")
+                    numSentViaTransport += 1
+                } catch (e: Throwable) {
+                    mutex.withLock {
+                        failTransport(e)
+                    }
+                    throw e
+                }
+            } else {
+                negotiatedTransportPendingOutgoingMessages.add(ByteString(message))
+            }
+        }
+        numSent += 1
+    }
+
+    override suspend fun waitForMessage(): ByteArray {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+        }
+        try {
+            return incomingMessages.receive().toByteArray()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            if (_state.value == State.CLOSED) {
+                throw MdocTransportClosedException("Transport was closed while waiting for message")
+            } else {
+                mutex.withLock {
+                    failTransport(error)
+                }
+                throw MdocTransportException("Failed while waiting for message", error)
+            }
+        }
+    }
+
+    override suspend fun close() {
+        mutex.withLock {
+            if (_state.value == State.CLOSED) {
+                return
+            }
+        }
+        mutex.withLock {
+            // Wait 500ms with canceling the I/O job to give the last sent message a chance to be sent. This
+            // is very common because a mdoc reader typically receives a response, then sends session a termination
+            // message, and then immediately closes the connection.
+            val tag = nfcTag
+            ioJob?.let {
+                CoroutineScope(Dispatchers.Default).launch {
+                    delay(500.milliseconds)
+                    it.cancel()
+                    tag.close()
+                }
+            } ?: tag.close()
+            ioJob = null
+            incomingMessages.close()
+            negotiatedTransportOpenJob?.cancel()
+            negotiatedTransportOpenJob = null
+            negotiatedTransport?.close()
+            if (_state.value != State.FAILED) {
+                _state.value = State.CLOSED
+            }
+        }
+    }
+
+    private var inError = false
+
+    private fun failTransport(error: Throwable) {
+        check(mutex.isLocked) { "failTransport called without holding lock" }
+        inError = true
+        if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+            return
+        }
+        Logger.w(TAG, "Failing transport with error", error)
+        incomingMessages.close(error)
+        ioJob?.cancel()
+        ioJob = null
+        incomingMessages.close()
+        _state.value = State.FAILED
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportStats.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportStats.kt
@@ -1,0 +1,27 @@
+package org.multipaz.mdoc.transport
+
+import org.multipaz.cbor.annotation.CborSerializable
+
+/**
+ * Count of messages sent and received on [NfcHybridTransportMdoc] and [NfcHybridTransportMdocReader] transports.
+ *
+ * @property numSent number of messages sent.
+ * @property numSentViaNfc number of messages sent via NFC channel.
+ * @property numSentViaTransport number of messages sent via Transport channel.
+ * @property numReceived number of messages received.
+ * @property numReceivedFirstOnNfc number of messages received on NFC before receiving on Transport.
+ * @property numReceivedFirstOnTransport number of messages received on Transport before receiving on NFC.
+ * @property nfcDisconnectedDuringTransaction true if NFC disconnected during the transaction.
+ */
+@CborSerializable
+data class NfcHybridTransportStats(
+    val numSent: Int,
+    val numSentViaNfc: Int,
+    val numSentViaTransport: Int,
+    val numReceived: Int,
+    val numReceivedFirstOnNfc: Int,
+    val numReceivedFirstOnTransport: Int,
+    val nfcDisconnectedDuringTransaction: Boolean
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
@@ -316,11 +316,11 @@ class NfcTransportMdoc(
                 Nfc.INS_ENVELOPE -> return processEnvelope(command)
                 Nfc.INS_GET_RESPONSE -> return processGetResponse(command)
             }
-            failTransport(Error("Command APDU $command not supported, returning 6d00"))
+            failTransport(IllegalStateException("Command APDU $command not supported, returning 6d00"))
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
         } catch (error: Exception) {
             error.printStackTrace()
-            failTransport(Error("Error processing APDU: ${error.message}", error))
+            failTransport(IllegalStateException("Error processing APDU: ${error.message}", error))
             val status = if (error is NfcError) {
                 error.status
             } else {
@@ -333,7 +333,7 @@ class NfcTransportMdoc(
     internal suspend fun onDeactivated() {
         mutex.withLock {
             instances.remove(this)
-            failTransport(Error("onDeactivated"))
+            failTransport(IllegalStateException("onDeactivated"))
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/Nfc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/Nfc.kt
@@ -16,6 +16,10 @@ object Nfc {
      */
     val NDEF_APPLICATION_ID = ByteString("D2760000850101".fromHex())
 
+    /** To be defined in 18013-5 Second Edition.
+     */
+    val MDOC_NFC_ENGAGEMENT_V2_AID = ByteString("A0000002480401".fromHex())
+
     /**
      * The Application ID for ISO mdoc NFC data transfer.
      *

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
@@ -49,9 +49,10 @@ abstract class NfcIsoTag {
      * Selects an application according to ISO 7816-4 clause 11.2.2.
      *
      * @param applicationId the application to select, e.g. [Nfc.NDEF_APPLICATION_ID].
+     * @return the response APDU.
      * @throws NfcCommandFailedException if the command fails.
      */
-    suspend fun selectApplication(applicationId: ByteString) {
+    suspend fun selectApplication(applicationId: ByteString): ResponseApdu {
         // ISO 7816-4 clause 11.2.2
         val response = transceive(
             CommandApdu(
@@ -66,6 +67,7 @@ abstract class NfcIsoTag {
         if (response.status != Nfc.RESPONSE_STATUS_SUCCESS) {
             throw NfcCommandFailedException("Error selecting application, status ${response.statusHexString}", response.status)
         }
+        return response
     }
 
     /**
@@ -183,12 +185,14 @@ abstract class NfcIsoTag {
      * @param ndefMessage the message to write.
      * @param wtInt Minimum waiting time as per NFC Forum Tag NDEF Exchange Protocol section 4.1.6.
      * @param nWait Maximum number of waiting time extensions as per NFC Forum Tag NDEF Exchange Protocol section 4.1.7.
+     * @param onMessageSent Optional callback to make when the message has been sent.
      * @return the message which was read.
      */
     suspend fun ndefTransact(
         ndefMessage: NdefMessage,
         wtInt: Int,
-        nWait: Int
+        nWait: Int,
+        onMessageSent: (suspend () -> Unit)? = null
     ): NdefMessage {
         val encodedNdefMessage = ndefMessage.encode()
 
@@ -233,6 +237,10 @@ abstract class NfcIsoTag {
         }
         val tWait = Duration.fromWtInt(wtInt)
         delay(tWait)
+
+        if (onMessageSent != null) {
+            onMessageSent()
+        }
 
         // Now read NDEF file...
         return ndefReadMessage(wtInt, nWait)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -79,7 +79,7 @@ suspend fun Iso18013Presentment(
                 it == MdocTransport.State.CLOSED
     }
     if (transport.state.value != MdocTransport.State.CONNECTED) {
-        throw Error("Expected state CONNECTED but found ${transport.state.value}")
+        throw IllegalStateException("Expected state CONNECTED but found ${transport.state.value}")
     }
     //Logger.iCbor(TAG, "DeviceEngagement", mechanism.encodedDeviceEngagement.toByteArray())
     var numRequestsServed = 0

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -141,7 +141,7 @@ suspend fun digitalCredentialsPresentment(
             )
         }
         else -> {
-            throw Error("Protocol $protocol is not supported")
+            throw IllegalStateException("Protocol $protocol is not supported")
         }
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelperTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelperTest.kt
@@ -1,0 +1,348 @@
+package org.multipaz.mdoc.nfc
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.EcPrivateKeyDoubleCoordinate
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfcV2
+import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.mdoc.sessionencryption.SessionEncryption
+import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.transport.NfcHybridTransportMdoc
+import org.multipaz.mdoc.transport.NfcHybridTransportMdocReader
+import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.NfcIsoTag
+import org.multipaz.nfc.ResponseApdu
+import org.multipaz.util.Constants
+import org.multipaz.util.UUID
+import org.multipaz.util.fromHex
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Duration
+
+private const val TAG = "MdocNfcV2EngagementHelperTest"
+
+/**
+ * This test is mainly for verifying the correct functionality of MdocNfcV2EngagementHelper (the wallet side)
+ * but it also exercises and verifies mdocReaderNfcHandover() and other things on the reader side.
+ */
+class MdocNfcV2EngagementHelperTest {
+
+    // Provides access to MdocNfcV2EngagementHelper via NfcIsoTag abstraction
+    class LoopbackIsoTag(val engagementHelper: MdocNfcV2EngagementHelper): NfcIsoTag() {
+        val transcript = StringBuilder()
+
+        override val maxTransceiveLength: Int
+            get() = 65536
+
+        override suspend fun close() {
+            transcript.appendLine("close")
+        }
+
+        override suspend fun updateDialogMessage(message: String) {}
+
+        override suspend fun transceive(command: CommandApdu): ResponseApdu {
+            transcript.appendLine("$command")
+            val response = engagementHelper.processApdu(command)
+            transcript.appendLine("$response")
+            return response
+        }
+    }
+
+    private suspend fun getEDeviceKey(): EcPrivateKey {
+        return EcPrivateKeyDoubleCoordinate(
+            curve = EcCurve.P256,
+            x = "711b420f708e686917b799e5991346c318a6bd89ac32d04e78cb537cd89dcaa9".fromHex(),
+            y = "1b99557fca9a63617246669eababc7a36068db058e9c98b067a5eba3233b451c".fromHex(),
+            d = "18c78253d73ceb03088a1b3a9a14317aef2af89ea0d6a435eaac3fc19d5fe02d".fromHex()
+        )
+    }
+
+    private suspend fun getEReaderKey(): EcPrivateKey {
+        return EcPrivateKeyDoubleCoordinate(
+            curve = EcCurve.P256,
+            x = "db1b6d2cc5e6baebd12fb76d4fa40957659832e41cade15db9038f37ef5ba321".fromHex(),
+            y = "b0361e208471bb94a687089c4957fc4d9983abe04cdeeb155bcd690640137727".fromHex(),
+            d = "4e1238f4f265bf02e63af384690940ddf67a9d19577119a48e78fcc4a3fed971".fromHex()
+        )
+    }
+
+    @Test
+    fun testNfcOnly() = runTest {
+        val eDeviceKey = getEDeviceKey()
+        val eReaderKey = getEReaderKey()
+
+        lateinit var mdocReaderTransport: NfcHybridTransportMdocReader
+        lateinit var mdocTransport: NfcHybridTransportMdoc
+
+        var handoverComplete = false
+        val engagementHelper = MdocNfcV2EngagementHelper(
+            eDeviceKey = eDeviceKey.publicKey,
+            onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
+                handoverComplete = true
+            },
+            onMessageReceived = {
+                message -> mdocTransport.onMessageReceivedViaNfc(message)
+            },
+            onError = { error ->
+                fail("onError should not be called with $error")
+            },
+            negotiatedHandoverPicker = { connectionMethods ->
+                assertEquals(1, connectionMethods.size)
+                assertTrue(connectionMethods.first() is MdocConnectionMethodNfcV2)
+                connectionMethods.first()
+            },
+        )
+
+        val tag = LoopbackIsoTag(engagementHelper)
+        val handoverResult = mdocReaderNfcHandover(
+            tag = tag,
+            negotiatedHandoverConnectionMethods = emptyList(),
+            options = MdocReaderNfcHandoverOptions(useNfcV2 = true)
+        )
+        assertNotNull(handoverResult)
+        assertEquals(1, handoverResult.connectionMethods.size)
+        assertEquals(MdocHandoverType.V2_HANDOVER, handoverResult.type)
+        assertTrue(handoverResult.connectionMethods.first() is MdocConnectionMethodNfcV2)
+
+        assertTrue(handoverComplete)
+
+        mdocReaderTransport = NfcHybridTransportMdocReader(
+            nfcTag = tag,
+            negotiatedTransport = null
+        )
+        mdocReaderTransport.open(eReaderKey.publicKey)
+
+        mdocTransport = NfcHybridTransportMdoc(
+            sendMessageViaNfc = {
+                message -> engagementHelper.sendMessage(message)
+                true
+            }
+        )
+        mdocTransport.open(eDeviceKey.publicKey)
+
+        val request = Cbor.encode(buildCborMap {
+            put("data", Bstr(byteArrayOf(1, 2, 3)))
+        })
+        mdocReaderTransport.sendMessage(request)
+        assertContentEquals(request, mdocTransport.waitForMessage())
+
+        val response = Cbor.encode(buildCborMap {
+            put("data", Bstr(byteArrayOf(1, 2, 3, 4)))
+        })
+        mdocTransport.sendMessage(response)
+        assertContentEquals(response, mdocReaderTransport.waitForMessage())
+
+        val sessionTermination = SessionEncryption.encodeStatus(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)
+
+        mdocReaderTransport.sendMessage(sessionTermination)
+        assertContentEquals(sessionTermination, mdocTransport.waitForMessage())
+
+        assertEquals(
+            """
+                CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=a0000002480401), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=7 hex=a1001a00010000))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=17 hex=530fa100a10281830501a1001a00010000), le=65536)
+                ResponseApdu(status=36864, payload=ByteString(size=104 hex=5366a100a30063312e30018201d818584ba401022001215820711b420f708e686917b799e5991346c318a6bd89ac32d04e78cb537cd89dcaa92258201b99557fca9a63617246669eababc7a36068db058e9c98b067a5eba3233b451c0281830501a1001a00010000))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=12 hex=530aa1646461746143010203), le=65530)
+                ResponseApdu(status=36864, payload=ByteString(size=13 hex=530ba164646174614401020304))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=11 hex=5309a16673746174757314), le=65530)
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
+        )
+    }
+
+    class LoopbackTransport(
+        override val role: MdocRole,
+        override val connectionMethod: MdocConnectionMethod,
+        val incomingMessages: Channel<ByteString>,
+        val outgoingMessages: Channel<ByteString>
+    ): MdocTransport() {
+
+        val mutableState = MutableStateFlow<State>(State.IDLE)
+
+        override val state = mutableState.asStateFlow()
+
+        override val scanningTime: Duration?
+            get() = TODO("Not yet implemented")
+
+        override suspend fun advertise() {}
+
+        private var closed = false
+
+        override suspend fun close() {
+            closed = true
+        }
+
+        override suspend fun open(eSenderKey: EcPublicKey) {
+        }
+
+        override suspend fun sendMessage(message: ByteArray) {
+            outgoingMessages.send(ByteString(message))
+        }
+
+        override suspend fun waitForMessage(): ByteArray {
+            return incomingMessages.receive().toByteArray()
+        }
+    }
+
+    @Test
+    fun testWithBle() = runTest {
+        val eDeviceKey = getEDeviceKey()
+        val eReaderKey = getEReaderKey()
+
+        lateinit var mdocReaderTransport: NfcHybridTransportMdocReader
+        lateinit var mdocTransport: NfcHybridTransportMdoc
+
+        val methods = listOf(MdocConnectionMethodBle(
+            supportsPeripheralServerMode = false,
+            supportsCentralClientMode = true,
+            peripheralServerModeUuid = null,
+            centralClientModeUuid = UUID(1UL, 2UL),
+            peripheralServerModePsm = 192,
+            peripheralServerModeMacAddress = null
+        ))
+
+        var handoverComplete = false
+        val engagementHelper = MdocNfcV2EngagementHelper(
+            eDeviceKey = eDeviceKey.publicKey,
+            onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
+                handoverComplete = true
+            },
+            onMessageReceived = {
+                    message -> mdocTransport.onMessageReceivedViaNfc(message)
+            },
+            onError = { error ->
+                fail("onError should not be called with $error")
+            },
+            negotiatedHandoverPicker = { connectionMethods ->
+                assertEquals(2, connectionMethods.size)
+                assertTrue(connectionMethods.first() is MdocConnectionMethodNfcV2)
+                assertEquals(methods.first(), connectionMethods[1])
+                // Pick the BLE method
+                connectionMethods[1]
+            },
+        )
+
+        val tag = LoopbackIsoTag(engagementHelper)
+        val handoverResult = mdocReaderNfcHandover(
+            tag = tag,
+            negotiatedHandoverConnectionMethods = methods,
+            options = MdocReaderNfcHandoverOptions(useNfcV2 = true)
+        )
+        assertNotNull(handoverResult)
+        assertEquals(MdocHandoverType.V2_HANDOVER, handoverResult.type)
+        assertEquals(1, handoverResult.connectionMethods.size)
+        assertEquals(methods.first(), handoverResult.connectionMethods[0])
+
+        assertTrue(handoverComplete)
+
+        val mdocToReader = Channel<ByteString>(Channel.UNLIMITED)
+        val readerToMdoc = Channel<ByteString>(Channel.UNLIMITED)
+
+        val bleMdocReaderTransport = LoopbackTransport(
+            role = MdocRole.MDOC_READER,
+            connectionMethod = methods[0],
+            incomingMessages = mdocToReader,
+            outgoingMessages = readerToMdoc
+        )
+
+        val bleMdocTransport = LoopbackTransport(
+            role = MdocRole.MDOC,
+            connectionMethod = methods[0],
+            incomingMessages = readerToMdoc,
+            outgoingMessages = mdocToReader
+        )
+
+        mdocReaderTransport = NfcHybridTransportMdocReader(
+            nfcTag = tag,
+            negotiatedTransport = bleMdocReaderTransport
+        )
+        mdocReaderTransport.open(eReaderKey.publicKey)
+
+        mdocTransport = NfcHybridTransportMdoc(
+            sendMessageViaNfc = { message ->
+                engagementHelper.sendMessage(message)
+                true
+            }
+        )
+        mdocTransport.open(eDeviceKey.publicKey)
+        mdocTransport.setTransport(bleMdocTransport)
+
+        val request = Cbor.encode(buildCborMap {
+            put("data", Bstr(byteArrayOf(1, 2, 3)))
+        })
+        mdocReaderTransport.sendMessage(request)
+        assertContentEquals(request, mdocTransport.waitForMessage())
+
+        val response = Cbor.encode(buildCborMap {
+            put("data", Bstr(byteArrayOf(1, 2, 3, 4)))
+        })
+        mdocTransport.sendMessage(response)
+        assertContentEquals(response, mdocReaderTransport.waitForMessage())
+
+        val sessionTermination = SessionEncryption.encodeStatus(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)
+
+        mdocReaderTransport.sendMessage(sessionTermination)
+        assertContentEquals(sessionTermination, mdocTransport.waitForMessage())
+
+        mdocTransport.sendMessage(sessionTermination)
+        assertContentEquals(sessionTermination, mdocReaderTransport.waitForMessage())
+
+        /* TODO
+        assertEquals(
+            """
+                CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=a0000002480401), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=5 hex=a10019fde8))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=19 hex=5311a100a10281830501a20019fde80119fde8), le=65536)
+                ResponseApdu(status=36864, payload=ByteString(size=106 hex=5368a100a30063312e30018201d818584ba401022001215820711b420f708e686917b799e5991346c318a6bd89ac32d04e78cb537cd89dcaa92258201b99557fca9a63617246669eababc7a36068db058e9c98b067a5eba3233b451c0281830501a20019fde80119fde8))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=12 hex=530aa1646461746143010203), le=65530)
+                ResponseApdu(status=36864, payload=ByteString(size=13 hex=530ba164646174614401020304))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=11 hex=5309a16673746174757314), le=65530)
+                ResponseApdu(status=36864, payload=ByteString(size=11 hex=5309a16673746174757314))
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
+        )
+         */
+    }
+}
+
+fun CoroutineScope.pipeChannels(
+    source: ReceiveChannel<ByteString>,
+    destination: SendChannel<ByteString>
+) = launch {
+    try {
+        // consumeEach automatically cancels the source channel if an exception
+        // is thrown inside the block (e.g., if the destination closes early).
+        source.consumeEach { chunk ->
+            destination.send(chunk)
+        }
+
+        // If the source finishes normally, close the destination normally.
+        destination.close()
+    } catch (e: Throwable) {
+        // If anything fails, close the destination with the exception.
+        destination.close(e)
+    }
+}

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
@@ -241,14 +241,14 @@ internal class BleCentralManagerIos : BleCentralManager {
         override fun peripheral(peripheral: CBPeripheral, didModifyServices: List<*>) {
             val invalidatedServices = didModifyServices
             Logger.d(TAG, "peripheral:didModifyServices invalidatedServices=${invalidatedServices}")
-            onError(Error("Remote service vanished"))
+            onError(IllegalStateException("Remote service vanished"))
         }
 
         override fun peripheral(peripheral: CBPeripheral, didOpenL2CAPChannel: CBL2CAPChannel?, error: NSError?) {
             Logger.d(TAG, "peripheralDidOpenL2CAPChannel")
             if (waitFor?.state == WaitState.OPEN_L2CAP_CHANNEL) {
                 if (error != null) {
-                    resumeWaitWithException(Error("peripheralDidOpenL2CAPChannel failed", error.toKotlinError()))
+                    resumeWaitWithException(IllegalStateException("peripheralDidOpenL2CAPChannel failed", error.toKotlinError()))
                 } else {
                     this@BleCentralManagerIos.l2capChannel = didOpenL2CAPChannel
                     resumeWait()
@@ -274,7 +274,7 @@ internal class BleCentralManagerIos : BleCentralManager {
                 CBCharacteristicWriteWithoutResponse
             )
             if (peripheral!!.canSendWriteWithoutResponse) {
-                throw Error("canSendWriteWithoutResponse is true right after writing value")
+                throw IllegalStateException("canSendWriteWithoutResponse is true right after writing value")
             }
         }
     }
@@ -286,7 +286,7 @@ internal class BleCentralManagerIos : BleCentralManager {
 
     private fun handleIncomingData(chunk: ByteArray) {
         if (chunk.size < 1) {
-            throw Error("Invalid data length ${chunk.size} for Server2Client characteristic")
+            throw IllegalStateException("Invalid data length ${chunk.size} for Server2Client characteristic")
         }
         incomingMessage.append(chunk, 1, chunk.size)
         when {
@@ -310,7 +310,7 @@ internal class BleCentralManagerIos : BleCentralManager {
             }
 
             else -> {
-                throw Error(
+                throw IllegalStateException(
                     "Invalid first byte ${chunk[0]} in Server2Client data chunk, " +
                             "expected 0 or 1"
                 )
@@ -330,7 +330,7 @@ internal class BleCentralManagerIos : BleCentralManager {
                 if (centralManager.state == CBCentralManagerStatePoweredOn) {
                     resumeWait()
                 } else {
-                    resumeWaitWithException(Error("Excepted poweredOn, got ${centralManager.state}"))
+                    resumeWaitWithException(IllegalStateException("Excepted poweredOn, got ${centralManager.state}"))
                 }
             } else {
                 Logger.w(TAG, "CBCentralManagerDelegate didUpdateState callback but not waiting")
@@ -380,7 +380,7 @@ internal class BleCentralManagerIos : BleCentralManager {
         ) {
             Logger.d(TAG, "didDisconnectPeripheral: peripheral=$didDisconnectPeripheral timestamp=${timestamp} " +
                     "isReconnecting=$isReconnecting error=${error?.toKotlinError()}")
-            onError(Error("Peripheral unexpectedly disconnected"))
+            onError(IllegalStateException("Peripheral unexpectedly disconnected"))
         }
     }
 
@@ -533,7 +533,7 @@ internal class BleCentralManagerIos : BleCentralManager {
         val identValue = identCharacteristic!!.value!!.toByteArray()
         if (!(expectedIdentValue contentEquals identValue)) {
             close()
-            throw Error(
+            throw IllegalStateException(
                 "Ident doesn't match, expected ${expectedIdentValue.toHex()} " +
                         " got ${identValue.toHex()}"
             )
@@ -634,7 +634,7 @@ internal class BleCentralManagerIos : BleCentralManager {
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            onError(Error("Reading from L2CAP channel failed", e))
+            onError(IllegalStateException("Reading from L2CAP channel failed", e))
         }
     }
 

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
@@ -140,7 +140,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
 
     private fun handleIncomingData(chunk: ByteArray) {
         if (chunk.size < 1) {
-            throw Error("Invalid data length ${chunk.size} for Client2Server characteristic")
+            throw IllegalStateException("Invalid data length ${chunk.size} for Client2Server characteristic")
         }
         incomingMessage.append(chunk, 1, chunk.size)
         when {
@@ -161,7 +161,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
             }
 
             else -> {
-                throw Error("Invalid first byte ${chunk[0]} in Client2Server data chunk, " +
+                throw IllegalStateException("Invalid first byte ${chunk[0]} in Client2Server data chunk, " +
                             "expected 0 or 1")
             }
         }
@@ -175,7 +175,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
                 if (peripheralManager.state == CBPeripheralManagerStatePoweredOn) {
                     resumeWait()
                 } else {
-                    resumeWaitWithException(Error("Excepted poweredOn, got ${peripheralManager.state}"))
+                    resumeWaitWithException(IllegalStateException("Excepted poweredOn, got ${peripheralManager.state}"))
                 }
             }
         }
@@ -194,7 +194,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
                                 BleTransportConstants.STATE_CHARACTERISTIC_START.toByte()
                         ))) {
                             resumeWaitWithException(
-                                Error("Expected 0x01 to be written to state characteristic, got ${data.toHex()}")
+                                IllegalStateException("Expected 0x01 to be written to state characteristic, got ${data.toHex()}")
                             )
                         } else {
                             // Now that the central connected, figure out how big the buffer is for writes.
@@ -223,7 +223,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
                         handleIncomingData(data)
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
-                        onError(Error("Error processing incoming data", e))
+                        onError(IllegalStateException("Error processing incoming data", e))
                     }
                 } else {
                     Logger.w(TAG, "Unexpected write to characteristic with UUID " +
@@ -236,7 +236,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
             val attRequest = didReceiveReadRequest
             if (attRequest.characteristic == identCharacteristic) {
                 if (identValue == null) {
-                    onError(Error("Received request for ident before it's set.."))
+                    onError(IllegalStateException("Received request for ident before it's set.."))
                 } else {
                     attRequest.value = identValue!!.toNSData()
                     peripheralManager.respondToRequest(attRequest, CBATTErrorSuccess)
@@ -258,7 +258,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
             Logger.i(TAG, "peripheralManager didPublishL2CAPChannel")
             if (waitFor?.state == WaitState.PUBLISH_L2CAP_CHANNEL) {
                 if (error != null) {
-                    resumeWaitWithException(Error("peripheralManager didPublishL2CAPChannel failed", error.toKotlinError()))
+                    resumeWaitWithException(IllegalStateException("peripheralManager didPublishL2CAPChannel failed", error.toKotlinError()))
                 } else {
                     _l2capPsm = didPublishL2CAPChannel.toInt()
                     resumeWait()
@@ -497,7 +497,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            onError(Error("Reading from L2CAP channel failed", e))
+            onError(IllegalStateException("Reading from L2CAP channel failed", e))
         }
     }
 

--- a/samples/testapp/iosApp/TestApp/Info.plist
+++ b/samples/testapp/iosApp/TestApp/Info.plist
@@ -148,6 +148,7 @@
 		<string>D2760000850101</string>
 		<string>A0000002471001</string>
 		<string>A0000002480400</string>
+		<string>A0000002480401</string>
 	</array>
     <key>UTExportedTypeDeclarations</key>
     <array>

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -196,6 +196,20 @@
         </service>
 
         <service
+            android:name=".TestAppMdocNfcV2Service"
+            android:exported="true"
+            android:label="@string/nfc_mdoc_engagement_service_aid_group_description"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/nfc_mdoc_nfcv2_service" />
+        </service>
+
+        <service
             android:name=".NfcObserveModeHelperService"
             android:exported="true"
             android:label="@string/nfc_ndef_service_description"

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcV2Service.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcV2Service.kt
@@ -1,0 +1,43 @@
+package org.multipaz.testapp
+
+import org.multipaz.compose.mdoc.MdocNfcV2Service
+import org.multipaz.compose.prompt.PresentmentActivity
+import org.multipaz.mdoc.transport.MdocTransportOptions
+import org.multipaz.util.Logger
+import kotlin.time.Clock
+
+private const val TAG = "TestAppMdocNfcV2Service"
+
+class TestAppMdocNfcV2Service: MdocNfcV2Service() {
+    override suspend fun getSettings(): MdocNfcV2Service.Settings {
+        // TODO: optimize initialization of App so we can just get settingsModel and presentmentSource() out
+        val t0 = Clock.System.now()
+        val app = App.getInstance()
+        app.initialize()
+        val t1 = Clock.System.now()
+        Logger.i(TAG, "App initialized in ${(t1 - t0).inWholeMilliseconds} ms")
+
+        TestAppConfiguration.cryptoInit(app.settingsModel)
+
+        val source = app.getPresentmentSource()
+        PresentmentActivity.presentmentModel.reset(
+            source = source,
+            // TODO: if user is currently selecting a document, pass it here
+            preselectedDocuments = emptyList()
+        )
+
+        return Settings(
+            source = app.getPresentmentSource(),
+            promptModel = PresentmentActivity.promptModel,
+            presentmentModel = PresentmentActivity.presentmentModel,
+            activityClass = PresentmentActivity::class.java,
+            sessionEncryptionCurve = app.settingsModel.presentmentSessionEncryptionCurve.value,
+            useNegotiatedHandover = app.settingsModel.presentmentUseNegotiatedHandover.value,
+            negotiatedHandoverPreferredOrder = app.settingsModel.presentmentNegotiatedHandoverPreferredOrder.value,
+            transportOptions = MdocTransportOptions(
+                bleUseL2CAP = app.settingsModel.presentmentBleL2CapEnabled.value,
+                bleUseL2CAPInEngagement = app.settingsModel.presentmentBleL2CapInEngagementEnabled.value
+            ),
+        )
+    }
+}

--- a/samples/testapp/src/androidMain/res/values/strings.xml
+++ b/samples/testapp/src/androidMain/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="nfc_ndef_service_description">@string/app_name</string>
     <string name="nfc_ndef_service_aid_group_description">ISO/IEC 18013-5:2021 NFC engagement</string>
     <string name="mdoc_nfc_data_transfer_service_aid_group_description">ISO/IEC 18013-5:2021 NFC data transfer</string>
+    <string name="nfc_mdoc_engagement_service_aid_group_description">ISO/IEC 18013-5 Second Edition NFC v2 engagement</string>
     <string name="quick_access_wallet_empty_state_text">No Cards</string>
     <string name="quick_access_wallet_button_text">@string/app_name</string>
 </resources>

--- a/samples/testapp/src/androidMain/res/xml/nfc_mdoc_nfcv2_service.xml
+++ b/samples/testapp/src/androidMain/res/xml/nfc_mdoc_nfcv2_service.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- NOTE: This app uses made-up credentials so it's not a concern to handle credential
+           requests on the lock screen because there is no PII. For an app with real
+           user data it might be a privacy problem to show PII on the lock screen.
+-->
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:description="@string/nfc_ndef_service_description"
+    android:requireDeviceUnlock="false"
+    android:requireDeviceScreenOn="false"
+    tools:ignore="UnusedAttribute">
+
+    <aid-group android:description="@string/nfc_mdoc_engagement_service_aid_group_description" android:category="other">
+        <!--  -->
+        <aid-filter android:name="A0000002480401"/>
+    </aid-group>
+
+</host-apdu-service>

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ShowResponseMetadata.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ShowResponseMetadata.kt
@@ -1,6 +1,7 @@
 package org.multipaz.testapp
 
 import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.mdoc.transport.NfcHybridTransportStats
 
 @CborSerializable
 data class ShowResponseMetadata(
@@ -10,7 +11,8 @@ data class ShowResponseMetadata(
     val responseSize: Long,
     val durationMsecNfcTapToEngagement: Long?,
     val durationMsecEngagementReceivedToRequestSent: Long?,
-    val durationMsecRequestSentToResponseReceived: Long
+    val durationMsecRequestSentToResponseReceived: Long,
+    val nfcHybridTransportStats: NfcHybridTransportStats?
 ) {
     companion object
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -171,6 +171,8 @@ class TestAppSettingsModel private constructor(
         bind(observeModeEmitPollingFramesAsReader, "observeModeEmitPollingFramesAsReader", false)
 
         bind(currentlyFocusedDocumentId, "currentlyFocusedDocumentId", "")
+
+        bind(signRequest, "signRequest", true)
     }
 
     val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
@@ -201,6 +203,7 @@ class TestAppSettingsModel private constructor(
     val observeModeEnabled = MutableStateFlow<Boolean>(false)
     val observeModeEmitPollingFramesAsReader = MutableStateFlow<Boolean>(false)
     val currentlyFocusedDocumentId = MutableStateFlow<String>("")
+    val signRequest = MutableStateFlow<Boolean>(true)
 }
 
 // Default to our open CSA, where "open" means it'll work with even unlocked bootloaders

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -104,6 +104,7 @@ object TestAppUtils {
         request: DocumentCannedRequest,
         encodedSessionTranscript: ByteArray,
         readerKey: AsymmetricKey.X509Compatible,
+        signRequest: Boolean = true,
         zkSystemRepository: ZkSystemRepository? = null,
     ): ByteArray {
         val deviceRequest = when (request) {
@@ -138,15 +139,26 @@ object TestAppUtils {
                                 taggedItem = Cbor.encode(transactionData.attributes).toDataItem()
                             )
                         }
-                        addDocRequest(
-                            docType = mdocRequest.docType,
-                            nameSpaces = itemsToRequest,
-                            docRequestInfo = DocRequestInfo(
-                                zkRequest = zkRequest,
-                                otherInfo = otherInfo
-                            ),
-                            readerKey = readerKey,
-                        )
+                        if (signRequest) {
+                            addDocRequest(
+                                docType = mdocRequest.docType,
+                                nameSpaces = itemsToRequest,
+                                docRequestInfo = DocRequestInfo(
+                                    zkRequest = zkRequest,
+                                    otherInfo = otherInfo
+                                ),
+                                readerKey = readerKey,
+                            )
+                        } else {
+                            addDocRequest(
+                                docType = mdocRequest.docType,
+                                nameSpaces = itemsToRequest,
+                                docRequestInfo = DocRequestInfo(
+                                    zkRequest = zkRequest,
+                                    otherInfo = otherInfo
+                                )
+                            )
+                        }
                     }
                 }
             }
@@ -155,7 +167,9 @@ object TestAppUtils {
                     sessionTranscript = RawCbor(encodedSessionTranscript),
                     dcql = Json.decodeFromString<JsonObject>( request.dcqlString)
                 ) {
-                    addReaderAuthAll(readerKey)
+                    if (signRequest) {
+                        addReaderAuthAll(readerKey)
+                    }
                 }
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsClient.kt
@@ -43,7 +43,7 @@ class MultiDeviceTestsClient(
             val cmd = receiveChannel.readUTF8Line(LINE_LIMIT)
             Logger.i(TAG, "Received command '$cmd'")
             if (cmd == null) {
-                throw Error("Receive channel was closed")
+                throw IllegalStateException("Receive channel was closed")
             } else if (cmd == "Done") {
                 break
             } else if (cmd.startsWith("TestPresentationPrepare ")) {
@@ -116,7 +116,7 @@ class MultiDeviceTestsClient(
                             Test.MDOC_PERIPHERAL_SERVER_MODE_L2CAP_PSM_IN_DEVICE_ENGAGEMENT -> {
                                 // Expects termination in initial message
                                 if (statusCode != Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
-                                    throw Error("Expected status 20, got $statusCode")
+                                    throw IllegalStateException("Expected status 20, got $statusCode")
                                 }
                             }
                             Test.MDOC_CENTRAL_CLIENT_MODE_HOLDER_TERMINATION_MSG,
@@ -124,25 +124,25 @@ class MultiDeviceTestsClient(
                             Test.MDOC_CENTRAL_CLIENT_MODE_L2CAP_HOLDER_TERMINATION_MSG,
                             Test.MDOC_PERIPHERAL_SERVER_MODE_L2CAP_HOLDER_TERMINATION_MSG -> {
                                 if (statusCode != null) {
-                                    throw Error("Expected status to be unset got $statusCode")
+                                    throw IllegalStateException("Expected status to be unset got $statusCode")
                                 }
                                 val (deviceResponse, statusCode) = sessionEncryption.decryptMessage(
                                     transport.waitForMessage()
                                 )
                                 if (deviceResponse != null ||
                                     statusCode != Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
-                                    throw Error("Expected empty message and status 20")
+                                    throw IllegalStateException("Expected empty message and status 20")
                                 }
                             }
                             Test.MDOC_CENTRAL_CLIENT_MODE_HOLDER_TERMINATION_BLE,
                             Test.MDOC_PERIPHERAL_SERVER_MODE_HOLDER_TERMINATION_BLE -> {
                                 if (statusCode != null) {
-                                    throw Error("Expected status to be unset got $statusCode")
+                                    throw IllegalStateException("Expected status to be unset got $statusCode")
                                 }
                                 // Expects a termination via BLE
                                 val sessionData = transport.waitForMessage()
                                 if (sessionData.isNotEmpty()) {
-                                    throw Error("Expected transport-specific termination, got non-empty message")
+                                    throw IllegalStateException("Expected transport-specific termination, got non-empty message")
                                 }
                             }
                             Test.MDOC_CENTRAL_CLIENT_MODE_READER_TERMINATION_MSG,
@@ -150,7 +150,7 @@ class MultiDeviceTestsClient(
                             Test.MDOC_CENTRAL_CLIENT_MODE_L2CAP_READER_TERMINATION_MSG,
                             Test.MDOC_PERIPHERAL_SERVER_MODE_L2CAP_READER_TERMINATION_MSG -> {
                                 if (statusCode != null) {
-                                    throw Error("Expected status to be unset got $statusCode")
+                                    throw IllegalStateException("Expected status to be unset got $statusCode")
                                 }
                                 // Expects reader to terminate via message
                                 transport.sendMessage(
@@ -160,7 +160,7 @@ class MultiDeviceTestsClient(
                             Test.MDOC_CENTRAL_CLIENT_MODE_READER_TERMINATION_BLE,
                             Test.MDOC_PERIPHERAL_SERVER_MODE_READER_TERMINATION_BLE -> {
                                 if (statusCode != null) {
-                                    throw Error("Expected status to be unset got $statusCode")
+                                    throw IllegalStateException("Expected status to be unset got $statusCode")
                                 }
                                 // Expects reader to terminate via BLE
                                 transport.sendMessage(byteArrayOf())
@@ -185,7 +185,7 @@ class MultiDeviceTestsClient(
                 }
 
             } else {
-                throw Error("Unknown command $cmd")
+                throw IllegalStateException("Unknown command $cmd")
             }
         }
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -250,7 +250,7 @@ class MultiDeviceTestsServer(
                         )
                         val (deviceRequest, statusCode) = sessionEncryption.decryptMessage(transport.waitForMessage())
                         if (deviceRequest != null || statusCode != Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
-                            throw Error("Expected empty message and status 20")
+                            throw IllegalStateException("Expected empty message and status 20")
                         }
                     }
                     Test.MDOC_CENTRAL_CLIENT_MODE_READER_TERMINATION_BLE,
@@ -264,7 +264,7 @@ class MultiDeviceTestsServer(
                         )
                         val sessionData = transport.waitForMessage()
                         if (sessionData.isNotEmpty()) {
-                            throw Error("Expected transport-specific termination, got non-empty message")
+                            throw IllegalStateException("Expected transport-specific termination, got non-empty message")
                         }
                     }
                 }
@@ -296,7 +296,7 @@ class MultiDeviceTestsServer(
         } else if (response == "TestPresentationFailed") {
             numReaderErrors += 1
         } else {
-            throw Error("Unexpected TestPresentation response '$response'")
+            throw IllegalStateException("Unexpected TestPresentation response '$response'")
         }
 
         if (holderScanningTimeMsec > 0 && readerScanningTimeMsec > 0) {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -391,7 +391,8 @@ private suspend fun doDcRequestFlow(
         responseSize = Json.encodeToString(dcResponseObject).length.toLong(),
         durationMsecNfcTapToEngagement = null,
         durationMsecEngagementReceivedToRequestSent = null,
-        durationMsecRequestSentToResponseReceived = (Clock.System.now() - t0).inWholeMilliseconds
+        durationMsecRequestSentToResponseReceived = (Clock.System.now() - t0).inWholeMilliseconds,
+        nfcHybridTransportStats = null
     )
     when (dcResponse) {
         is MdocApiDcResponse -> {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -70,9 +70,12 @@ import org.multipaz.compose.permissions.rememberBluetoothEnabledState
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import org.multipaz.documenttype.knowntypes.wellKnownMultipleDocumentRequests
 import org.multipaz.mdoc.engagement.DeviceEngagement
+import org.multipaz.mdoc.nfc.MdocHandoverType
+import org.multipaz.mdoc.nfc.MdocReaderNfcHandoverOptions
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NfcScanOptions
 import org.multipaz.nfc.NfcTagReader
+import org.multipaz.mdoc.transport.NfcHybridTransportMdocReader
 import org.multipaz.testapp.ShowResponseMetadata
 import org.multipaz.util.fromHex
 import kotlin.time.Clock
@@ -284,7 +287,8 @@ fun IsoMdocProximityReadingScreen(
                                     }
                                     transferProtocol = connectionMethod.toString()
                                     connectionMethod
-                                }
+                                },
+                                signRequest = app.settingsModel.signRequest.value
                             )
                             if (readerMostRecentDeviceResponse.value != null) {
                                 showResponse(
@@ -301,6 +305,7 @@ fun IsoMdocProximityReadingScreen(
                                         durationMsecNfcTapToEngagement = null,
                                         durationMsecEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent.value?.inWholeMilliseconds ?: 0,
                                         durationMsecRequestSentToResponseReceived = durationRequestSentToResponseReceived.value?.inWholeMilliseconds ?: 0,
+                                        nfcHybridTransportStats = null
                                     )
                                 )
                             }
@@ -388,6 +393,7 @@ fun IsoMdocProximityReadingScreen(
                                             request = requestSelected.value.request,
                                             encodedSessionTranscript = readerSessionTranscript.value!!,
                                             readerKey = app.readerKey,
+                                            signRequest = app.settingsModel.signRequest.value
                                         )
                                     readerMostRecentDeviceResponse.value = byteArrayOf()
                                     readerTransport.value!!.sendMessage(
@@ -522,147 +528,192 @@ fun IsoMdocProximityReadingScreen(
                         content = { Text("Request mdoc via QR Code") }
                     )
                 }
+
+                fun launchNfcScan(handoverOptions: MdocReaderNfcHandoverOptions, nfcOnly: Boolean) {
+                    readerJob = coroutineScope.launch {
+                        try {
+                            val negotiatedHandoverConnectionMethods = mutableListOf<MdocConnectionMethod>()
+                            if (!nfcOnly) {
+                                val bleUuid = UUID.randomUUID()
+                                if (app.settingsModel.readerBleCentralClientModeEnabled.value) {
+                                    negotiatedHandoverConnectionMethods.add(
+                                        MdocConnectionMethodBle(
+                                            supportsPeripheralServerMode = false,
+                                            supportsCentralClientMode = true,
+                                            peripheralServerModeUuid = null,
+                                            centralClientModeUuid = bleUuid,
+                                        )
+                                    )
+                                }
+                                if (app.settingsModel.readerBlePeripheralServerModeEnabled.value) {
+                                    negotiatedHandoverConnectionMethods.add(
+                                        MdocConnectionMethodBle(
+                                            supportsPeripheralServerMode = true,
+                                            supportsCentralClientMode = false,
+                                            peripheralServerModeUuid = bleUuid,
+                                            centralClientModeUuid = null,
+                                        )
+                                    )
+                                }
+                                if (app.settingsModel.readerNfcDataTransferEnabled.value) {
+                                    negotiatedHandoverConnectionMethods.add(
+                                        MdocConnectionMethodNfc(
+                                            commandDataFieldMaxLength = 0xffff,
+                                            responseDataFieldMaxLength = 0x10000
+                                        )
+                                    )
+                                }
+                            }
+
+                            val nfcScanOptions = if (app.settingsModel.observeModeEmitPollingFramesAsReader.value) {
+                                NfcScanOptions(pollingFrameData = ByteString("6a0281030000".fromHex()))
+                            } else {
+                                NfcScanOptions()
+                            }
+                            Logger.i(TAG, "nfcScanOptions: $nfcScanOptions")
+                            val reader =  readerSelected.value.getNfcTagReader()
+                            val scanResult = reader.scanMdocReader(
+                                message = "Hold near credential holder's phone.",
+                                options = MdocTransportOptions(
+                                    bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
+                                    bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value
+                                ),
+                                selectConnectionMethod = { connectionMethods ->
+                                    if (connectionMethods.size == 1) {
+                                        connectionMethods[0]
+                                    } else if (app.settingsModel.readerAutomaticallySelectTransport.value) {
+                                        showToast("Auto-selected first from $connectionMethods")
+                                        connectionMethods[0]
+                                    } else {
+                                        selectConnectionMethod(
+                                            connectionMethods,
+                                            connectionMethodPickerData
+                                        )
+                                    }
+                                },
+                                negotiatedHandoverConnectionMethods = negotiatedHandoverConnectionMethods,
+                                nfcScanOptions = nfcScanOptions,
+                                handoverOptions = handoverOptions
+                            )
+                            if (scanResult != null) {
+                                val transferProtocol = scanResult.transport.connectionMethod.toString()
+                                doReaderFlow(
+                                    app = app,
+                                    nfcTagReader = reader,
+                                    encodedDeviceEngagement = scanResult.encodedDeviceEngagement,
+                                    existingTransport = scanResult.transport,
+                                    handover = scanResult.handover,
+                                    allowMultipleRequests = app.settingsModel.readerAllowMultipleRequests.value,
+                                    bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
+                                    bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value,
+                                    showToast = showToast,
+                                    readerTransport = readerTransport,
+                                    readerSessionEncryption = readerSessionEncryption,
+                                    readerSessionTranscript = readerSessionTranscript,
+                                    readerMostRecentDeviceRequest = readerMostRecentDeviceRequest,
+                                    readerMostRecentDeviceResponse = readerMostRecentDeviceResponse,
+                                    eReaderKey = eReaderKey,
+                                    durationEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent,
+                                    durationRequestSentToResponseReceived = durationRequestSentToResponseReceived,
+                                    requestSelected = requestSelected,
+                                    selectConnectionMethod = { connectionMethods ->
+                                        if (app.settingsModel.readerAutomaticallySelectTransport.value) {
+                                            showToast("Auto-selected first from $connectionMethods")
+                                            connectionMethods[0]
+                                        } else {
+                                            selectConnectionMethod(
+                                                connectionMethods,
+                                                connectionMethodPickerData
+                                            )
+                                        }
+                                    },
+                                    signRequest = app.settingsModel.signRequest.value
+                                )
+                                readerJob = null
+                                if (readerMostRecentDeviceResponse.value != null) {
+                                    with(Dispatchers.Main) {
+                                        val nfcEngagementType = when (scanResult.type) {
+                                            MdocHandoverType.STATIC_HANDOVER -> "NFC Static Handover"
+                                            MdocHandoverType.NEGOTIATED_HANDOVER -> "NFC Negotiated Handover"
+                                            MdocHandoverType.V2_HANDOVER -> "NFC Handover V2"
+                                        }
+                                        showResponse(
+                                            /* vpToken = */ null,
+                                            /* deviceResponse = */ Cbor.decode(readerMostRecentDeviceResponse.value!!),
+                                            /* sessionTranscript = */ Cbor.decode(readerSessionTranscript.value!!),
+                                            /* nonce = */ null,
+                                            /* eReaderKey */ eReaderKey.value!!,
+                                            /* metadata = */ ShowResponseMetadata(
+                                                engagementType = nfcEngagementType,
+                                                transferProtocol = transferProtocol,
+                                                requestSize = readerMostRecentDeviceRequest.value?.size?.toLong() ?: 0L,
+                                                responseSize = readerMostRecentDeviceResponse.value?.size?.toLong() ?: 0L,
+                                                durationMsecNfcTapToEngagement = scanResult.processingDuration.inWholeMilliseconds,
+                                                durationMsecEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent.value?.inWholeMilliseconds ?: 0,
+                                                durationMsecRequestSentToResponseReceived = durationRequestSentToResponseReceived.value?.inWholeMilliseconds ?: 0,
+                                                nfcHybridTransportStats = (scanResult.transport as? NfcHybridTransportMdocReader)?.stats
+                                            )
+                                        )
+                                    }
+                                }
+                            } else {
+                                // when cancelled/dismissed
+                                readerJob = null
+                            }
+                        } catch (e: Throwable) {
+                            Logger.e(TAG, "NFC engagement failed", e)
+                            showToast("NFC engagement failed with $e")
+                            readerJob = null
+                        }
+                    }
+                }
+
                 item {
                     TextButton(
                         onClick = {
+                            launchNfcScan(MdocReaderNfcHandoverOptions(useNfcV2 = false), nfcOnly = false)
                             readerMostRecentDeviceResponse.value = null
-
                             eReaderKey.value = null
-                            readerJob = coroutineScope.launch {
-                                try {
-                                    val negotiatedHandoverConnectionMethods = mutableListOf<MdocConnectionMethod>()
-                                    val bleUuid = UUID.randomUUID()
-                                    if (app.settingsModel.readerBleCentralClientModeEnabled.value) {
-                                        negotiatedHandoverConnectionMethods.add(
-                                            MdocConnectionMethodBle(
-                                                supportsPeripheralServerMode = false,
-                                                supportsCentralClientMode = true,
-                                                peripheralServerModeUuid = null,
-                                                centralClientModeUuid = bleUuid,
-                                            )
-                                        )
-                                    }
-                                    if (app.settingsModel.readerBlePeripheralServerModeEnabled.value) {
-                                        negotiatedHandoverConnectionMethods.add(
-                                            MdocConnectionMethodBle(
-                                                supportsPeripheralServerMode = true,
-                                                supportsCentralClientMode = false,
-                                                peripheralServerModeUuid = bleUuid,
-                                                centralClientModeUuid = null,
-                                            )
-                                        )
-                                    }
-                                    if (app.settingsModel.readerNfcDataTransferEnabled.value) {
-                                        negotiatedHandoverConnectionMethods.add(
-                                            MdocConnectionMethodNfc(
-                                                commandDataFieldMaxLength = 0xffff,
-                                                responseDataFieldMaxLength = 0x10000
-                                            )
-                                        )
-                                    }
-
-                                    val nfcScanOptions = if (app.settingsModel.observeModeEmitPollingFramesAsReader.value) {
-                                        NfcScanOptions(pollingFrameData = ByteString("6a0281030000".fromHex()))
-                                    } else {
-                                        NfcScanOptions()
-                                    }
-                                    Logger.i(TAG, "nfcScanOptions: $nfcScanOptions")
-                                    val reader = readerSelected.value!!.getNfcTagReader()
-                                    val scanResult = reader.scanMdocReader(
-                                        message = "Hold near credential holder's phone.",
-                                        options = MdocTransportOptions(
-                                            bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
-                                            bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value
-                                        ),
-                                        selectConnectionMethod = { connectionMethods ->
-                                            if (connectionMethods.size == 1) {
-                                                connectionMethods[0]
-                                            } else if (app.settingsModel.readerAutomaticallySelectTransport.value) {
-                                                showToast("Auto-selected first from $connectionMethods")
-                                                connectionMethods[0]
-                                            } else {
-                                                selectConnectionMethod(
-                                                    connectionMethods,
-                                                    connectionMethodPickerData
-                                                )
-                                            }
-                                        },
-                                        negotiatedHandoverConnectionMethods = negotiatedHandoverConnectionMethods,
-                                        nfcScanOptions = nfcScanOptions
-                                    )
-                                    if (scanResult != null) {
-                                        val transferProtocol = scanResult.transport.connectionMethod.toString()
-                                        doReaderFlow(
-                                            app = app,
-                                            nfcTagReader = reader,
-                                            encodedDeviceEngagement = scanResult.encodedDeviceEngagement,
-                                            existingTransport = scanResult.transport,
-                                            handover = scanResult.handover,
-                                            allowMultipleRequests = app.settingsModel.readerAllowMultipleRequests.value,
-                                            bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
-                                            bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value,
-                                            showToast = showToast,
-                                            readerTransport = readerTransport,
-                                            readerSessionEncryption = readerSessionEncryption,
-                                            readerSessionTranscript = readerSessionTranscript,
-                                            readerMostRecentDeviceRequest = readerMostRecentDeviceRequest,
-                                            readerMostRecentDeviceResponse = readerMostRecentDeviceResponse,
-                                            eReaderKey = eReaderKey,
-                                            durationEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent,
-                                            durationRequestSentToResponseReceived = durationRequestSentToResponseReceived,
-                                            requestSelected = requestSelected,
-                                            selectConnectionMethod = { connectionMethods ->
-                                                if (app.settingsModel.readerAutomaticallySelectTransport.value) {
-                                                    showToast("Auto-selected first from $connectionMethods")
-                                                    connectionMethods[0]
-                                                } else {
-                                                    selectConnectionMethod(
-                                                        connectionMethods,
-                                                        connectionMethodPickerData
-                                                    )
-                                                }
-                                            },
-                                        )
-                                        readerJob = null
-                                        if (readerMostRecentDeviceResponse.value != null) {
-                                            with(Dispatchers.Main) {
-                                                val nfcEngagementType = if (scanResult.handover.asArray[1] == Simple.NULL) {
-                                                    "NFC Static Handover"
-                                                } else {
-                                                    "NFC Negotiated Handover"
-                                                }
-                                                showResponse(
-                                                    /* vpToken = */ null,
-                                                    /* deviceResponse = */ Cbor.decode(readerMostRecentDeviceResponse.value!!),
-                                                    /* sessionTranscript = */ Cbor.decode(readerSessionTranscript.value!!),
-                                                    /* nonce = */ null,
-                                                    /* eReaderKey */ eReaderKey.value!!,
-                                                    /* metadata = */ ShowResponseMetadata(
-                                                        engagementType = nfcEngagementType,
-                                                        transferProtocol = transferProtocol,
-                                                        requestSize = readerMostRecentDeviceRequest.value?.size?.toLong() ?: 0L,
-                                                        responseSize = readerMostRecentDeviceResponse.value?.size?.toLong() ?: 0L,
-                                                        durationMsecNfcTapToEngagement = scanResult.processingDuration.inWholeMilliseconds,
-                                                        durationMsecEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent.value?.inWholeMilliseconds ?: 0,
-                                                        durationMsecRequestSentToResponseReceived = durationRequestSentToResponseReceived.value?.inWholeMilliseconds ?: 0,
-                                                    )
-                                                )
-                                            }
-                                        }
-                                    } else {
-                                        // when cancelled/dismissed
-                                        readerJob = null
-                                    }
-                                } catch (e: Exception) {
-                                    if (e is CancellationException) throw e
-                                    Logger.e(TAG, "NFC engagement failed", e)
-                                    showToast("NFC engagement failed with $e")
-                                    readerJob = null
-                                }
-                            }
                         },
                         content = { Text("Request mdoc via NFC") }
                     )
+                }
+                item {
+                    TextButton(
+                        onClick = {
+                            launchNfcScan(MdocReaderNfcHandoverOptions(useNfcV2 = true), nfcOnly = false)
+                            readerMostRecentDeviceResponse.value = null
+                            eReaderKey.value = null
+                        },
+                        content = { Text("Request mdoc via NFCv2") }
+                    )
+                }
+                item {
+                    TextButton(
+                        onClick = {
+                            launchNfcScan(MdocReaderNfcHandoverOptions(useNfcV2 = true), nfcOnly = true)
+                            readerMostRecentDeviceResponse.value = null
+                            eReaderKey.value = null
+                        },
+                        content = { Text("Request mdoc via NFCv2 (NFC only)") }
+                    )
+                }
+
+                item {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = app.settingsModel.signRequest.collectAsState().value,
+                            onCheckedChange = { value ->
+                                app.settingsModel.signRequest.value = value
+                            },
+                        )
+                        Text(
+                            text = "Sign the request",
+                        )
+                    }
                 }
                 item {
                     Row(
@@ -670,7 +721,7 @@ fun IsoMdocProximityReadingScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
-                            checked =  app.settingsModel.observeModeEmitPollingFramesAsReader.collectAsState().value,
+                            checked = app.settingsModel.observeModeEmitPollingFramesAsReader.collectAsState().value,
                             onCheckedChange = { value ->
                                 app.settingsModel.observeModeEmitPollingFramesAsReader.value = value
                             },
@@ -720,7 +771,8 @@ private suspend fun doReaderFlow(
     durationEngagementReceivedToRequestSent: MutableState<Duration?>,
     durationRequestSentToResponseReceived: MutableState<Duration?>,
     requestSelected: MutableState<RequestPickerEntry>,
-    selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?
+    selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?,
+    signRequest: Boolean
 ) {
     Logger.iCbor(TAG, "DeviceEngagement", encodedDeviceEngagement.toByteArray())
     val deviceEngagement = DeviceEngagement.fromDataItem(Cbor.decode(encodedDeviceEngagement.toByteArray()))
@@ -729,6 +781,7 @@ private suspend fun doReaderFlow(
     eReaderKey.value = Crypto.createEcPrivateKey(eDeviceKey.curve)
 
     val transport = if (existingTransport != null) {
+        Logger.i(TAG, "existingTransport: $existingTransport")
         if (existingTransport is NfcTransportMdocReader) {
             existingTransport.updateDialogMessage("Transferring data, keep in reader's field")
         }
@@ -773,6 +826,7 @@ private suspend fun doReaderFlow(
                         selectedRequest = requestSelected,
                         eDeviceKey = eDeviceKey,
                         eReaderKey = eReaderKey.value!!,
+                        signRequest = signRequest
                     )
                 }
             )
@@ -797,6 +851,7 @@ private suspend fun doReaderFlow(
         selectedRequest = requestSelected,
         eDeviceKey = eDeviceKey,
         eReaderKey = eReaderKey.value!!,
+        signRequest = signRequest
     )
 }
 
@@ -817,6 +872,7 @@ private suspend fun doReaderFlowWithTransport(
     selectedRequest: MutableState<RequestPickerEntry>,
     eDeviceKey: EcPublicKey,
     eReaderKey: EcPrivateKey,
+    signRequest: Boolean,
 ) {
     readerTransport.value = transport
     val encodedSessionTranscript = TestAppUtils.generateEncodedSessionTranscript(
@@ -837,6 +893,7 @@ private suspend fun doReaderFlowWithTransport(
         encodedSessionTranscript = readerSessionTranscript.value!!,
         readerKey = app.readerKey,
         zkSystemRepository = app.zkSystemRepository,
+        signRequest = signRequest
     )
     Logger.iCbor(TAG, "deviceRequest", encodedDeviceRequest)
     try {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ShowResponse.kt
@@ -257,6 +257,18 @@ private suspend fun parseResponse(
         lines.add(Line("Transfer Protocol", ValueText(metadata.transferProtocol)))
         lines.add(Line("Request size", ValueSize(metadata.requestSize)))
         lines.add(Line("Response size", ValueSize(metadata.responseSize)))
+        metadata.nfcHybridTransportStats?.let { stats ->
+            lines.add(Line("Number of messages sent",
+                ValueText("${stats.numSent} (${stats.numSentViaNfc} on NFC, ${stats.numSentViaTransport} on Transport)")
+            ))
+            lines.add(Line("Number of messages received",
+                ValueText("${stats.numReceived} (${stats.numReceivedFirstOnNfc} first on NFC, " +
+                        "${stats.numReceivedFirstOnTransport} first on Transport)")
+            ))
+            lines.add(Line("NFC disconnected during transaction",
+                ValueText("${stats.nfcDisconnectedDuringTransaction}")
+            ))
+        }
         lines.add(Line("Tap to engagement received", ValueDuration(
             metadata.durationMsecNfcTapToEngagement?.toDuration(DurationUnit.MILLISECONDS)
         )))


### PR DESCRIPTION
This PR implements NFCv2 according to the latest documents in Action Point 112.05 in ISO/IEC SC17 WG10.

Also fix a bunch of uses of `java.lang.Error` to throw errors which are supposed to be recoverable, so use `IllegalStateException` instead. The problem with using `java.lang.Error` is that it's derived from `Throwable` - not `Exception` - meaning that it's not catchable unless you catch `Throwable` which is a big no-no according to CODING-STYLE.md. Also add language to CODING-STYLE.md to recommend against throwing this exception.

Go through all relevant code for NFC engagement (`MdocTransport`-derived classes, `MdocNfcEngagementHelper`, `MdocNdefService`, and the same for the new V2 variants) and make sure it's using Kotlin Coroutines correctly. A number of race conditions and non-ideomatic uses were fixed.

Properly handle when Android re-uses a `HostApduService` for a second tap soon after a first tap, that is, when `onDestroy` / `onCreate` isn't called. The symptom was that we would hang on the second tap. With these changes NFC engagement is now bullet-proof.

This is a work-in-progress so implementation details can and will change as the small group working on AP 112.05 meets. The scaffolding however - `MdocNfcV2Service`, `MdocNfcV2EngagementHelper` and `MdocReaderNfcHandoverOptions` - are expected to not change. This means that it should be safe to start using this in Multipaz Wallet and other applications without any API changes.

Test: New unit tests and manually tested.
