### PR TITLE
Audit logging, eliminate PII from default logs, and configure debug toggle.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/digitalcredentials/CredentialManagerPresentmentActivity.kt
@@ -141,11 +141,11 @@ abstract class CredentialManagerPresentmentActivity: FragmentActivity() {
                 ?: getAppOrigin(callingAppInfo.signingInfoCompat.signingCertificateHistory[0].toByteArray())
             val option = credentialRequest.credentialOptions[0] as GetDigitalCredentialOption
             val json = Json.parseToJsonElement(option.requestJson).jsonObject
-            Logger.iJson(TAG, "Request Json", json)
+            Logger.dJson(TAG, "Request Json", json)
             val selectionInfo = getSetSelection(credentialRequest)
                 ?: getSelection(credentialRequest)
                 ?:  throw IllegalStateException("Unable to get credman selection")
-            Logger.i(TAG, "SelectionInfo: $selectionInfo")
+            Logger.d(TAG, "SelectionInfo: $selectionInfo")
 
             val documents = selectionInfo.documentIds.map {
                 settings.source.documentStore.lookupForCredmanId(it)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
@@ -366,7 +366,7 @@ class Document internal constructor(
     private suspend fun deleteCredentialIfInvalidated(credential: Credential) {
         try {
             if (credential.isInvalidated()) {
-                Logger.i(TAG, "Deleting invalidated credential ${credential.identifier}")
+                Logger.d(TAG, "Deleting invalidated credential ${credential.identifier}")
                 deleteCredential(credential.identifier)
             }
         } catch (err: IllegalArgumentException) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/devicesigned/DeviceNamespaces.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/devicesigned/DeviceNamespaces.kt
@@ -40,7 +40,7 @@ data class DeviceNamespaces(
          * @return the parsed representation.
          */
         fun fromDataItem(nameSpaces: DataItem): DeviceNamespaces {
-            Logger.iCbor("TAG", "nameSpaces", nameSpaces)
+            Logger.dCbor("TAG", "nameSpaces", nameSpaces)
             val ret = mutableMapOf<String, MutableMap<String, DataItem>>()
             for ((namespaceDataItemKey, namespaceDataItemValue) in nameSpaces.asMap) {
                 val namespaceName = namespaceDataItemKey.asTstr

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelper.kt
@@ -165,6 +165,7 @@ class MdocNfcEngagementHelper(
                         )
                     )
                     val initialNdefMessagePayload = initialNdefMessage.encode()
+                    Logger.dHex(TAG, "Prepared NDEF message", initialNdefMessagePayload)
                     val bsb = ByteStringBuilder()
                     bsb.append((initialNdefMessagePayload.size/0x100).and(0xff).toByte())
                     bsb.append(initialNdefMessagePayload.size.and(0xff).toByte())
@@ -187,6 +188,7 @@ class MdocNfcEngagementHelper(
                         skipUuids = false,
                     )
                     val hsPayload = handoverSelectMessage.encode()
+                    Logger.dHex(TAG, "Prepared Handover Select message", hsPayload)
 
                     val handover = buildCborArray {
                         add(hsPayload)                      // Handover Select message
@@ -344,12 +346,19 @@ class MdocNfcEngagementHelper(
     }
 
     private suspend fun ndefTransact(message: NdefMessage): NdefMessage {
-        return when (negotiatedHandoverState) {
+        if (Logger.isDebugEnabled) {
+            Logger.dHex(TAG, "Received NDEF message", message.encode())
+        }
+        val response = when (negotiatedHandoverState) {
             NegotiatedHandoverState.NOT_STARTED -> throw IllegalStateException("Unexpected message - Negotiated Handover not started")
             NegotiatedHandoverState.EXPECT_SERVICE_SELECT -> ndefTransactHandleServiceSelect(message)
             NegotiatedHandoverState.EXPECT_HANDOVER_REQUEST_MESSAGE -> ndefTransactHandleHandoverRequest(message)
             NegotiatedHandoverState.EXPECT_HANDOVER_SELECT_MESSAGE -> throw IllegalStateException("Negotiated Handover is complete")
         }
+        if (Logger.isDebugEnabled) {
+            Logger.dHex(TAG, "Responding with NDEF message", response.encode())
+        }
+        return response
     }
 
     private suspend fun processUpdateBinaryNdefMessage(message: NdefMessage): ResponseApdu {
@@ -435,28 +444,42 @@ class MdocNfcEngagementHelper(
      * @return the response.
      */
     suspend fun processApdu(command: CommandApdu): ResponseApdu {
-        if (raisedError) {
-            Logger.w(TAG, "processApdu: Already in error state, responding to APDU with status 6f00")
-            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
+        if (Logger.isDebugEnabled) {
+            Logger.dHex(TAG, "Command APDU", command.encode())
         }
-        try {
-            when (command.ins) {
-                Nfc.INS_SELECT -> {
-                    when (command.p1) {
-                        Nfc.INS_SELECT_P1_FILE -> return processSelectFile(command)
-                        Nfc.INS_SELECT_P1_APPLICATION -> return processSelectApplication(command)
+        val response = if (raisedError) {
+            Logger.w(TAG, "processApdu: Already in error state, responding to APDU with status 6f00")
+            ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
+        } else {
+            try {
+                when (command.ins) {
+                    Nfc.INS_SELECT -> {
+                        when (command.p1) {
+                            Nfc.INS_SELECT_P1_FILE -> processSelectFile(command)
+                            Nfc.INS_SELECT_P1_APPLICATION -> processSelectApplication(command)
+                            else -> {
+                                raiseError("Command ${command.p1} of INS_SELECT in $command not supported, returning 6d00")
+                                ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
+                            }
+                        }
+                    }
+                    Nfc.INS_READ_BINARY -> processReadBinary(command)
+                    Nfc.INS_UPDATE_BINARY -> processUpdateBinary(command)
+                    else -> {
+                        raiseError("Instruction ${command.ins} of $command not supported, returning 6d00")
+                        ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
                     }
                 }
-                Nfc.INS_READ_BINARY -> return processReadBinary(command)
-                Nfc.INS_UPDATE_BINARY -> return processUpdateBinary(command)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                raiseError("Error processing APDU: ${error.message}", error)
+                ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
             }
-            raiseError("Command APDU $command not supported, returning 6d00")
-            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
-        } catch (error: Exception) {
-            if (error is CancellationException) throw error
-            raiseError("Error processing APDU: ${error.message}", error)
-            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
         }
+        if (Logger.isDebugEnabled) {
+            Logger.dHex(TAG, "Response APDU", response.encode())
+        }
+        return response
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelper.kt
@@ -104,7 +104,7 @@ class MdocNfcV2EngagementHelper(
 
     private suspend fun nfcV2TransactHandleHandoverRequest(message: ByteString): ByteString {
         val nfcV2HandoverRequest = Cbor.decode(message.toByteArray())
-        Logger.iCbor(TAG, "Received nfcV2HandoverRequest", nfcV2HandoverRequest)
+        Logger.dCbor(TAG, "Received nfcV2HandoverRequest", nfcV2HandoverRequest)
 
         // ReaderEngagement is at key 0
         val readerEngagementDataItem = nfcV2HandoverRequest.get(0)
@@ -113,7 +113,7 @@ class MdocNfcV2EngagementHelper(
         val availableConnectionMethods = readerEngagementDataItem.get(2).asArray.mapNotNull {
             val cm = MdocConnectionMethod.fromDeviceEngagement(Cbor.encode(it))
             if (cm == null) {
-                Logger.iCbor(TAG, "Unknown data retrieval method", it)
+                Logger.dCbor(TAG, "Unknown data retrieval method", it)
             }
             cm
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/mdocReaderNfcHandover.kt
@@ -102,7 +102,7 @@ suspend fun mdocReaderNfcHandover(
         }
         if (selectApplicationResponse != null) {
             Logger.i(TAG, "Successfully selected NFCv2 AID")
-            Logger.i(TAG, "payload: ${selectApplicationResponse.payload.toByteArray().toHex()}")
+            Logger.d(TAG, "payload: ${selectApplicationResponse.payload.toByteArray().toHex()}")
             val payload = Cbor.decode(selectApplicationResponse.payload.toByteArray())
             val mdocNfcMaxCommandApduSize = payload.get(0).asNumber.toInt()
             Logger.i(TAG, "mdoc indicates APDU max command length is $mdocNfcMaxCommandApduSize")
@@ -135,6 +135,9 @@ suspend fun mdocReaderNfcHandover(
     tag.selectFile(ndefFileId)
 
     val initialNdefMessage = tag.ndefReadMessage()
+    if (Logger.isDebugEnabled) {
+        Logger.dHex(TAG, "Initial NDEF message", initialNdefMessage.encode())
+    }
 
     // First see if we should use negotiated handover by looking for the Handover Service parameter record...
     val hspr = initialNdefMessage.records.mapNotNull {
@@ -142,6 +145,7 @@ suspend fun mdocReaderNfcHandover(
         if (parsed?.serviceNameUri == "urn:nfc:sn:handover") parsed else null
     }.firstOrNull()
     if (hspr == null) {
+        Logger.i(TAG, "No service parameter record, assuming Static Handover")
         val (encodedDeviceEngagement, connectionMethods) = parseHandoverSelectMessage(initialNdefMessage, null)
         check(!connectionMethods.isEmpty()) { "No connection methods in Handover Select" }
         val handover = buildCborArray {
@@ -163,6 +167,7 @@ suspend fun mdocReaderNfcHandover(
     // Select the service, the resulting NDEF message is specified in
     // in Tag NDEF Exchange Protocol Technical Specification Version 1.0
     // section 4.3 TNEP Status Message
+    Logger.i(TAG, "Service parameter record found, continuing with Static Handover")
     val serviceSelectionResponse = tag.ndefTransact(
         NdefMessage(listOf(
             ServiceSelectRecord(Nfc.SERVICE_NAME_CONNECTION_HANDOVER).toNdefRecord()
@@ -225,7 +230,6 @@ private suspend fun mdocReaderNfcV2Handover(
     val combinedNegotiatedHandoverConnectionMethods = listOf(MdocConnectionMethodNfcV2()) +
             MdocConnectionMethod.combine(negotiatedHandoverConnectionMethods)
 
-
     val nfcV2HandoverRequest = buildCborMap {
         // ReaderEngagement is at key 0
         putCborMap(0) {
@@ -239,12 +243,14 @@ private suspend fun mdocReaderNfcV2Handover(
         }
     }
     val encodedNfcV2HandoverRequest = Cbor.encode(nfcV2HandoverRequest)
+    Logger.dCbor(TAG, "NFCv2 Handover Request", nfcV2HandoverRequest)
 
     val encodedNfcV2HandoverSelect = tag.nfcV2Transact(
         message = ByteString(encodedNfcV2HandoverRequest),
         commandDataFieldMaxLength = tag.maxTransceiveLength,
         responseDataFieldMaxLength = tag.maxTransceiveLength
     ).toByteArray()
+    Logger.dCbor(TAG, "NFCv2 Handover Select", encodedNfcV2HandoverSelect)
 
     Logger.i(TAG, "Handover complete")
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/NfcIsoTag.kt
@@ -6,6 +6,7 @@ import org.multipaz.util.putUInt16
 import kotlinx.coroutines.delay
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.buildByteString
+import org.multipaz.util.Logger
 import kotlin.time.Duration
 
 /**
@@ -195,6 +196,7 @@ abstract class NfcIsoTag {
         onMessageSent: (suspend () -> Unit)? = null
     ): NdefMessage {
         val encodedNdefMessage = ndefMessage.encode()
+        Logger.dHex(TAG, "ndefTransact: Sending NDEF message", encodedNdefMessage)
 
         // See Type 4 Tag Technical Specification Version 1.2 section 7.5.5 NDEF Write Procedure
         // for how this is done.
@@ -243,7 +245,11 @@ abstract class NfcIsoTag {
         }
 
         // Now read NDEF file...
-        return ndefReadMessage(wtInt, nWait)
+        val responseMessage = ndefReadMessage(wtInt, nWait)
+        if (Logger.isDebugEnabled) {
+            Logger.dHex(TAG, "ndefTransact: Received NDEF message", responseMessage.encode())
+        }
+        return responseMessage
     }
 
     companion object {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -343,7 +343,7 @@ object OpenID4VP {
         requesterIdentities: List<RequesterIdentity>,
         onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): OpenID4VPResponse {
-        Logger.iJson(TAG, "request", request)
+        Logger.dJson(TAG, "request", request)
 
         val nonce = request["nonce"]!!.jsonPrimitive.content
         val responseModeText = request["response_mode"]!!.jsonPrimitive.content
@@ -564,7 +564,7 @@ object OpenID4VP {
                 }
             }
         }
-        Logger.iJson(TAG, "vpToken", vpToken)
+        Logger.dJson(TAG, "vpToken", vpToken)
 
         // If using ZKP the response will be huge so compression helps
         val compressionLevel = if (usingZk) 9 else null
@@ -689,7 +689,7 @@ object OpenID4VP {
                 }
             }
         )
-        Logger.iCbor(TAG, "handoverInfo", handoverInfo)
+        Logger.dCbor(TAG, "handoverInfo", handoverInfo)
 
         val handoverString = if (responseUri != null) {
             "OpenID4VPHandover"
@@ -707,8 +707,8 @@ object OpenID4VP {
                 }
             }
         )
-        Logger.iCbor(TAG, "handoverInfo", handoverInfo)
-        Logger.iCbor(TAG, "encodedSessionTranscript", encodedSessionTranscript)
+        Logger.dCbor(TAG, "handoverInfo", handoverInfo)
+        Logger.dCbor(TAG, "encodedSessionTranscript", encodedSessionTranscript)
 
         val mdocCredential = match.credential as MdocCredential
         val document = MdocDocument.fromPresentment(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -83,7 +83,8 @@ suspend fun Iso18013Presentment(
     if (transport.state.value != MdocTransport.State.CONNECTED) {
         throw IllegalStateException("Expected state CONNECTED but found ${transport.state.value}")
     }
-    //Logger.iCbor(TAG, "DeviceEngagement", mechanism.encodedDeviceEngagement.toByteArray())
+    Logger.dCbor(TAG, "Handover", handover)
+    Logger.dCbor(TAG, "DeviceEngagement", deviceEngagement)
     var numRequestsServed = 0
     var sendSessionTermination = true
     var sessionEncryption: SessionEncryption? = null
@@ -119,6 +120,7 @@ suspend fun Iso18013Presentment(
                     add(Tagged(Tagged.ENCODED_CBOR, Bstr(eReaderKey.encodedCoseKey)))
                     add(handover)
                 }
+                Logger.dCbor(TAG, "SessionTranscript", sessionTranscript)
                 encodedSessionTranscript = Cbor.encode(sessionTranscript)
                 sessionEncryption = SessionEncryption(
                     role = MdocRole.MDOC,
@@ -137,7 +139,6 @@ suspend fun Iso18013Presentment(
             }
 
             val deviceRequestCbor = Cbor.decode(encodedDeviceRequest!!)
-            Logger.iCbor(TAG, "DeviceRequest", deviceRequestCbor)
             val deviceRequest = DeviceRequest.fromDataItem(deviceRequestCbor)
             deviceRequest.verifyReaderAuthentication(sessionTranscript)
             val responseObject = mdocPresentment(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -123,9 +123,11 @@ suspend fun digitalCredentialsPresentment(
     source: PresentmentSource,
     onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
 ): JsonObject {
-    when (protocol) {
+    Logger.d(TAG, "Handling W3C DC request from origin $origin and appId ${appId ?: "<not set>"}")
+    Logger.dJson(TAG, "Request", data)
+    val response = when (protocol) {
         "openid4vp", "openid4vp-v1-unsigned", "openid4vp-v1-signed", "openid4vp-v1-multisigned" -> {
-            return digitalCredentialsOpenID4VPProtocol(
+            digitalCredentialsOpenID4VPProtocol(
                 protocol = protocol,
                 data = data,
                 appId = appId,
@@ -136,7 +138,7 @@ suspend fun digitalCredentialsPresentment(
             )
         }
         "org.iso.mdoc", "org-iso-mdoc" -> {
-            return digitalCredentialsMdocApiProtocol(
+            digitalCredentialsMdocApiProtocol(
                 protocol = protocol,
                 data = data,
                 appId = appId,
@@ -150,6 +152,8 @@ suspend fun digitalCredentialsPresentment(
             throw IllegalStateException("Protocol $protocol is not supported")
         }
     }
+    Logger.dJson(TAG, "Response", response)
+    return response
 }
 
 @OptIn(ExperimentalEncodingApi::class)
@@ -251,12 +255,11 @@ private suspend fun digitalCredentialsMdocApiProtocol(
     source: PresentmentSource,
     onDocumentsInFocus: (documents: List<Document>) -> Unit
 ): JsonObject {
-    val arfRequest = data
-    val deviceRequestBase64 = arfRequest["deviceRequest"]!!.jsonPrimitive.content
-    val encryptionInfoBase64 = arfRequest["encryptionInfo"]!!.jsonPrimitive.content
+    val deviceRequestBase64 = data["deviceRequest"]!!.jsonPrimitive.content
+    val encryptionInfoBase64 = data["encryptionInfo"]!!.jsonPrimitive.content
 
     val encryptionInfo = Cbor.decode(encryptionInfoBase64.fromBase64Url())
-    Logger.iCbor(TAG, "encryptionInfo", encryptionInfo)
+    Logger.dCbor(TAG, "encryptionInfo", encryptionInfo)
     if (encryptionInfo.asArray[0].asTstr != "dcapi") {
         throw IllegalArgumentException("Malformed EncryptionInfo")
     }
@@ -268,7 +271,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         add(origin)
     }
 
-    Logger.iCbor(TAG, "dcapiInfo", dcapiInfo)
+    Logger.dCbor(TAG, "dcapiInfo", dcapiInfo)
     val dcapiInfoDigest = Crypto.digest(Algorithm.SHA256, Cbor.encode(dcapiInfo))
     val sessionTranscript = buildCborArray {
         add(Simple.NULL) // DeviceEngagementBytes
@@ -278,6 +281,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
             add(dcapiInfoDigest)
         }
     }
+    Logger.dCbor(TAG, "SessionTranscript", sessionTranscript)
 
     val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(deviceRequestBase64.fromBase64Url()))
     deviceRequest.verifyReaderAuthentication(sessionTranscript)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -250,6 +250,7 @@ private suspend fun mdocUriSchemePresentment(
         add(Cbor.decode(readerEngagement.eDeviceKeyBytes.toByteArray()))
         add(engagementToApp)
     }
+    Logger.dCbor(TAG, "SessionTranscript", sessionTranscript)
 
     val sessionEncryption = SessionEncryption(
         role = MdocRole.MDOC,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -50,9 +50,34 @@ object Logger {
          * The log level, from the lowest to the highest priority.
          */
         enum class Level {
+            /**
+             * This level contains debug information, including traces of structures that may contain PII.
+             *
+             * This is disabled by default, use [isDebugEnabled] to enable.
+             */
             DEBUG,
+
+            /**
+             * This level contains information messages which may help developers and should never contain
+             * any PII since it's enabled by default.
+             */
             INFO,
+
+            /**
+             * This level contains warning messages for unexpected conditions, recoverable failures, or non-fatal
+             * events (such as retries, fallback behavior, or degraded functionality) that do not prevent the app
+             * or operation from continuing.
+             *
+             * Like [INFO], this level is enabled by default and should never contain any PII.
+             */
             WARNING,
+
+            /**
+             * This level contains error messages for severe issues, unhandled exceptions, or unrecoverable failures
+             * where an operation or process failed to complete successfully.
+             *
+             * Like [INFO], this level is enabled by default and should never contain any PII.
+             */
             ERROR,
         }
 
@@ -62,7 +87,15 @@ object Logger {
         fun print(level: Level, tag: String, msg: String, throwable: Throwable?)
     }
 
-    var isDebugEnabled = true // TODO: make false by default
+    /**
+     * Whether to print debug messages or not.
+     *
+     * **Note**: turning on debug messages significantly increasing the amount of messages being
+     * printed and these messages may include PII. Use with caution.
+     *
+     * Note that this is process-wide so library code should never touch this.
+     */
+    var isDebugEnabled = false
 
     /**
      * Optional [LogPrinter] property for overriding the default functionality with a custom

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -279,7 +279,7 @@ object VerificationUtil {
                         }
                     }.toDataItem()
                 )
-                Logger.iCbor(TAG, "deviceRequest", encodedDeviceRequest)
+                Logger.dCbor(TAG, "deviceRequest", encodedDeviceRequest)
                 val dr = DeviceRequest.fromDataItem(Cbor.decode(encodedDeviceRequest))
                 dr.verifyReaderAuthentication(sessionTranscript)
                 val base64DeviceRequest = encodedDeviceRequest.toBase64Url()
@@ -660,7 +660,7 @@ object VerificationUtil {
                     }
                 }
                 val encodedHandoverInfo = Cbor.encode(handoverInfo)
-                Logger.iCbor(TAG, "handoverInfo", encodedHandoverInfo)
+                Logger.dCbor(TAG, "handoverInfo", encodedHandoverInfo)
                 val encodedHandoverInfoDigest = Crypto.digest(Algorithm.SHA256, encodedHandoverInfo)
                 val sessionTranscript = buildCborArray {
                     add(Simple.NULL) // DeviceEngagementBytes
@@ -670,7 +670,7 @@ object VerificationUtil {
                         add(encodedHandoverInfoDigest)
                     }
                 }
-                Logger.iCbor(TAG, "sessionTranscript", Cbor.encode(sessionTranscript))
+                Logger.dCbor(TAG, "sessionTranscript", Cbor.encode(sessionTranscript))
                 return OpenID4VPDcResponse(
                     vpToken = vpToken,
                     sessionTranscript = sessionTranscript

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -17,6 +17,7 @@ import org.multipaz.cbor.Simple
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.digitalcredentials.DigitalCredentials
 import org.multipaz.digitalcredentials.getDefault
+import org.multipaz.util.Logger
 import kotlin.Boolean
 
 /**
@@ -183,6 +184,14 @@ class TestAppSettingsModel private constructor(
         bind(currentlyFocusedDocumentId, "currentlyFocusedDocumentId", "")
 
         bind(signRequest, "signRequest", true)
+
+        bind(loggingDebugEnabled, "loggingDebugEnabled", false)
+        Logger.isDebugEnabled = loggingDebugEnabled.value
+        CoroutineScope(Dispatchers.Default).launch {
+            loggingDebugEnabled.collect { enabled ->
+                Logger.isDebugEnabled = enabled
+            }
+        }
     }
 
     val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
@@ -215,6 +224,8 @@ class TestAppSettingsModel private constructor(
     val observeModeEmitPollingFramesAsReader = MutableStateFlow<Boolean>(false)
     val currentlyFocusedDocumentId = MutableStateFlow<String>("")
     val signRequest = MutableStateFlow<Boolean>(true)
+
+    val loggingDebugEnabled = MutableStateFlow<Boolean>(false)
 }
 
 // Default to our open CSA, where "open" means it'll work with even unlocked bootloaders

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SettingsScreen.kt
@@ -333,6 +333,17 @@ fun SettingsScreen(
         }
 
         item {
+            SettingHeadline("Logging Options")
+        }
+        item {
+            SettingToggle(
+                title = "Enable Debug Logging",
+                isChecked = app.settingsModel.loggingDebugEnabled.collectAsState().value,
+                onCheckedChange = { app.settingsModel.loggingDebugEnabled.value = it },
+            )
+        }
+
+        item {
             HorizontalDivider(
                 modifier = Modifier.padding(8.dp)
             )


### PR DESCRIPTION
- Elaborate KDoc for WARNING and ERROR levels in Logger.kt, noting that default-enabled levels must never emit PII.
- Default Logger.isDebugEnabled to false.
- Audit and convert all INFO-level logging containing PII or sensitive protocol payloads (vpToken, deviceRequest, nameSpaces, handoverInfo, sessionTranscript, etc.) to DEBUG level across multipaz and multipaz-compose.
- Add debug logging statements (Logger.dCbor) across engagement and presentment handlers (MdocNfcEngagementHelper, MdocNfcV2EngagementHelper, NfcIsoTag, digitalCredentialsPresentment, uriSchemePresentment, OpenID4VP) for printing SessionTranscript data when debug logging is enabled.
- Add loggingDebugEnabled setting in TestAppSettingsModel (defaulting to off) and expose a toggle in testapp's SettingsScreen, dynamically updating Logger.isDebugEnabled on application startup and when modified.

Fixes #1834.

Test: Unit tests and manually tested.
