### PR TITLE
Add EventVerification event type and UI rendering in testapp

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/Event.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/Event.kt
@@ -37,5 +37,3 @@ sealed class Event(
 
     companion object
 }
-
-// TODO: Add events for provisioning, PII updates, MSO updates, etc

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventLogger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventLogger.kt
@@ -22,8 +22,8 @@ interface EventLogger {
      * coroutine and thus not slow down a time-sensitive code such as credential presentment
      * where an external component is waiting for data to be returned.
      *
-     * @param event The [Event] to be recorded, note that [Event.identifier], [Event.timestamp],
-     * and [Event.appData] will be overwritten.
+     * @param event The [Event] to be recorded, note that [Event.identifier] and [Event.timestamp]
+     * will be overwritten, and [Event.appData] will be updated to include any injected application data.
      * @return A copy of the [Event] with assigned id, timestamp, and appData. Returns `null` if
      * the event was dropped.
      */

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerification.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerification.kt
@@ -1,0 +1,24 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.verification.PresentmentRecord
+import kotlin.time.Instant
+
+/**
+ * An event representing a verification event.
+ *
+ * @property presentmentRecord a [PresentmentRecord] with the result of the presentation.
+ */
+data class EventVerification(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    val presentmentRecord: PresentmentRecord
+): Event(identifier, timestamp, appData) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentRecord = this.presentmentRecord
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/SimpleEventLogger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/SimpleEventLogger.kt
@@ -39,7 +39,7 @@ private const val TAG = "SimpleEventLogger"
  * @property partitionId A logical partition identifier to group events. Defaults to "default".
  * @property expireAfter the amount of time to keep events, use [Duration.INFINITE] to never expire events.
  * @property clock The time source used to timestamp events. Defaults to [Clock.System].
- * @property onAddEvent Function to inject additional metadata or drop the event by returning `null`.
+ * @property onAddEvent Function to inject additional metadata or drop the event by returning `null`. Note that the injected data is added (merged) to the event's existing application-specific data, rather than replacing it.
  * @property scope a [CoroutineScope] used by [addEventAsync], to add events asynchronously.
  */
 class SimpleEventLogger(
@@ -117,18 +117,18 @@ class SimpleEventLogger(
         val eventWithTimestamp = event.copy(
             identifier = key,
             timestamp = now,
-            appData = emptyMap()
+            appData = event.appData
         )
 
-        val appData = onAddEvent(eventWithTimestamp)
-        if (appData == null) {
+        val injectedAppData = onAddEvent(eventWithTimestamp)
+        if (injectedAppData == null) {
             return null
         }
 
         val eventWithAppData = event.copy(
             identifier = key,
             timestamp = now,
-            appData = appData
+            appData = event.appData + injectedAppData
         )
 
         storageTable.insert(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
@@ -511,6 +511,55 @@ class SimpleEventLoggerTests {
         job.cancel()
     }
 
+    @Test
+    fun testOnAddEventAppendsToAppData() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(1000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val originalAppData = mapOf("original_key" to "original_value".toDataItem())
+        val injectedAppData = mapOf("injected_key" to "injected_value".toDataItem())
+
+        val logger = SimpleEventLogger(
+            storage = ephemeralStorage,
+            partitionId = "test-partition",
+            clock = fakeClock,
+            onAddEvent = { _ -> injectedAppData }
+        )
+
+        val eventBase = EventPresentmentIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            appData = originalAppData,
+            presentmentData = EventPresentmentData(
+                requesterName = "Test Requester",
+                requesterCertChain = null,
+                trustMetadata = null,
+                requestedDocuments = listOf(
+                    EventPresentmentDataDocument(
+                        documentId = "test-document-id",
+                        documentName = "Test Document",
+                        claims = emptyMap()
+                    )
+                ),
+            ),
+            request = Simple.NULL,
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL
+        )
+
+        val savedEvent = logger.addEvent(eventBase)
+
+        // Verify returned event contains the merged appData
+        assertNotNull(savedEvent)
+        assertEquals(2, savedEvent.appData.size)
+        assertEquals("original_value".toDataItem(), savedEvent.appData["original_key"])
+        assertEquals("injected_value".toDataItem(), savedEvent.appData["injected_key"])
+
+        // Verify storage state contains the merged appData
+        val eventsInDb = logger.getEvents()
+        assertEquals(1, eventsInDb.size)
+        assertEquals(savedEvent.appData, eventsInDb.first().appData)
+    }
+
     // --- Fakes ---
 
     class FakeClock(var currentTime: Instant = Instant.fromEpochMilliseconds(0)) : Clock {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -36,6 +36,7 @@ import org.multipaz.testapp.DcqlRequestDefinition
 import org.multipaz.verification.VerificationSession
 import org.multipaz.verification.VerificationUtil
 import org.multipaz.verification.VerifierIdentity
+import org.multipaz.eventlogger.EventVerification
 import kotlin.random.Random
 import kotlin.time.Clock
 
@@ -346,6 +347,9 @@ private suspend fun doDcRequestFlow(
     val t0 = Clock.System.now()
     val dcResponseObject = app.digitalCredentials.request(dcRequestObject)
     Logger.iJson(TAG, "Response", dcResponseObject)
+
+    val presentmentRecord = session.processDcResponse(dcResponse = dcResponseObject)
+    app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
 
     val metadata = ShowResponseMetadata(
         engagementType = "OS-provided CredentialManager API",

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -52,7 +52,11 @@ import org.multipaz.eventlogger.EventPresentmentIso18013Proximity
 import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
 import org.multipaz.eventlogger.EventProvisioning
 import org.multipaz.eventlogger.EventSimple
+import org.multipaz.eventlogger.EventVerification
 import org.multipaz.eventlogger.SimpleEventLogger
+import org.multipaz.verification.Iso18013PresentmentRecord
+import org.multipaz.verification.OpenID4VPPresentmentRecord
+import org.multipaz.compose.getOutlinedImageVector
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -208,6 +212,16 @@ private fun EventItem(
                 modifier = modifier
             )
         }
+        is EventVerification -> {
+            EventItemVerification(
+                event = event,
+                imageLoader = imageLoader,
+                documentModel = documentModel,
+                imageSize = imageSize,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
         is EventSimple -> {
             FloatingItemCenteredText(
                 text = "EventSimple w/ ${event.appData.size} bytes of data"
@@ -309,4 +323,34 @@ private fun getSharingType(origin: String?): String {
         }
     }
     return "Shared with website"
+}
+
+@Composable
+private fun EventItemVerification(
+    event: EventVerification,
+    imageLoader: ImageLoader,
+    documentModel: DocumentModel,
+    imageSize: Dp = 40.dp,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val eventDateTimeString = event.timestamp.toLocalDateTime(timeZone = timeZone).formatLocalized()
+    val protocol = when (event.presentmentRecord) {
+        is Iso18013PresentmentRecord -> "ISO 18013-5"
+        is OpenID4VPPresentmentRecord -> "OpenID4VP"
+    }
+    val text = "$eventDateTimeString • $protocol"
+
+    FloatingItemText(
+        modifier = modifier,
+        image = {
+            Icon(
+                imageVector = org.multipaz.documenttype.Icon.BADGE.getOutlinedImageVector(),
+                contentDescription = null,
+                modifier = Modifier.size(imageSize)
+            )
+        },
+        text = "Verified credentials",
+        secondary = text,
+    )
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -80,11 +80,20 @@ import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
 import org.multipaz.eventlogger.EventProvisioning
 import org.multipaz.eventlogger.EventProvisioningIssuerDataOpenID4VCI
 import org.multipaz.eventlogger.EventSimple
+import org.multipaz.eventlogger.EventVerification
 import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.toDataItem
 import org.multipaz.prompt.PromptModel
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
+import org.multipaz.verification.MdocVerifiedPresentation
+import org.multipaz.verification.JsonVerifiedPresentation
+import org.multipaz.verification.VerifiedPresentation
+import org.multipaz.verification.Iso18013PresentmentRecord
+import org.multipaz.verification.OpenID4VPPresentmentRecord
+import org.multipaz.compose.getOutlinedImageVector
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.CancellationException
 import kotlin.time.Clock
 
 @OptIn(ExperimentalMaterial3Api::class, FormatStringsInDatetimeFormats::class)
@@ -261,6 +270,17 @@ private fun EventViewer(
         }
         is EventProvisioning -> {
             EventViewerProvisioning(
+                event = event,
+                documentTypeRepository = documentTypeRepository,
+                documentModel = documentModel,
+                imageLoader = imageLoader,
+                onViewCertificateChain = onViewCertificateChain,
+                timeZone = timeZone,
+                modifier = modifier
+            )
+        }
+        is EventVerification -> {
+            EventViewerVerification(
                 event = event,
                 documentTypeRepository = documentTypeRepository,
                 documentModel = documentModel,
@@ -599,5 +619,155 @@ private fun ExtractClaimsItems(
                 )
             }
         )
+    }
+}
+
+@Composable
+private fun EventViewerVerification(
+    event: EventVerification,
+    documentTypeRepository: DocumentTypeRepository,
+    documentModel: DocumentModel,
+    imageLoader: ImageLoader,
+    onViewCertificateChain: (certChain: X509CertChain) -> Unit,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    modifier: Modifier = Modifier
+) {
+    val eventDateTime = event.timestamp.toLocalDateTime(timeZone = timeZone)
+    val eventDateTimeString = eventDateTime.formatLocalized(
+        dateStyle = FormatStyle.LONG,
+        timeStyle = FormatStyle.LONG
+    )
+
+    val protocol = when (event.presentmentRecord) {
+        is Iso18013PresentmentRecord -> "ISO 18013-5 mdoc presentment"
+        is OpenID4VPPresentmentRecord -> "OpenID4VP presentation"
+    }
+
+    var verifiedPresentations by remember { mutableStateOf<List<VerifiedPresentation>?>(null) }
+    var verificationError by remember { mutableStateOf<Throwable?>(null) }
+
+    LaunchedEffect(event) {
+        try {
+            verifiedPresentations = event.presentmentRecord.verify(
+                atTime = event.timestamp,
+                documentTypeRepository = documentTypeRepository
+            )
+        } catch (t: Throwable) {
+            if (t is CancellationException) throw t
+            verificationError = t
+        }
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val imageSize = 80.dp
+        Icon(
+            imageVector = org.multipaz.documenttype.Icon.BADGE.getOutlinedImageVector(),
+            contentDescription = null,
+            modifier = Modifier.size(imageSize)
+        )
+
+        Text(
+            text = "Verification Result",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+
+        FloatingItemList(
+            modifier = Modifier.padding(top = 10.dp, bottom = 20.dp)
+        ) {
+            FloatingItemHeadingAndText(
+                heading = "Date and time",
+                text = eventDateTimeString
+            )
+
+            FloatingItemHeadingAndText(
+                heading = "Presentment protocol",
+                text = protocol
+            )
+
+            if (verificationError != null) {
+                FloatingItemHeadingAndText(
+                    heading = "Verification status",
+                    text = buildAnnotatedString {
+                        withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                            append("Failed: ${verificationError?.message}")
+                        }
+                    }
+                )
+            } else if (verifiedPresentations == null) {
+                FloatingItemHeadingAndText(
+                    heading = "Verification status",
+                    text = "Verifying..."
+                )
+            } else {
+                FloatingItemHeadingAndText(
+                    heading = "Verification status",
+                    text = "Verified successfully"
+                )
+            }
+        }
+
+        verifiedPresentations?.forEachIndexed { index, vp ->
+            val formatText = when (vp) {
+                is MdocVerifiedPresentation -> "ISO mdoc"
+                is JsonVerifiedPresentation -> "IETF SD-JWT VC"
+            }
+            val titleText = when (vp) {
+                is MdocVerifiedPresentation -> "Document ${index + 1}: ${vp.docType} ($formatText)"
+                is JsonVerifiedPresentation -> "Document ${index + 1}: ${vp.vct} ($formatText)"
+            }
+            FloatingItemList(
+                modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
+                title = titleText
+            ) {
+                vp.documentSignerCertChain?.let { certChain ->
+                    FloatingItemHeadingAndText(
+                        heading = "Issuer certificate chain",
+                        text = "Click to view",
+                        modifier = Modifier.clickable {
+                            onViewCertificateChain(certChain)
+                        }
+                    )
+                }
+
+                if (vp.zkpUsed) {
+                    FloatingItemHeadingAndText(
+                        heading = "ZK proof",
+                        text = "Successfully verified \uD83E\uDE84"
+                    )
+                }
+
+                for (n in listOf(0, 1)) {
+                    val (claims, suffix) = if (n == 0) {
+                        Pair(vp.issuerSignedClaims, "")
+                    } else {
+                        Pair(vp.deviceSignedClaims, " (Device Signed)")
+                    }
+                    claims.forEach { claim ->
+                        val typedClaim = Claim.fromDataItem(
+                            dataItem = claim.toDataItem(),
+                            documentTypeRepository = documentTypeRepository
+                        )
+                        val textValue = typedClaim.render()
+                        FloatingItemHeadingAndText(
+                            heading = typedClaim.displayName + suffix,
+                            text = textValue,
+                            image = {
+                                val icon = typedClaim.attribute?.icon ?: org.multipaz.documenttype.Icon.PERSON
+                                Icon(
+                                    imageVector = icon.getOutlinedImageVector(),
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -79,6 +79,7 @@ import org.multipaz.testapp.ShowResponseMetadata
 import org.multipaz.util.fromHex
 import org.multipaz.utopia.knowntypes.wellKnownMultipleDocumentRequests
 import org.multipaz.verification.VerificationSession
+import org.multipaz.eventlogger.EventVerification
 import kotlin.time.Clock
 import kotlin.time.Duration
 
@@ -327,10 +328,14 @@ fun IsoMdocProximityReadingScreen(
                                 signRequest = app.settingsModel.signRequest.value
                             )
                             if (readerMostRecentDeviceResponse.value != null) {
+                                val deviceResponse = Cbor.decode(readerMostRecentDeviceResponse.value!!)
+                                val session = readerSession.value!!
+                                val presentmentRecord = session.processIso18013ProximityResponse(deviceResponse = deviceResponse)
+                                app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
                                 showResponse(
                                     /* vpToken = */ null,
-                                    /* deviceResponse = */ Cbor.decode(readerMostRecentDeviceResponse.value!!),
-                                    /* readerSession = */ readerSession.value!!,
+                                    /* deviceResponse = */ deviceResponse,
+                                    /* readerSession = */ session,
                                     /* eReaderKey = */ eReaderKey.value!!,
                                     /* metadata = */ ShowResponseMetadata(
                                         engagementType = "QR Code",
@@ -682,10 +687,14 @@ fun IsoMdocProximityReadingScreen(
                                             MdocHandoverType.NEGOTIATED_HANDOVER -> "NFC Negotiated Handover"
                                             MdocHandoverType.V2_HANDOVER -> "NFC Handover V2"
                                         }
+                                        val deviceResponse = Cbor.decode(readerMostRecentDeviceResponse.value!!)
+                                        val session = readerSession.value!!
+                                        val presentmentRecord = session.processIso18013ProximityResponse(deviceResponse = deviceResponse)
+                                        app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
                                         showResponse(
                                             /* vpToken = */ null,
-                                            /* deviceResponse = */ Cbor.decode(readerMostRecentDeviceResponse.value!!),
-                                            /* session = */ readerSession.value!!,
+                                            /* deviceResponse = */ deviceResponse,
+                                            /* session = */ session,
                                             /* eReaderKey */ eReaderKey.value!!,
                                             /* metadata = */ ShowResponseMetadata(
                                                 engagementType = nfcEngagementType,


### PR DESCRIPTION
- Add EventVerification class to represent credential verification events.
- Update SimpleEventLogger.addEvent() to merge lambda-injected appData with existing event appData instead of replacing it, and update KDocs accordingly.
- Add testOnAddEventAppendsToAppData() unit test in SimpleEventLoggerTests.
- Log EventVerification events in IsoMdocProximityReadingScreen (for QR and NFC engagements) and in DcRequestScreen (for OS CredentialManager W3C DC API calls).
- Add EventItemVerification composable to EventLoggerScreen to render verification events in the event log list.
- Add EventViewerVerification composable to EventViewerScreen to display detailed verification results, including status, protocol, issuer cert chain, ZK proofs, and presented claims.

Fixes #1829.

Test: Unit tests and manually tested.
