### PR TITLE
SD-JWT VC over 18013-5: Use correct compression algorithm.

### DIFF
--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -94,8 +94,8 @@ import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.fromHexByteString
-import org.multipaz.util.inflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibInflate
 import org.multipaz.utopia.knowntypes.addUtopiaTypes
 import org.multipaz.verification.VerificationUtil
 import java.net.URLEncoder
@@ -1630,7 +1630,7 @@ private suspend fun handleGetDataMdoc(
         for (otherDocument in deviceResponse.otherDocuments) {
             lines.add(ResultLine("OtherDocument", otherDocument.docFormat))
             if (otherDocument.docFormat == "sd-jwt+kb") {
-                val compactSerialization = otherDocument.data.toByteArray().inflate().decodeToString()
+                val compactSerialization = otherDocument.data.toByteArray().zlibInflate().decodeToString()
                 handleGetDataAppendSdJwt(
                     compactSerialization = compactSerialization,
                     lines = lines

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/OtherDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/OtherDocument.kt
@@ -12,8 +12,8 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.presentment.TransactionData
 import org.multipaz.sdjwt.SdJwtKb
 import org.multipaz.util.Logger
-import org.multipaz.util.inflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibInflate
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
@@ -58,7 +58,7 @@ data class OtherDocument(
         transactionData: List<TransactionData>,
         atTime: Instant,
     ): Map<String, Map<String, DataItem>> {
-        val sdJwtKb = SdJwtKb.fromCompactSerialization(data.toByteArray().inflate().decodeToString())
+        val sdJwtKb = SdJwtKb.fromCompactSerialization(data.toByteArray().zlibInflate().decodeToString())
 
         val issuerCertChain = sdJwtKb.sdJwt.x5c
             ?: throw IllegalStateException("Issuer-signed key not in `x5c` in header")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -33,8 +33,8 @@ import org.multipaz.request.Requester
 import org.multipaz.sdjwt.SdJwt
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.util.Logger
-import org.multipaz.util.deflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibDeflate
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -261,7 +261,7 @@ suspend fun mdocPresentment(
                     )
                     val otherDocument = OtherDocument(
                         docFormat = "sd-jwt+kb",
-                        data = ByteString(sdJwtKb.compactSerialization.encodeToByteArray().deflate())
+                        data = ByteString(sdJwtKb.compactSerialization.encodeToByteArray().zlibDeflate())
                     )
                     match.source.docRequest.docRequestInfo?.docResponseEncryption?.let { encryptionParameters ->
                         addEncryptedDocuments(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -53,8 +53,8 @@ import org.multipaz.sdjwt.SdJwt
 import org.multipaz.sdjwt.SdJwtKb
 import org.multipaz.util.Logger
 import org.multipaz.util.fromBase64Url
-import org.multipaz.util.inflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibInflate
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.coroutines.cancellation.CancellationException
@@ -1017,7 +1017,7 @@ object VerificationUtil {
                 Logger.w(TAG, "Unknown docFormat ${document.docFormat}")
                 continue
             }
-            val sdJwtKbCompactSerialization = document.data.toByteArray().inflate().decodeToString()
+            val sdJwtKbCompactSerialization = document.data.toByteArray().zlibInflate().decodeToString()
 
             val sessionTranscriptBytes = Tagged(
                 tagNumber = Tagged.ENCODED_CBOR,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/presentment/MdocPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/presentment/MdocPresentmentTest.kt
@@ -31,8 +31,8 @@ import org.multipaz.presentment.DocumentStoreTestHarness
 import org.multipaz.presentment.mdocPresentment
 import org.multipaz.sdjwt.SdJwtKb
 import org.multipaz.util.fromBase64Url
-import org.multipaz.util.inflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibInflate
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -209,7 +209,7 @@ class MdocPresentmentTest {
 
         assertEquals(1, dr.otherDocuments.size)
         assertEquals("sd-jwt+kb", dr.otherDocuments[0].docFormat)
-        val decompressedData = dr.otherDocuments[0].data.toByteArray().inflate()
+        val decompressedData = dr.otherDocuments[0].data.toByteArray().zlibInflate()
         val sdJwtKb = SdJwtKb.fromCompactSerialization(decompressedData.decodeToString())
         val sessionTranscriptBytes = Tagged(
             tagNumber = Tagged.ENCODED_CBOR,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseTest.kt
@@ -53,10 +53,10 @@ import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import org.multipaz.util.Logger
-import org.multipaz.util.deflate
 import org.multipaz.util.fromHex
-import org.multipaz.util.inflate
 import org.multipaz.util.toBase64Url
+import org.multipaz.util.zlibDeflate
+import org.multipaz.util.zlibInflate
 import kotlin.experimental.xor
 import kotlin.random.Random
 import kotlin.test.BeforeTest
@@ -1097,7 +1097,7 @@ class DeviceResponseTest {
                 addOtherDocument(
                     OtherDocument(
                         docFormat = "sd-jwt+kb",
-                        data = ByteString(compactSerialization.encodeToByteArray().deflate())
+                        data = ByteString(compactSerialization.encodeToByteArray().zlibDeflate())
                     )
                 )
             }
@@ -1136,7 +1136,7 @@ class DeviceResponseTest {
         assertEquals(1, encDocs.otherDocuments.size)
 
         assertEquals("sd-jwt+kb", encDocs.otherDocuments[0].docFormat)
-        val sdJwtKbCompactSerialization = encDocs.otherDocuments[0].data.toByteArray().inflate().decodeToString()
+        val sdJwtKbCompactSerialization = encDocs.otherDocuments[0].data.toByteArray().zlibInflate().decodeToString()
         val processedPayload = SdJwtKb.fromCompactSerialization(sdJwtKbCompactSerialization)
             .verify(
                 issuerKey = euPidDsKey.publicKey,
@@ -1188,7 +1188,7 @@ class DeviceResponseTest {
             addOtherDocument(
                 otherDocument = OtherDocument(
                     docFormat = "xyz123-abc",
-                    data = ByteString(byteArrayOf(1, 2, 3).deflate())
+                    data = ByteString(byteArrayOf(1, 2, 3).zlibDeflate())
                 )
             )
         }
@@ -1199,6 +1199,6 @@ class DeviceResponseTest {
 
         assertEquals(1, drParsed.otherDocuments.size)
         assertEquals("xyz123-abc", drParsed.otherDocuments[0].docFormat)
-        assertContentEquals(byteArrayOf(1, 2, 3), drParsed.otherDocuments[0].data.toByteArray().inflate())
+        assertContentEquals(byteArrayOf(1, 2, 3), drParsed.otherDocuments[0].data.toByteArray().zlibInflate())
     }
 }


### PR DESCRIPTION
The proposed change to 18013-5 for supporting SD-JWT VC calls for using DEFLATE [RFC1951] with the ZLIB [RFC1950] data format (same method as specified for Status List), not just raw DEFLATE.

Test: Manually tested and all unit tests work.
