### PR TITLE
Work around broken VICALs and RICALs.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/rical/SignedRical.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/rical/SignedRical.kt
@@ -20,6 +20,7 @@ import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.util.Logger
+import org.multipaz.util.toHex
 
 data class SignedRical(
     val rical: Rical,
@@ -167,12 +168,20 @@ data class SignedRical(
 
             val certificateInfos = mutableListOf<RicalCertificateInfo>()
             (ricalMap["certificateInfos"] as CborArray).items.forEachIndexed { certInfoIndex, certInfo ->
-                val ski = ByteString(certInfo["ski"].asBstr)
                 // Be lenient about missing isTrustAnchor for now
                 val isTrustAnchor = certInfo.getOrNull("isTrustAnchor")?.asBoolean ?: true.also {
                     Logger.w(TAG, "isTrustAnchor not present in RICAL entry $certInfoIndex")
                 }
                 val certBytes = certInfo["certificate"].asBstr
+                val certificate = X509Cert(ByteString(certBytes))
+                val ski = certificate.subjectKeyIdentifier?.let { ByteString(it) }
+                    ?: throw IllegalArgumentException("No SKI in certificate")
+                val skiInCertInfo = ByteString(certInfo["ski"].asBstr)
+                if (ski != skiInCertInfo) {
+                    Logger.w(TAG, "For certificate with subject ${certificate.subject.name} the SKI in "
+                            + "RICALCertificateInfo (${skiInCertInfo.toHex()}) differs from SKI in X.509 certificate " +
+                            "(${ski.toHex()})")
+                }
                 val extensionsInCertInfo = certInfo.getOrNull("extensions")?.let {
                     it.asMap.entries.associate { (extName, extValue) -> Pair(extName.asTstr, extValue) }
                 } ?: emptyMap()
@@ -194,7 +203,7 @@ data class SignedRical(
                 }
                 require(serialNumberTaggedItem.tagNumber == Tagged.UNSIGNED_BIGNUM)
                 certificateInfos.add(RicalCertificateInfo(
-                    certificate = X509Cert(ByteString(certBytes)),
+                    certificate = certificate,
                     serialNumber = ByteString(serialNumberTaggedItem.taggedItem.asBstr),
                     isTrustAnchor = isTrustAnchor,
                     ski = ski,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/SignedVical.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/SignedVical.kt
@@ -19,6 +19,8 @@ import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
+import org.multipaz.util.Logger
+import org.multipaz.util.toHex
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -153,8 +155,16 @@ data class SignedVical(
             val certificateInfos = mutableListOf<VicalCertificateInfo>()
 
             for (certInfo in (vicalMap["certificateInfos"] as CborArray).items) {
-                val ski = ByteString(certInfo["ski"].asBstr)
                 val certBytes = certInfo["certificate"].asBstr
+                val certificate = X509Cert(ByteString(certBytes))
+                val ski = certificate.subjectKeyIdentifier?.let { ByteString(it) }
+                    ?: throw IllegalArgumentException("No SKI in certificate")
+                val skiInCertInfo = ByteString(certInfo["ski"].asBstr)
+                if (ski != skiInCertInfo) {
+                    Logger.w(TAG, "For certificate with subject ${certificate.subject.name} the SKI in "
+                        + "CertificateInfo (${skiInCertInfo.toHex()}) differs from SKI in X.509 certificate " +
+                            "(${ski.toHex()})")
+                }
                 val docTypes = (certInfo["docType"] as CborArray).items.map { it.asTstr }
                 val certProfiles = certInfo.getOrNull("certificateProfile")?.let {
                     (it as CborArray).items.map { it.asTstr }


### PR DESCRIPTION
For VICALs and RICALs according to ISO 18013-5 the SKI (Subject Key Identifier) is present in both `CertificateInfo` / `RICALCertificateInfo` CBOR and the X.509 certificate itself. Our parsers use the CBOR value which is less than ideal for VICALs and RICALs that encode this field incorrectly. Instead, use the value from the certificate and log a warning if the two SKIs differ.

Fixes #1806.