### PR TITLE
Crypto: Add checks for key sizes used with AES-GCM encryption.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
@@ -169,7 +169,7 @@ class SessionEncryption(
             iv.append(ivIdentifier)
             iv.append(encryptedCounter.toUInt())
             messageCiphertext = Crypto.encrypt(
-                Algorithm.A128GCM,
+                Algorithm.A256GCM,
                 skSelf,
                 iv.toByteString().toByteArray(),
                 messagePlaintext
@@ -230,7 +230,7 @@ class SessionEncryption(
             iv.append(ivIdentifier)
             iv.append(decryptedCounter.toUInt())
             plainText = Crypto.decrypt(
-                Algorithm.A128GCM,
+                Algorithm.A256GCM,
                 skRemote,
                 iv.toByteString().toByteArray(),
                 messageCiphertext

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -103,7 +103,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
                 val cleartextPrivateKey = Cbor.encode(privateKey.toCoseKey().toDataItem())
                 val iv = Random.Default.nextBytes(12)
                 val encryptedPrivateKey = Crypto.encrypt(
-                    Algorithm.A128GCM,
+                    Algorithm.A256GCM,
                     secretKey,
                     iv,
                     cleartextPrivateKey

--- a/multipaz/src/iosMain/kotlin/org/multipaz/crypto/CryptoIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/crypto/CryptoIos.kt
@@ -65,6 +65,12 @@ actual object Crypto {
         messagePlaintext: ByteArray,
         aad: ByteArray?
     ): ByteArray {
+        when (algorithm) {
+            Algorithm.A128GCM -> require(key.size == 16) { "Key size must be 16 bytes for AES-128-GCM" }
+            Algorithm.A192GCM -> require(key.size == 24) { "Key size must be 24 bytes for AES-192-GCM" }
+            Algorithm.A256GCM -> require(key.size == 32) { "Key size must be 32 bytes for AES-256-GCM" }
+            else -> throw IllegalArgumentException("Unsupported algorithm $algorithm")
+        }
         return SwiftBridge.aesGcmEncrypt(
             key.toNSData(),
             messagePlaintext.toNSData(),

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
@@ -152,12 +152,10 @@ actual object Crypto {
         aad: ByteArray?
     ): ByteArray {
         when (algorithm) {
-            Algorithm.A128GCM -> {}
-            Algorithm.A192GCM -> {}
-            Algorithm.A256GCM -> {}
-            else -> {
-                throw IllegalArgumentException("Unsupported algorithm $algorithm")
-            }
+            Algorithm.A128GCM -> require(key.size == 16) { "Key size must be 16 bytes for AES-128-GCM" }
+            Algorithm.A192GCM -> require(key.size == 24) { "Key size must be 24 bytes for AES-192-GCM" }
+            Algorithm.A256GCM -> require(key.size == 32) { "Key size must be 32 bytes for AES-256-GCM" }
+            else -> throw IllegalArgumentException("Unsupported algorithm $algorithm")
         }
         return Cipher.getInstance("AES/GCM/NoPadding").run {
             init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(128, nonce))

--- a/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/crypto/Crypto.web.kt
@@ -171,6 +171,12 @@ actual object Crypto {
         messagePlaintext: ByteArray,
         aad: ByteArray?
     ): ByteArray {
+        when (algorithm) {
+            Algorithm.A128GCM -> require(key.size == 16) { "Key size must be 16 bytes for AES-128-GCM" }
+            Algorithm.A192GCM -> require(key.size == 24) { "Key size must be 24 bytes for AES-192-GCM" }
+            Algorithm.A256GCM -> require(key.size == 32) { "Key size must be 32 bytes for AES-256-GCM" }
+            else -> throw IllegalArgumentException("Unsupported algorithm $algorithm")
+        }
         val algorithm = unsafeJso<AesGcmParams> {
             name = "AES-GCM"
             additionalData = (aad ?: byteArrayOf()).toBufferSource()


### PR DESCRIPTION
Also update `SessionEncryption` and `SoftwareSecureArea` to pass `Algorithm.A256GCM` instead of `Algorithm.A128GCM`.

Fixes #1779.

Test: All unit tests pass.
