### PR TITLE
KeyUnlockDataProvider: Make it work for both Key Agreement and Signing.

### DIFF
--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
@@ -836,6 +836,7 @@ class CloudSecureAreaTest {
         override suspend fun getKeyUnlockData(
             secureArea: SecureArea,
             alias: String,
+            algorithm: Algorithm,
             unlockReason: Reason
         ): KeyUnlockData = keyUnlockData
     }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreDefaultKeyUnlockDataProvider.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreDefaultKeyUnlockDataProvider.kt
@@ -1,5 +1,6 @@
 package org.multipaz.securearea
 
+import org.multipaz.crypto.Algorithm
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.PromptModelNotAvailableException
 import org.multipaz.prompt.Reason
@@ -9,6 +10,7 @@ object AndroidKeystoreDefaultKeyUnlockDataProvider: KeyUnlockDataProvider {
     override suspend fun getKeyUnlockData(
         secureArea: SecureArea,
         alias: String,
+        algorithm: Algorithm,
         unlockReason: Reason
     ): KeyUnlockData {
         check(secureArea is AndroidKeystoreSecureArea)
@@ -21,7 +23,13 @@ object AndroidKeystoreDefaultKeyUnlockDataProvider: KeyUnlockDataProvider {
         }
         val humanReadable = promptModel.toHumanReadable(unlockReason, null)
         if (!promptModel.showBiometricPrompt(
-                cryptoObject = unlockData.getCryptoObjectForSigning(),
+                cryptoObject = if (algorithm.isSigning) {
+                    unlockData.getCryptoObjectForSigning()
+                } else if (algorithm.isKeyAgreement) {
+                    unlockData.cryptoObjectForKeyAgreement
+                } else {
+                    throw IllegalArgumentException("Algorithm isn't for signing or key agreement")
+                },
                 reason = unlockReason,
                 userAuthenticationTypes = keyInfo.userAuthenticationTypes,
                 requireConfirmation = humanReadable.requireConfirmation

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -460,7 +460,12 @@ class AndroidKeystoreSecureArea private constructor(
         } catch (_: KeyLockedException) {
             val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
                 ?: AndroidKeystoreDefaultKeyUnlockDataProvider
-            val unlockData = unlockDataProvider.getKeyUnlockData(this, alias, unlockReason)
+            val unlockData = unlockDataProvider.getKeyUnlockData(
+                secureArea = this,
+                alias = alias,
+                algorithm = getKeyInfo(alias).algorithm,
+                unlockReason = unlockReason
+            )
             signNonInteractive(alias, dataToSign, unlockData)
         }
 
@@ -522,7 +527,11 @@ class AndroidKeystoreSecureArea private constructor(
             } catch (_: KeyLockedException) {
                 val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
                     ?: AndroidKeystoreDefaultKeyUnlockDataProvider
-                unlockDataProvider.getKeyUnlockData(this, alias, unlockReason)
+                unlockDataProvider.getKeyUnlockData(
+                    secureArea = this,
+                    alias = alias,
+                    algorithm = getKeyInfo(alias).algorithm,
+                    unlockReason = unlockReason)
             }
         } while (true)
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
@@ -1,5 +1,6 @@
 package org.multipaz.securearea
 
+import org.multipaz.crypto.Algorithm
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import org.multipaz.prompt.PromptModel
@@ -34,11 +35,13 @@ interface KeyUnlockDataProvider : CoroutineContext.Element {
      *
      * @param secureArea Secure Area where the locked key resides
      * @param alias locked key's alias
+     * @param algorithm the algorithm to use for the key,
      * @param unlockReason conveys the reason for the operation (e.g. credential presentment)
      */
     suspend fun getKeyUnlockData(
         secureArea: SecureArea,
         alias: String,
+        algorithm: Algorithm,
         unlockReason: Reason
     ): KeyUnlockData
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -716,6 +716,7 @@ open class CloudSecureArea protected constructor(
                     val unlockData = unlockDataProvider.getKeyUnlockData(
                         secureArea = this,
                         alias = alias,
+                        algorithm = getKeyInfo(alias).algorithm,
                         unlockReason = unlockReason
                     )
                     op.invoke(unlockData)
@@ -971,6 +972,7 @@ open class CloudSecureArea protected constructor(
         override suspend fun getKeyUnlockData(
             secureArea: SecureArea,
             alias: String,
+            algorithm: Algorithm,
             unlockReason: Reason
         ): KeyUnlockData {
             check(secureArea is CloudSecureArea)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -225,6 +225,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             val unlockData = unlockDataProvider.getKeyUnlockData(
                 secureArea = this,
                 alias = alias,
+                algorithm = getKeyInfo(alias).algorithm,
                 unlockReason = unlockReason
             )
             op.invoke(unlockData)
@@ -298,6 +299,7 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         override suspend fun getKeyUnlockData(
             secureArea: SecureArea,
             alias: String,
+            algorithm: Algorithm,
             unlockReason: Reason
         ): KeyUnlockData {
             secureArea as SoftwareSecureArea
@@ -318,7 +320,6 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
                             PassphraseEvaluation.OK
                         } catch (e: Exception) {
                             if (e is CancellationException) throw e
-                            // TODO: translations
                             PassphraseEvaluation.TryAgain
                         }
                     }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
@@ -407,6 +407,7 @@ class SoftwareSecureAreaTest {
         override suspend fun getKeyUnlockData(
             secureArea: SecureArea,
             alias: String,
+            algorithm: Algorithm,
             unlockReason: Reason
         ): KeyUnlockData = keyUnlockData
     }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
@@ -171,7 +171,12 @@ class SecureEnclaveSecureArea private constructor(
         // TODO: implement default KeyUnlockDataProvider by converting
         //  OperationReason to OperationReason.HumanReadable using PromptModel
         //  and the creating LAContext with title/subtitle from OperationReason.HumanReadable
-        val unlockData = unlockDataProvider?.getKeyUnlockData(this, alias, unlockReason)
+        val unlockData = unlockDataProvider?.getKeyUnlockData(
+            secureArea = this,
+            alias = alias,
+            algorithm = getKeyInfo(alias).algorithm,
+            unlockReason = unlockReason
+        )
         check(unlockData is SecureEnclaveKeyUnlockData?)
         return Crypto.secureEnclaveEcSign(keyBlob, dataToSign, unlockData)
     }
@@ -188,7 +193,12 @@ class SecureEnclaveSecureArea private constructor(
         // TODO: implement default KeyUnlockDataProvider by converting
         //  OperationReason to OperationReason.HumanReadable using PromptModel
         //  and the creating LAContext with title/subtitle from OperationReason.HumanReadable
-        val unlockData = unlockDataProvider?.getKeyUnlockData(this, alias, unlockReason)
+        val unlockData = unlockDataProvider?.getKeyUnlockData(
+            secureArea = this,
+            alias = alias,
+            algorithm = getKeyInfo(alias).algorithm,
+            unlockReason = unlockReason
+        )
         check(unlockData is SecureEnclaveKeyUnlockData?)
         return Crypto.secureEnclaveEcKeyAgreement(keyBlob, otherKey, unlockData)
     }

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
@@ -191,6 +191,7 @@ private class TestKeyUnlockDataProvider(
     override suspend fun getKeyUnlockData(
         secureArea: SecureArea,
         alias: String,
+        algorithm: Algorithm,
         unlockReason: Reason
     ): KeyUnlockData = keyUnlockData
 }


### PR DESCRIPTION
For the `AndroidKeystoreSecureArea` implementation of `SecureArea` the `CryptoObject` to create depends on whether we are signing or performing key agreement. To do this we need to pass the algorithm being used to `KeyUnlockDataProvider.getKeyUnlockData()`

Fixes #1800.

Test: Manually tested and all unit tests pass.
