### PR TITLE
DeviceRequestInfo: Preserve serialization order.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -113,7 +113,7 @@ data class DeviceRequest private constructor(
                 if (deviceRequestInfo != null) {
                     add(Tagged(
                         tagNumber = Tagged.ENCODED_CBOR,
-                        taggedItem = Bstr(Cbor.encode(deviceRequestInfo.toDataItem()))
+                        taggedItem = Bstr(Cbor.encode(deviceRequestInfo.dataItem))
                     ))
                 } else {
                     add(Simple.NULL)
@@ -193,7 +193,7 @@ data class DeviceRequest private constructor(
         deviceRequestInfo?.let {
             put("deviceRequestInfo", Tagged(
                 tagNumber = Tagged.ENCODED_CBOR,
-                taggedItem = Bstr(Cbor.encode(it.toDataItem()))
+                taggedItem = Bstr(Cbor.encode(it.dataItem))
             ))
         }
         if (readerAuthAll_.isNotEmpty()) {
@@ -224,7 +224,7 @@ data class DeviceRequest private constructor(
             }
             val deviceRequestInfo = dataItem.getOrNull("deviceRequestInfo")?.let {
                 if (version.mdocVersionCompareTo("1.1") >= 0) {
-                    DeviceRequestInfo.fromDataItem(it.asTaggedEncodedCbor)
+                    DeviceRequestInfo(it.asTaggedEncodedCbor)
                 } else {
                     Logger.w(TAG, "Ignoring deviceRequestInfo field since version is less than 1.1")
                     null
@@ -419,7 +419,7 @@ data class DeviceRequest private constructor(
                 deviceRequestInfo?.let {
                     add(Tagged(
                         tagNumber = Tagged.ENCODED_CBOR,
-                        taggedItem = Bstr(Cbor.encode(it.toDataItem()))
+                        taggedItem = Bstr(Cbor.encode(it.dataItem))
                     ))
                 } ?: add(Simple.NULL)
             }
@@ -1135,14 +1135,14 @@ internal fun deviceRequestCalcDeviceRequestInfo(
     }
 
     return if (useCases.isNotEmpty()) {
-        DeviceRequestInfo(
+        DeviceRequestInfo.fromValues(
             useCases = useCases,
             otherInfo = otherInfo
         )
     } else {
         // TODO: UseCases is optional even in a 1.1 request but iOS 26 currently assumes it's set.
         //   This has been reported to Apple so this can be removed once their bug-fix is out.
-        DeviceRequestInfo(
+        DeviceRequestInfo.fromValues(
             useCases = listOf(
                 UseCase(
                     mandatory = true,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestInfo.kt
@@ -6,43 +6,45 @@ import org.multipaz.cbor.putCborArray
 
 
 /**
- * Device request info according to ISO 18013-5.
+ * Device request info according to ISO 18013-5 Second Edition.
  *
- * @property useCases list of use-cases.
- * @property otherInfo other request info.
+ * This is represented as a [DataItem] to preserve the order for serialization and deserialization.
+ *
+ * @property dataItem a [DataItem] which is a map as defined in ISO/IEC 18013-5 Second Edition.
  */
 data class DeviceRequestInfo(
-    val useCases: List<UseCase> = emptyList(),
-    val otherInfo: Map<String, DataItem> = emptyMap()
+    val dataItem: DataItem
 ) {
-    internal fun toDataItem() = buildCborMap {
-        if (useCases.isNotEmpty()) {
-            putCborArray("useCases") {
-                useCases.forEach {
-                    add(it.toDataItem())
-                }
-            }
-        }
-        otherInfo.forEach { (key, value) ->
-            put(key, value)
-        }
-    }
+    /** @property useCases list of use-cases.
+     */
+    val useCases: List<UseCase>
+        get() = dataItem.getOrNull("useCases")?.asArray?.map { UseCase.fromDataItem(it) } ?: emptyList()
 
     companion object {
-        internal fun fromDataItem(dataItem: DataItem): DeviceRequestInfo {
-            val otherInfo = mutableMapOf<String, DataItem>()
-            for ((otherKeyDataItem, otherValue) in dataItem.asMap) {
-                val otherKey = otherKeyDataItem.asTstr
-                when (otherKey) {
-                    "useCases" -> continue
-                    else -> otherInfo[otherKey] = otherValue
+        /**
+         * Constructs a [org.multipaz.mdoc.request.DeviceRequestInfo] from values.
+         *
+         * @property useCases list of use-cases.
+         * @property otherInfo other request info.
+         * @return a [org.multipaz.mdoc.request.DeviceRequestInfo].
+         */
+        fun fromValues(
+            useCases: List<UseCase> = emptyList(),
+            otherInfo: Map<String, DataItem> = emptyMap()
+        ): DeviceRequestInfo {
+            val dataItem = buildCborMap {
+                if (useCases.isNotEmpty()) {
+                    putCborArray("useCases") {
+                        useCases.forEach {
+                            add(it.toDataItem())
+                        }
+                    }
+                }
+                otherInfo.forEach { (key, value) ->
+                    put(key, value)
                 }
             }
-            return DeviceRequestInfo(
-                useCases = dataItem.getOrNull("useCases")?.asArray?.map { UseCase.fromDataItem(it) }
-                    ?: emptyList(),
-                otherInfo = otherInfo
-            )
+            return DeviceRequestInfo(dataItem)
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -387,7 +387,7 @@ object VerificationUtil {
                     sessionTranscript = sessionTranscript,
                     // TODO: UseCases is optional even in a 1.1 request but iOS 26 currently assumes it's set.
                     //   This has been reported to Apple so this can be removed once their bug-fix is out.
-                    deviceRequestInfo = DeviceRequestInfo(
+                    deviceRequestInfo = DeviceRequestInfo.fromValues(
                         useCases = listOf(UseCase(
                             mandatory = true,
                             documentSets = listOf(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/presentment/MdocPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/presentment/MdocPresentmentTest.kt
@@ -83,7 +83,7 @@ class MdocPresentmentTest {
 
         val deviceRequest = buildDeviceRequest(
             sessionTranscript = sessionTranscript,
-            deviceRequestInfo = DeviceRequestInfo(useCases = listOf(UseCase(
+            deviceRequestInfo = DeviceRequestInfo.fromValues(useCases = listOf(UseCase(
                 mandatory = true,
                 documentSets = listOf(DocumentSet(docRequestIds = listOf(0, 1))),
                 purposeHints = mapOf()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestTest.kt
@@ -5,15 +5,20 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.io.bytestring.ByteString
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.addCborArray
+import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.putCborArray
+import org.multipaz.cbor.putCborMap
 import org.multipaz.cose.Cose
 import org.multipaz.cose.toCoseLabel
 import org.multipaz.crypto.Algorithm
@@ -33,10 +38,12 @@ import org.multipaz.mdoc.zkp.ZkSystemSpec
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.util.Logger
 import org.multipaz.util.fromHex
 import org.multipaz.util.fromHexByteString
 import org.multipaz.util.toHex
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -915,7 +922,7 @@ class DeviceRequestTest {
         val sessionTranscript = buildCborArray { add("Doesn't matter") }
         val deviceRequest = buildDeviceRequest(
             sessionTranscript = sessionTranscript,
-            deviceRequestInfo = DeviceRequestInfo(
+            deviceRequestInfo = DeviceRequestInfo.fromValues(
                 useCases = listOf(
                     UseCase(
                         mandatory = true,
@@ -1032,7 +1039,7 @@ class DeviceRequestTest {
         val sessionTranscript = buildCborArray { add("Doesn't matter") }
         val deviceRequest = buildDeviceRequest(
             sessionTranscript = sessionTranscript,
-            deviceRequestInfo = DeviceRequestInfo(
+            deviceRequestInfo = DeviceRequestInfo.fromValues(
                 useCases = listOf(
                     UseCase(
                         mandatory = true,
@@ -1205,7 +1212,7 @@ class DeviceRequestTest {
         val sessionTranscript = buildCborArray { add("Doesn't matter") }
         val deviceRequest = buildDeviceRequest(
             sessionTranscript = sessionTranscript,
-            deviceRequestInfo = DeviceRequestInfo(
+            deviceRequestInfo = DeviceRequestInfo.fromValues(
                 otherInfo = mapOf(
                     "com.example.foobar" to buildCborArray { add(42); add(43) }
                 )
@@ -1264,6 +1271,130 @@ class DeviceRequestTest {
         // available from https://developer.apple.com/documentation/proximityreader/checking-ids-with-the-verifier-api
         val deviceRequestBytes = "a46776657273696f6e63312e306b646f63526571756573747381a26a726561646572417574688443a10126a11821835907ad308207a93082072fa00302010202101777c779ee218c8cfe278f7322a36e44300a06082a8648ce3d040303307c3130302e06035504030c274170706c65204170706c69636174696f6e20496e746567726174696f6e2043412037202d20473131263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3235313030323136333134395a170d3235313030343136333134385a3081ca31653063060a0992268993f22c6401010c55564b453247334b3536562e636f6d2e6578616d706c652e6170706c652d73616d706c65636f64652e76657269666965722d6170692d73616d706c652d646973706c61792d72657175657374564b453247334b3536563149304706035504030c403133396533396332333762343061663530663161663634366333663630393363346436356338303637323764616365326539633032313664323065343264623831163014060355040a0c0d4461766964205a65757468656e3059301306072a8648ce3d020106082a8648ce3d030107034200045aa47259f13b2ba2d4af525da4fc8cfaac9d730022b692f992b49635a12ae61669450606c9f57c6364e1ea7f2eef1a985e68dd6e15813145a93270b330fb4f96a38205423082053e300c0603551d130101ff04023000301f0603551d230418301680141a38fe7f80e56dc83716591e1b10f2fa302dafd83082011d0603551d2004820114308201103082010c06092a864886f7636405013081fe3081c306082b060105050702023081b60c81b352656c69616e6365206f6e207468697320636572746966696361746520627920616e7920706172747920617373756d657320616363657074616e6365206f6620746865207468656e206170706c696361626c65207374616e64617264207465726d7320616e6420636f6e646974696f6e73206f66207573652c20636572746966696361746520706f6c69637920616e642063657274696669636174696f6e2070726163746963652073746174656d656e74732e303606082b06010505070201162a68747470733a2f2f7777772e6170706c652e636f6d2f6365727469666963617465617574686f7269747930200603551d250101ff04163014060728818c5d05010606092a864886f763640415301d0603551d0e04160414e83c3b0d7e9d5aced7187dd14e89ebf1453a2267300e0603551d0f0101ff040403020780300f06092a864886f763640650040205003082037706092a864886f76364064e0482036830820364a04a304816156f72672e69736f2e31383031332e352e312e6d444c16166f72672e69736f2e32333232302e312e6a702e6d6e6316176f72672e69736f2e32333232302e70686f746f69642e31a18203143082031016276f72672e69736f2e31383031332e352e312e61616d76613a616b615f66616d696c795f6e616d65162a6f72672e69736f2e31383031332e352e312e61616d76613a616b615f66616d696c795f6e616d652e763216266f72672e69736f2e31383031332e352e312e61616d76613a616b615f676976656e5f6e616d6516296f72672e69736f2e31383031332e352e312e61616d76613a616b615f676976656e5f6e616d652e763216226f72672e69736f2e31383031332e352e312e61616d76613a616b615f737566666978162e6f72672e69736f2e31383031332e352e312e61616d76613a66616d696c795f6e616d655f7472756e636174696f6e162d6f72672e69736f2e31383031332e352e312e61616d76613a676976656e5f6e616d655f7472756e636174696f6e16236f72672e69736f2e31383031332e352e312e61616d76613a6e616d655f737566666978161e6f72672e69736f2e31383031332e352e313a6167655f696e5f7965617273161d6f72672e69736f2e31383031332e352e313a6167655f6f7665725f4e4e161d6f72672e69736f2e31383031332e352e313a66616d696c795f6e616d65161c6f72672e69736f2e31383031332e352e313a676976656e5f6e616d65161a6f72672e69736f2e31383031332e352e313a706f72747261697416246f72672e69736f2e32333232302e312e6a703a66756c6c5f6e616d655f756e69636f6465161b6f72672e69736f2e32333232302e312e6a703a706f727472616974161c6f72672e69736f2e32333232302e313a6167655f696e5f7965617273161b6f72672e69736f2e32333232302e313a6167655f6f7665725f4e4e16226f72672e69736f2e32333232302e313a66616d696c795f6e616d655f6c6174696e3116236f72672e69736f2e32333232302e313a66616d696c795f6e616d655f756e69636f646516216f72672e69736f2e32333232302e313a676976656e5f6e616d655f6c6174696e3116226f72672e69736f2e32333232302e313a676976656e5f6e616d655f756e69636f646516186f72672e69736f2e32333232302e313a706f727472616974300f06092a864886f76364065104020500300a06082a8648ce3d040303036800306502300e75111780bffc77384b40cf78fa0be22af04da134c16700be00ca7c3d7865108ab0d520ad16fb01c99140119c60c92b023100c679268553ea215173610d8df7640579fbf60cd83684feec3ed59fce864ab7581a53bce493045042c637ce4ed1137a785903203082031c308202a3a00302010202140945077ff346e881707ac440b4ae048788d59718300a06082a8648ce3d0403033067311b301906035504030c124170706c6520526f6f74204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3233303330313232313230375a170d3338303330333030303030305a307c3130302e06035504030c274170706c65204170706c69636174696f6e20496e746567726174696f6e2043412037202d20473131263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533076301006072a8648ce3d020106052b8104002203620004740692c5db79bd33ea8b26080ca783ce4fbe9afe993d4deb4286270b8776b30bf0535e43e00675c78f9f9ea1db0504e1242ff2fdbe548b0609b57a039c2e8958f4048ccdaf5902815090a4c2709bf120f9234ff37a835842a5633267b5d54c21a381fa3081f730120603551d130101ff040830060101ff020100301f0603551d23041830168014bbb0dea15833889aa48a99debebdebafdacb24ab304606082b06010505070101043a3038303606082b06010505073001862a687474703a2f2f6f6373702e6170706c652e636f6d2f6f63737030332d6170706c65726f6f746361673330370603551d1f0430302e302ca02aa0288626687474703a2f2f63726c2e6170706c652e636f6d2f6170706c65726f6f74636167332e63726c301d0603551d0e041604141a38fe7f80e56dc83716591e1b10f2fa302dafd8300e0603551d0f0101ff0404030201063010060a2a864886f7636406021f04020500300a06082a8648ce3d040303036700306402301267f36547ba5133c3e3037f65944b766b9ea80f08a7d5498b366c7523ab4b3dee2dea52eb4015892214c62a32b6a80d023029eea2a737ae204b51027ab8eca6b972d174a32d4a04d31b3440bc4dfcc9bde5172667090068c368f45e2f95df23ae8059024730820243308201c9a00302010202082dc5fc88d2c54b95300a06082a8648ce3d0403033067311b301906035504030c124170706c6520526f6f74204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3134303433303138313930365a170d3339303433303138313930365a3067311b301906035504030c124170706c6520526f6f74204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533076301006072a8648ce3d020106052b810400220362000498e92f3d4072a4ed93227281131cdd1095f1c5a34e71dc1416d90ee5a6052a77647b5f4e38d3bb1c44b57ff51fb632625dc9e9845b4f304f115a00fd58580ca5f50f2c4d07471375da9797976f315ced2b9d7b203bd8b954d95e99a43a510a31a3423040301d0603551d0e04160414bbb0dea15833889aa48a99debebdebafdacb24ab300f0603551d130101ff040530030101ff300e0603551d0f0101ff040403020106300a06082a8648ce3d040303036800306502310083e9c1c4165e1a5d3418d9edeff46c0e00464bb8dfb24611c50ffde67a8ca1a66bcec203d49cf593c674b86adfaa231502306d668a10cad40dd44fcd8d433eb48a63a5336ee36dda17b7641fc85326f9886274390b175bcb51a80ce81803e7a2b228f6584024285443042fc5ea7ce21401ba442fefa5a90faf1d41eeed7d1b309f15b21c7d1717ad12562107703d371bdbc5a76ff7f8382498843612762441b0911b1b89d96c6974656d7352657175657374d818589fa367646f6354797065756f72672e69736f2e31383031332e352e312e6d444c6a6e616d65537061636573a1716f72672e69736f2e31383031332e352e31a268706f727472616974f46b6167655f6f7665725f3231f46b72657175657374496e666fa1783a636f6d2e6170706c652e696e746572707265742d77696c6c2d6e6f742d72657461696e2d696e74656e742d61732d646973706c61792d6f6e6c79f56d72656164657241757468416c6cf67164657669636552657175657374496e666ff6".fromHex()
         val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(deviceRequestBytes))
+    }
+
+    /**
+     * Checks that DeviceRequestInfo serialization is preserved.
+     *
+     * This is important because this is part of ReaderAuthenticationAll.
+     *
+     * This was reported in https://github.com/openwallet-foundation/multipaz/issues/1724
+     */
+    @Test
+    fun testDeviceRequestInfoSerialization() {
+        fun buildDrForDri(dri: DataItem) = buildCborMap {
+            put("version", "1.1")
+            putCborArray("docRequests") {
+                addCborMap {
+                    putTaggedEncodedCbor(
+                        "itemsRequest",
+                        Cbor.encode(buildCborMap {
+                            put("docType", "org.iso.18013.5.1.mDL")
+                            putCborMap("nameSpaces") {
+                                putCborMap("org.iso.18013.5.1") {
+                                    put("age_over_18", true)
+                                    put("portrait", true)
+                                }
+                            }
+                        })
+                    )
+                }
+            }
+            putTaggedEncodedCbor(
+                "deviceRequestInfo",
+                Cbor.encode(dri)
+            )
+        }
+
+        val dri1 = buildCborMap {
+            putCborArray("useCases") {
+                addCborMap {
+                    put("mandatory", true)
+                    putCborArray("documentSets") {
+                        addCborArray {
+                            add(0)
+                        }
+                    }
+                }
+            }
+        }
+        assertContentEquals(
+            Cbor.encode(dri1),
+            Cbor.encode(DeviceRequest.fromDataItem(buildDrForDri(dri1)).deviceRequestInfo!!.dataItem)
+        )
+
+        val dri2 = buildCborMap {
+            putCborArray("useCases") {
+                addCborMap {
+                    putCborArray("documentSets") {
+                        addCborArray {
+                            add(0)
+                        }
+                    }
+                    put("mandatory", true)
+                }
+            }
+        }
+        assertContentEquals(
+            Cbor.encode(dri2),
+            Cbor.encode(DeviceRequest.fromDataItem(buildDrForDri(dri2)).deviceRequestInfo!!.dataItem)
+        )
+    }
+
+    /**
+     * Tests that itemsRequest serialization is preserved.
+     *
+     * This is important because this is part of ReaderAuthentication.
+     */
+    @Test
+    fun testItemsRequestSerializationPreserved() {
+        val drRequest1 = buildCborMap {
+            put("version", "1.0")
+            putCborArray("docRequests") {
+                addCborMap {
+                    putTaggedEncodedCbor(
+                        "itemsRequest",
+                        Cbor.encode(buildCborMap {
+                            put("docType", "org.iso.18013.5.1.mDL")
+                            putCborMap("nameSpaces") {
+                                putCborMap("org.iso.18013.5.1") {
+                                    put("age_over_18", true)
+                                    put("portrait", true)
+                                }
+                            }
+                        })
+                    )
+                }
+            }
+        }
+        assertContentEquals(
+            Cbor.encode(drRequest1),
+            Cbor.encode(DeviceRequest.fromDataItem(drRequest1).toDataItem())
+        )
+
+        val drRequest2 = buildCborMap {
+            put("version", "1.0")
+            putCborArray("docRequests") {
+                addCborMap {
+                    putTaggedEncodedCbor(
+                        "itemsRequest",
+                        Cbor.encode(buildCborMap {
+                            putCborMap("nameSpaces") {
+                                putCborMap("org.iso.18013.5.1") {
+                                    put("portrait", true)
+                                    put("age_over_18", true)
+                                }
+                            }
+                            put("docType", "org.iso.18013.5.1.mDL")
+                        })
+                    )
+                }
+            }
+        }
+        assertContentEquals(
+            Cbor.encode(drRequest2),
+            Cbor.encode(DeviceRequest.fromDataItem(drRequest2).toDataItem())
+        )
     }
 
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestMdlAndPid.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestMdlAndPid.kt
@@ -47,7 +47,7 @@ class Iso18013TestMdlAndPid {
         private fun mdlAndPidQuery(): DeviceRequest {
             return buildDeviceRequest(
                 sessionTranscript = buildCborArray { add("doesn't"); add("matter") },
-                deviceRequestInfo = DeviceRequestInfo(
+                deviceRequestInfo = DeviceRequestInfo.fromValues(
                     useCases = listOf(
                         UseCase(
                             mandatory = true,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestMdlOrPid.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestMdlOrPid.kt
@@ -48,7 +48,7 @@ class Iso18013TestMdlOrPid {
         private fun mdlOrPidQuery(): DeviceRequest {
             return buildDeviceRequest(
                 sessionTranscript = buildCborArray { add("doesn't"); add("matter") },
-                deviceRequestInfo = DeviceRequestInfo(
+                deviceRequestInfo = DeviceRequestInfo.fromValues(
                     useCases = listOf(
                         UseCase(
                             mandatory = true,

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/request/Iso18013Request.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/request/Iso18013Request.kt
@@ -33,7 +33,7 @@ data class Iso18013Request(
         // Rebuild the parsed request as a proper DeviceRequest...
         val deviceRequest = buildDeviceRequest(
             sessionTranscript = Simple.NULL,
-            deviceRequestInfo =  DeviceRequestInfo(
+            deviceRequestInfo =  DeviceRequestInfo.fromValues(
                 useCases = presentmentRequests.map { pr ->
                     UseCase(
                         mandatory = pr.isMandatory,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/ConsentPromptScreen.kt
@@ -1027,7 +1027,7 @@ private suspend fun getQueryResult(
                         )
                     ),
                 )
-                setDeviceRequestInfo(DeviceRequestInfo(
+                setDeviceRequestInfo(DeviceRequestInfo.fromValues(
                     useCases = listOf(UseCase(
                         mandatory = true,
                         documentSets = listOf(


### PR DESCRIPTION
The `DeviceRequestInfo` structure is used in `ReaderAuthAll` so we need to preserve the exact serialization. Achieve this by slightly changing the API to store the `DataItem` instead of parsed out values.

Also add a test to check that itemsRequest serialization is also preserved (it is but we didn't have a test for it).

Fixes #1724.

Test: New unit test to check that serialization is preserved.
