### PR TITLE
SdJwt: Handle SD-JWTs with a single disclosure for age_equal_or_over.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -156,7 +156,10 @@ suspend fun uriSchemePresentment(
         )
     }
     check(postResponseResponse.status == HttpStatusCode.OK)
-    check(postResponseResponse.contentType()!! == ContentType.Application.Json)
+    val contentType = postResponseResponse.contentType()
+    check(contentType != null && contentType.match(ContentType.Application.Json)) {
+        "Expected ${ContentType.Application.Json}, got $contentType"
+    }
     val bodyText = (postResponseResponse.body() as ByteArray).decodeToString()
     val postResponseBody = Json.decodeFromString<JsonObject>(bodyText)
     val redirectUri = postResponseBody["redirect_uri"]?.jsonPrimitive?.content

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -6,6 +6,7 @@ import kotlin.time.Instant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
@@ -162,6 +163,42 @@ class SdJwt private constructor(
     }
 
     /**
+     * Checks if a disclosure path matches a requested path according to OpenID4VP section 7.1.
+     *
+     * The matching logic compares components at each index:
+     * - A `null` value (JsonNull) in the requested path matches any non-negative integer array index in the disclosure path.
+     * - String keys or specific array indices match if their string values are equal.
+     *
+     * In addition, the two paths match if they are equal or if one is a prefix of the other (so that
+     * ancestors and descendants are matched, satisfying the RFC 9901 section 7.2 requirement that parent
+     * disclosures are preserved to allow traversing to nested children).
+     *
+     * @param path the disclosure's component path.
+     * @param pathToInclude the requested component path.
+     * @return `true` if the disclosure path matches the requested path, `false` otherwise.
+     */
+    private fun pathMatches(path: JsonArray, pathToInclude: JsonArray): Boolean {
+        val minLen = minOf(path.size, pathToInclude.size)
+        for (i in 0 until minLen) {
+            val Cd = path[i]
+            val Cr = pathToInclude[i]
+            if (Cr is JsonNull) {
+                // null matches all elements of array(s) (non-negative integer indices)
+                if (Cd !is JsonPrimitive || Cd.isString || Cd.content.toIntOrNull()?.let { it >= 0 } != true) {
+                    return false
+                }
+            } else if (Cr is JsonPrimitive && Cd is JsonPrimitive) {
+                if (Cr.content != Cd.content) {
+                    return false
+                }
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
      * Generates a new SD-JWT by filtering which claims should be included,
      *
      * The resulting SD-JWT will be constructed so it satisfies the requirement in section 7.2
@@ -175,12 +212,9 @@ class SdJwt private constructor(
     suspend fun filter(
         pathsToInclude: List<JsonArray>
     ): SdJwt {
-        val pathToIncludeStrings = pathsToInclude.map { it.joinToString(".") }
-
         return filter { path: JsonArray, value: JsonElement ->
-            val pathOfDisclosure = path.toList().joinToString(".")
-            for (pathToIncludeString in pathToIncludeStrings) {
-                if (pathOfDisclosure.startsWith(pathToIncludeString)) {
+            for (pathToInclude in pathsToInclude) {
+                if (pathMatches(path, pathToInclude)) {
                     return@filter true
                 }
             }
@@ -206,6 +240,8 @@ class SdJwt private constructor(
      *  ```
      * the hash for the disclosure of the `age_over_or_equal.18` is not included in the Issuer-signed
      * JWT claims, instead it's in the disclosure for the `age_over_or_equal` value.
+     *
+     * This implementation follows the rules for selection in OpenID4VP section 7.1.
      *
      * @param includeDisclosure a function to determine if a given disclosure should be included.
      * @return the resulting [SdJwt].

--- a/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/sdjwt/SdJwtTest.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -2723,6 +2725,47 @@ class SdJwtTest {
                 }
             """.trimIndent().trim(),
             prettyJson.encodeToString(filteredSdJwt.verify(sdJwtRfcIssuerKey))
+        )
+    }
+
+    @Test
+    fun testObjectNotDisclosed() = runTest {
+        // This is a SD-JWT from the issuer in https://github.com/openwallet-foundation/multipaz/issues/1742
+        // which has a single disclosure for the object `age_equal_or_over` like this:
+        //
+        //  Key: age_equal_or_over
+        //  Value: { "12": true, "14": true, "16": true, "18": true, "21": true, "65": false }
+        //
+        val sdJwt = SdJwt.fromCompactSerialization(
+            "eyJ0eXAiOiJkYytzZC1qd3QiLCJhbGciOiJFUzI1NiIsIng1YyI6WyJNSUlCMERDQ0FYYWdBd0lCQWdJUUF4NmMyWXhZRlFaNTdFTHJMa0RCWnpBS0JnZ3Foa2pPUFFRREFqQXFNUXN3Q1FZRFZRUUdFd0pFUlRFYk1Ca0dBMVVFQXhNU1VHeGhlV2R5YjNWdVpDQlNiMjkwSUVOQk1CNFhEVEkyTURVeU1UQTRNemd4T0ZvWERUSTNNRFV5TVRBNE16Z3hPRm93SWpFTE1Ba0dBMVVFQmhNQ1JFVXhFekFSQmdOVkJBTVRDbEJzWVhsbmNtOTFibVF3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVQ2N1dEeWpCZmhZSVYxSXA5NVZaQnMxWjd1RFNKOXZwREpZODdSZXZ3OGkveW1xWUtZRVhQZEFPbkd5YWNidFBsTzJJVEtUSmIrWDhDa0xBTmUxcUxpbzRHRk1JR0NNQ0lHQTFVZEVRUWJNQm1DRjJWMVpHbHdiRzh1WlhWa2FTMTNZV3hzWlhRdVpHVjJNQXdHQTFVZEV3RUIvd1FDTUFBd0RnWURWUjBQQVFIL0JBUURBZ1dnTUIwR0ExVWREZ1FXQkJUY2hhNE10bFIxdjE1WlNRSEN5L2lVVlFqYm5qQWZCZ05WSFNNRUdEQVdnQlR6SE1CNU43K2dZUEI4NGxSZmMxRVJpemFaakRBS0JnZ3Foa2pPUFFRREFnTklBREJGQWlFQTc0NHhVVnVnV2FzWms2RGpMclhqdDF2anNWQUZXZzZodGN5VW1xSEp1bGdDSUZJdjVxZkJ6QnArVE41bFJyVVdNQXAzc0YrQmFkZmUvWllxTmRJRFg0Q0giXX0.eyJpc3MiOiJodHRwczovL2V1ZGlwbG8uZXVkaS13YWxsZXQuZGV2L2lzc3VlcnMvcGxheWdyb3VuZCIsImlhdCI6MTc3OTgwODcxMywiZXhwIjoxNzgwNDEzNTEzLCJ2Y3QiOiJ1cm46ZXVkaTpwaWQ6ZGU6MSIsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJjSkxLYTdHSlZKdHoxS1ItUVd0cGFmTjRCZVVoV1BsdnRpZWRjRHNqSjdnIiwieSI6ImFfYWVsOFZpT1Faa3BfNHlOejdzSGNLMmt5b3pSVHZjVmRzaHVhanJkQ2ciLCJraWQiOiI4ZnhveWdMX2lLZUQifX0sInN0YXR1cyI6eyJzdGF0dXNfbGlzdCI6eyJpZHgiOjI4OTYsInVyaSI6Imh0dHBzOi8vZXVkaXBsby5ldWRpLXdhbGxldC5kZXYvaXNzdWVycy9wbGF5Z3JvdW5kL3N0YXR1cy1tYW5hZ2VtZW50L3N0YXR1cy1saXN0L3BpZCJ9fSwiX3NkIjpbIjY4MmFpZ0l3Sm96ajdjZXI3LUdHM25YQXh4aUNLZmNlRFlzMWtrSTloM3MiLCI2OW1nSzNVZkdzVmphbFllcTdUSnhHTEROUDlKYnZuNEt4R3dHN3FZalNRIiwiTW1Ma1BKaWdlOV9aUk1NOVkyUzg2YzZoRkhxeWJ4Y2FjWUoyRV8wcUhvayIsIldZTERZT0dKRjRFWWJLcDFkZGUxbWdZNmM0SjFBM1ZWYkNpcURVSjVGbDAiLCJaX2ZrZERSMjNJSHZTQXRGVjNwQnh0NDJwV2F4UzVMZ0xjNFRjRHlWYllNIiwiZnhfbXNSZmxxOTk1eWIxQmozRVpCYi1IenhrNlg3dkkzaC1Na0xLX25HZyIsImxIUFZUa3BNWkRWb3QxRTJ6eVowYzU1bEdybWF0b2VGXzg0d2haU0FQU3ciLCJtVFpOUjRfcUFLcHdGSXhkRHFIb1lNRFhPcWF5MXJMSnFNcHlnMGV1X28wIiwibjhBNkZ3V0pxSEtUT1VoUXFMZ0JWUnhBd2U4NUpEWTdhUG1VRmQ4QnlUMCIsInF4Yjk0cEFBVklqc3BoX1JQdF9PblNmcl9VbDFwYXZuQmlBazhLbWNMRGsiLCJyZGo3Z0QzWVpOWk12ejBIa0dkcTdwV19OR2UwOTBOODRycUhZYmdhX1YwIiwidFlJQVdxc01hZWVGc3JDYkNvN3hZSmdxSzdONHBlSEZDRkhmdmQ4XzI4MCJdLCJfc2RfYWxnIjoic2hhLTI1NiJ9.Akjo1M1RD_wnrF9Rv3wWrpCaTL5rnMwt8xOZsFHlVqtPk6XcMOlkYfxaagUnSICYzhiQ4qykgxUFYO_zdxaHBA~WyIxMjg3YmFjZDQ2MWQxMDA0Iiwic3RyZWV0X2FkZHJlc3MiLCJNVVNURVJTVFJBU1NFIDEyMyJd~WyJhNzU1MDg5ZDQ3NWNmODRhIiwibG9jYWxpdHkiLCJCRVJMSU4iXQ~WyI0MTBhNDNmYTk0M2MyYzQyIiwiY291bnRyeSIsIkRFIl0~WyJmZjc5NGZiOThhOGQzYzIwIiwicG9zdGFsX2NvZGUiLCIxMDExNSJd~WyJjYTY2ZjdiYmM3Nzg4NjQ0IiwiaXNzdWluZ19jb3VudHJ5IiwiREUiXQ~WyI1YzRkMjhlM2VkMjVhOGU3IiwiaXNzdWluZ19hdXRob3JpdHkiLCJERSJd~WyJhZjk4Yjk3MGM1MzkyMWQ3Iiwic291cmNlX2RvY3VtZW50X3R5cGUiLCJpZF9jYXJkIl0~WyI1NTkzYjYwZDllY2ZhNWRlIiwiZ2l2ZW5fbmFtZSIsIk1BWCJd~WyI3OTg2NzA0ZmFhOGNiNDFiIiwiZmFtaWx5X25hbWUiLCJNVVNURVJNQU5OIl0~WyI1YjhhMGIyZGM5NWI3NTQzIiwiYmlydGhkYXRlIiwiMTk5MC0wMS0xNSJd~WyIxNTA2YmU3OGEyY2I5YzkyIiwiYWdlX2JpcnRoX3llYXIiLDE5OTBd~WyJkOWU5OTZkYjM3MjUwOWMyIiwiYWdlX2luX3llYXJzIiwzNl0~WyI4N2U5NjY1YmU0MzZkYWM1IiwiYWdlX2VxdWFsX29yX292ZXIiLHsiMTIiOnRydWUsIjE0Ijp0cnVlLCIxNiI6dHJ1ZSwiMTgiOnRydWUsIjIxIjp0cnVlLCI2NSI6ZmFsc2V9XQ~WyI4NTRlZjRlYjFhOWQ0NzgwIiwicGxhY2Vfb2ZfYmlydGgiLHsibG9jYWxpdHkiOiJCRVJMSU4ifV0~WyI4YWYzNjFjYWQ3ZWE5MGM2IiwiYWRkcmVzcyIseyJfc2QiOlsiOF9ORE9rRzRNOEtLVUZGZnZGa2dRTlZFWWZhZi03cGtfUTY1cVZ4QWdLWSIsIlNGSUh2Y2RqYXdYRF94anhfcjI3LUttOXNmZWl4NDllV285RTNWZ3JIaE0iLCJYSm9TR0hmNVB2N29XY3BnLXJnLVYzVl9VZFpQQWFFT1ZQODVNeWJ3VVhjIiwibGJRdDZQN1U5Z3BVUlBRUHlXZFZtZXpfRWJDWW93X3RyRnpIUXUwNTBZOCJdfV0~WyI1MjFlZGY3OGIyYzE5ZjBiIiwibmF0aW9uYWxpdGllcyIsWyJERSJdXQ~"
+        )
+
+        val ageEqualOrOverFilteredSdJwt =  sdJwt.filter(
+            pathsToInclude = listOf(
+                buildJsonArray { add("age_equal_or_over") }
+            )
+        )
+        assertEquals(1, ageEqualOrOverFilteredSdJwt.disclosures.size)
+        assertEquals(
+            """
+                ["87e9665be436dac5","age_equal_or_over",{"12":true,"14":true,"16":true,"18":true,"21":true,"65":false}]
+            """.trimIndent(),
+            ageEqualOrOverFilteredSdJwt.disclosures[0].fromBase64Url().decodeToString()
+        )
+
+        // This should return the disclosure which contains `age_equal_or_over` which unfortunately
+        // will leak other ages too...
+        val ageEqualOrOver16FilteredSdJwt =  sdJwt.filter(
+            pathsToInclude = listOf(
+                buildJsonArray { add("age_equal_or_over"); add("16") }
+            )
+        )
+        assertEquals(1, ageEqualOrOver16FilteredSdJwt.disclosures.size)
+        assertEquals(
+            """
+                ["87e9665be436dac5","age_equal_or_over",{"12":true,"14":true,"16":true,"18":true,"21":true,"65":false}]
+            """.trimIndent(),
+            ageEqualOrOver16FilteredSdJwt.disclosures[0].fromBase64Url().decodeToString()
         )
     }
 


### PR DESCRIPTION
Corrected the path-filtering implementation in `SdJwt.filter(pathsToInclude)`.

Instead of naive string-based `startsWith` comparison on dot-joined paths, we implemented proper component-by-component comparison matching components according to OpenID4VP section 7.1 and SD-JWT / RFC 9901 section 7.2

Also fix a bug in how we compare content-types when doing URI-scheme based OpenID4VP presentment.

Fixes #1742.

Test: New unit test and manually tested.
