### PR TITLE
multipaz-tools: Add Certificate Converter and generic certificate builder.

### DIFF
--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CertConverterComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CertConverterComponent.kt
@@ -1,0 +1,297 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+package org.multipaz.tools.frontend
+
+import emotion.react.css
+import react.FC
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h2
+import react.dom.html.ReactHTML.h3
+import react.dom.html.ReactHTML.p
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.textarea
+import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.span
+import react.useState
+import web.cssom.*
+import kotlinx.browser.window
+import org.multipaz.crypto.X509Cert
+import org.multipaz.util.toBase64
+import org.multipaz.util.toBase64Url
+import org.multipaz.util.toHex
+import org.multipaz.util.fromBase64
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.fromHex
+
+val CertConverterComponent = FC {
+    var certInput by useState("")
+    var certPemOutput by useState("")
+    var certHexOutput by useState("")
+    var certBase64Output by useState("")
+    var certBase64UrlOutput by useState("")
+    var certError by useState("")
+    var parsedCertInfo by useState<CertInfo?>(null)
+
+    fun convertCert(input: String) {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) {
+            parsedCertInfo = null
+            certError = ""
+            certPemOutput = ""
+            certHexOutput = ""
+            certBase64Output = ""
+            certBase64UrlOutput = ""
+            return
+        }
+
+        try {
+            val bytes = if (trimmed.contains("-----BEGIN")) {
+                val pemBody = trimmed.lines()
+                    .filter { !it.startsWith("-----") }
+                    .joinToString("")
+                    .replace("\r", "")
+                    .replace("\n", "")
+                    .replace(" ", "")
+                    .trim()
+                pemBody.fromBase64()
+            } else if (trimmed.all { it in "0123456789abcdefABCDEF \n\r:" }) {
+                val hexClean = trimmed.replace(" ", "").replace(":", "").replace("\n", "").replace("\r", "")
+                hexClean.fromHex()
+            } else {
+                val cleanB64 = trimmed.replace("\n", "").replace("\r", "").replace(" ", "")
+                try {
+                    cleanB64.fromBase64()
+                } catch (e: Throwable) {
+                    cleanB64.fromBase64Url()
+                }
+            }
+
+            val cert = X509Cert(kotlinx.io.bytestring.ByteString(bytes))
+            val subjectStr = cert.subject.name
+            val issuerStr = cert.issuer.name
+            val serialStr = cert.serialNumber.value.toHex()
+            val validFromStr = cert.validityNotBefore.toString()
+            val validToStr = cert.validityNotAfter.toString()
+            val curveStr = try {
+                cert.ecPublicKey.curve.name
+            } catch (e: Throwable) {
+                null
+            }
+
+            parsedCertInfo = CertInfo(
+                subject = subjectStr,
+                issuer = issuerStr,
+                serial = serialStr,
+                validFrom = validFromStr,
+                validTo = validToStr,
+                curve = curveStr
+            )
+            certError = ""
+
+            val base64Str = bytes.toBase64()
+            certHexOutput = bytes.toHex()
+            certBase64Output = base64Str
+            certBase64UrlOutput = bytes.toBase64Url()
+            
+            val chunks = base64Str.chunked(64).joinToString("\n")
+            certPemOutput = "-----BEGIN CERTIFICATE-----\n$chunks\n-----END CERTIFICATE-----"
+        } catch (e: Throwable) {
+            parsedCertInfo = null
+            certError = e.message ?: "Invalid certificate"
+            certPemOutput = ""
+            certHexOutput = ""
+            certBase64Output = ""
+            certBase64UrlOutput = ""
+        }
+    }
+
+    div {
+        css {
+            background = Color("#1e293b")
+            borderRadius = 16.px
+            border = Border(1.px, LineStyle.solid, Color("#334155"))
+            padding = 32.px
+        }
+
+        h2 {
+            css {
+                fontSize = 1.8.rem
+                fontWeight = FontWeight.bold
+                margin = Margin(0.px, 0.px, 16.px, 0.px)
+                color = Color("#f8fafc")
+            }
+            +"Certificate Converter"
+        }
+
+        p {
+            css {
+                color = Color("#94a3b8")
+                marginBottom = 24.px
+            }
+            +"Paste a certificate in PEM, Hex, Base64, or Base64Url format. It will be validated and converted to all formats simultaneously."
+        }
+
+        label {
+            css {
+                display = Display.block
+                fontWeight = FontWeight.bold
+                marginBottom = 8.px
+                color = Color("#cbd5e1")
+            }
+            +"Paste Certificate:"
+        }
+
+        textarea {
+            css {
+                width = 100.pct
+                height = 150.px
+                background = Color("#0f172a")
+                border = Border(1.px, LineStyle.solid, Color("#475569"))
+                borderRadius = 8.px
+                color = Color("#f1f5f9")
+                fontFamily = FontFamily.monospace
+                padding = 12.px
+                resize = "none".unsafeCast<Resize>()
+                marginBottom = 24.px
+                focus {
+                    outline = None.none
+                    borderColor = Color("#3b82f6")
+                }
+            }
+            value = certInput
+            placeholder = "-----BEGIN CERTIFICATE-----\n...\nor hex (e.g. 3082...)\nor Base64..."
+            onChange = { e ->
+                certInput = e.target.value
+                convertCert(e.target.value)
+            }
+        }
+
+        if (certError.isNotEmpty()) {
+            div {
+                css {
+                    color = Color("#ef4444")
+                    fontWeight = FontWeight.bold
+                    marginBottom = 24.px
+                    padding = 12.px
+                    background = Color("#7f1d1d")
+                    border = Border(1.px, LineStyle.solid, Color("#fca5a5"))
+                    borderRadius = 8.px
+                }
+                +certError
+            }
+        }
+
+        if (parsedCertInfo != null) {
+            // Info block
+            div {
+                css {
+                    background = Color("#0f172a")
+                    border = Border(1.px, LineStyle.solid, Color("#334155"))
+                    borderRadius = 12.px
+                    padding = 20.px
+                    marginBottom = 24.px
+                }
+                h3 {
+                    css { margin = 0.px; fontSize = 1.2.rem; color = Color("#38bdf8"); marginBottom = 12.px }
+                    +"Certificate Details"
+                }
+                div {
+                    css {
+                        display = Display.grid
+                        gridTemplateColumns = "repeat(auto-fit, minmax(280px, 1fr))".unsafeCast<GridTemplateColumns>()
+                        gap = 16.px
+                    }
+                    div {
+                        p { css { margin = 0.px; color = Color("#94a3b8"); fontSize = 12.px }; +"Subject" }
+                        p { css { margin = Margin(4.px, 0.px, 0.px, 0.px); color = Color("#f1f5f9"); fontWeight = FontWeight.bold; fontSize = 13.px }; +parsedCertInfo!!.subject }
+                    }
+                    div {
+                        p { css { margin = 0.px; color = Color("#94a3b8"); fontSize = 12.px }; +"Issuer" }
+                        p { css { margin = Margin(4.px, 0.px, 0.px, 0.px); color = Color("#f1f5f9"); fontWeight = FontWeight.bold; fontSize = 13.px }; +parsedCertInfo!!.issuer }
+                    }
+                    div {
+                        p { css { margin = 0.px; color = Color("#94a3b8"); fontSize = 12.px }; +"Serial Number (Hex)" }
+                        p { css { margin = Margin(4.px, 0.px, 0.px, 0.px); color = Color("#34d399"); fontFamily = FontFamily.monospace; fontSize = 13.px }; +parsedCertInfo!!.serial }
+                    }
+                    div {
+                        p { css { margin = 0.px; color = Color("#94a3b8"); fontSize = 12.px }; +"Validity" }
+                        p { css { margin = Margin(4.px, 0.px, 0.px, 0.px); color = Color("#f1f5f9"); fontSize = 13.px }; +"${parsedCertInfo!!.validFrom} to ${parsedCertInfo!!.validTo}" }
+                    }
+                    parsedCertInfo!!.curve?.let { c ->
+                        div {
+                            p { css { margin = 0.px; color = Color("#94a3b8"); fontSize = 12.px }; +"Public Key Curve" }
+                            p { css { margin = Margin(4.px, 0.px, 0.px, 0.px); color = Color("#f1f5f9"); fontSize = 13.px }; +c }
+                        }
+                    }
+                }
+            }
+
+            // Four conversion output cards side by side
+            div {
+                css {
+                    display = Display.grid
+                    gridTemplateColumns = "repeat(auto-fit, minmax(280px, 1fr))".unsafeCast<GridTemplateColumns>()
+                    gap = 20.px
+                }
+
+                listOf(
+                    "PEM format" to certPemOutput,
+                    "Hex format (DER)" to certHexOutput,
+                    "Base64 format (DER)" to certBase64Output,
+                    "Base64Url format (DER)" to certBase64UrlOutput
+                ).forEach { (title, outputVal) ->
+                    div {
+                        css {
+                            background = Color("#0f172a")
+                            border = Border(1.px, LineStyle.solid, Color("#334155"))
+                            borderRadius = 10.px
+                            padding = 16.px
+                            display = Display.flex
+                            flexDirection = FlexDirection.column
+                            gap = 8.px
+                        }
+                        div {
+                            css { display = Display.flex; justifyContent = JustifyContent.spaceBetween; alignItems = AlignItems.center }
+                            span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold; fontSize = 13.px }; +title }
+                            button {
+                                css {
+                                    background = Color("#1e293b")
+                                    border = Border(1.px, LineStyle.solid, Color("#334155"))
+                                    color = Color("#60a5fa")
+                                    padding = Padding(4.px, 8.px)
+                                    borderRadius = 6.px
+                                    cursor = Cursor.pointer
+                                    fontSize = 11.px
+                                    fontWeight = FontWeight.bold
+                                    hover { background = Color("#334155") }
+                                }
+                                onClick = {
+                                    window.navigator.asDynamic().clipboard.writeText(outputVal)
+                                }
+                                +"Copy"
+                            }
+                        }
+                        textarea {
+                            css {
+                                width = 100.pct; height = 120.px; background = Color("#1e293b")
+                                border = Border(1.px, LineStyle.solid, Color("#334155")); borderRadius = 6.px
+                                color = Color("#38bdf8"); fontFamily = FontFamily.monospace; padding = 8.px; fontSize = 11.px
+                                resize = "none".unsafeCast<Resize>()
+                            }
+                            readOnly = true
+                            value = outputVal
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class CertInfo(
+    val subject: String,
+    val issuer: String,
+    val serial: String,
+    val validFrom: String,
+    val validTo: String,
+    val curve: String?
+)

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CertGeneratorComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CertGeneratorComponent.kt
@@ -1,4 +1,7 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(
+    kotlin.time.ExperimentalTime::class,
+    kotlin.io.encoding.ExperimentalEncodingApi::class
+)
 package org.multipaz.tools.frontend
 
 import emotion.react.css
@@ -26,11 +29,28 @@ import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509KeyUsage
 import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.asn1.ASN1
+import org.multipaz.asn1.ASN1Object
+import org.multipaz.asn1.ASN1Boolean
+import org.multipaz.asn1.ASN1Sequence
+import org.multipaz.asn1.ASN1TaggedObject
+import org.multipaz.asn1.ASN1TagClass
+import org.multipaz.asn1.ASN1Encoding
+import org.multipaz.asn1.ASN1BitString
+import org.multipaz.asn1.ASN1OctetString
+import org.multipaz.asn1.ASN1ObjectIdentifier
 import org.multipaz.asn1.ASN1Integer
+import org.multipaz.asn1.OID
+import kotlin.io.encoding.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import org.multipaz.util.toHex
 
 val CertGeneratorComponent = FC {
@@ -44,6 +64,8 @@ val CertGeneratorComponent = FC {
     var serialNumber by useState("1")
     var validityDays by useState("1200")
     var curve by useState(EcCurve.P256)
+    var useCustomKey by useState(false)
+    var customPrivateKeyPem by useState("")
 
     // Sub-tab Specific Inputs
     var issuerAltNameUrl by useState("http://iaca.example.com")
@@ -53,6 +75,25 @@ val CertGeneratorComponent = FC {
     // Signing Key/Cert inputs (for DS & Reader certificates)
     var signingKeyPem by useState("")
     var signingCertPem by useState("")
+
+    // Generic Tab State
+    var genericIsCa by useState(false)
+    var genericPathLen by useState("")
+    var genericKeyUsageEnabled by useState(false)
+    var genericKeyUsages by useState(setOf<X509KeyUsage>())
+    var genericEkuEnabled by useState(false)
+    var genericExtendedKeyUsages by useState(setOf<String>())
+    var genericBasicConstraintsEnabled by useState(false)
+    var genericSanDns by useState("")
+    var genericSanUri by useState("")
+    var genericIssuerAltName by useState("")
+    var genericCrlUrl by useState("")
+    var genericIncludeSubjectKeyIdentifier by useState(true)
+    var genericIncludeAuthorityKeyIdentifier by useState(true)
+    var genericUseSigningCert by useState(false)
+    var genericSigningKeyPem by useState("")
+    var genericSigningCertPem by useState("")
+    var genericCustomExtensions by useState(listOf<CustomExtItem>())
 
     // Outputs
     var generatedCertPem by useState("")
@@ -111,7 +152,8 @@ val CertGeneratorComponent = FC {
                 "iaca" to "IACA Certificate",
                 "ds" to "DS Certificate",
                 "reader-root" to "Reader Root Cert",
-                "reader" to "Reader Cert"
+                "reader" to "Reader Cert",
+                "generic" to "Generic Certificate"
             ).forEach { (subTabId, title) ->
                 button {
                     css {
@@ -158,6 +200,11 @@ val CertGeneratorComponent = FC {
                                 subjectDn = "CN=Test Reader Client,O=Multipaz,C=US"
                                 serialNumber = "1"
                                 validityDays = "180"
+                            }
+                            "generic" -> {
+                                subjectDn = "CN=Generic Test Cert,O=Multipaz,C=US"
+                                serialNumber = "1"
+                                validityDays = "365"
                             }
                         }
                     }
@@ -311,6 +358,54 @@ val CertGeneratorComponent = FC {
                         option {
                             value = c.name
                             +c.name
+                        }
+                    }
+                }
+            }
+
+            label {
+                css {
+                    display = Display.flex
+                    alignItems = AlignItems.center
+                    gap = 8.px
+                    fontWeight = FontWeight.bold
+                    color = Color("#cbd5e1")
+                    cursor = Cursor.pointer
+                    marginTop = 16.px
+                    marginBottom = 16.px
+                }
+                input {
+                    type = "checkbox".unsafeCast<InputType>()
+                    checked = useCustomKey
+                    onChange = {
+                        useCustomKey = it.target.checked
+                        resetOutputs()
+                    }
+                }
+                +"Use custom private key (PEM or JWK)"
+            }
+
+            if (useCustomKey) {
+                div {
+                    css {
+                        marginBottom = 24.px
+                    }
+                    label {
+                        css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1") }
+                        +"Custom Private Key (PEM or JWK format):"
+                    }
+                    textarea {
+                        css {
+                            width = 100.pct; height = 120.px; background = Color("#0f172a")
+                            border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 8.px
+                            color = Color("#34d399"); fontFamily = FontFamily.monospace; padding = 10.px; fontSize = 12.px
+                            resize = "none".unsafeCast<Resize>()
+                        }
+                        value = customPrivateKeyPem
+                        placeholder = "-----BEGIN PRIVATE KEY-----\n...\n\nor\n\n{\n  \"kty\": \"EC\",\n  \"crv\": \"P-256\",\n  \"x\": \"...\",\n  \"y\": \"...\",\n  \"d\": \"...\"\n}"
+                        onChange = {
+                            customPrivateKeyPem = it.target.value
+                            resetOutputs()
                         }
                     }
                 }
@@ -521,6 +616,415 @@ val CertGeneratorComponent = FC {
             }
         }
 
+        if (activeSubTab == "generic") {
+            div {
+                css {
+                    display = Display.flex
+                    flexDirection = FlexDirection.column
+                    gap = 20.px
+                    marginBottom = 28.px
+                    background = Color("#0f172a")
+                    border = Border(1.px, LineStyle.solid, Color("#334155"))
+                    borderRadius = 12.px
+                    padding = 24.px
+                }
+
+                h3 {
+                    css { margin = 0.px; fontSize = 1.3.rem; color = Color("#f1f5f9"); borderBottom = Border(1.px, LineStyle.solid, Color("#1e293b")); paddingBottom = 8.px }
+                    +"Generic Extensions & Configuration"
+                }
+
+                // 1. Basic Constraints & CA
+                div {
+                    css {
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 12.px
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#f1f5f9"); fontWeight = FontWeight.bold; cursor = Cursor.pointer }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericBasicConstraintsEnabled
+                            onChange = { genericBasicConstraintsEnabled = it.target.checked }
+                        }
+                        +"Enable Basic Constraints Extension"
+                    }
+                    if (genericBasicConstraintsEnabled) {
+                        div {
+                            css { display = Display.flex; gap = 20.px; paddingLeft = 24.px }
+                            label {
+                                css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#cbd5e1"); cursor = Cursor.pointer }
+                                input {
+                                    type = "checkbox".unsafeCast<InputType>()
+                                    checked = genericIsCa
+                                    onChange = { genericIsCa = it.target.checked }
+                                }
+                                +"Is Certificate Authority (CA)"
+                            }
+                            if (genericIsCa) {
+                                div {
+                                    css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px }
+                                    span { css { color = Color("#94a3b8"); fontSize = 13.px }; +"Path Length Constraint:" }
+                                    input {
+                                        type = "number".unsafeCast<InputType>()
+                                        css {
+                                            width = 80.px; padding = 6.px; background = Color("#1e293b")
+                                            border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9")
+                                        }
+                                        value = genericPathLen
+                                        placeholder = "None"
+                                        onChange = { genericPathLen = it.target.value }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 2. Key Usage
+                div {
+                    css {
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 12.px
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#f1f5f9"); fontWeight = FontWeight.bold; cursor = Cursor.pointer }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericKeyUsageEnabled
+                            onChange = { genericKeyUsageEnabled = it.target.checked }
+                        }
+                        +"Enable Key Usage Extension"
+                    }
+                    if (genericKeyUsageEnabled) {
+                        div {
+                            css {
+                                display = Display.grid
+                                gridTemplateColumns = "repeat(auto-fit, minmax(180px, 1fr))".unsafeCast<GridTemplateColumns>()
+                                gap = 10.px
+                                paddingLeft = 24.px
+                            }
+                            X509KeyUsage.entries.forEach { usage ->
+                                label {
+                                    css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 13.px }
+                                    input {
+                                        type = "checkbox".unsafeCast<InputType>()
+                                        checked = genericKeyUsages.contains(usage)
+                                        onChange = {
+                                            genericKeyUsages = if (it.target.checked) {
+                                                genericKeyUsages + usage
+                                            } else {
+                                                genericKeyUsages - usage
+                                            }
+                                        }
+                                    }
+                                    +usage.description
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 3. Extended Key Usage (EKU)
+                div {
+                    css {
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 12.px
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#f1f5f9"); fontWeight = FontWeight.bold; cursor = Cursor.pointer }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericEkuEnabled
+                            onChange = { genericEkuEnabled = it.target.checked }
+                        }
+                        +"Enable Extended Key Usage (EKU) Extension"
+                    }
+                    if (genericEkuEnabled) {
+                        div {
+                            css {
+                                display = Display.grid
+                                gridTemplateColumns = "repeat(auto-fit, minmax(220px, 1fr))".unsafeCast<GridTemplateColumns>()
+                                gap = 10.px
+                                paddingLeft = 24.px
+                            }
+                            listOf(
+                                "1.3.6.1.5.5.7.3.1" to "Server Authentication",
+                                "1.3.6.1.5.5.7.3.2" to "Client Authentication",
+                                "1.3.6.1.5.5.7.3.3" to "Code Signing",
+                                "1.3.6.1.5.5.7.3.4" to "Email Protection",
+                                "1.3.6.1.5.5.7.3.8" to "Time Stamping",
+                                "1.3.6.1.5.5.7.3.9" to "OCSP Signing"
+                            ).forEach { (oid, name) ->
+                                label {
+                                    css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 13.px }
+                                    input {
+                                        type = "checkbox".unsafeCast<InputType>()
+                                        checked = genericExtendedKeyUsages.contains(oid)
+                                        onChange = {
+                                            genericExtendedKeyUsages = if (it.target.checked) {
+                                                genericExtendedKeyUsages + oid
+                                            } else {
+                                                genericExtendedKeyUsages - oid
+                                            }
+                                        }
+                                    }
+                                    +"$name ($oid)"
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 4. SAN DNS Names and URIs
+                div {
+                    css {
+                        display = Display.grid
+                        gridTemplateColumns = "repeat(auto-fit, minmax(280px, 1fr))".unsafeCast<GridTemplateColumns>()
+                        gap = 20.px
+                    }
+                    div {
+                        label {
+                            css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                            +"Subject Alternative Name - DNS Name:"
+                        }
+                        input {
+                            type = "text".unsafeCast<InputType>()
+                            css { width = 100.pct; padding = 10.px; background = Color("#1e293b"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9") }
+                            value = genericSanDns
+                            placeholder = "e.g. example.com"
+                            onChange = { genericSanDns = it.target.value }
+                        }
+                    }
+                    div {
+                        label {
+                            css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                            +"Subject Alternative Name - URI:"
+                        }
+                        input {
+                            type = "text".unsafeCast<InputType>()
+                            css { width = 100.pct; padding = 10.px; background = Color("#1e293b"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9") }
+                            value = genericSanUri
+                            placeholder = "e.g. urn:example:service"
+                            onChange = { genericSanUri = it.target.value }
+                        }
+                    }
+                }
+
+                // 5. Issuer Alt Name and CRL Distribution Points
+                div {
+                    css {
+                        display = Display.grid
+                        gridTemplateColumns = "repeat(auto-fit, minmax(280px, 1fr))".unsafeCast<GridTemplateColumns>()
+                        gap = 20.px
+                    }
+                    div {
+                        label {
+                            css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                            +"Issuer Alternative Name (URL):"
+                        }
+                        input {
+                            type = "text".unsafeCast<InputType>()
+                            css { width = 100.pct; padding = 10.px; background = Color("#1e293b"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9") }
+                            value = genericIssuerAltName
+                            placeholder = "e.g. http://iaca.example.com"
+                            onChange = { genericIssuerAltName = it.target.value }
+                        }
+                    }
+                    div {
+                        label {
+                            css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                            +"CRL Distribution Point (URL):"
+                        }
+                        input {
+                            type = "text".unsafeCast<InputType>()
+                            css { width = 100.pct; padding = 10.px; background = Color("#1e293b"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9") }
+                            value = genericCrlUrl
+                            placeholder = "e.g. http://example.com/crl"
+                            onChange = { genericCrlUrl = it.target.value }
+                        }
+                    }
+                }
+
+                // 6. Subject Key Identifier and Authority Key Identifier
+                div {
+                    css {
+                        display = Display.flex
+                        gap = 24.px
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 13.px }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericIncludeSubjectKeyIdentifier
+                            onChange = { genericIncludeSubjectKeyIdentifier = it.target.checked }
+                        }
+                        +"Include Subject Key Identifier"
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 13.px }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericIncludeAuthorityKeyIdentifier
+                            onChange = { genericIncludeAuthorityKeyIdentifier = it.target.checked }
+                        }
+                        +"Include Authority Key Identifier"
+                    }
+                }
+
+                // 7. Custom Extensions Block
+                div {
+                    css {
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 12.px
+                    }
+                    div {
+                        css { display = Display.flex; justifyContent = JustifyContent.spaceBetween; alignItems = AlignItems.center }
+                        span { css { color = Color("#cbd5e1"); fontWeight = FontWeight.bold }; +"Custom Extensions" }
+                        button {
+                            css {
+                                padding = Padding(4.px, 10.px); fontSize = 12.px; fontWeight = FontWeight.bold
+                                backgroundColor = Color("#1e293b"); color = Color("#60a5fa")
+                                border = Border(1.px, LineStyle.solid, Color("#334155")); borderRadius = 6.px; cursor = Cursor.pointer
+                                hover { backgroundColor = Color("#334155") }
+                            }
+                            onClick = {
+                                genericCustomExtensions = genericCustomExtensions + CustomExtItem("", false, "")
+                            }
+                            +"+ Add Custom Extension"
+                        }
+                    }
+                    genericCustomExtensions.forEachIndexed { i, ext ->
+                        div {
+                            css {
+                                display = Display.flex; gap = 12.px; alignItems = AlignItems.center; background = Color("#1e293b")
+                                padding = 12.px; borderRadius = 8.px; border = Border(1.px, LineStyle.solid, Color("#334155"))
+                            }
+                            input {
+                                type = "text".unsafeCast<InputType>()
+                                css { width = 160.px; padding = 6.px; background = Color("#0f172a"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#f1f5f9"); fontSize = 12.px }
+                                value = ext.oid
+                                placeholder = "OID (e.g. 1.2.3.4)"
+                                onChange = { e ->
+                                    genericCustomExtensions = genericCustomExtensions.toMutableList().apply {
+                                        this[i] = this[i].copy(oid = e.target.value)
+                                    }
+                                }
+                            }
+                            label {
+                                css { display = Display.flex; alignItems = AlignItems.center; gap = 6.px; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 12.px }
+                                input {
+                                    type = "checkbox".unsafeCast<InputType>()
+                                    checked = ext.isCritical
+                                    onChange = { e ->
+                                        genericCustomExtensions = genericCustomExtensions.toMutableList().apply {
+                                            this[i] = this[i].copy(isCritical = e.target.checked)
+                                        }
+                                    }
+                                }
+                                +"Critical"
+                            }
+                            input {
+                                type = "text".unsafeCast<InputType>()
+                                css { flexGrow = number(1.0); padding = 6.px; background = Color("#0f172a"); border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 6.px; color = Color("#34d399"); fontSize = 12.px; fontFamily = FontFamily.monospace }
+                                value = ext.hexData
+                                placeholder = "Hex Data Value (e.g. 020101)"
+                                onChange = { e ->
+                                    genericCustomExtensions = genericCustomExtensions.toMutableList().apply {
+                                        this[i] = this[i].copy(hexData = e.target.value)
+                                    }
+                                }
+                            }
+                            button {
+                                css {
+                                    padding = Padding(6.px, 10.px); fontSize = 12.px; fontWeight = FontWeight.bold
+                                    backgroundColor = Color("#7f1d1d"); color = Color("#fca5a5")
+                                    border = None.none; borderRadius = 6.px; cursor = Cursor.pointer
+                                    hover { backgroundColor = Color("#991b1b") }
+                                }
+                                onClick = {
+                                    genericCustomExtensions = genericCustomExtensions.toMutableList().apply {
+                                        removeAt(i)
+                                    }
+                                }
+                                +"Remove"
+                            }
+                        }
+                    }
+                }
+
+                // 8. Signing CA Certificate
+                div {
+                    css {
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 12.px
+                        borderTop = Border(1.px, LineStyle.solid, Color("#1e293b"))
+                        paddingTop = 16.px
+                    }
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; gap = 8.px; color = Color("#f1f5f9"); fontWeight = FontWeight.bold; cursor = Cursor.pointer }
+                        input {
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = genericUseSigningCert
+                            onChange = { genericUseSigningCert = it.target.checked }
+                        }
+                        +"Sign with another CA Certificate (otherwise self-signed)"
+                    }
+                    if (genericUseSigningCert) {
+                        div {
+                            css {
+                                display = Display.grid
+                                gridTemplateColumns = "repeat(auto-fit, minmax(300px, 1fr))".unsafeCast<GridTemplateColumns>()
+                                gap = 20.px
+                                paddingLeft = 24.px
+                            }
+
+                            div {
+                                label {
+                                    css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                                    +"Signing CA Private Key (PEM or JWK):"
+                                }
+                                textarea {
+                                    css {
+                                        width = 100.pct; height = 120.px; background = Color("#1e293b")
+                                        border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 8.px
+                                        color = Color("#38bdf8"); fontFamily = FontFamily.monospace; padding = 10.px; fontSize = 12.px
+                                        resize = "none".unsafeCast<Resize>()
+                                    }
+                                    value = genericSigningKeyPem
+                                    placeholder = "-----BEGIN PRIVATE KEY-----\n..."
+                                    onChange = { genericSigningKeyPem = it.target.value }
+                                }
+                            }
+
+                            div {
+                                label {
+                                    css { display = Display.block; fontWeight = FontWeight.bold; marginBottom = 6.px; color = Color("#cbd5e1"); fontSize = 13.px }
+                                    +"Signing CA Certificate PEM:"
+                                }
+                                textarea {
+                                    css {
+                                        width = 100.pct; height = 120.px; background = Color("#1e293b")
+                                        border = Border(1.px, LineStyle.solid, Color("#475569")); borderRadius = 8.px
+                                        color = Color("#34d399"); fontFamily = FontFamily.monospace; padding = 10.px; fontSize = 12.px
+                                        resize = "none".unsafeCast<Resize>()
+                                    }
+                                    value = genericSigningCertPem
+                                    placeholder = "-----BEGIN CERTIFICATE-----\n..."
+                                    onChange = { genericSigningCertPem = it.target.value }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Generate Action Button
         button {
             css {
@@ -552,14 +1056,24 @@ val CertGeneratorComponent = FC {
                         val now = Clock.System.now()
                         val expiration = now + validityDays.trim().toInt().days
 
-                        // Generate certificate's public/private key pair
-                        val generatedKey = Crypto.createEcPrivateKey(curve)
-                        generatedPrivateKeyPem = generatedKey.toPem()
+                        // Generate or parse certificate's public/private key pair
+                        val certKey = if (useCustomKey) {
+                            if (customPrivateKeyPem.trim().isEmpty()) {
+                                throw IllegalArgumentException("Custom Private Key PEM is empty.")
+                            }
+                            val parsedPair = parsePrivateKeyAndPublicKey(customPrivateKeyPem.trim())
+                            generatedPrivateKeyPem = ""
+                            parsedPair.first
+                        } else {
+                            val generatedKey = Crypto.createEcPrivateKey(curve)
+                            generatedPrivateKeyPem = generatedKey.toPem()
+                            generatedKey
+                        }
 
                         val cert = when (activeSubTab) {
                             "iaca" -> {
                                 MdocUtil.generateIacaCertificate(
-                                    iacaKey = AsymmetricKey.AnonymousExplicit(generatedKey),
+                                    iacaKey = AsymmetricKey.AnonymousExplicit(certKey),
                                     subject = parsedSubject,
                                     serial = parsedSerial,
                                     validFrom = now,
@@ -570,7 +1084,7 @@ val CertGeneratorComponent = FC {
                             }
                             "reader-root" -> {
                                 MdocUtil.generateReaderRootCertificate(
-                                    readerRootKey = AsymmetricKey.AnonymousExplicit(generatedKey),
+                                    readerRootKey = AsymmetricKey.AnonymousExplicit(certKey),
                                     subject = parsedSubject,
                                     serial = parsedSerial,
                                     validFrom = now,
@@ -587,7 +1101,7 @@ val CertGeneratorComponent = FC {
                                 val certifiedKey = AsymmetricKey.X509CertifiedExplicit(X509CertChain(listOf(iacaCert)), iacaPriv)
                                 MdocUtil.generateDsCertificate(
                                     iacaKey = certifiedKey,
-                                    dsKey = generatedKey.publicKey,
+                                    dsKey = certKey.publicKey,
                                     subject = parsedSubject,
                                     serial = parsedSerial,
                                     validFrom = now,
@@ -603,13 +1117,155 @@ val CertGeneratorComponent = FC {
                                 val certifiedKey = AsymmetricKey.X509CertifiedExplicit(X509CertChain(listOf(rootCert)), rootPriv)
                                 MdocUtil.generateReaderCertificate(
                                     readerRootKey = certifiedKey,
-                                    readerKey = generatedKey.publicKey,
+                                    readerKey = certKey.publicKey,
                                     subject = parsedSubject,
                                     dnsName = if (dnsName.trim().isNotEmpty()) dnsName.trim() else null,
                                     serial = parsedSerial,
                                     validFrom = now,
                                     validUntil = expiration
                                 )
+                            }
+                            "generic" -> {
+                                val sKey = if (genericUseSigningCert) {
+                                    if (genericSigningKeyPem.trim().isEmpty() || genericSigningCertPem.trim().isEmpty()) {
+                                        throw IllegalArgumentException("Signing CA Private Key and Certificate are required.")
+                                    }
+                                    val parentCert = X509Cert.fromPem(genericSigningCertPem.trim())
+                                    val parentPrivKey = parsePrivateKeyAndPublicKey(genericSigningKeyPem.trim()).first
+                                    AsymmetricKey.X509CertifiedExplicit(X509CertChain(listOf(parentCert)), parentPrivKey)
+                                } else {
+                                    AsymmetricKey.AnonymousExplicit(certKey)
+                                }
+
+                                val issuerName = if (genericUseSigningCert) {
+                                    X509Cert.fromPem(genericSigningCertPem.trim()).subject
+                                } else {
+                                    parsedSubject
+                                }
+
+                                val b = X509Cert.Builder(
+                                    publicKey = certKey.publicKey,
+                                    signingKey = sKey,
+                                    serialNumber = parsedSerial,
+                                    subject = parsedSubject,
+                                    issuer = issuerName,
+                                    validFrom = now,
+                                    validUntil = expiration
+                                )
+
+                                if (genericBasicConstraintsEnabled) {
+                                    b.setBasicConstraints(
+                                        ca = genericIsCa,
+                                        pathLenConstraint = if (genericIsCa && genericPathLen.trim().isNotEmpty()) genericPathLen.trim().toInt() else null
+                                    )
+                                }
+
+                                if (genericKeyUsageEnabled && genericKeyUsages.isNotEmpty()) {
+                                    b.setKeyUsage(genericKeyUsages)
+                                }
+
+                                if (genericEkuEnabled && genericExtendedKeyUsages.isNotEmpty()) {
+                                    val ekuSeq = ASN1Sequence(
+                                        genericExtendedKeyUsages.map { ASN1ObjectIdentifier(it) }
+                                    )
+                                    b.addExtension(
+                                        OID.X509_EXTENSION_EXTENDED_KEY_USAGE.oid,
+                                        false,
+                                        ASN1.encode(ekuSeq)
+                                    )
+                                }
+
+                                val sanList = mutableListOf<ASN1Object>()
+                                if (genericSanDns.trim().isNotEmpty()) {
+                                    sanList.add(
+                                        ASN1TaggedObject(
+                                            ASN1TagClass.CONTEXT_SPECIFIC,
+                                            ASN1Encoding.PRIMITIVE,
+                                            2, // dNSName
+                                            genericSanDns.trim().encodeToByteArray()
+                                        )
+                                    )
+                                }
+                                if (genericSanUri.trim().isNotEmpty()) {
+                                    sanList.add(
+                                        ASN1TaggedObject(
+                                            ASN1TagClass.CONTEXT_SPECIFIC,
+                                            ASN1Encoding.PRIMITIVE,
+                                            6, // uniformResourceIdentifier
+                                            genericSanUri.trim().encodeToByteArray()
+                                        )
+                                    )
+                                }
+                                if (sanList.isNotEmpty()) {
+                                    b.addExtension(
+                                        OID.X509_EXTENSION_SUBJECT_ALT_NAME.oid,
+                                        false,
+                                        ASN1.encode(ASN1Sequence(sanList))
+                                    )
+                                }
+
+                                if (genericIssuerAltName.trim().isNotEmpty()) {
+                                    b.addExtension(
+                                        OID.X509_EXTENSION_ISSUER_ALT_NAME.oid,
+                                        false,
+                                        ASN1.encode(
+                                            ASN1Sequence(listOf(
+                                                ASN1TaggedObject(
+                                                    ASN1TagClass.CONTEXT_SPECIFIC,
+                                                    ASN1Encoding.PRIMITIVE,
+                                                    6, // URI
+                                                    genericIssuerAltName.trim().encodeToByteArray()
+                                                )
+                                            ))
+                                        )
+                                    )
+                                }
+
+                                if (genericCrlUrl.trim().isNotEmpty()) {
+                                    b.addExtension(
+                                        OID.X509_EXTENSION_CRL_DISTRIBUTION_POINTS.oid,
+                                        false,
+                                        ASN1.encode(
+                                            ASN1Sequence(listOf(
+                                                ASN1Sequence(listOf(
+                                                    ASN1TaggedObject(ASN1TagClass.CONTEXT_SPECIFIC, ASN1Encoding.CONSTRUCTED, 0, ASN1.encode(
+                                                        ASN1TaggedObject(ASN1TagClass.CONTEXT_SPECIFIC, ASN1Encoding.CONSTRUCTED, 0, ASN1.encode(
+                                                            ASN1TaggedObject(ASN1TagClass.CONTEXT_SPECIFIC, ASN1Encoding.PRIMITIVE, 6,
+                                                                genericCrlUrl.trim().encodeToByteArray()
+                                                            )
+                                                        ))
+                                                    ))
+                                                ))
+                                            ))
+                                        )
+                                    )
+                                }
+
+                                if (genericIncludeSubjectKeyIdentifier) {
+                                    b.includeSubjectKeyIdentifier(true)
+                                }
+
+                                if (genericIncludeAuthorityKeyIdentifier) {
+                                    if (genericUseSigningCert) {
+                                        val parentCert = X509Cert.fromPem(genericSigningCertPem.trim())
+                                        b.setAuthorityKeyIdentifierToCertificate(parentCert)
+                                    } else {
+                                        b.includeAuthorityKeyIdentifierAsSubjectKeyIdentifier(true)
+                                    }
+                                }
+
+                                for (customExt in genericCustomExtensions) {
+                                    if (customExt.oid.trim().isNotEmpty()) {
+                                        val extBytes = decodeHex(customExt.hexData.trim().replace(" ", "").replace(":", ""))
+                                        b.addExtension(
+                                            customExt.oid.trim(),
+                                            customExt.isCritical,
+                                            extBytes
+                                        )
+                                    }
+                                }
+
+                                b.build()
                             }
                             else -> throw IllegalStateException("Unknown sub-tab type")
                         }
@@ -712,53 +1368,55 @@ val CertGeneratorComponent = FC {
                     }
 
                     // Private Key Output Card
-                    div {
-                        css {
-                            background = Color("#0f172a")
-                            border = Border(1.px, LineStyle.solid, Color("#334155"))
-                            borderRadius = 12.px
-                            padding = 24.px
-                            display = Display.flex
-                            flexDirection = FlexDirection.column
-                            gap = 12.px
-                        }
+                    if (!useCustomKey && generatedPrivateKeyPem.isNotEmpty()) {
                         div {
                             css {
+                                background = Color("#0f172a")
+                                border = Border(1.px, LineStyle.solid, Color("#334155"))
+                                borderRadius = 12.px
+                                padding = 24.px
                                 display = Display.flex
-                                justifyContent = JustifyContent.spaceBetween
-                                alignItems = AlignItems.center
+                                flexDirection = FlexDirection.column
+                                gap = 12.px
                             }
-                            h3 {
-                                css { margin = 0.px; fontSize = 1.2.rem; color = Color("#f1f5f9") }
-                                +"Private Key"
-                            }
-                            button {
+                            div {
                                 css {
-                                    background = Color(if (copyKeySuccess) "#10b981" else "#334155")
-                                    border = None.none
-                                    color = Color("#ffffff")
-                                    padding = Padding(6.px, 12.px)
-                                    borderRadius = 6.px
-                                    cursor = Cursor.pointer
-                                    fontSize = 12.px
-                                    fontWeight = FontWeight.bold
+                                    display = Display.flex
+                                    justifyContent = JustifyContent.spaceBetween
+                                    alignItems = AlignItems.center
                                 }
-                                onClick = {
-                                    window.navigator.asDynamic().clipboard.writeText(generatedPrivateKeyPem)
-                                    copyKeySuccess = true
+                                h3 {
+                                    css { margin = 0.px; fontSize = 1.2.rem; color = Color("#f1f5f9") }
+                                    +"Private Key"
                                 }
-                                +(if (copyKeySuccess) "Copied!" else "Copy")
+                                button {
+                                    css {
+                                        background = Color(if (copyKeySuccess) "#10b981" else "#334155")
+                                        border = None.none
+                                        color = Color("#ffffff")
+                                        padding = Padding(6.px, 12.px)
+                                        borderRadius = 6.px
+                                        cursor = Cursor.pointer
+                                        fontSize = 12.px
+                                        fontWeight = FontWeight.bold
+                                    }
+                                    onClick = {
+                                        window.navigator.asDynamic().clipboard.writeText(generatedPrivateKeyPem)
+                                        copyKeySuccess = true
+                                    }
+                                    +(if (copyKeySuccess) "Copied!" else "Copy")
+                                }
                             }
-                        }
-                        textarea {
-                            css {
-                                width = 100.pct; height = 240.px; background = Color("#1e293b")
-                                border = Border(1.px, LineStyle.solid, Color("#334155")); borderRadius = 8.px
-                                color = Color("#38bdf8"); fontFamily = FontFamily.monospace; padding = 12.px; fontSize = 12.px
-                                resize = "none".unsafeCast<Resize>()
+                            textarea {
+                                css {
+                                    width = 100.pct; height = 240.px; background = Color("#1e293b")
+                                    border = Border(1.px, LineStyle.solid, Color("#334155")); borderRadius = 8.px
+                                    color = Color("#38bdf8"); fontFamily = FontFamily.monospace; padding = 12.px; fontSize = 12.px
+                                    resize = "none".unsafeCast<Resize>()
+                                }
+                                readOnly = true
+                                value = generatedPrivateKeyPem
                             }
-                            readOnly = true
-                            value = generatedPrivateKeyPem
                         }
                     }
                 }
@@ -810,3 +1468,99 @@ private fun decodeHex(hex: String): ByteArray {
     }
     return result
 }
+
+private fun parsePrivateKeyAndPublicKey(input: String): Pair<EcPrivateKey, EcPublicKey> {
+    val trimmed = input.trim()
+    if (trimmed.startsWith("{")) {
+        try {
+            val json = Json.parseToJsonElement(trimmed).jsonObject
+            val privKey = EcPrivateKey.fromJwk(json)
+            val pubKey = privKey.publicKey
+            return Pair(privKey, pubKey)
+        } catch (e: Throwable) {
+            throw IllegalArgumentException("Failed to parse private key as JWK: ${e.message}", e)
+        }
+    }
+
+    // PEM parsing
+    val encoded = Base64.Mime.decode(trimmed
+        .replace("-----BEGIN PRIVATE KEY-----", "")
+        .replace("-----END PRIVATE KEY-----", "")
+        .replace("-----BEGIN EC PRIVATE KEY-----", "")
+        .replace("-----END EC PRIVATE KEY-----", "")
+        .trim())
+    
+    val rootObj = ASN1.decode(encoded) as ASN1Sequence
+    val privateKeySeq = if (rootObj.elements.size > 2 && rootObj.elements[2] is ASN1OctetString) {
+        val octetString = rootObj.elements[2] as ASN1OctetString
+        ASN1.decode(octetString.value) as ASN1Sequence
+    } else {
+        rootObj
+    }
+
+    val privateKeyInfo = rootObj
+    val privateKeyAlgorithm = privateKeyInfo.elements[1] as ASN1Sequence
+    val algorithm = privateKeyAlgorithm.elements[0] as ASN1ObjectIdentifier
+    val curve = when (algorithm.oid) {
+        OID.EC_PUBLIC_KEY.oid -> {
+            val ecCurveString = privateKeyAlgorithm.elements[1] as ASN1ObjectIdentifier
+            when (ecCurveString.oid) {
+                "1.2.840.10045.3.1.7" -> EcCurve.P256
+                "1.3.132.0.34" -> EcCurve.P384
+                "1.3.132.0.35" -> EcCurve.P521
+                "1.3.36.3.3.2.8.1.1.7" -> EcCurve.BRAINPOOLP256R1
+                "1.3.36.3.3.2.8.1.1.9" -> EcCurve.BRAINPOOLP320R1
+                "1.3.36.3.3.2.8.1.1.11" -> EcCurve.BRAINPOOLP384R1
+                "1.3.36.3.3.2.8.1.1.13" -> EcCurve.BRAINPOOLP512R1
+                else -> throw IllegalStateException("Unexpected curve OID ${ecCurveString.oid}")
+            }
+        }
+        "1.3.101.110" -> EcCurve.X25519
+        "1.3.101.111" -> EcCurve.X448
+        "1.3.101.112" -> EcCurve.ED25519
+        "1.3.101.113" -> EcCurve.ED448
+        else -> throw IllegalStateException("Unexpected OID ${algorithm.oid}")
+    }
+
+    var publicKeyBitString: ByteArray? = null
+    for (element in privateKeySeq.elements) {
+        if (element is ASN1TaggedObject && element.tag == 1) {
+            val decodedBitString = ASN1.decode(element.content)
+            if (decodedBitString is ASN1BitString) {
+                publicKeyBitString = decodedBitString.value
+            } else if (decodedBitString is ASN1OctetString) {
+                publicKeyBitString = decodedBitString.value
+            } else {
+                publicKeyBitString = element.content
+            }
+            break
+        }
+    }
+
+    if (publicKeyBitString == null) {
+        throw IllegalArgumentException("The private key PEM does not contain the optional public key structure. Please use a private key PEM containing the public key (SEC1/PKCS#8 with embedded public key).")
+    }
+
+    val pubKey = when (curve) {
+        EcCurve.P256,
+        EcCurve.P384,
+        EcCurve.P521,
+        EcCurve.BRAINPOOLP256R1,
+        EcCurve.BRAINPOOLP320R1,
+        EcCurve.BRAINPOOLP384R1,
+        EcCurve.BRAINPOOLP512R1 -> {
+            org.multipaz.crypto.EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(curve, publicKeyBitString)
+        }
+        EcCurve.ED25519,
+        EcCurve.X25519,
+        EcCurve.ED448,
+        EcCurve.X448 -> {
+            org.multipaz.crypto.EcPublicKeyOkp(curve, publicKeyBitString)
+        }
+    }
+
+    val privKey = EcPrivateKey.fromPem(trimmed, pubKey)
+    return Pair(privKey, pubKey)
+}
+
+data class CustomExtItem(val oid: String, val isCritical: Boolean, val hexData: String)

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
@@ -41,6 +41,7 @@ fun pathToTab(path: String): String {
         "/compress" -> "compress"
         "/converter" -> "converter"
         "/x509" -> "x509"
+        "/cert-converter" -> "cert-converter"
         "/keygen" -> "key-generator"
         "/cert" -> "cert-generator"
         "/ndef" -> "ndef-parse"
@@ -56,6 +57,7 @@ fun tabToPath(tab: String): String {
         "compress" -> "/compress"
         "converter" -> "/converter"
         "x509" -> "/x509"
+        "cert-converter" -> "/cert-converter"
         "key-generator" -> "/keygen"
         "cert-generator" -> "/cert"
         "ndef-parse" -> "/ndef"
@@ -138,13 +140,14 @@ val App = FC {
 
             val tabs = listOf(
                 "cbor-decode" to "CBOR Decoder",
-                "mdoc-view" to "ISO mdoc DeviceResponse inspector",
+                "mdoc-view" to "ISO mdoc DeviceResponse Parser",
                 "sd-jwt-inspect" to "SD-JWT Parser",
                 "compress" to "Compression Tool",
                 "converter" to "Format Converter",
-                "x509" to "X.509 Certificate Parser",
-                "key-generator" to "Key Generator",
+                "x509" to "Certificate Parser",
+                "cert-converter" to "Certificate Converter",
                 "cert-generator" to "Certificate Generator",
+                "key-generator" to "Key Generator",
                 "ndef-parse" to "NDEF Parser"
             )
 
@@ -194,6 +197,7 @@ val App = FC {
                 "compress" -> CompressionComponent {}
                 "converter" -> ConverterComponent {}
                 "x509" -> X509ParserComponent {}
+                "cert-converter" -> CertConverterComponent {}
                 "key-generator" -> KeyGeneratorComponent {}
                 "cert-generator" -> CertGeneratorComponent {}
                 "ndef-parse" -> NdefParserComponent {}

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
@@ -52,7 +52,7 @@ val X509ParserComponent = FC {
                 margin = Margin(0.px, 0.px, 16.px, 0.px)
                 color = Color("#f8fafc")
             }
-            +"X.509 Certificate Parser"
+            +"Certificate Parser"
         }
 
         if (parsedCert != null || parseError.isNotEmpty()) {


### PR DESCRIPTION
- Implement a standalone Certificate Converter tab supporting decoding from PEM, Hex, Base64, and Base64Url, with a summary display and immediate conversion to all formats.

- Add support to the Certificate Generator to inject an existing private key in PEM or JWK format rather than auto-generating one.

- Implement the 'generic' certificate builder options in the generator tab, allowing fine-grained controls for Basic Constraints, Key Usages, Subject Alternative Names, Authority Key Identifier (AKI), Subject Key Identifier (SKI), CRL Distribution Points, Issuer Alt Names, and custom X.509 extensions (OID, criticality, hex payload).

- Enable signing generated certificates using a custom CA key and certificate.

- Group the three certificate-related tabs consecutively in the navigation header and rename 'X.509 Certificate Parser' to 'Certificate Parser' for consistency.

Fixes #1814.

Test: Manaully tested.
