### PR TITLE
added .build/ folder to git ignore..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .kotlin
+.build/
 *.iml
 .gradle**/build/
 xcuserdata


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

.gitignore is missing a .build/ ignore and creates mess when incorporating as a submodule. suggest reviewing your ignores. 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR