### PR TITLE
BLE: Implement retry logic for L2CAP connect().

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.context.initializeApplication
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -33,6 +34,7 @@ import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
 import org.multipaz.mdoc.transport.NfcHybridTransportMdoc
 import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.ResponseApdu
 import org.multipaz.presentment.Iso18013Presentment
 import org.multipaz.presentment.PresentmentCanceledException
@@ -380,6 +382,17 @@ abstract class MdocNfcV2Service: HostApduService() {
         listenForCancellationFromUiJob = null
     }
 
+    private val CommandApdu.isApplicationSelect: Boolean
+        get() = ins == Nfc.INS_SELECT && p1 == Nfc.INS_SELECT_P1_APPLICATION
+
+    private val firstCommandResponse = ResponseApdu(
+        status = Nfc.RESPONSE_STATUS_SUCCESS,
+        payload = ByteString(Cbor.encode(buildCborMap {
+            put(0, 65536L /* apduCommandMaxSize */)
+        }))
+    )
+    private var applicationSelectProcessed = false
+
     // Called by coroutine running in I/O thread, see onCreate() for details
     private suspend fun processCommandApdu(commandApdu: CommandApdu): ResponseApdu? {
         // TODO: maybe need replay and super-fast response as in mdocReaderNfcHandover.kt function processCommandApdu()
@@ -390,7 +403,11 @@ abstract class MdocNfcV2Service: HostApduService() {
         try {
             engagement?.let {
                 val responseApdu = it.processApdu(commandApdu)
-                return responseApdu
+                if (commandApdu.isApplicationSelect && applicationSelectProcessed) {
+                    Logger.i(TAG, "Skipping response to APPLICATION SELECT since it's already been processed")
+                } else {
+                    return responseApdu
+                }
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -426,7 +443,14 @@ abstract class MdocNfcV2Service: HostApduService() {
         // Bounce the APDU to processCommandApdu() above via the coroutine in I/O thread set up in onCreate()
         val commandApdu = CommandApdu.decode(encodedCommandApdu)
         if (!engagementComplete) {
-            val unused = dispatchChannel.trySend(CommandApduData(commandApdu))
+            if (commandApdu.isApplicationSelect) {
+                applicationSelectProcessed = true
+                Logger.i(TAG, "Processing APPLICATION SELECT synchronously")
+                val unused = dispatchChannel.trySend(CommandApduData(commandApdu))
+                return firstCommandResponse.encode()
+            } else {
+                val unused = dispatchChannel.trySend(CommandApduData(commandApdu))
+            }
         } else {
             Logger.w(TAG, "Engagement complete but received APDU $commandApdu")
         }

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
@@ -128,7 +128,14 @@ enum class ServerIdentity(
      * RPC authentication to access [PaymentProcessor] interface used by a verifier
      * that can accept payment transactions.
      */
-    PAYMENT_PROCESSOR("Payment Processor");
+    PAYMENT_PROCESSOR("Payment Processor"),
+
+    /**
+     * An identity for reader root CA.
+     */
+    READER_ROOT("Reader Root")
+
+    ;
 
     /**
      * A name for the identity that is formatted for use in JSON and in URLs (lowercase,

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -17,6 +17,7 @@ import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.os.Build
 import android.os.ParcelUuid
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
@@ -38,6 +39,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.buildByteString
@@ -46,9 +48,11 @@ import org.multipaz.util.appendByteArray
 import org.multipaz.util.appendUInt32
 import org.multipaz.util.getUInt32
 import java.io.InputStream
+import kotlin.compareTo
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.math.min
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -172,7 +176,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
 
     private class ConnectionFailedException(
         message: String
-    ) : Throwable(message)
+    ) : Exception(message)
 
     private val scanCallback: ScanCallback = object : ScanCallback() {
         override fun onScanResult(callbackType: Int, result: ScanResult) {
@@ -507,6 +511,18 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             //
             Logger.i(TAG, "Failed to find peripheral after $retryCount attempt(s) of 10 secs. Restarting scan.")
         }
+        // Defensively cancel Classic Discovery.
+        if (bluetoothManager.adapter.isDiscovering) {
+            try {
+                Logger.i(TAG, "Calling cancelDiscovery()")
+                bluetoothManager.adapter.cancelDiscovery()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Ignoring error when calling cancelDiscovery", e)
+            }
+        }
+        // Give the radio time to actually transition out of the scanning state.
+        delay(150.milliseconds)
     }
 
     override suspend fun connectToPeripheral() {
@@ -745,10 +761,79 @@ internal class BleCentralManagerAndroid : BleCentralManager {
         }
     }
 
+
+    private suspend fun callWithRetry(
+        maxRetries: Int = 10,
+        initialDelay: Duration = 500.milliseconds,
+        maxDelay: Duration = 4.seconds,
+        action: suspend () -> Unit,
+        cleanupOnFailure: suspend () -> Unit
+    ) {
+        var currentDelay = initialDelay
+        var numTries = 0
+        while (true) {
+            try {
+                numTries++
+                action()
+                return
+            } catch (e: Exception) {
+                cleanupOnFailure()
+
+                // Re-throw CancellationException immediately so coroutine cancellation works
+                if (e is CancellationException) throw e
+
+                if (numTries >= maxRetries) {
+                    throw IllegalStateException("Failed after $maxRetries attempts", e)
+                }
+
+                Logger.i(TAG, "Failed (Attempt $numTries), trying again in $currentDelay. Error: ${e.message}")
+                delay(currentDelay)
+                currentDelay = (currentDelay.inWholeMilliseconds * 2).milliseconds
+                if (currentDelay > maxDelay) {
+                    currentDelay = maxDelay
+                }
+            }
+        }
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.Q)
-    private fun connectL2capQ(psm: Int) {
-        l2capSocket = device!!.createInsecureL2capChannel(psm)
-        l2capSocket!!.connect()
+    private suspend fun connectL2capQ(psm: Int) {
+        callWithRetry(
+            action = {
+                l2capSocket = device!!.createInsecureL2capChannel(psm)
+                val result = withTimeoutOrNull(3.seconds) {
+                    suspendCancellableCoroutine<Unit> { cont ->
+                        val connectJob = CoroutineScope(Dispatchers.IO).launch {
+                            try {
+                                l2capSocket!!.connect()
+                                if (cont.isActive) cont.resume(Unit)
+                            } catch (e: Exception) {
+                                if (cont.isActive) cont.resumeWithException(e)
+                            }
+                        }
+                        cont.invokeOnCancellation {
+                            Logger.w(TAG, "Connection timeout triggered, aggressively closing socket")
+                            try {
+                                l2capSocket?.close()
+                            } catch (_: Exception) {
+                            }
+                            connectJob.cancel()
+                        }
+                    }
+                }
+                if (result == null) {
+                    throw ConnectionFailedException("L2CAP connection timed out after 3 seconds")
+                }
+            },
+            cleanupOnFailure = {
+                try {
+                    l2capSocket?.close()
+                } catch (e: Exception) {
+                    Logger.w(TAG, "Error during cleanup close", e)
+                }
+                l2capSocket = null
+            }
+        )
 
         // Start reading in a coroutine
         CoroutineScope(Dispatchers.IO).launch {

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
@@ -37,9 +37,11 @@ class MainActivity : FragmentActivity() {
         super.onResume()
         NfcAdapter.getDefaultAdapter(this)?.let { adapter ->
             val cardEmulation = CardEmulation.getInstance(adapter)
-            val componentName = ComponentName(this, TestAppMdocNdefService::class.java)
-            if (!cardEmulation.setPreferredService(this, componentName)) {
-                Logger.w(TAG, "CardEmulation.setPreferredService() returned false")
+            for (klass in listOf(TestAppMdocNdefService::class.java, TestAppMdocNfcV2Service::class.java)) {
+                val componentName = ComponentName(this, klass)
+                if (!cardEmulation.setPreferredService(this, componentName)) {
+                    Logger.w(TAG, "CardEmulation.setPreferredService() returned false")
+                }
             }
             if (!cardEmulation.categoryAllowsForegroundPreference(CardEmulation.CATEGORY_OTHER)) {
                 Logger.w(TAG, "CardEmulation.categoryAllowsForegroundPreference(CATEGORY_OTHER) returned false")

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
@@ -114,7 +114,8 @@ actual object TestAppConfiguration {
                 )
             },
             preferredServices = listOf(
-                ComponentName(applicationContext, TestAppMdocNdefService::class.java)
+                ComponentName(applicationContext, TestAppMdocNdefService::class.java),
+                ComponentName(applicationContext, TestAppMdocNfcV2Service::class.java)
             )
         )
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -181,7 +181,7 @@ class MultiDeviceTestsServer(
             }
             delay(prewarmDuration)
             Logger.i(TAG, "Done waiting")
-            withTimeout(15.seconds) {
+            withTimeout(45.seconds) {
                 sendChannel.writeStringUtf8("TestPresentationStart\n")
                 transport.open(eDeviceKey.publicKey)
                 val sessionEstablishmentMessage = transport.waitForMessage()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/Plan.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/Plan.kt
@@ -68,4 +68,11 @@ enum class Plan(
         ),
         prewarm = true,
     ),
+    BLE_CENTRAL_CLIENT_MODE_L2CAP_PSM_IN_TWO_WAY_ENGAGEMENT_LONG(
+        description = "BLE Central Client L2CAP w/ PSM in Engagement",
+        tests = listOf(
+            Pair(Test.MDOC_CENTRAL_CLIENT_MODE_L2CAP_PSM_IN_TWO_WAY_ENGAGEMENT, 200),
+        ),
+        prewarm = true,
+    ),
 }


### PR DESCRIPTION
On Android, about 1 in ~20 L2CAP connections will fail with "Error: A Bluetooth Socket failure occurred" which indicates some kind of internal race-condition or bug in the underlying Bluetooth stack on the Android device attempting the connection. Just retrying the `connect()` call after a timeout will end up working so do that. This does involves some timeouts so roughly increases transaction time from ~2 seconds to ~6 seconds but this is much better than failing.

Also add a delay of ~150ms between scan result and connection as recommended to work around the fact that the Android bluetooth stack takes a while to turn off scanning. Also call `cancelDiscovery()` as recommended by the Android Bluetooth docs although since this only applies to classic Bluetooth we end up not doing this in practice a lot.

Tested this by running "BLE Central Client L2CAP w/ PSM in Engagement" multi-device automated test with 200 iterations and not a single failure and 7 retries which before this PR would otherwise have been errors.

Also add `READER_ROOT` to `ServerIdentity` since we need that in Multipaz Wallet for the built-in reader functionality.

Also remember to call setPreferredService for our NFCv2 service for MainActivity and PresentmentActivity, this was an oversight in the NFCv2 PR.

Also, in NFCv2 process first APDU synchronously to indicate to the OS that we are to be selected for this service when in the foreground.

Test: Manually tested.
