### PR TITLE
enforce issue creation before a PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Fixes #<issue_number_goes_here>
 
-> It's a good idea to open an issue first for discussion.
+> It is mandatory to create an issue before opening a PR!
 
 - [ ] Tests pass
 - [ ] Appropriate changes to README are included in PR

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,27 @@
+name: Require Linked Issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR links an issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Matches: Fixes #12 | Closes owner/repo#12 | Resolves https://github.com/owner/repo/issues/12
+          # Requires real digits after '#', so the template placeholder
+          # '#<issue_number_goes_here>' does NOT count as a match.
+          pattern='(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(#[0-9]+|[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+|https://github\.com/[^ ]+/issues/[0-9]+)'
+          if echo "$PR_BODY" | grep -iEq "$pattern"; then
+            echo "✅ Linked issue found."
+          else
+            echo "::error::This PR must link an issue using a keyword like `Fixes #123`. See the PR template."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ here are some pointers about what we're looking for:
 
 ## Contributing to Code
 
+- Every PR must link an issue. Reference it in the PR description using a closing keyword,
+  e.g. `Fixes #123` (or `Closes`/`Resolves`), as prompted by the PR template. This is enforced
+  in CI, so a PR that doesn't link an issue will fail the `check-linked-issue` check. It's a good
+  idea to open an issue first for discussion.
 - A PR should not contain unrelated changes
   - In particular do not include unrelated changes even despite how tempting it is to e.g. change
     `check(!something.isEmpty())` to `check(something.isNotEmpty())` in a unrelated file,


### PR DESCRIPTION
Fixes https://github.com/openwallet-foundation/multipaz/issues/1808

- [x] Tests pass (test PR: https://github.com/VishnuSanal/multipaz-identity-credential/pull/9)
- [x] Appropriate changes to README are included in PR

we can also do the following to enforce this check (optional)

- "Add classic branch protection rule" on https://github.com/openwallet-foundation/multipaz/settings/branches
- `main` to "Branch name pattern"
- check "Require status checks to pass before merging"
- search for the new workflow in the search box and select it
- save changes