### PR TITLE
Various fixes and support for sequence numbers when using NFCv2.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
@@ -476,7 +476,17 @@ abstract class MdocNdefService: HostApduService() {
     // Called by OS when an APDU arrives
     override fun processCommandApdu(encodedCommandApdu: ByteArray, extras: Bundle?): ByteArray? {
         // Bounce the APDU to processCommandApdu() above via the coroutine in I/O thread set up in onCreate()
-        val commandApdu = CommandApdu.decode(encodedCommandApdu)
+        //
+        // With Extended APDUs it's possible we get a partial APDU so gracefully handle if decoding fails. Simply
+        // log and discard, we'll likely get hit with an onDeactivated call soon anyway.
+        //
+        val commandApdu = try {
+            CommandApdu.decode(encodedCommandApdu)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Logger.w(TAG, "Error decoding APDU", e)
+            return null
+        }
         if (!engagementComplete) {
             val unused = channel.trySend(CommandApduData(commandApdu))
         } else {

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
@@ -267,6 +267,7 @@ abstract class MdocNfcV2Service: HostApduService() {
                     hybridTransport!!.open(eDeviceKey.publicKey)
                     val duration = Clock.System.now() - timeStarted
                     startTransaction(
+                        transport = hybridTransport!!,
                         settings = settings,
                         connectionMethod = connectionMethod,
                         encodedDeviceEngagement = encodedDeviceEngagement,
@@ -306,6 +307,7 @@ abstract class MdocNfcV2Service: HostApduService() {
     }
 
     private suspend fun startTransaction(
+        transport: NfcHybridTransportMdoc,
         settings: Settings,
         connectionMethod: MdocConnectionMethod,
         encodedDeviceEngagement: ByteString,
@@ -314,33 +316,31 @@ abstract class MdocNfcV2Service: HostApduService() {
         engagementDuration: Duration,
     ) {
         val transactionJobContext = currentCoroutineContext()
-
         if (connectionMethod is MdocConnectionMethodNfcV2) {
-            hybridTransport?.setExpectTransport(false)
+            transport.setExpectTransport(false)
             // Nothing to do
         } else {
-            hybridTransport?.setExpectTransport(true)
+            transport.setExpectTransport(true)
             // Wait for the non-NFC transport in a coroutine so we are not blocking
             // initiating presentment....
             waitForTransportJob = serviceScope.launch(Dispatchers.IO) {
                 try {
-                    val transport = MdocTransportFactory.Default.createTransport(
+                    val negotiatedTransport = MdocTransportFactory.Default.createTransport(
                         connectionMethod = connectionMethod,
                         role = MdocRole.MDOC,
                         options = settings.transportOptions
                     )
-                    transport.open(eSenderKey = eDeviceKey.publicKey)
+                    negotiatedTransport.open(eSenderKey = eDeviceKey.publicKey)
+                    transport.setTransport(negotiatedTransport)
 
                     // Monitor the secondary transport
                     launch {
-                        transport.state.collect { state ->
+                        negotiatedTransport.state.collect { state ->
                             if (state == MdocTransport.State.FAILED || state == MdocTransport.State.CLOSED) {
                                 transactionJobContext.cancel(CancellationException("Secondary transport $state"))
                             }
                         }
                     }
-
-                    hybridTransport?.setTransport(transport)
                 } catch (e: Exception) {
                     Logger.w(TAG, "Error opening non-NFC transport", e)
                 }
@@ -350,12 +350,13 @@ abstract class MdocNfcV2Service: HostApduService() {
         try {
             settings.presentmentModel?.setConnecting()
             Iso18013Presentment(
-                transport = hybridTransport!!,
+                transport = transport,
                 eDeviceKey = eDeviceKey,
                 deviceEngagement = Cbor.decode(encodedDeviceEngagement.toByteArray()),
                 handover = handover,
                 source = settings.source,
                 keyAgreementPossible = listOf(eDeviceKey.curve),
+                insertSequenceNumbers = true,
                 onWaitingForRequest = { settings.presentmentModel?.setWaitingForReader() },
                 onWaitingForUserInput = { settings.presentmentModel?.setWaitingForUserInput() },
                 onDocumentsInFocus = { documents ->
@@ -440,8 +441,18 @@ abstract class MdocNfcV2Service: HostApduService() {
 
     // Called by OS when an APDU arrives
     override fun processCommandApdu(encodedCommandApdu: ByteArray, extras: Bundle?): ByteArray? {
-        // Bounce the APDU to processCommandApdu() above via the coroutine in I/O thread set up in onCreate()
-        val commandApdu = CommandApdu.decode(encodedCommandApdu)
+        // Bounce the APDU to processCommandApdu() above via the coroutine in I/O thread set up in onCreate().
+        //
+        // With Extended APDUs it's possible we get a partial APDU so gracefully handle if decoding fails. Simply
+        // log and discard, we'll likely get hit with an onDeactivated call soon anyway.
+        //
+        val commandApdu = try {
+            CommandApdu.decode(encodedCommandApdu)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Logger.w(TAG, "Error decoding APDU", e)
+            return null
+        }
         if (!engagementComplete) {
             if (commandApdu.isApplicationSelect) {
                 applicationSelectProcessed = true

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -502,6 +502,10 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
     }
 
     override suspend fun waitForStateCharacteristicWriteOrL2CAPClient() {
+        if (device != null) {
+            Logger.i(TAG, "The device is already connected, no need to wait")
+            return
+        }
         suspendCancellableCoroutine<Boolean> { continuation ->
             setWaitCondition(WaitState.STATE_CHARACTERISTIC_WRITTEN_OR_L2CAP_CLIENT, continuation)
         }
@@ -617,19 +621,20 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
         try {
             l2capSocket = l2capServerSocket!!.accept()
 
+            val psm = l2capPsm
             l2capServerSocket?.close()
             l2capServerSocket = null
 
             if (waitFor?.state == WaitState.STATE_CHARACTERISTIC_WRITTEN_OR_L2CAP_CLIENT) {
-                Logger.i(TAG, "L2CAP connection")
+                Logger.i(TAG, "L2CAP client at PSM $psm")
                 device = l2capSocket!!.remoteDevice
-                // Since the central found us, we can stop advertising....
-                advertiser?.stopAdvertising(advertiseCallback)
                 resumeWait()
             } else {
-                Logger.w(TAG, "Got a L2CAP client but not waiting")
-                return
+                Logger.i(TAG, "L2CAP client at PSM $psm (but not yet waiting)")
+                device = l2capSocket!!.remoteDevice
             }
+            // Since the central found us, we can stop advertising....
+            advertiser?.stopAdvertising(advertiseCallback)
 
             val inputStream = l2capSocket!!.inputStream
             while (true) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
@@ -204,6 +204,23 @@ sealed class DataItem(
         }
 
     /**
+     * The data-time from a tstr with tag [Tagged.FULL_DATE_STRING] or [Tagged.DATE_TIME_STRING].
+     *
+     * @throws IllegalArgumentException if the data item isn't a tag with tag [Tagged.FULL_DATE_STRING] or
+     * [Tagged.DATE_TIME_STRING] containing a tstr with valid date format.
+     */
+    val asDateStringOrDateTimeString: LocalDate
+        get() {
+            require(this is Tagged)
+            require(this.taggedItem is Tstr)
+            when (this.tagNumber) {
+                Tagged.DATE_TIME_STRING -> return LocalDate.parse(this.taggedItem.value.substring(0, 10))
+                Tagged.FULL_DATE_STRING -> return LocalDate.parse(this.taggedItem.value)
+                else -> throw IllegalArgumentException("Unexpected tag number ${this.tagNumber}")
+            }
+        }
+
+    /**
      * Returns whether a map has a value for a given key
      *
      * @param key the key to check for.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
@@ -26,6 +26,9 @@ import kotlinx.io.bytestring.ByteStringBuilder
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.crypto.Hkdf
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.util.Logger
+
+private const val TAG = "SessionEncryption"
 
 /**
  * Helper class for implementing session encryption according to ISO/IEC 18013-5:2021
@@ -44,21 +47,38 @@ import org.multipaz.mdoc.role.MdocRole
  * it's the for the mdoc.
  * @param remotePublicKey The public ephemeral key of the other end.
  * @param encodedSessionTranscript The bytes of the `SessionTranscript` CBOR.
+ * @param insertSequenceNumbers if `true`, inserts sequence numbers in generated messages.
  */
 class SessionEncryption(
     val role: MdocRole,
     private val eSelfKey: EcPrivateKey,
     private val remotePublicKey: EcPublicKey,
-    private val encodedSessionTranscript: ByteArray
+    private val encodedSessionTranscript: ByteArray,
+    private val insertSequenceNumbers: Boolean = false
 ) {
     private var sessionEstablishmentSent = false
     private lateinit var skRemote: ByteArray
     private lateinit var skSelf: ByteArray
+    private var nextSequenceNumber_ = 0
     private var decryptedCounter = 1
     private var encryptedCounter = 1
     private var sendSessionEstablishment = true
 
     private var initialized: Boolean = false
+
+    /**
+     * Returns the next sequence number that will be used.
+     *
+     * @throws IllegalStateException if the [org.multipaz.mdoc.sessionencryption.SessionEncryption] was constructed
+     *   with [insertSequenceNumbers] set to `false`
+     */
+    val nextSequenceNumber: Int
+        get() {
+            check(insertSequenceNumbers) {
+                "This object was constructed with insertSequenceNumber set to false"
+            }
+            return nextSequenceNumber_
+        }
 
     private suspend fun ensureInitialized() {
         if (initialized) {
@@ -169,6 +189,10 @@ class SessionEncryption(
             if (statusCode != null) {
                 put("status", statusCode)
             }
+            if (insertSequenceNumbers) {
+                put("seq", nextSequenceNumber_)
+            }
+            nextSequenceNumber_++
         })
         sessionEstablishmentSent = true
         return messageData
@@ -234,11 +258,18 @@ class SessionEncryption(
          * code and no data.
          *
          * @param statusCode the intended status code, with value as defined in ISO/IEC 18013-5 Table 20.
+         * @param sequenceNumber optional sequence number or `null`
          * @return a byte array with the encoded CBOR message
          */
-        fun encodeStatus(statusCode: Long): ByteArray = Cbor.encode(
+        fun encodeStatus(
+            statusCode: Long,
+            sequenceNumber: Int? = null,
+        ): ByteArray = Cbor.encode(
             buildCborMap {
                 put("status", statusCode)
+                sequenceNumber?.let {
+                    put("seq", it)
+                }
             }
         )
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/VicalCertificateInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/VicalCertificateInfo.kt
@@ -3,6 +3,10 @@ package org.multipaz.mdoc.vical
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.X509Cert
+import org.multipaz.util.Logger
+import org.multipaz.util.toHex
+
+private const val TAG = "VicalCertificateInfo"
 
 /**
  * An entry in a VICAL according to ISO/IEC 18013-5:2021.
@@ -28,6 +32,8 @@ data class VicalCertificateInfo(
     val extensions: Map<String, DataItem> = emptyMap()
 ) {
     init {
-        require(docTypes.isNotEmpty())
+        if (docTypes.isEmpty()) {
+            Logger.w(TAG, "Ignoring empty docTypes for certificate with ski ${ski.toHex()}")
+        }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -38,6 +38,7 @@ private const val TAG = "Iso180135Presentment"
  * @param handover the handover.
  * @param source the source of truth used for presentment.
  * @param keyAgreementPossible the list of curves for which key agreement is possible.
+ * @param insertSequenceNumbers if `true`, inserts sequence numbers in session encryption messages.
  * @param timeout the maximum time to wait for the first message from the remote reader or `null` to wait indefinitely.
  * @param timeoutSubsequentRequests the maximum time to wait for subsequent messages or `null` to wait indefinitely.
  * @param onWaitingForRequest called when waiting for a request from the remote reader.
@@ -65,7 +66,8 @@ suspend fun Iso18013Presentment(
     handover: DataItem,
     source: PresentmentSource,
     keyAgreementPossible: List<EcCurve>,
-    timeout: Duration? = 10.seconds,
+    insertSequenceNumbers: Boolean = false,
+    timeout: Duration? = 15.seconds,
     timeoutSubsequentRequests: Duration? = 30.seconds,
     onWaitingForRequest: () -> Unit = {},
     onWaitingForUserInput: () -> Unit = {},
@@ -84,8 +86,8 @@ suspend fun Iso18013Presentment(
     //Logger.iCbor(TAG, "DeviceEngagement", mechanism.encodedDeviceEngagement.toByteArray())
     var numRequestsServed = 0
     var sendSessionTermination = true
+    var sessionEncryption: SessionEncryption? = null
     try {
-        var sessionEncryption: SessionEncryption? = null
         lateinit var eReaderKey: EReaderKey
         lateinit var sessionTranscript: DataItem
         lateinit var encodedSessionTranscript: ByteArray
@@ -119,10 +121,11 @@ suspend fun Iso18013Presentment(
                 }
                 encodedSessionTranscript = Cbor.encode(sessionTranscript)
                 sessionEncryption = SessionEncryption(
-                    MdocRole.MDOC,
-                    eDeviceKey,
-                    eReaderKey.publicKey,
-                    encodedSessionTranscript,
+                    role = MdocRole.MDOC,
+                    eSelfKey = eDeviceKey,
+                    remotePublicKey = eReaderKey.publicKey,
+                    encodedSessionTranscript = encodedSessionTranscript,
+                    insertSequenceNumbers = insertSequenceNumbers
                 )
             }
             val (encodedDeviceRequest, status) = sessionEncryption.decryptMessage(sessionData)
@@ -173,7 +176,14 @@ suspend fun Iso18013Presentment(
             Logger.i(TAG, "Sending session-termination")
             try {
                 transport.sendMessage(
-                    SessionEncryption.encodeStatus(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)
+                    SessionEncryption.encodeStatus(
+                        statusCode = Constants.SESSION_DATA_STATUS_SESSION_TERMINATION,
+                        sequenceNumber = if (insertSequenceNumbers) {
+                            sessionEncryption?.nextSequenceNumber
+                        } else {
+                            null
+                        }
+                    )
                 )
             } catch (e: Exception) {
                 if (e is CancellationException) throw e

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.Simple
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.digitalcredentials.DigitalCredentials
 import org.multipaz.digitalcredentials.getDefault
@@ -88,33 +89,37 @@ class TestAppSettingsModel private constructor(
         if (!readOnly) {
             CoroutineScope(Dispatchers.Default).launch {
                 variable.asStateFlow().collect { newValue ->
-                    val dataItem = when (T::class) {
-                        Boolean::class -> {
-                            (newValue as Boolean).toDataItem()
-                        }
-
-                        String::class -> {
-                            (newValue as String).toDataItem()
-                        }
-
-                        List::class -> {
-                            buildCborArray {
-                                (newValue as List<*>).forEach { add(Tstr(it as String)) }
+                    val dataItem = if (newValue == null) {
+                        Simple.NULL
+                    } else {
+                        when (T::class) {
+                            Boolean::class -> {
+                                (newValue as Boolean).toDataItem()
                             }
-                        }
 
-                        Set::class -> {
-                            buildCborArray {
-                                (newValue as Set<*>).forEach { add(Tstr(it as String)) }
+                            String::class -> {
+                                (newValue as String).toDataItem()
                             }
-                        }
 
-                        EcCurve::class -> {
-                            (newValue as EcCurve).name.toDataItem()
-                        }
+                            List::class -> {
+                                buildCborArray {
+                                    (newValue as List<*>).forEach { add(Tstr(it as String)) }
+                                }
+                            }
 
-                        else -> {
-                            throw IllegalStateException("Type not supported")
+                            Set::class -> {
+                                buildCborArray {
+                                    (newValue as Set<*>).forEach { add(Tstr(it as String)) }
+                                }
+                            }
+
+                            EcCurve::class -> {
+                                (newValue as EcCurve).name.toDataItem()
+                            }
+
+                            else -> {
+                                throw IllegalStateException("Type not supported")
+                            }
                         }
                     }
                     if (settingsTable.get(key) == null) {
@@ -161,6 +166,7 @@ class TestAppSettingsModel private constructor(
         bind(readerBleL2CapInEngagementEnabled, "readerBleL2CapInEngagementEnabled", true)
         bind(readerAutomaticallySelectTransport, "readerAutomaticallySelectTransport", false)
         bind(readerAllowMultipleRequests, "readerAllowMultipleRequests", false)
+        bind(readerLastSelectedRequestId, "readerLastSelectedRequestId", null)
 
         bind(cloudSecureAreaUrl, "cloudSecureAreaUrl", CSA_URL_DEFAULT)
         bind(dcApiProtocols, "dcApiProtocols", digitalCredentials.supportedProtocols)
@@ -194,6 +200,7 @@ class TestAppSettingsModel private constructor(
     val readerBleL2CapInEngagementEnabled = MutableStateFlow<Boolean>(false)
     val readerAutomaticallySelectTransport = MutableStateFlow<Boolean>(false)
     val readerAllowMultipleRequests = MutableStateFlow<Boolean>(false)
+    val readerLastSelectedRequestId = MutableStateFlow<String?>(null)
 
     val cloudSecureAreaUrl = MutableStateFlow<String>(CSA_URL_DEFAULT)
     val dcApiProtocols = MutableStateFlow<Set<String>>(emptySet())

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -103,12 +103,12 @@ private suspend fun selectConnectionMethod(
 }
 
 private data class RequestPickerEntry(
+    val id: String,
     val displayName: String,
     val request: DocumentCannedRequest,
     val requestSdJwtVc: Boolean
 )
 
-private var lastRequest: Int = 0
 internal var lastNfcReaderSelected: Int = 0
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalCoroutinesApi::class)
@@ -131,6 +131,7 @@ fun IsoMdocProximityReadingScreen(
             if (sampleRequest.mdocRequest != null) {
                 requestOptions.add(
                     RequestPickerEntry(
+                        id = "mdoc_" + documentType.mdocDocumentType!!.docType + "_" + sampleRequest.id,
                         displayName = "${documentType.displayName}: ${sampleRequest.displayName}",
                         request = sampleRequest,
                         requestSdJwtVc = false
@@ -142,6 +143,7 @@ fun IsoMdocProximityReadingScreen(
             if (sampleRequest.jsonRequest != null) {
                 requestOptions.add(
                     RequestPickerEntry(
+                        id = "json_" + documentType.jsonDocumentType!!.vct + "_" + sampleRequest.id,
                         displayName = "${documentType.displayName}: ${sampleRequest.displayName} (SD-JWT VC)",
                         request = sampleRequest,
                         requestSdJwtVc = true
@@ -152,13 +154,18 @@ fun IsoMdocProximityReadingScreen(
     }
     for (request in wellKnownMultipleDocumentRequests) {
         requestOptions.add(RequestPickerEntry(
+            id = "multidoc_" + request.id,
             displayName = "Multi-doc: ${request.displayName}",
             request = request,
             requestSdJwtVc = false
         ))
     }
     val requestDropdownExpanded = remember { mutableStateOf(false) }
-    val requestSelected = remember { mutableStateOf(requestOptions[lastRequest]) }
+    val requestSelected = remember { mutableStateOf(
+        requestOptions.find {
+            it.id == app.settingsModel.readerLastSelectedRequestId.value
+        } ?: requestOptions.first()
+    )}
     val blePermissionState = rememberBluetoothPermissionState()
     val bleEnabledState = rememberBluetoothEnabledState()
     val coroutineScope = rememberCoroutineScope { app.promptModel }
@@ -279,6 +286,7 @@ fun IsoMdocProximityReadingScreen(
                                 existingTransport = null,
                                 handover = Simple.NULL,
                                 allowMultipleRequests = app.settingsModel.readerAllowMultipleRequests.value,
+                                insertSequenceNumbers = false,
                                 bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
                                 bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value,
                                 showToast = showToast,
@@ -535,7 +543,9 @@ fun IsoMdocProximityReadingScreen(
                         comboBoxSelected = requestSelected,
                         comboBoxExpanded = requestDropdownExpanded,
                         getDisplayName = { it.displayName },
-                        onSelected = { index, value -> lastRequest = index }
+                        onSelected = { index, value ->
+                            app.settingsModel.readerLastSelectedRequestId.value = value.id
+                        }
                     )
                 }
                 item {
@@ -623,6 +633,7 @@ fun IsoMdocProximityReadingScreen(
                                     existingTransport = scanResult.transport,
                                     handover = scanResult.handover,
                                     allowMultipleRequests = app.settingsModel.readerAllowMultipleRequests.value,
+                                    insertSequenceNumbers = scanResult.type == MdocHandoverType.V2_HANDOVER,
                                     bleUseL2CAP = app.settingsModel.readerBleL2CapEnabled.value,
                                     bleUseL2CAPInEngagement = app.settingsModel.readerBleL2CapInEngagementEnabled.value,
                                     showToast = showToast,
@@ -778,6 +789,7 @@ private suspend fun doReaderFlow(
     existingTransport: MdocTransport?,
     handover: DataItem,
     allowMultipleRequests: Boolean,
+    insertSequenceNumbers: Boolean,
     bleUseL2CAP: Boolean,
     bleUseL2CAPInEngagement: Boolean,
     showToast: (message: String) -> Unit,
@@ -834,6 +846,7 @@ private suspend fun doReaderFlow(
                         encodedDeviceEngagement = encodedDeviceEngagement,
                         handover = handover,
                         allowMultipleRequests = allowMultipleRequests,
+                        insertSequenceNumbers = insertSequenceNumbers,
                         showToast = showToast,
                         readerTransport = readerTransport,
                         readerSessionEncryption = readerSessionEncryption,
@@ -859,6 +872,7 @@ private suspend fun doReaderFlow(
         encodedDeviceEngagement = encodedDeviceEngagement,
         handover = handover,
         allowMultipleRequests = allowMultipleRequests,
+        insertSequenceNumbers = insertSequenceNumbers,
         showToast = showToast,
         readerTransport = readerTransport,
         readerSessionEncryption = readerSessionEncryption,
@@ -880,6 +894,7 @@ private suspend fun doReaderFlowWithTransport(
     encodedDeviceEngagement: ByteString,
     handover: DataItem,
     allowMultipleRequests: Boolean,
+    insertSequenceNumbers: Boolean,
     showToast: (message: String) -> Unit,
     readerTransport: MutableState<MdocTransport?>,
     readerSessionEncryption: MutableState<SessionEncryption?>,
@@ -900,10 +915,11 @@ private suspend fun doReaderFlowWithTransport(
         eReaderKey.publicKey
     )
     val sessionEncryption = SessionEncryption(
-        MdocRole.MDOC_READER,
-        eReaderKey,
-        eDeviceKey,
-        encodedSessionTranscript,
+        role = MdocRole.MDOC_READER,
+        eSelfKey = eReaderKey,
+        remotePublicKey = eDeviceKey,
+        encodedSessionTranscript = encodedSessionTranscript,
+        insertSequenceNumbers = insertSequenceNumbers
     )
     readerSessionEncryption.value = sessionEncryption
     readerSessionTranscript.value = encodedSessionTranscript


### PR DESCRIPTION
The final version of NFCv2 for the mDL test event this month now has a requirement for messages to include sequence numbers. Add support for this in `SessionEncryption` and enable it only if NFCv2 is used.

Also handle the case where we receive partial APDUs which is a lot more likely with NFCv2 since the request can be several kB. For good measure, also handle it in normal NFC handover although we're a lot less likely to hit it there.

Also fix a race in BLE L2CAP on the server-side where the client connects before we expect them to. This can happen if e.g. advertising the services takes an unusually long time. This seems to happen about 1% of the time and this fixes that bug.

Also fix a race condition in MdocNfcV2Service where the negotiated transport wouldn't always get set on NfcHybridTransportMdoc, leading to flaky behavior.

Also add `DataItem.asDateStringOrDateTimeString` which is useful for data elements that can be either `tdate` or `fulldate` such as the `issue_date` and `expiry_date` data elements in mDL doctype. We need that in Multipaz Wallet.

Also make the request in "ISO mdoc proximity reading" screen in TestApp sticky.

Also be lenient about VICALs with an empty DocType list (spec requires at least one DocType in there), for now. The VICAL for the test event next week has a certificate with this.

Test: Manually tested.
