### PR TITLE
Don't call CardEmulation.unsetPreferredService().

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
@@ -15,8 +15,10 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 import kotlinx.io.bytestring.ByteString
@@ -308,26 +310,25 @@ abstract class MdocNdefService(
             eDeviceKey = eDeviceKey.publicKey,
             onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
                 // OK, we're done with engagement and we're communicating with a bona fide ISO/IEC 18013-5:2021 reader.
-                // Start the activity and also launch a new job for handling the transaction...
+                // Let the user know and launch a new job to start the transaction.
                 //
-                //engagementComplete = true
                 vibrateSuccess()
-
-                if (settings.activityClass != null) {
-                    val intent = Intent(applicationContext, settings.activityClass)
-                    intent.addFlags(
-                        Intent.FLAG_ACTIVITY_NEW_TASK or
-                                Intent.FLAG_ACTIVITY_NO_HISTORY or
-                                Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
-                                Intent.FLAG_ACTIVITY_NO_ANIMATION
-                    )
-                    applicationContext.startActivity(intent)
-                }
 
                 // We launch transactionJob in a new detached scope so it survives both
                 // NFC deactivation (the reader moving away) and the Service's onDestroy
                 // (as the transaction may continue over BLE and wait for UI consent).
                 transactionJob = CoroutineScope(Dispatchers.IO + settings.promptModel).launch {
+                    if (settings.activityClass != null) {
+                        val intent = Intent(applicationContext, settings.activityClass)
+                        intent.addFlags(
+                            Intent.FLAG_ACTIVITY_NEW_TASK or
+                                    Intent.FLAG_ACTIVITY_NO_HISTORY or
+                                    Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
+                                    Intent.FLAG_ACTIVITY_NO_ANIMATION
+                        )
+                        applicationContext.startActivity(intent)
+                    }
+
                     val duration = Clock.System.now() - timeStarted
                     startTransaction(
                         settings = settings,
@@ -341,7 +342,7 @@ abstract class MdocNdefService(
             },
             onError = { error ->
                 // Engagement failed. This can happen if a NDEF tag reader - for example another unlocked
-                // Android device - is reading this device. So we really don't want any user-visible side-effects
+                // Android device - is reading this device. So we really don't want any user-visible side effects
                 // here such as showing an error or vibrating the phone.
                 //
                 engagementComplete = true

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
@@ -245,22 +245,10 @@ abstract class MdocNfcV2Service(
         engagement = MdocNfcV2EngagementHelper(
             eDeviceKey = eDeviceKey.publicKey,
             onHandoverComplete = { connectionMethod, encodedDeviceEngagement, handover ->
-                // OK, we're done with engagement and we're communicating with a bona fide ISO/IEC 18013-5 Second
-                // Edition reader capable of NFCv2. Start the activity and also launch a new job for handling the
-                // transaction...
+                // OK, we're done with engagement, and we're communicating with a bona fide ISO/IEC 18013-5 Second
+                // Edition reader capable of NFCv2. Let the user know and launch a new job to start the transaction.
                 //
                 vibrateSuccess()
-
-                if (settings.activityClass != null) {
-                    val intent = Intent(applicationContext, settings.activityClass)
-                    intent.addFlags(
-                        Intent.FLAG_ACTIVITY_NEW_TASK or
-                                Intent.FLAG_ACTIVITY_NO_HISTORY or
-                                Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
-                                Intent.FLAG_ACTIVITY_NO_ANIMATION
-                    )
-                    applicationContext.startActivity(intent)
-                }
 
                 hybridTransport = NfcHybridTransportMdoc(
                     sendMessageViaNfc = { message ->
@@ -275,6 +263,19 @@ abstract class MdocNfcV2Service(
                 // NFC deactivation (the reader moving away) and the Service's onDestroy
                 // (as the transaction may continue over BLE and wait for UI consent).
                 transactionJob = CoroutineScope(Dispatchers.IO + settings.promptModel).launch {
+                    // Start PresentmentActivity...
+                    if (settings.activityClass != null) {
+                        val intent = Intent(applicationContext, settings.activityClass)
+                        intent.addFlags(
+                            Intent.FLAG_ACTIVITY_NEW_TASK or
+                                    Intent.FLAG_ACTIVITY_NO_HISTORY or
+                                    Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
+                                    Intent.FLAG_ACTIVITY_NO_ANIMATION
+                        )
+                        applicationContext.startActivity(intent)
+                    }
+
+                    // Connect to the transport and start the transaction...
                     hybridTransport!!.open(eDeviceKey.publicKey)
                     val duration = Clock.System.now() - timeStarted
                     startTransaction(
@@ -293,7 +294,7 @@ abstract class MdocNfcV2Service(
             },
             onError = { error ->
                 // Engagement failed. This can happen if a NDEF tag reader - for example another unlocked
-                // Android device - is reading this device. So we really don't want any user-visible side-effects
+                // Android device - is reading this device. So we really don't want any user-visible side effects
                 // here such as showing an error or vibrating the phone.
                 //
                 engagementComplete = true
@@ -335,7 +336,7 @@ abstract class MdocNfcV2Service(
             transport.setExpectTransport(true)
             // Wait for the non-NFC transport in a coroutine so we are not blocking
             // initiating presentment....
-            waitForTransportJob = serviceScope.launch(Dispatchers.IO) {
+            waitForTransportJob = CoroutineScope(transactionJobContext).launch(Dispatchers.IO) {
                 try {
                     val negotiatedTransport = MdocTransportFactory.Default.createTransport(
                         connectionMethod = connectionMethod,

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -244,19 +244,6 @@ class PresentmentActivity: FragmentActivity() {
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        val state = presentmentModel.state.value
-        if (state is PresentmentModel.State.Reset && presentmentModel.showDocumentChooser != null) {
-            NfcAdapter.getDefaultAdapter(this)?.let {
-                val cardEmulation = CardEmulation.getInstance(it)
-                if (!cardEmulation.unsetPreferredService(this)) {
-                    Logger.w(TAG, "CardEmulation.unsetPreferredService() return false")
-                }
-            }
-        }
-    }
-
     override fun onStop() {
         super.onStop()
         Logger.i(TAG, "in onStop(), canceling")

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
@@ -48,16 +48,6 @@ class MainActivity : FragmentActivity() {
         App.existingApp()?.cancelAllPendingAppLinks()
     }
 
-    override fun onPause() {
-        super.onPause()
-        NfcAdapter.getDefaultAdapter(this)?.let {
-            val cardEmulation = CardEmulation.getInstance(it)
-            if (!cardEmulation.unsetPreferredService(this)) {
-                Logger.w(TAG, "CardEmulation.unsetPreferredService() return false")
-            }
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initializeApplication(this.applicationContext)


### PR DESCRIPTION
A bug was recently fixed in both Android 16 and Android 17 which breaks Multipaz TestApp. The problem is that if an application calls [`CardEmulation.unsetPreferredService()`](https://developer.android.com/reference/android/nfc/cardemulation/CardEmulation#unsetPreferredService(android.app.Activity)) then the `HostApduService` (that is `MdocNdefService` or `MdocNfcV2Service`) owned by the app would be killed. Before the bug-fix this didn't happen.

Since Multipaz TestApp does this in `Activity.onPause()` for both `MainActivity` and `PresentmentActivity` this bug-fix manifests itself as in-person presentment with NFC engagement not working if Testapp is in the foreground.

Removing the calls to `CardEmulation.unsetPreferredService()` fixes the problem and they're not necessary anyway because the Android NFC stack tracks the status anyway.

Manually tested this by verifying that both NFC Negotiated and NFCv2 handovers work with Multipaz TestApp both in the foreground and not in the foreground. Also tested when it's the Wallet Role Owner and not the role owner.

Also fix a bug where some of the jobs in the engagement was launched in the wrong context.

Test: Manually tested, see above.
