### PR TITLE
Work around KSP bug for MdocRequestedClaim.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/JsonRequestedClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/JsonRequestedClaim.kt
@@ -1,6 +1,8 @@
 package org.multipaz.request
 
 import kotlinx.serialization.json.JsonArray
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializationImplemented
 import org.multipaz.documenttype.DocumentAttribute
 
 /**
@@ -9,11 +11,21 @@ import org.multipaz.documenttype.DocumentAttribute
  * @property vctValues the Verifiable Credential Types that can satisfy the request.
  * @property claimPath the claims path pointer.
  */
+@CborSerializationImplemented(schemaId = "")
 data class JsonRequestedClaim(
     override val id: String? = null,
     val vctValues: List<String>,
     val claimPath: JsonArray,
     override val values: JsonArray? = null
 ): RequestedClaim(id = id, values = values) {
-    companion object
+    companion object {
+        /**
+         * Creates a [JsonRequestedClaim] from a [DataItem].
+         *
+         * @param dataItem a [DataItem].
+         * @return a [JsonRequestedClaim].
+         */
+        fun fromDataItem(dataItem: DataItem): JsonRequestedClaim =
+            RequestedClaim.fromDataItem(dataItem) as JsonRequestedClaim
+    }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/request/MdocRequestedClaim.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/request/MdocRequestedClaim.kt
@@ -1,6 +1,8 @@
 package org.multipaz.request
 
 import kotlinx.serialization.json.JsonArray
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializationImplemented
 import org.multipaz.documenttype.DocumentAttribute
 
 /**
@@ -11,6 +13,7 @@ import org.multipaz.documenttype.DocumentAttribute
  * @property dataElementName the data element name.
  * @property intentToRetain `true` if the requester intends to retain the value.
  */
+@CborSerializationImplemented(schemaId = "")
 data class MdocRequestedClaim(
     override val id: String? = null,
     val docType: String,
@@ -18,4 +21,15 @@ data class MdocRequestedClaim(
     val dataElementName: String,
     val intentToRetain: Boolean,
     override val values: JsonArray? = null
-): RequestedClaim(id = id, values = values)
+): RequestedClaim(id = id, values = values) {
+    companion object {
+        /**
+         * Creates a [MdocRequestedClaim] from a [DataItem].
+         *
+         * @param dataItem a [DataItem].
+         * @return a [MdocRequestedClaim].
+         */
+        fun fromDataItem(dataItem: DataItem): MdocRequestedClaim =
+            RequestedClaim.fromDataItem(dataItem) as MdocRequestedClaim
+    }
+}

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
@@ -1,7 +1,10 @@
 package org.multipaz.rpc
 
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.cbor.annotation.CborSerializationImplemented
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.util.fromBase64Url
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -152,6 +155,54 @@ data class IscInheritsRoot(
     val foo: Boolean
 ): IscRoot(stuff)
 
+@CborSerializationImplemented(schemaId = "")
+sealed class SiRoot(
+    open val stuff: String
+) {
+    fun toDataItem() = buildCborMap {
+        put("stuff", stuff)
+        when (this@SiRoot) {
+            is SiInheritsA -> {
+                put("type", "A")
+                put("otherStuff", otherStuff)
+            }
+            is SiInheritsB -> {
+                put("type", "B")
+                put("moarStuff", moarStuff)
+            }
+        }
+    }
+
+    companion object {
+        fun fromDataItem(dataItem: DataItem): SiRoot {
+            when (val type = dataItem["type"].asTstr) {
+                "A" -> {
+                    return SiInheritsA(
+                        stuff = dataItem["stuff"].asTstr,
+                        otherStuff = dataItem["otherStuff"].asBoolean
+                    )
+                }
+                "B" -> {
+                    return SiInheritsB(
+                        stuff = dataItem["stuff"].asTstr,
+                        moarStuff = dataItem["moarStuff"].asTstr
+                    )
+                }
+                else -> throw IllegalArgumentException("Unexpected type value $type")
+            }
+        }
+    }
+}
+
+data class SiInheritsA(
+    override val stuff: String,
+    val otherStuff: Boolean,
+): SiRoot(stuff)
+
+data class SiInheritsB(
+    override val stuff: String,
+    val moarStuff: String,
+): SiRoot(stuff)
 
 class CborSerializationTest {
     @Test
@@ -305,6 +356,21 @@ class CborSerializationTest {
         assertEquals(
             IscRoot.fromDataItem(inheritsIntermediate.toDataItem()),
             inheritsIntermediate
+        )
+    }
+
+    @Test
+    fun serializationImplemented() {
+        val a = SiInheritsA("stuff", true)
+        assertEquals(
+            a,
+            SiRoot.fromDataItem(a.toDataItem())
+        )
+
+        val b = SiInheritsB("stuff2", "yes")
+        assertEquals(
+            b,
+            SiRoot.fromDataItem(b.toDataItem())
         )
     }
 }


### PR DESCRIPTION
When using Multipaz from Multipaz Wallet, the KSP compiler complains "org.multipaz.request.MdocRequestedClaim: not Cbor-serializable, must be marked with either @CborSerializationImplemented or CborSerializable" which, of course it already is.

Wrote a test-case with the intent of fixing the bug but it works fine in-tree so it must be a bug in KSP. Leave the test-case and add code to work around this for now.

Test: New unit tests.
