### PR TITLE
Fix Curve25519 (Ed25519) signing in AndroidKeystoreSecureArea

### DIFF
--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -261,15 +261,15 @@ class AndroidKeystoreSecureAreaTest {
         }
     }
 
-    // Curve 25519 on Android is currently broken, see b/282063229 for details. Ignore test for now.
-    @Ignore
+    // Curve 25519 keystore signing was broken on older Android (b/282063229) and the test was
+    // @Ignore'd. It works where KeyMint actually implements Curve25519 (verified on Pixel 10 Pro /
+    // API 36); the remaining breakage was in this SecureArea's key reload + signature decoding,
+    // fixed below. Gated on the device capability, not an SDK version: KeyMint < 2.0 (e.g. many
+    // API 31/32 devices and vendors with NIST-only secure hardware) cannot create an ed25519 key.
     @Test
     fun testEcKeySigningEd25519() = runTest {
-        // ECDH is only available on Android 12 or later (only HW-backed on Keymint 1.0 or later)
-        //
-        // Also note it's not available on StrongBox.
-        //
-        Assume.assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+        Assume.assumeTrue(AndroidKeystoreSecureArea.Capabilities().curve25519Supported)
+        Assume.assumeFalse(TestUtil.isRunningOnEmulator)
         val ks = secureAreaProvider.get()
 
         val challenge = ByteString(1, 2, 3)
@@ -299,6 +299,28 @@ class AndroidKeystoreSecureAreaTest {
             Algorithm.EDDSA,
             signature
         )
+    }
+
+    // Exercises the getKey()-based reload path for an Ed25519 key separately from key
+    // creation: a fresh getKeyInfo() load must return the right metadata (hitting the
+    // EdDSA->EC KeyFactory fallback) and a healthy key must not be reported invalidated.
+    @Test
+    fun testEcKeyInfoReloadEd25519() = runTest {
+        Assume.assumeTrue(AndroidKeystoreSecureArea.Capabilities().curve25519Supported)
+        Assume.assumeFalse(TestUtil.isRunningOnEmulator)
+        val ks = secureAreaProvider.get()
+        ks.createKey(
+            "testKey",
+            AndroidKeystoreCreateKeySettings.Builder(ByteString(1, 2, 3))
+                .setAlgorithm(Algorithm.ED25519)
+                .build()
+        )
+        // Fresh load via getKey(), independent of createKey()'s own getKeyInfo() call.
+        val keyInfo = ks.getKeyInfo("testKey")
+        assertEquals(Algorithm.ED25519, keyInfo.algorithm)
+        assertEquals(EcCurve.ED25519, keyInfo.publicKey.curve)
+        // A healthy key must not be reported invalidated (loadKey -> getKey -> non-null).
+        Assert.assertFalse(ks.getKeyInvalidated("testKey"))
     }
 
     @Test

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
@@ -6,6 +6,8 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.securearea.KeyUnlockData
 import java.security.KeyFactory
 import java.security.KeyStore
+import java.security.NoSuchAlgorithmException
+import java.security.PrivateKey
 import java.security.Signature
 import java.security.spec.InvalidKeySpecException
 
@@ -44,10 +46,15 @@ class AndroidKeystoreKeyUnlockData(
         try {
             val ks = KeyStore.getInstance("AndroidKeyStore")
             ks.load(null)
-            val entry = ks.getEntry(alias, null)
+            // getKey() rather than getEntry(): getEntry()'s PrivateKeyEntry rejects Ed25519
+            // (private-key algo "EdDSA" vs the cert) — see AndroidKeystoreSecureArea (b/282063229).
+            val privateKey = (ks.getKey(alias, null) as? PrivateKey)
                 ?: throw IllegalArgumentException("No entry for alias")
-            val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
-            val factory = KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+            val factory = try {
+                KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+            } catch (e: NoSuchAlgorithmException) {
+                KeyFactory.getInstance("EC", "AndroidKeyStore") // "EdDSA" has no dedicated factory
+            }
             try {
                 val keyInfo = factory.getKeySpec(
                     privateKey,
@@ -93,10 +100,13 @@ class AndroidKeystoreKeyUnlockData(
             try {
                 val ks = KeyStore.getInstance("AndroidKeyStore")
                 ks.load(null)
-                val entry = ks.getEntry(alias, null)
+                val privateKey = (ks.getKey(alias, null) as? PrivateKey)
                     ?: throw IllegalArgumentException("No entry for alias")
-                val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
-                val factory = KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+                val factory = try {
+                    KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+                } catch (e: NoSuchAlgorithmException) {
+                    KeyFactory.getInstance("EC", "AndroidKeyStore")
+                }
                 try {
                     val keyInfo = factory.getKeySpec(
                         privateKey,

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -62,10 +62,12 @@ import java.security.KeyStore
 import java.security.KeyStoreException
 import java.security.NoSuchAlgorithmException
 import java.security.NoSuchProviderException
+import java.security.PrivateKey
 import java.security.ProviderException
 import java.security.Signature
 import java.security.SignatureException
 import java.security.UnrecoverableEntryException
+import java.security.UnrecoverableKeyException
 import java.security.cert.CertificateException
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.InvalidKeySpecException
@@ -239,7 +241,12 @@ class AndroidKeystoreSecureArea private constructor(
             if (aSettings.algorithm != Algorithm.ANDROID_KEYSTORE_ATTEST_KEY) {
                 when (aSettings.algorithm.curve) {
                     EcCurve.P256 -> builder.setDigests(KeyProperties.DIGEST_SHA256)
-                    EcCurve.ED25519 -> builder.setAlgorithmParameterSpec(ECGenParameterSpec("ed25519"))
+                    EcCurve.ED25519 -> {
+                        builder.setAlgorithmParameterSpec(ECGenParameterSpec("ed25519"))
+                        // Ed25519 hashes internally; the keystore op must be authorized for
+                        // DIGEST_NONE or signing fails with "Keystore operation failed".
+                        builder.setDigests(KeyProperties.DIGEST_NONE)
+                    }
                     EcCurve.X25519 -> builder.setAlgorithmParameterSpec(ECGenParameterSpec("x25519"))
                     else -> throw IllegalArgumentException("Curve is not supported")
                 }
@@ -347,12 +354,18 @@ class AndroidKeystoreSecureArea private constructor(
         withContext(Dispatchers.IO) {
             ks.load(null)
         }
-        val entry = ks.getEntry(existingAlias, null)
+        // getKey() rather than getEntry(): getEntry() builds a PrivateKeyEntry that rejects
+        // Curve25519 keys on some devices (b/282063229); see loadKeyIgnoreKeyInvalidated.
+        val privateKey = (ks.getKey(existingAlias, null) as? PrivateKey)
             ?: throw IllegalArgumentException("A key with this alias doesn't exist")
 
         val keyInfo = try {
-            val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
-            val factory = KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+            // "EdDSA" has no dedicated AndroidKeyStore factory; fall back to "EC" for Curve25519.
+            val factory = try {
+                KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+            } catch (e: NoSuchAlgorithmException) {
+                KeyFactory.getInstance("EC", "AndroidKeyStore")
+            }
             factory.getKeySpec(privateKey, KeyInfo::class.java)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -456,7 +469,7 @@ class AndroidKeystoreSecureArea private constructor(
         dataToSign: ByteArray,
         keyUnlockData: KeyUnlockData?,
     ): EcSignature {
-        val (entry, data) = loadKey(alias)
+        val (privateKey, data) = loadKey(alias)
         val decodedData = AndroidSecureAreaKeyMetadata.fromCbor(data)
         val algorithm = decodedData.algorithm
         if (keyUnlockData != null) {
@@ -476,7 +489,6 @@ class AndroidKeystoreSecureArea private constructor(
         }
 
         return try {
-            val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
             val s = Signature.getInstance(getSignatureAlgorithmName(algorithm))
             s.initSign(privateKey)
             s.update(dataToSign)
@@ -519,9 +531,8 @@ class AndroidKeystoreSecureArea private constructor(
         alias: String,
         otherKey: EcPublicKey,
     ): ByteArray {
-        val (entry, _) = loadKey(alias)
+        val (privateKey, _) = loadKey(alias)
         return try {
-            val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
             val ka = KeyAgreement.getInstance("ECDH", "AndroidKeyStore")
             ka.init(privateKey)
             ka.doPhase(otherKey.javaPublicKey, true)
@@ -546,26 +557,17 @@ class AndroidKeystoreSecureArea private constructor(
 
     // @throws IllegalArgumentException if the key doesn't exist.
     // @throws KeyInvalidatedException if LSKF was removed and the key is no longer available.
-    private suspend fun loadKey(alias: String): Pair<KeyStore.Entry, ByteArray> {
-        val data = storageTable.get(alias, partitionId)
-            ?: throw IllegalArgumentException("No key with given alias")
-
-        val ks = KeyStore.getInstance("AndroidKeyStore")
-        withContext(Dispatchers.IO) {
-            ks.load(null)
-        }
-        // If the LSKF is removed, all auth-bound keys are removed and the result is
-        // that KeyStore.getEntry() returns null.
-        //
-        val entry = ks.getEntry(alias, null)
-            ?: throw KeyInvalidatedException("This key is no longer available")
-
-        return Pair(entry, data.toByteArray())
+    private suspend fun loadKey(alias: String): Pair<PrivateKey, ByteArray> {
+        val (privateKey, data) = loadKeyIgnoreKeyInvalidated(alias)
+        return Pair(
+            privateKey ?: throw KeyInvalidatedException("This key is no longer available"),
+            data
+        )
     }
 
     // @throws IllegalArgumentException if the key doesn't exist.
     // @throws KeyInvalidatedException if LSKF was removed and the key is no longer available.
-    private suspend fun loadKeyIgnoreKeyInvalidated(alias: String): Pair<KeyStore.Entry?, ByteArray> {
+    private suspend fun loadKeyIgnoreKeyInvalidated(alias: String): Pair<PrivateKey?, ByteArray> {
         val data = storageTable.get(alias, partitionId)
             ?: throw IllegalArgumentException("No key with given alias")
 
@@ -573,8 +575,18 @@ class AndroidKeystoreSecureArea private constructor(
         withContext(Dispatchers.IO) {
             ks.load(null)
         }
-        val entry = ks.getEntry(alias, null)
-        return Pair(entry, data.toByteArray())
+        // Use getKey() rather than getEntry(): getEntry() builds a KeyStore.PrivateKeyEntry
+        // whose constructor rejects Curve25519 keys on some devices because the private key's
+        // algorithm name ("EdDSA") disagrees with the self-signed certificate's public-key
+        // algorithm (b/282063229). getKey() returns the PrivateKey directly and sidesteps that
+        // check. If the LSKF is removed, all auth-bound keys are removed and getKey() returns
+        // null (or throws UnrecoverableKeyException) — both mean the key is no longer available.
+        val privateKey = try {
+            ks.getKey(alias, null) as? PrivateKey
+        } catch (e: UnrecoverableKeyException) {
+            null
+        }
+        return Pair(privateKey, data.toByteArray())
     }
 
     override suspend fun getKeyInvalidated(alias: String): Boolean {
@@ -587,11 +599,17 @@ class AndroidKeystoreSecureArea private constructor(
     }
 
     override suspend fun getKeyInfo(alias: String): AndroidKeystoreKeyInfo {
-        val (entry, data) = loadKeyIgnoreKeyInvalidated(alias)
+        val (privateKey, data) = loadKeyIgnoreKeyInvalidated(alias)
         return try {
-            val keyInfo = if (entry != null) {
-                val privateKey = (entry as KeyStore.PrivateKeyEntry).privateKey
-                val factory = KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+            val keyInfo = if (privateKey != null) {
+                // AndroidKeyStore exposes its KeyInfo transform under the "EC" factory for both
+                // EC and Curve25519 keys; a Curve25519 private key reports algorithm "EdDSA",
+                // which has no dedicated AndroidKeyStore factory, so fall back to "EC".
+                val factory = try {
+                    KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+                } catch (e: NoSuchAlgorithmException) {
+                    KeyFactory.getInstance("EC", "AndroidKeyStore")
+                }
                 factory.getKeySpec(privateKey, KeyInfo::class.java)
             } else {
                 null
@@ -932,11 +950,24 @@ class AndroidKeystoreSecureArea private constructor(
         }
 
         internal fun signatureFromDer(curve: EcCurve, derEncodedSignature: ByteArray): EcSignature {
+            val keySize = (curve.bitSize + 7)/8
+
+            // Curve25519 (EdDSA) signing returns a raw r||s pair from the platform, not a
+            // DER SEQUENCE, so split it directly instead of ASN.1-decoding (b/282063229).
+            if (curve == EcCurve.ED25519) {
+                check(derEncodedSignature.size == keySize * 2) {
+                    "Expected raw ${keySize * 2}-byte Ed25519 signature, got ${derEncodedSignature.size}"
+                }
+                return EcSignature(
+                    r = derEncodedSignature.copyOfRange(0, keySize),
+                    s = derEncodedSignature.copyOfRange(keySize, keySize * 2)
+                )
+            }
+
             val seq = ASN1.decode(derEncodedSignature) as ASN1Sequence
             val r = stripLeadingZeroes((seq.elements[0] as ASN1Integer).value)
             val s = stripLeadingZeroes((seq.elements[1] as ASN1Integer).value)
 
-            val keySize = (curve.bitSize + 7)/8
             check(r.size <= keySize)
             check(s.size <= keySize)
 

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -276,8 +276,9 @@ actual fun AndroidKeystoreSecureAreaScreen(
                     Triple(AUTH_BIOMETRIC_ONLY, 0L, "- Auth (Biometric Only)"),
                     Triple(AUTH_LSKF_OR_BIOMETRIC, -1L, "- Auth (No Confirmation)"),
                 )) {
+                    val curveMatch = algorithm.curve!! == EcCurve.P256 || algorithm.curve!! == EcCurve.ED25519
                     // For brevity, Only do auth for P-256 Sign and Mac
-                    if (algorithm.curve!! != EcCurve.P256 && userAuthType != AUTH_NONE) {
+                    if (!curveMatch && userAuthType != AUTH_NONE) {
                         continue
                     }
 


### PR DESCRIPTION
## Summary

Ed25519 (Curve25519) signing in `AndroidKeystoreSecureArea` is broken end to end; `testEcKeySigningEd25519` has been `@Ignore`'d since `b/282063229`. KeyMint 2.0+ supports it at the platform level, but five SecureArea issues kept the path broken. This fixes all five and re-enables the test. No public API changes; EC/P-256 and ECDH paths are unchanged.

## Fixes

1. **Key reload.** `getEntry()` rejects Ed25519 (private key reports "EdDSA", mismatching the cert). Switch to `getKey()`; treat null / `UnrecoverableKeyException` as invalidation. Same in `createKeyForExistingAlias`.
2. **KeyInfo lookup.** `getKeyInfo()` resolved `KeyFactory` by "EdDSA" (no such factory). Fall back to "EC".
3. **Digest.** The ED25519 `createKey` branch authorized no digest. Add `DIGEST_NONE` (Ed25519 hashes internally).
4. **Signature decoding.** The platform returns a raw 64-byte `r||s` for Ed25519; split it directly for `EcCurve.ED25519` (ECDSA DER path unchanged).
5. **Biometric path.** `AndroidKeystoreKeyUnlockData.getCryptoObject*` had the same `getEntry()` / algorithm issues; same `getKey()` + "EC" fallback.

## Testing

- **Pixel 10 Pro (KeyMint 2.0):** re-enabled `testEcKeySigningEd25519` and new `testEcKeyInfoReloadEd25519` pass; biometric path verified in the testapp.
- **Non-GMS device (Android 12):** both Ed25519 tests skip cleanly (no Curve25519).

Tests gate on `Capabilities().curve25519Supported` and `assumeFalse(isRunningOnEmulator)`, so they skip on CI's emulator and on pre-2.0 hardware, and run on real KeyMint 2.0+ devices (where this was verified).

## Context

Discussed with the Multipaz maintainers (David Zeuthen and Peter) as the foundation for x402 payment accounts as hardware-backed credentials. First of a short series; a follow-up adds the payment document types. Stands on its own as a bug fix.
