### PR TITLE
multipaz-tools: Add ASN.1 decoder and group tool nav in dropdowns.

### DIFF
--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Asn1DecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Asn1DecoderComponent.kt
@@ -1,0 +1,183 @@
+package org.multipaz.tools.frontend
+
+import emotion.react.css
+import react.FC
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.h2
+import react.dom.html.ReactHTML.p
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.textarea
+import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.pre
+import react.dom.html.ReactHTML.code
+import react.useState
+import web.cssom.*
+import kotlinx.browser.window
+import org.multipaz.asn1.ASN1
+
+val Asn1DecoderComponent = FC {
+    var rawInput by useState("")
+    var outputText by useState("")
+    var copyStatus by useState("")
+
+    div {
+        css {
+            background = Color("#1e293b")
+            borderRadius = 16.px
+            border = Border(1.px, LineStyle.solid, Color("#334155"))
+            padding = 32.px
+        }
+
+        h2 {
+            css {
+                fontSize = 1.8.rem
+                fontWeight = FontWeight.bold
+                margin = Margin(0.px, 0.px, 16.px, 0.px)
+                color = Color("#f8fafc")
+            }
+            +"ASN.1 Decoder"
+        }
+
+        p {
+            css {
+                color = Color("#94a3b8")
+                marginBottom = 24.px
+            }
+            +"Decode raw ASN.1 DER bytes (represented as Hex or Base64 / Base64Url) to a human-readable structure tree."
+        }
+
+        label {
+            css {
+                display = Display.block
+                fontWeight = FontWeight.normal
+                marginBottom = 8.px
+                color = Color("#cbd5e1")
+            }
+            +"ASN.1 Raw Data (Hex, Base64 or Base64Url):"
+        }
+
+        textarea {
+            css {
+                width = 100.pct
+                height = 150.px
+                background = Color("#0f172a")
+                border = Border(1.px, LineStyle.solid, Color("#475569"))
+                borderRadius = 8.px
+                color = Color("#f1f5f9")
+                fontFamily = FontFamily.monospace
+                padding = 12.px
+                resize = "none".unsafeCast<Resize>()
+                marginBottom = 16.px
+                focus {
+                    outline = None.none
+                    borderColor = Color("#3b82f6")
+                }
+            }
+            value = rawInput
+            placeholder = "Paste ASN.1 DER hex (e.g. 308201a0...) or Base64 here"
+            onChange = { rawInput = it.target.value }
+        }
+
+        button {
+            css {
+                padding = Padding(12.px, 24.px)
+                fontSize = 16.px
+                fontWeight = FontWeight.bold
+                backgroundColor = Color("#3b82f6")
+                color = Color("#ffffff")
+                border = None.none
+                borderRadius = 8.px
+                cursor = Cursor.pointer
+                transition = "all 0.2s".unsafeCast<Transition>()
+                hover {
+                    backgroundColor = Color("#2563eb")
+                }
+                disabled {
+                    backgroundColor = Color("#475569")
+                    cursor = Cursor.notAllowed
+                }
+            }
+            disabled = rawInput.trim().isEmpty()
+            onClick = {
+                try {
+                    val bytes = decodeInputToBytes(rawInput)
+                    if (bytes.isEmpty()) {
+                        outputText = "Input is empty"
+                    } else {
+                        val objects = ASN1.decodeMultiple(bytes)
+                        if (objects.isEmpty()) {
+                            outputText = "No ASN.1 objects decoded."
+                        } else {
+                            outputText = objects.joinToString("\n") { ASN1.print(it) }
+                        }
+                    }
+                } catch (e: Exception) {
+                    outputText = "Error decoding: " + (e.message ?: "Unknown decoding error")
+                }
+            }
+            +"Decode ASN.1"
+        }
+
+        if (outputText.isNotEmpty()) {
+            div {
+                css {
+                    marginTop = 32.px
+                }
+                div {
+                    css {
+                        display = Display.flex
+                        justifyContent = JustifyContent.spaceBetween
+                        alignItems = AlignItems.center
+                        marginBottom = 8.px
+                    }
+                    label {
+                        css {
+                            fontWeight = FontWeight.normal
+                            color = Color("#cbd5e1")
+                        }
+                        +"Pretty Printed ASN.1 Structure:"
+                    }
+                    button {
+                        css {
+                            background = Color("#334155")
+                            border = None.none
+                            color = Color("#f1f5f9")
+                            padding = Padding(6.px, 12.px)
+                            borderRadius = 6.px
+                            cursor = Cursor.pointer
+                            fontSize = 13.px
+                            fontWeight = FontWeight.normal
+                            hover {
+                                background = Color("#475569")
+                            }
+                        }
+                        onClick = {
+                            window.navigator.asDynamic().clipboard.writeText(outputText)
+                            copyStatus = "Copied!"
+                            window.setTimeout({ copyStatus = "" }, 2000)
+                        }
+                        if (copyStatus.isNotEmpty()) +copyStatus else +"Copy to Clipboard"
+                    }
+                }
+                pre {
+                    css {
+                        background = Color("#020617")
+                        border = Border(1.px, LineStyle.solid, Color("#334155"))
+                        borderRadius = 8.px
+                        padding = 16.px
+                        overflow = "auto".unsafeCast<Overflow>()
+                        maxHeight = 500.px
+                    }
+                    code {
+                        css {
+                            fontFamily = FontFamily.monospace
+                            color = if (outputText.startsWith("Error")) Color("#ef4444") else Color("#38bdf8")
+                            fontSize = 14.px
+                        }
+                        +outputText
+                    }
+                }
+            }
+        }
+    }
+}

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
@@ -42,6 +42,7 @@ fun pathToTab(path: String): String {
         "/compress" -> "compress"
         "/converter" -> "converter"
         "/x509" -> "x509"
+        "/asn1" -> "asn1"
         "/cert-converter" -> "cert-converter"
         "/keygen" -> "key-generator"
         "/cert" -> "cert-generator"
@@ -59,6 +60,7 @@ fun tabToPath(tab: String): String {
         "compress" -> "/compress"
         "converter" -> "/converter"
         "x509" -> "/x509"
+        "asn1" -> "/asn1"
         "cert-converter" -> "/cert-converter"
         "key-generator" -> "/keygen"
         "cert-generator" -> "/cert"
@@ -69,6 +71,7 @@ fun tabToPath(tab: String): String {
 
 val App = FC {
     var activeTab by useState(pathToTab(window.location.pathname))
+    var activeDropdown by useState<String?>(null)
 
     useEffect(activeTab) {
         val currentPath = tabToPath(activeTab)
@@ -88,6 +91,7 @@ val App = FC {
     }
 
     div {
+        onClick = { activeDropdown = null }
         css {
             minHeight = 100.vh
             display = Display.flex
@@ -134,51 +138,132 @@ val App = FC {
             css {
                 display = Display.flex
                 justifyContent = JustifyContent.center
-                gap = 12.px
+                gap = 24.px
                 padding = Padding(16.px, 24.px)
                 background = Color("#1e293b") // slate 800
                 borderBottom = Border(1.px, LineStyle.solid, Color("#334155"))
             }
 
-            val tabs = listOf(
-                "cbor-decode" to "CBOR Decoder",
-                "mdoc-view" to "ISO mdoc DeviceResponse Parser",
-                "mso-namespaces-view" to "ISO mdoc MSO and IssuerNameSpaces",
-                "sd-jwt-inspect" to "SD-JWT Parser",
-                "compress" to "Compression Tool",
-                "converter" to "Format Converter",
-                "x509" to "Certificate Parser",
-                "cert-converter" to "Certificate Converter",
-                "cert-generator" to "Certificate Generator",
-                "key-generator" to "Key Generator",
-                "ndef-parse" to "NDEF Parser"
+            data class Category(
+                val id: String,
+                val title: String,
+                val tabs: List<Pair<String, String>>
             )
 
-            for ((tabId, tabTitle) in tabs) {
-                button {
+            val categories = listOf(
+                Category("decoders", "Decoders & Parsers", listOf(
+                    "cbor-decode" to "CBOR Decoder",
+                    "asn1" to "ASN.1 Decoder",
+                    "ndef-parse" to "NDEF Parser"
+                )),
+                Category("identity", "ISO mdoc & SD-JWT", listOf(
+                    "mdoc-view" to "ISO mdoc DeviceResponse Parser",
+                    "mso-namespaces-view" to "ISO mdoc MSO & IssuerNameSpaces",
+                    "sd-jwt-inspect" to "SD-JWT Parser"
+                )),
+                Category("certs", "Certificates & Keys", listOf(
+                    "x509" to "Certificate Parser",
+                    "cert-converter" to "Certificate Converter",
+                    "cert-generator" to "Certificate Generator",
+                    "key-generator" to "Key Generator"
+                )),
+                Category("utilities", "Utilities", listOf(
+                    "compress" to "Compression Tool",
+                    "converter" to "Format Converter"
+                ))
+            )
+
+            for (category in categories) {
+                val isCategoryActive = category.tabs.any { it.first == activeTab }
+                val isOpen = activeDropdown == category.id
+
+                div {
                     css {
-                        padding = Padding(10.px, 20.px)
-                        border = None.none
-                        borderRadius = 8.px
-                        fontSize = 15.px
-                        fontWeight = FontWeight.bold
-                        cursor = Cursor.pointer
-                        transition = "all 0.2s".unsafeCast<Transition>()
-                        if (activeTab == tabId) {
-                            background = Color("#3b82f6") // blue 500
-                            color = Color("#ffffff")
-                            boxShadow = BoxShadow(0.px, 4.px, 12.px, Color("rgba(59, 130, 246, 0.3)"))
-                        } else {
-                            background = Color("transparent")
-                            color = Color("#94a3b8")
-                            hover {
-                                background = Color("#334155")
-                                color = Color("#f1f5f9")
+                        position = Position.relative
+                    }
+
+                    button {
+                        css {
+                            padding = Padding(10.px, 20.px)
+                            border = None.none
+                            borderRadius = 8.px
+                            fontSize = 15.px
+                            fontWeight = FontWeight.bold
+                            cursor = Cursor.pointer
+                            transition = "all 0.2s".unsafeCast<Transition>()
+                            if (isCategoryActive) {
+                                background = Color("#3b82f6") // blue 500
+                                color = Color("#ffffff")
+                                boxShadow = BoxShadow(0.px, 4.px, 12.px, Color("rgba(59, 130, 246, 0.3)"))
+                            } else {
+                                background = if (isOpen) Color("#334155") else Color("transparent")
+                                color = if (isOpen) Color("#f1f5f9") else Color("#94a3b8")
+                                hover {
+                                    background = Color("#334155")
+                                    color = Color("#f1f5f9")
+                                }
+                            }
+                        }
+                        onClick = { event ->
+                            event.stopPropagation()
+                            activeDropdown = if (isOpen) null else category.id
+                        }
+                        +category.title
+                        +" ▾"
+                    }
+
+                    if (isOpen) {
+                        div {
+                            css {
+                                position = Position.absolute
+                                top = 100.pct
+                                marginTop = 8.px
+                                left = 0.px
+                                zIndex = integer(50)
+                                background = Color("#1e293b")
+                                border = Border(1.px, LineStyle.solid, Color("#334155"))
+                                borderRadius = 8.px
+                                padding = 8.px
+                                display = Display.flex
+                                flexDirection = FlexDirection.column
+                                gap = 4.px
+                                minWidth = 260.px
+                                boxShadow = BoxShadow(0.px, 10.px, 15.px, Color("rgba(0, 0, 0, 0.5)"))
+                            }
+
+                            for ((tabId, tabTitle) in category.tabs) {
+                                val isTabActive = activeTab == tabId
+                                button {
+                                    css {
+                                        padding = Padding(8.px, 16.px)
+                                        textAlign = TextAlign.left
+                                        border = None.none
+                                        borderRadius = 6.px
+                                        cursor = Cursor.pointer
+                                        fontSize = 14.px
+                                        fontWeight = FontWeight.bold
+                                        transition = "all 0.2s".unsafeCast<Transition>()
+                                        if (isTabActive) {
+                                            background = Color("#2563eb") // blue 600
+                                            color = Color("#ffffff")
+                                        } else {
+                                            background = Color("transparent")
+                                            color = Color("#94a3b8")
+                                            hover {
+                                                background = Color("#334155")
+                                                color = Color("#f1f5f9")
+                                            }
+                                        }
+                                    }
+                                    onClick = {
+                                        activeTab = tabId
+                                        activeDropdown = null
+                                    }
+                                    +tabTitle
+                                }
                             }
                         }
                     }
-                    onClick = { activeTab = tabId }
-                    +tabTitle
                 }
             }
         }
@@ -201,6 +286,7 @@ val App = FC {
                 "compress" -> CompressionComponent {}
                 "converter" -> ConverterComponent {}
                 "x509" -> X509ParserComponent {}
+                "asn1" -> Asn1DecoderComponent {}
                 "cert-converter" -> CertConverterComponent {}
                 "key-generator" -> KeyGeneratorComponent {}
                 "cert-generator" -> CertGeneratorComponent {}


### PR DESCRIPTION
- Add a new tab to multipaz-tools SPA: "ASN.1 Decoder" right after the "Certificate Parser" tab, using built-in ASN.1 decoder and pretty-printer.

- Group the 12 tools in the SPA's navigation bar into four click-activated dropdown categories (Decoders & Parsers, ISO mdoc & SD-JWT, Certificates & Keys, and Utilities) to prevent horizontal overflow.

- Implement dismiss-on-click-outside and event propagation handling for dropdowns.

Fixes #1814.

Test: Manually tested.
