### PR TITLE
SwiftUI: Add state to VerticalCardList.

### DIFF
--- a/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
+++ b/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
@@ -2,6 +2,56 @@ import SwiftUI
 import UIKit
 import Combine
 
+/// State object for `VerticalCardList`.
+///
+/// Stores and synchronizes order, dragging, and scroll properties to enable smooth layout transitions.
+@Observable
+public class VerticalCardListState {
+    /// The current display order of the cards, tracked by identifier.
+    public var displayOrderIdentifiers: [String] = []
+    
+    /// The identifier of the card currently being dragged, if any.
+    public var draggedCardIdentifier: String? = nil
+    
+    /// The current Y position of the dragged card.
+    public var dragCurrentY: CGFloat = 0
+    
+    /// Whether a drag operation just ended.
+    public var dragJustEnded: Bool = false
+    
+    /// The identifier of the card currently focused, if any.
+    public var internalFocusedCardIdentifier: String? = nil
+    
+    /// Whether to animate spatial transitions (like sliding cards) when entering this screen.
+    /// This should typically be set to true only when navigating directly between two list states.
+    public var animateListTransitions: Bool = true
+    
+    /// The current scroll offset, normalized against the initial content offset.
+    public var scrollOffset: CGFloat = 0
+    
+    /// The initial content offset measured when the scroll view layout is established.
+    public var initialContentOffset: CGFloat = 0
+    
+    /// Whether the initial content offset has been captured and resolved.
+    public var isScrollOffsetInitialized: Bool = false
+    
+    public init() {}
+    
+    /// Unfocuses the currently focused card with animation, and calls the completion block when finished.
+    public func unfocus(completion: @escaping () -> Void) {
+        if internalFocusedCardIdentifier != nil {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                self.internalFocusedCardIdentifier = nil
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                completion()
+            }
+        } else {
+            completion()
+        }
+    }
+}
+
 private struct CardListScrollOffsetKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -57,8 +107,6 @@ private struct CardInteractionView: UIViewRepresentable {
         }
         
         @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
-            // Tracking globally against the window ensures dragging isn't warped
-            // by the SwiftUI view's own visual offset changes during its animation.
             let location = gesture.location(in: nil)
             
             switch gesture.state {
@@ -77,6 +125,92 @@ private struct CardInteractionView: UIViewRepresentable {
     }
 }
 
+fileprivate struct ScrollViewObserver: UIViewRepresentable {
+    var state: VerticalCardListState
+    
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        DispatchQueue.main.async {
+            if let scrollView = view.findAncestorScrollView() {
+                context.coordinator.setup(scrollView)
+            }
+        }
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let scrollView = uiView.findAncestorScrollView() {
+            if state.isScrollOffsetInitialized {
+                let targetContentOffset = state.scrollOffset + state.initialContentOffset
+                if abs(scrollView.contentOffset.y - targetContentOffset) > 1 {
+                    context.coordinator.isUpdatingOffset = true
+                    scrollView.contentOffset.y = targetContentOffset
+                    context.coordinator.isUpdatingOffset = false
+                }
+            }
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject {
+        var parent: ScrollViewObserver
+        var scrollView: UIScrollView?
+        var observation: NSKeyValueObservation?
+        var isUpdatingOffset = false
+        
+        init(_ parent: ScrollViewObserver) {
+            self.parent = parent
+        }
+        
+        func setup(_ scrollView: UIScrollView) {
+            self.scrollView = scrollView
+            if !parent.state.isScrollOffsetInitialized {
+                parent.state.initialContentOffset = scrollView.contentOffset.y
+                parent.state.scrollOffset = 0
+                parent.state.isScrollOffsetInitialized = true
+            } else {
+                let targetContentOffset = parent.state.scrollOffset + parent.state.initialContentOffset
+                if abs(scrollView.contentOffset.y - targetContentOffset) > 1 {
+                    isUpdatingOffset = true
+                    scrollView.contentOffset.y = targetContentOffset
+                    isUpdatingOffset = false
+                }
+            }
+            observation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
+                guard let self = self else { return }
+                guard !self.isUpdatingOffset else { return }
+                guard scrollView.isDragging || scrollView.isDecelerating || scrollView.isTracking else { return }
+                let newY = scrollView.contentOffset.y
+                let newRelativeOffset = newY - self.parent.state.initialContentOffset
+                if abs(self.parent.state.scrollOffset - newRelativeOffset) > 1 {
+                    self.parent.state.scrollOffset = newRelativeOffset
+                }
+            }
+        }
+        
+        deinit {
+            observation?.invalidate()
+        }
+    }
+}
+
+extension UIView {
+    fileprivate func findAncestorScrollView() -> UIScrollView? {
+        var current: UIView? = self
+        while current != nil {
+            if let scrollView = current as? UIScrollView {
+                return scrollView
+            }
+            current = current?.superview
+        }
+        return nil
+    }
+}
+
 /// A vertically scrolling list of cards that mimics a physical wallet experience.
 ///
 /// In its default state, cards are displayed as a vertical list. The amount of
@@ -87,58 +221,79 @@ private struct CardInteractionView: UIViewRepresentable {
 /// to the top of the viewport. A dynamic content section (`showCardInfo`) fades in immediately
 /// below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
 /// bottom of the screen.
-///
-/// - Parameters:
-///   - cardInfos: The list of `CardInfo` objects to display.
-///   - focusedCard: The currently focused card. When `nil`, the component operates in
-///     standard list mode. When set to a `CardInfo`, that card is brought to the top and
-///     detailed information is displayed.
-///   - unfocusedVisiblePercent: Determines how much of each card is visible when not focused. A
-///     value of `100` displays cards with standard spacing (no overlap). Lower values cause cards to
-///     overlap, allowing more cards to fit on screen. Must be between 0 and 100.
-///   - allowCardReordering: If `true`, users can long-press and drag cards to reorder them
-///     when in standard list mode. Defaults to `true`.
-///   - showStackWhileFocused: If `true`, unfocused cards will collapse into a 3D stack at the bottom
-///     of the screen when a card is focused. If `false`, unfocused cards fade away entirely to maximize
-///     screen real estate for the detail view. Defaults to `true`.
-///   - showCardInfo: A `@ViewBuilder` closure that renders the detailed content below the focused card.
-///     It is horizontally centered by default.
-///   - emptyContent: A `@ViewBuilder` closure displayed inside a dashed placeholder card when the
-///     `cardInfos` list is empty.
-///   - onCardReordered: Callback invoked when a drag-and-drop reordering operation completes.
-///     Provides the `CardInfo` of the moved card and its new index position in the list.
-///   - onCardFocused: Callback invoked when a card is tapped to be focused.
-///   - onCardFocusedTapped: Callback invoked when the currently focused card is tapped.
-///   - onCardFocusedStackTapped: Callback invoked when the unfocused card stack is tapped while another card is in focus.
 public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View {
+    /// The list of `CardInfo` objects to display.
     public var cardInfos: [CardInfo]
+    
+    /// The currently focused card. When `nil`, the component operates in standard list mode.
     public var focusedCard: CardInfo?
+    
+    /// Determines how much of each card is visible when not focused. A value of `100` displays
+    /// cards with standard spacing (no overlap). Lower values cause cards to overlap.
     public var unfocusedVisiblePercent: Int
+    
+    /// If `true`, users can long-press and drag cards to reorder them in standard list mode.
     public var allowCardReordering: Bool
+    
+    /// If `true`, unfocused cards will collapse into a 3D stack at the bottom of the screen.
     public var showStackWhileFocused: Bool
     
+    /// The state object used to control or observe the list's state.
+    public var state: VerticalCardListState
+    
+    /// Whether to animate transitions when entering or navigating between list states.
+    public var animateListTransitions: Bool
+    
+    /// Renders the detailed content below the focused card.
     @ViewBuilder public var showCardInfo: (CardInfo) -> SelectedContent
+    
+    /// Displayed inside a dashed placeholder card when the card list is empty.
     @ViewBuilder public var emptyContent: () -> EmptyContent
+    
+    /// Callback invoked when a drag-and-drop reordering operation completes.
     public var onCardReordered: (CardInfo, Int) -> Void
+    
+    /// Callback invoked when a card is tapped to be focused.
     public var onCardFocused: (CardInfo) -> Void
+    
+    /// Callback invoked when the currently focused card is tapped.
     public var onCardFocusedTapped: (CardInfo) -> Void
+    
+    /// Callback invoked when the unfocused card stack is tapped while another card is in focus.
     public var onCardFocusedStackTapped: (CardInfo) -> Void
 
-    @State private var displayOrder: [CardInfo] = []
-    @State private var scrollOffset: CGFloat = 0
+    @State private var displayOrder: [CardInfo]
     
-    @State private var draggedCardIndex: Int? = nil
-    @State private var dragCurrentY: CGFloat = 0
     @State private var startDragY: CGFloat = 0
     @State private var isDragging: Bool = false
     @State private var lastDragEndTime: Date = .distantPast
     
+
+    
+    /// Initializes a `VerticalCardList` view.
+    ///
+    /// - Parameters:
+    ///   - cardInfos: The list of `CardInfo` objects to display.
+    ///   - focusedCard: The currently focused card.
+    ///   - unfocusedVisiblePercent: Percent of card visible when unfocused (0 to 100).
+    ///   - allowCardReordering: Whether to allow dragging to reorder cards.
+    ///   - showStackWhileFocused: Whether to show the collapsed 3D card stack at the bottom of the screen.
+    ///   - state: The list state tracker object.
+    ///   - animateListTransitions: Whether to animate view list transitions.
+    ///   - showCardInfo: Closure rendering detailed info view for a card.
+    ///   - emptyContent: Closure rendering layout when the card list is empty.
+    ///   - onCardReordered: Callback triggered on card reordering completion.
+    ///   - onCardFocused: Callback triggered on selecting a card.
+    ///   - onCardFocusedTapped: Callback triggered on tapping a focused card.
+    ///   - onCardFocusedStackTapped: Callback triggered on tapping the background stack while focused.
     public init(
         cardInfos: [CardInfo],
         focusedCard: CardInfo?,
         unfocusedVisiblePercent: Int = 25,
         allowCardReordering: Bool = true,
         showStackWhileFocused: Bool = true,
+        state: VerticalCardListState = VerticalCardListState(),
+        animateListTransitions: Bool = true,
         @ViewBuilder showCardInfo: @escaping (CardInfo) -> SelectedContent = { _ in EmptyView() },
         @ViewBuilder emptyContent: @escaping () -> EmptyContent = { EmptyView() },
         onCardReordered: @escaping (CardInfo, Int) -> Void = { _, _ in },
@@ -151,12 +306,34 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
         self.unfocusedVisiblePercent = unfocusedVisiblePercent
         self.allowCardReordering = allowCardReordering
         self.showStackWhileFocused = showStackWhileFocused
+        self.state = state
+        self.animateListTransitions = animateListTransitions
         self.showCardInfo = showCardInfo
         self.emptyContent = emptyContent
         self.onCardReordered = onCardReordered
         self.onCardFocused = onCardFocused
         self.onCardFocusedTapped = onCardFocusedTapped
         self.onCardFocusedStackTapped = onCardFocusedStackTapped
+        
+        let initialDisplayOrder = state.displayOrderIdentifiers.isEmpty
+            ? cardInfos
+            : state.displayOrderIdentifiers.compactMap { id in cardInfos.first { $0.identifier == id } }
+        self._displayOrder = State(initialValue: initialDisplayOrder)
+        
+        if !animateListTransitions {
+            state.internalFocusedCardIdentifier = focusedCard?.identifier
+        }
+    }
+    
+    private func syncDisplayOrder() {
+        let currentCardIdentifiers = cardInfos.map { $0.identifier }
+        if state.draggedCardIdentifier == nil && state.displayOrderIdentifiers != currentCardIdentifiers {
+            state.displayOrderIdentifiers = currentCardIdentifiers
+        }
+        
+        displayOrder = state.displayOrderIdentifiers.compactMap { id in
+            cardInfos.first { $0.identifier == id }
+        }
     }
     
     public var body: some View {
@@ -168,14 +345,14 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
             let paddingTop: CGFloat = 24
             let spacing: CGFloat = 16
             
-            let cardWidth = maxWidth - 2 * paddingHorizontal
-            let cardHeight = cardWidth / 1.586
+            let cardWidth = max(0, maxWidth - 2 * paddingHorizontal)
+            let cardHeight = max(0, cardWidth / 1.586)
             
-            let listStep: CGFloat = unfocusedVisiblePercent == 100
+            let listStep: CGFloat = max(0, unfocusedVisiblePercent == 100
                 ? cardHeight + spacing
-                : cardHeight * (CGFloat(unfocusedVisiblePercent) / 100.0)
+                : cardHeight * (CGFloat(unfocusedVisiblePercent) / 100.0))
             
-            let totalHeight = paddingTop + CGFloat(max(0, displayOrder.count - 1)) * listStep + cardHeight + paddingTop
+            let totalHeight = max(0, paddingTop + CGFloat(max(0, displayOrder.count - 1)) * listStep + cardHeight + paddingTop)
             
             let maxStackIndex = max(0, displayOrder.count - 2)
             let maxVisibleCardsInStack = 5
@@ -184,9 +361,13 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
             let stackOffset: CGFloat = 14
             let frontCardVisibleHeight = cardHeight * 0.25
             
-            let detailBottomPadding: CGFloat = showStackWhileFocused
+            let detailBottomPadding: CGFloat = max(0, showStackWhileFocused
                 ? frontCardVisibleHeight + CGFloat(maxVisibleStackOffsets) * stackOffset + 16
-                : 16
+                : 16)
+            
+            let internalFocusedCard = focusedCard == nil ? nil : cardInfos.first {
+                $0.identifier == state.internalFocusedCardIdentifier
+            }
             
             if displayOrder.isEmpty && cardInfos.isEmpty {
                 VStack {
@@ -205,22 +386,15 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
                     ScrollViewReader { scrollProxy in
                         ScrollView {
                             ZStack(alignment: .topLeading) {
+                                ScrollViewObserver(state: state)
+                                
                                 Color.clear
                                     .contentShape(Rectangle())
                                     .frame(maxWidth: .infinity)
                                     .frame(height: totalHeight)
-                                    .background(
-                                        GeometryReader { geo in
-                                            let minY = geo.frame(in: .named("CardListSpace")).minY
-                                            Color.clear.preference(
-                                                key: CardListScrollOffsetKey.self,
-                                                value: minY
-                                            )
-                                        }
-                                    )
                                     .id("TopSpacer")
                                 
-                                if let focused = focusedCard {
+                                if let focused = internalFocusedCard {
                                     let detailHeight = max(0, maxHeight - detailBottomPadding)
                                     VStack {
                                         showCardInfo(focused)
@@ -229,17 +403,19 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
                                     .padding(.top, paddingTop + cardHeight * 1.05 + 24)
                                     .padding(.bottom, 24)
                                     .frame(width: maxWidth, height: detailHeight, alignment: .top)
-                                    .offset(y: scrollOffset)
+                                    .offset(y: state.scrollOffset)
                                     .transition(.opacity)
                                     .zIndex(50)
                                 }
                                 
-                                ForEach(Array(displayOrder.enumerated()), id: \.offset) { index, cardInfo in
+                                ForEach(displayOrder, id: \.identifier) { cardInfo in
+                                    let index = displayOrder.firstIndex(where: { $0.identifier == cardInfo.identifier }) ?? 0
                                     let cardState = calculateCardState(
                                         index: index, cardInfo: cardInfo, maxHeight: maxHeight, paddingTop: paddingTop,
                                         listStep: listStep, maxStackIndex: maxStackIndex, maxVisibleCardsInStack: maxVisibleCardsInStack,
                                         frontCardVisibleHeight: frontCardVisibleHeight, stackOffset: stackOffset
                                     )
+                                    let isDragged = cardInfo.identifier == state.draggedCardIdentifier
                                     
                                     ZStack(alignment: .topTrailing) {
                                         Image(uiImage: cardInfo.cardArt)
@@ -256,21 +432,17 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
                                         .opacity(cardState.alpha)
                                         .overlay(
                                             CardInteractionView(
-                                                allowReordering: focusedCard == nil && allowCardReordering,
+                                                allowReordering: state.internalFocusedCardIdentifier == nil && allowCardReordering,
                                                 onTap: {
-                                                    guard !isDragging && Date().timeIntervalSince(lastDragEndTime) > 0.3 else { return }
-                                                    if let focused = focusedCard {
-                                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                                                            if cardInfo.identifier == focused.identifier {
-                                                                onCardFocusedTapped(focused)
-                                                            } else {
-                                                                onCardFocusedStackTapped(focused)
-                                                            }
+                                                    guard !isDragging && !state.dragJustEnded && state.draggedCardIdentifier == nil && Date().timeIntervalSince(lastDragEndTime) > 0.3 else { return }
+                                                    if let focused = internalFocusedCard {
+                                                        if cardInfo.identifier == focused.identifier {
+                                                            onCardFocusedTapped(focused)
+                                                        } else {
+                                                            onCardFocusedStackTapped(focused)
                                                         }
                                                     } else {
-                                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                                                            onCardFocused(cardInfo)
-                                                        }
+                                                        onCardFocused(cardInfo)
                                                     }
                                                 },
                                                 onLongPressStart: {
@@ -278,38 +450,38 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
                                                     generator.impactOccurred()
                                                     withAnimation(.snappy) {
                                                         isDragging = true
-                                                        draggedCardIndex = index
+                                                        state.draggedCardIdentifier = cardInfo.identifier
                                                     }
                                                     startDragY = paddingTop + CGFloat(index) * listStep
-                                                    dragCurrentY = startDragY
+                                                    state.dragCurrentY = startDragY
                                                 },
                                                 onDragChanged: { translationY in
-                                                    guard isDragging, let currentIndex = draggedCardIndex else { return }
+                                                    guard isDragging, state.draggedCardIdentifier == cardInfo.identifier else { return }
                                                     
-                                                    dragCurrentY = startDragY + translationY
-                                                    let newIndexRaw = Int(round((dragCurrentY - paddingTop) / listStep))
+                                                    state.dragCurrentY = startDragY + translationY
+                                                    let newIndexRaw = Int(round((state.dragCurrentY - paddingTop) / listStep))
                                                     let newIndex = min(max(newIndexRaw, 0), displayOrder.count - 1)
-
-                                                    if currentIndex != newIndex {
+                                
+                                                    if index != newIndex {
                                                         withAnimation(.snappy) {
-                                                            let item = displayOrder.remove(at: currentIndex)
+                                                            let item = displayOrder.remove(at: index)
                                                             displayOrder.insert(item, at: newIndex)
-                                                            draggedCardIndex = newIndex
-                                                            // Update startDragY so further translation is relative to new index
-                                                            startDragY = paddingTop + CGFloat(newIndex) * listStep
-                                                            // We don't update dragCurrentY here because it's what we're currently using
                                                         }
                                                         let generator = UIImpactFeedbackGenerator(style: .light)
                                                         generator.impactOccurred()
                                                     }
                                                 },
                                                 onDragEnded: {
-                                                    guard isDragging, let finalIndex = draggedCardIndex else { return }
+                                                    guard isDragging, state.draggedCardIdentifier == cardInfo.identifier else { return }
                                                     let generator = UIImpactFeedbackGenerator(style: .medium)
                                                     generator.impactOccurred()
-                                                    onCardReordered(displayOrder[finalIndex], finalIndex)
+                                                    onCardReordered(cardInfo, index)
+                                                    
+                                                    state.displayOrderIdentifiers = displayOrder.map { $0.identifier }
+                                                    state.dragJustEnded = true
+                                                    state.draggedCardIdentifier = nil
+                                                    
                                                     withAnimation(.snappy) {
-                                                        draggedCardIndex = nil
                                                         isDragging = false
                                                         lastDragEndTime = Date()
                                                     }
@@ -318,30 +490,59 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
                                         )
                                         .offset(x: paddingHorizontal, y: cardState.y)
                                         .zIndex(cardState.zIndex)
-                                        .animation((index == draggedCardIndex) ? .interactiveSpring() : .spring(response: 0.4, dampingFraction: 0.8), value: cardState.y)
-                                        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.scale)
-                                        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.elevation)
-                                        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: cardState.alpha)
+                                        .animation(isDragged ? .interactiveSpring() : (animateListTransitions ? .spring(response: 0.4, dampingFraction: 0.8) : nil), value: cardState.y)
+                                        .animation(animateListTransitions ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.scale)
+                                        .animation(animateListTransitions ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.elevation)
+                                        .animation(animateListTransitions ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.alpha)
                                 }
                             }
                             .frame(width: maxWidth, height: totalHeight, alignment: .topLeading)
                         }
                         .coordinateSpace(name: "CardListSpace")
-                        .scrollDisabled(focusedCard != nil || isDragging)
-                        .onPreferenceChange(CardListScrollOffsetKey.self) { value in
-                            if value != -scrollOffset {
-                                scrollOffset = -value
-                            }
-                        }
+                        .scrollDisabled((focusedCard != nil && state.internalFocusedCardIdentifier != nil) || isDragging)
                     }
                 }
             }
         }
         .onAppear {
-            if displayOrder.isEmpty { displayOrder = cardInfos }
+            syncDisplayOrder()
+            
+            if animateListTransitions {
+                if state.internalFocusedCardIdentifier != focusedCard?.identifier {
+                    DispatchQueue.main.async {
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            state.internalFocusedCardIdentifier = focusedCard?.identifier
+                        }
+                    }
+                }
+            } else {
+                state.internalFocusedCardIdentifier = focusedCard?.identifier
+            }
         }
-        .onChange(of: cardInfos.count) { _, _ in
-             if !isDragging { displayOrder = cardInfos }
+        .onChange(of: cardInfos.map { $0.identifier }) { _, _ in
+             if !isDragging {
+                 syncDisplayOrder()
+             }
+        }
+        .onChange(of: focusedCard?.identifier) { _, newId in
+            if animateListTransitions {
+                if state.internalFocusedCardIdentifier != newId {
+                    DispatchQueue.main.async {
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            state.internalFocusedCardIdentifier = newId
+                        }
+                    }
+                }
+            } else {
+                state.internalFocusedCardIdentifier = newId
+            }
+        }
+        .onChange(of: state.dragJustEnded) { _, newValue in
+            if newValue {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    state.dragJustEnded = false
+                }
+            }
         }
     }
     
@@ -354,25 +555,25 @@ public struct VerticalCardList<EmptyContent: View, SelectedContent: View>: View 
     }
     
     private func calculateCardState(index: Int, cardInfo: CardInfo, maxHeight: CGFloat, paddingTop: CGFloat, listStep: CGFloat, maxStackIndex: Int, maxVisibleCardsInStack: Int, frontCardVisibleHeight: CGFloat, stackOffset: CGFloat) -> CardState {
-        let isFocused = cardInfo.identifier == focusedCard?.identifier
-        let isDragged = index == draggedCardIndex
-        let isAnyFocused = focusedCard != nil
-        let focusedIndex = displayOrder.firstIndex(where: { $0.identifier == focusedCard?.identifier }) ?? 0
+        let isFocused = cardInfo.identifier == state.internalFocusedCardIdentifier
+        let isDragged = cardInfo.identifier == state.draggedCardIdentifier
+        let isAnyFocused = focusedCard != nil && state.internalFocusedCardIdentifier != nil
+        let focusedIndex = focusedCard == nil ? 0 : (displayOrder.firstIndex(where: { $0.identifier == state.internalFocusedCardIdentifier }) ?? 0)
         
         if isAnyFocused {
             if isFocused {
-                return CardState(y: scrollOffset + paddingTop, scale: 1.05, elevation: 24, zIndex: 100, alpha: 1.0)
+                return CardState(y: state.scrollOffset + paddingTop, scale: 1.05, elevation: 24, zIndex: 100, alpha: 1.0)
             } else {
                 let stackIndex = index < focusedIndex ? index : index - 1
                 let distanceToFront = maxStackIndex - stackIndex
                 let clampedDistanceToFront = min(distanceToFront, maxVisibleCardsInStack - 1)
-                let frontCardY = maxHeight - frontCardVisibleHeight
-                let targetY = scrollOffset + frontCardY - CGFloat(clampedDistanceToFront) * stackOffset
+                let frontCardY = max(0, maxHeight - frontCardVisibleHeight)
+                let targetY = state.scrollOffset + frontCardY - CGFloat(clampedDistanceToFront) * stackOffset
                 let targetScale = max(0.6, 0.95 - (CGFloat(clampedDistanceToFront) * 0.025))
                 return CardState(y: targetY, scale: targetScale, elevation: 12, zIndex: Double(stackIndex), alpha: (!showStackWhileFocused || distanceToFront >= maxVisibleCardsInStack) ? 0.0 : 1.0)
             }
         } else {
-            let targetY = isDragged ? dragCurrentY : (paddingTop + CGFloat(index) * listStep)
+            let targetY = isDragged ? state.dragCurrentY : (paddingTop + CGFloat(index) * listStep)
             return CardState(y: targetY, scale: isDragged ? 1.05 : 1.0, elevation: isDragged ? 24 : 12, zIndex: isDragged ? 100 : Double(index), alpha: 1.0)
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -769,7 +769,7 @@ object VerificationUtil {
      *  in the request.
      * @return a list of [VerifiedPresentation], one for each credential in the response.
      */
-    internal suspend fun verifyOpenID4VPResponse(
+    suspend fun verifyOpenID4VPResponse(
         now: Instant,
         vpToken: JsonObject,
         sessionTranscript: DataItem?,
@@ -923,7 +923,7 @@ object VerificationUtil {
      * @param zkSystemRepository a [ZkSystemRepository] used for verifying ZKP proofs or `null`.
      * @return a list of [VerifiedPresentation], one for each document in the response.
      */
-    internal suspend fun verifyMdocDeviceResponse(
+    suspend fun verifyMdocDeviceResponse(
         now: Instant,
         deviceResponse: DataItem,
         sessionTranscript: DataItem,

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                 case .aboutScreen: AboutScreen()
                 case .documentStoreScreen: DocumentStoreScreen()
                 case .documentScreen(let documentId): DocumentScreen(documentId: documentId)
-                case .verticalCardListScreen: VerticalCardListScreen()
+                case .verticalCardListScreen(let focusedDocumentId): VerticalCardListScreen(focusedDocumentId: focusedDocumentId)
                 case .credentialScreen(documentId: let documentId, credentialId: let credentialId):
                     CredentialScreen(documentId: documentId, credentialId: credentialId)
                 case .claimsScreen(documentId: let documentId, credentialId: let credentialId):

--- a/samples/SwiftTestApp/SwiftTestApp/Destination.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/Destination.swift
@@ -12,6 +12,6 @@ enum Destination: Hashable {
     case iso18013ProximityPresentmentScreen
     case certificateViewerScreen(certificates: [X509Cert])
     case certificateExamplesScreen
-    case verticalCardListScreen
+    case verticalCardListScreen(focusedDocumentId: String?)
     case floatingItemListScreen
 }

--- a/samples/SwiftTestApp/SwiftTestApp/StartScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/StartScreen.swift
@@ -15,7 +15,7 @@ struct StartScreen: View {
                 Button(action: { viewModel.path.append(Destination.documentStoreScreen) }) {
                     Text("Document Store")
                 }
-                Button(action: { viewModel.path.append(Destination.verticalCardListScreen) }) {
+                Button(action: { viewModel.path.append(Destination.verticalCardListScreen(focusedDocumentId: nil)) }) {
                     Text("Vertical Card List")
                 }
                 Button(action: { viewModel.path.append(Destination.consentPromptScreen) }) {

--- a/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
@@ -3,10 +3,8 @@ import Multipaz
 
 struct VerticalCardListScreen: View {
     @Environment(ViewModel.self) private var viewModel
-    
-    @SceneStorage("focusedDocumentId") private var focusedDocumentId: String?
 
-    @SceneStorage("focusedDocumentShowMoreInfo") private var focusedDocumentShowMoreInfo: Bool = false
+    let focusedDocumentId: String?
 
     @Environment(\.dismiss) private var dismiss
     
@@ -21,21 +19,17 @@ struct VerticalCardListScreen: View {
                 unfocusedVisiblePercent: 25, // Show a bit more of the overlapping cards
                 allowCardReordering: true,
                 showStackWhileFocused: true,
+                state: viewModel.verticalCardListState,
                 showCardInfo: { cardInfo in
                     let docInfo = cardInfo as! DocumentInfo
                     VStack {
                         Text("\(docInfo.document.displayName ?? "Document") is focused")
                         Spacer()
-                        if (!focusedDocumentShowMoreInfo) {
-                            Text("Tap card for more info")
-                        } else {
-                            Button(action: {
-                                viewModel.path.append(Destination.documentScreen(documentId: docInfo.document.identifier))
-                            }) {
-                                Text("Even more info")
-                                    .cornerRadius(12)
-                            }
-                            .padding(.top, 8)
+                        Button(action: {
+                            viewModel.path.append(Destination.documentScreen(documentId: docInfo.document.identifier))
+                        }) {
+                            Text("More info")
+                                .cornerRadius(12)
                         }
                     }
                 },
@@ -61,43 +55,21 @@ struct VerticalCardListScreen: View {
                     }
                 },
                 onCardFocused: { cardInfo in
-                    focusedDocumentId = cardInfo.identifier
+                    viewModel.push(.verticalCardListScreen(focusedDocumentId: cardInfo.identifier))
                 },
                 onCardFocusedTapped: { _ in
-                    focusedDocumentShowMoreInfo = true
+                    viewModel.verticalCardListState.unfocus {
+                        viewModel.popWithoutAnimation()
+                    }
                 },
                 onCardFocusedStackTapped: { _ in
-                    focusedDocumentId = nil
+                    viewModel.verticalCardListState.unfocus {
+                        viewModel.popWithoutAnimation()
+                    }
                 }
             )
         }
-        .navigationTitle(focusedDocument != nil
-                         ? (focusedDocumentShowMoreInfo ? "Document Focused (more)" : "Document Focused")
-                         : "Vertical Card List"
-        )
-        // Override back button to unfocus...
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    if focusedDocumentId != nil {
-                        if (focusedDocumentShowMoreInfo) {
-                            focusedDocumentShowMoreInfo = false
-                        } else {
-                            focusedDocumentId = nil
-                        }
-                    } else {
-                        dismiss()
-                    }
-                }) {
-                    // Recreate the native iOS back button appearance
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.backward")
-                            .font(.system(size: 17, weight: .semibold))
-                    }
-                }
-            }
-        }
+        .navigationTitle(focusedDocument != nil ? "Document Focused" : "Vertical Card List")
     }
 }
 

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -8,7 +8,29 @@ import SwiftUI
 @Observable
 class ViewModel {
 
-    var path = NavigationPath()
+    var path: [Destination] = []
+
+    let verticalCardListState = VerticalCardListState()
+
+    func push(_ destination: Destination) {
+        if path.last != destination {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                path.append(destination)
+            }
+        }
+    }
+
+    func popWithoutAnimation() {
+        if !path.isEmpty {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                path.removeLast()
+            }
+        }
+    }
 
     var isLoading: Bool = true
 


### PR DESCRIPTION
We did this a while ago for the Compose version and we need this in the SwiftUI version for the same reasons, proper navigation. Adjust Swift TestApp to use this.

Also make `verifyOpenID4VPResponse()` and `verifyMdocDeviceResponse()` in `VerificationUtil` public as they were inadvertently made internal in PR #1725.

Test: Manually tested.
