### PR TITLE
Small fix - multipaz-server-deployment podman binary location

### DIFF
--- a/multipaz-server-deployment/build.gradle.kts
+++ b/multipaz-server-deployment/build.gradle.kts
@@ -77,6 +77,7 @@ tasks.register("buildAll") {
 fun getContainerTool(): String {
     return if (file("/usr/bin/podman").exists() ||
         file("/usr/local/bin/podman").exists() ||
+        file("/opt/podman/bin/podman").exists() ||
         file("/opt/homebrew/bin/podman").exists()) {
         "podman"
     } else {


### PR DESCRIPTION
If Podman is installed via the official installer on MacOS then the binary is not found on build for the multipaz-server-deployment. This is a quick fix to add the official installer podman path: /opt/podman/bin/podman to build.gradle.kts.

Tested manually