### PR TITLE
Fix external USB CCID reader NFCv2 transport and APDU framing.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/CcidDriver.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/CcidDriver.kt
@@ -6,7 +6,9 @@ import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
+import org.multipaz.util.Logger
 import org.multipaz.util.toHex
+import kotlin.math.min
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -26,7 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 internal class CcidDriver(
     private val usbManager: UsbManager,
-    private val device: UsbDevice
+    private val device: UsbDevice,
+    private val interfaceIndex: Int,
 ) {
     private var connection: UsbDeviceConnection? = null
     private var usbInterface: UsbInterface? = null
@@ -52,15 +55,18 @@ internal class CcidDriver(
         if (!usbManager.hasPermission(device)) {
             throw SecurityException("Permission denied for device ${device.deviceName}")
         }
-        usbInterface = findCcidInterface(device)
-            ?: throw IOException("CCID interface not found")
-
-        findEndpoints(usbInterface!!)
-        connection = usbManager.openDevice(device)
+        val conn = usbManager.openDevice(device)
             ?: throw IOException("Could not open device connection")
+        connection = conn
 
-        connection?.claimInterface(usbInterface, true)
+        val iface = findCcidInterface(device, conn)
+            ?: throw IOException("CCID interface not found")
+        usbInterface = iface
+
+        findEndpoints(iface)
+        conn.claimInterface(iface, true)
         isConnected = true
+        Logger.i(TAG, "Connected to CCID device ${device.deviceName} (interface id=${iface.id}), maxCommandLength=$maxCommandLength")
         startInterruptListener()
     }
     /**
@@ -137,9 +143,33 @@ internal class CcidDriver(
             isCardPoweredOn = true
         }
 
-        val xfrBlock = createXfrBlock(commandApdu)
-        val responseBuffer = sendAndReceive(xfrBlock)
-        val response = parseDataBlockResponse(responseBuffer)
+        val maxCcidLen = maxCcidDataLength
+        val response: ByteArray = if (commandApdu.size <= maxCcidLen) {
+            val xfrBlock = createXfrBlock(commandApdu, wLevelParameter = 0)
+            val responseBuffer = sendAndReceive(xfrBlock)
+            parseDataBlockResponse(responseBuffer)
+        } else {
+            // Send APDU using CCID block chaining
+            Logger.i(TAG, "Sending APDU of ${commandApdu.size} bytes using CCID block chaining in chunks of $maxCcidLen")
+            val offsets = 0 until commandApdu.size step maxCcidLen
+            var lastResponse = ByteArray(0)
+            for (offset in offsets) {
+                val isFirst = (offset == 0)
+                val isLast = (offset + maxCcidLen >= commandApdu.size)
+                val chunkSize = min(maxCcidLen, commandApdu.size - offset)
+                val chunkBytes = commandApdu.copyOfRange(offset, offset + chunkSize)
+                val wLevel: Short = when {
+                    isFirst -> 1 // 0x0001: First block of command APDU
+                    !isLast -> 3 // 0x0003: Intermediate block (another block is to follow)
+                    else -> 2    // 0x0002: Last block (continues command APDU and ends command)
+                }
+                val xfrBlock = createXfrBlock(chunkBytes, wLevelParameter = wLevel)
+                val responseBuffer = sendAndReceive(xfrBlock)
+                lastResponse = parseDataBlockResponse(responseBuffer)
+            }
+            lastResponse
+        }
+
         if (response.size < 2) {
             // If response is invalid, the card might have been removed.
             isCardPoweredOn = false
@@ -148,13 +178,15 @@ internal class CcidDriver(
 
         return response
     }
-    private fun createXfrBlock(data: ByteArray): ByteArray {
+
+    private fun createXfrBlock(data: ByteArray, wLevelParameter: Short = 0): ByteArray {
         val buffer = ByteBuffer.allocate(10 + data.size).order(ByteOrder.LITTLE_ENDIAN)
         buffer.put(PC_TO_RDR_XFRBLOCK)
         buffer.putInt(data.size)
         buffer.put(0x00) // bSlot
         buffer.put(sequence.getAndIncrement().toByte())
-        buffer.put(ByteArray(3)) // RFU
+        buffer.put(0x00) // bBWI
+        buffer.putShort(wLevelParameter)
         buffer.put(data)
         return buffer.array()
     }
@@ -180,22 +212,103 @@ internal class CcidDriver(
     }
 
     private fun sendAndReceive(command: ByteArray): ByteBuffer {
-        connection?.bulkTransfer(bulkOutEndpoint, command, command.size, TIMEOUT)
+        val bytesWritten = connection?.bulkTransfer(bulkOutEndpoint, command, command.size, TIMEOUT)
             ?: throw IOException("Failed to send command over bulk-out endpoint.")
-
-        val responseBytes = ByteArray(MAX_RESPONSE_LENGTH)
-        val bytesRead = connection?.bulkTransfer(bulkInEndpoint, responseBytes, responseBytes.size, TIMEOUT)
-            ?: throw IOException("Failed to read response from bulk-in endpoint.")
-
-        if (bytesRead < 10) throw IOException("Invalid response length: $bytesRead")
-
-        return ByteBuffer.wrap(responseBytes, 0, bytesRead).order(ByteOrder.LITTLE_ENDIAN)
+        if (bytesWritten < 0) {
+            throw IOException("Failed to send command over bulk-out endpoint: error $bytesWritten")
+        }
+        return readNextResponseBlock()
     }
 
+    private fun readNextResponseBlock(): ByteBuffer {
+        while (true) {
+            val responseBytes = ByteArray(MAX_RESPONSE_LENGTH)
+            val bytesRead = connection?.bulkTransfer(bulkInEndpoint, responseBytes, responseBytes.size, TIMEOUT)
+                ?: throw IOException("Failed to read response from bulk-in endpoint.")
+
+            if (bytesRead < 0) throw IOException("Failed to read response from bulk-in endpoint: error $bytesRead")
+            if (bytesRead < 10) throw IOException("Invalid response length: $bytesRead")
+
+            val responseBuffer = ByteBuffer.wrap(responseBytes, 0, bytesRead).order(ByteOrder.LITTLE_ENDIAN)
+            val statusByte = responseBuffer.get(7).toInt() and 0xFF
+            val commandStatus = statusByte and 0xC0
+            if (commandStatus == 0x80) {
+                // Time Extension requested by reader (bmCommandStatus = 10b), wait for next response
+                continue
+            }
+            return responseBuffer
+        }
+    }
+
+    val supportsCcidChaining: Boolean
+        get() {
+            val raw = try { connection?.rawDescriptors } catch (_: Throwable) { null }
+            val ifaceId = usbInterface?.id ?: 0
+            if (raw != null) {
+                val ccidDesc = getCcidDescriptorForInterface(raw, ifaceId)
+                if (ccidDesc != null && ccidDesc.size >= 44) {
+                    val dwFeatures = (ccidDesc[40].toInt() and 0xFF) or
+                            ((ccidDesc[41].toInt() and 0xFF) shl 8) or
+                            ((ccidDesc[42].toInt() and 0xFF) shl 16) or
+                            ((ccidDesc[43].toInt() and 0xFF) shl 24)
+                    val exchangeLevel = dwFeatures and 0x000F0000
+                    val supportsChaining = (exchangeLevel == 0x00040000) || (exchangeLevel == 0x00080000)
+                    return supportsChaining
+                }
+            }
+            return false
+        }
+
+    val maxCcidDataLength: Int
+        get() {
+            val raw = try { connection?.rawDescriptors } catch (_: Throwable) { null }
+            val ifaceId = usbInterface?.id ?: 0
+            if (raw != null) {
+                val ccidDesc = getCcidDescriptorForInterface(raw, ifaceId)
+                if (ccidDesc != null && ccidDesc.size >= 48) {
+                    val maxMsgLen = (ccidDesc[44].toInt() and 0xFF) or
+                            ((ccidDesc[45].toInt() and 0xFF) shl 8) or
+                            ((ccidDesc[46].toInt() and 0xFF) shl 16) or
+                            ((ccidDesc[47].toInt() and 0xFF) shl 24)
+                    if (maxMsgLen > 10) {
+                        return maxMsgLen - 10
+                    }
+                }
+            }
+            return 255
+        }
+
+    val maxCommandLength: Int
+        get() {
+            if (supportsCcidChaining) {
+                Logger.i(TAG, "Reader supports CCID block chaining (dwFeatures exchange level extended APDU) -> maxCommandLength=65535")
+                return 65535
+            }
+            val maxCcidLen = maxCcidDataLength
+            val maxCmdLen = if (maxCcidLen > 20) maxCcidLen - 10 else 255
+            Logger.i(TAG, "Reader does not report CCID chaining -> maxCcidDataLength=$maxCcidLen, maxCommandLength=$maxCmdLen")
+            return maxCmdLen
+        }
+
     private fun parseDataBlockResponse(responseBuffer: ByteBuffer): ByteArray {
-        val messageType = responseBuffer.get(0)
-        if (messageType != RDR_TO_PC_DATABLOCK.toByte()) {
-            throw IOException("Unexpected response message type, expected Data Block but got $messageType")
+        val messageType = responseBuffer.get(0).toInt() and 0xFF
+        if (messageType == RDR_TO_PC_SLOTSTATUS.toInt() and 0xFF) {
+            val statusByte = responseBuffer.get(7).toInt() and 0xFF
+            val errorCode = responseBuffer.get(8).toInt() and 0xFF
+            throw CcidException(
+                "CCID reader returned SlotStatus (0x81) instead of DataBlock: status 0x${statusByte.toString(16)}, error 0x${errorCode.toString(16)}"
+            )
+        }
+        if (messageType != RDR_TO_PC_DATABLOCK.toInt() and 0xFF) {
+            throw IOException(
+                "Unexpected response message type, expected Data Block (0x80) but got 0x${messageType.toString(16)}"
+            )
+        }
+        val statusByte = responseBuffer.get(7).toInt() and 0xFF
+        val commandStatus = statusByte and 0xC0
+        if (commandStatus == 0x40) {
+            val errorCode = responseBuffer.get(8).toInt() and 0xFF
+            throw CcidException("CCID command failed with status 0x${statusByte.toString(16)}, error code 0x${errorCode.toString(16)}")
         }
         val length = responseBuffer.getInt(1)
         if (length < 0 || length > responseBuffer.limit() - 10) {
@@ -204,14 +317,38 @@ internal class CcidDriver(
         val data = ByteArray(length)
         responseBuffer.position(10)
         responseBuffer.get(data)
+
+        // Handle CCID response block chaining per CCID Spec Rev 1.1 Section 6.2.1:
+        // bChainParameter values: 0x01 (First block), 0x03 (Intermediate block).
+        // Host requests next block using PC_to_RDR_XfrBlock with wLevelParameter = 0x0010.
+        val bChainParameter = responseBuffer.get(9).toInt() and 0xFF
+        val isChainedResponse = supportsCcidChaining && (bChainParameter == 0x01 || bChainParameter == 0x03)
+        if (isChainedResponse) {
+            Logger.i(TAG, "CCID response chaining: length=$length, bChainParameter=0x${bChainParameter.toString(16)}, requesting next chunk with wLevelParameter=0x0010")
+            val getNextChunkBlock = createXfrBlock(data = ByteArray(0), wLevelParameter = 0x0010)
+            val nextBuffer = sendAndReceive(getNextChunkBlock)
+            val nextData = parseDataBlockResponse(nextBuffer)
+            return data + nextData
+        }
+
         return data
     }
 
+    private fun hasApduStatusTrailer(data: ByteArray): Boolean {
+        if (data.size < 2) return false
+        val sw1 = data[data.size - 2].toInt() and 0xFF
+        return sw1 == 0x90 || (sw1 in 0x61..0x6F)
+    }
+
     private fun startInterruptListener() {
+        val endpoint = interruptEndpoint ?: run {
+            Logger.i(TAG, "No interrupt endpoint found for interface ${usbInterface?.id}")
+            return
+        }
         Thread {
-            val buffer = ByteArray(interruptEndpoint?.maxPacketSize ?: 2)
+            val buffer = ByteArray(endpoint.maxPacketSize)
             while (isConnected) {
-                val bytesRead = connection?.bulkTransfer(interruptEndpoint, buffer, buffer.size, 0)
+                val bytesRead = connection?.bulkTransfer(endpoint, buffer, buffer.size, 0)
                 if (bytesRead != null && bytesRead > 0) {
                     handleInterrupt(buffer)
                 }
@@ -234,12 +371,36 @@ internal class CcidDriver(
             }
         }
     }
-    private fun findCcidInterface(device: UsbDevice): UsbInterface? {
+
+    private fun findCcidInterface(device: UsbDevice, connection: UsbDeviceConnection?): UsbInterface? {
+        val iface = try { device.getInterface(interfaceIndex) } catch (_: Throwable) { null }
+        if (iface != null) {
+            Logger.i(TAG, "Using specified USB interface id=${iface.id} for device ${device.deviceName}")
+            return iface
+        }
         for (i in 0 until device.interfaceCount) {
-            val iface = device.getInterface(i)
-            if (iface.interfaceClass == UsbConstants.USB_CLASS_CSCID) {
-                return iface
+            val candidate = device.getInterface(i)
+            if (candidate.interfaceClass == UsbConstants.USB_CLASS_CSCID) {
+                Logger.i(TAG, "Defaulting to first CCID interface id=${candidate.id} for device ${device.deviceName}")
+                return candidate
             }
+        }
+        return null
+    }
+
+    private fun getCcidDescriptorForInterface(raw: ByteArray, targetIfaceNum: Int): ByteArray? {
+        var idx = 0
+        var currentIfaceNum = -1
+        while (idx < raw.size - 2) {
+            val len = raw[idx].toInt() and 0xFF
+            val type = raw[idx + 1].toInt() and 0xFF
+            if (len <= 0) break
+            if (type == 0x04 && len >= 9 && idx + 9 <= raw.size) {
+                currentIfaceNum = raw[idx + 2].toInt() and 0xFF
+            } else if (type == 0x21 && currentIfaceNum == targetIfaceNum && len >= 0x36 && idx + len <= raw.size) {
+                return raw.copyOfRange(idx, idx + len)
+            }
+            idx += len
         }
         return null
     }
@@ -260,6 +421,7 @@ internal class CcidDriver(
     }
 
     companion object {
+        private const val TAG = "CcidDriver"
         private const val TIMEOUT = 5000
         private const val MAX_RESPONSE_LENGTH = 65546
 

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.android.kt
@@ -1,7 +1,12 @@
 package org.multipaz.nfc
 
-import android.hardware.usb.UsbManager
+import android.content.Context
+import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import org.multipaz.context.applicationContext
 import org.multipaz.util.Logger
 
 private const val TAG = "ExternalNfcReaderStore"
@@ -40,27 +45,111 @@ private const val TAG = "ExternalNfcReaderStore"
 suspend fun ExternalNfcReaderStore.handleUsbDeviceAttached(device: UsbDevice): ExternalNfcReaderUsb {
     val deviceDisplayName = device.getNiceDisplayName()
     Logger.d(TAG, "USB Device attached: $deviceDisplayName")
-    val existingReader = this.readers.value.find { externalNfcReader ->
+
+    // If at least one interface for this USB device (VID/PID) already exists in the store,
+    // skip examining/adding any new interfaces for this device. When a multi-interface CCID
+    // reader is plugged in for the first time, all candidate NFC CCID interfaces are added to the store
+    // so the user can manually delete any non-NFC interfaces (e.g. SAM or contact card slots)
+    // from the UI. Preserving existing entries allows the user's manual deletions to persist
+    // when the device is re-plugged.
+    val existingReaderForDevice = this.readers.value.find { externalNfcReader ->
         (externalNfcReader as? ExternalNfcReaderUsb)?.let {
-            if (it.vendorId == device.vendorId && it.productId == device.productId) true else false
+            it.vendorId == device.vendorId && it.productId == device.productId
         } ?: false
     }
-    if (existingReader != null) {
-        return existingReader as ExternalNfcReaderUsb
+    if (existingReaderForDevice != null) {
+        Logger.i(TAG, "Device vid=${device.vendorId} pid=${device.productId} already has interface(s) configured in store, skipping auto-adding interfaces.")
+        return existingReaderForDevice as ExternalNfcReaderUsb
     }
+
+    val ccidInterfaces = (0 until device.interfaceCount)
+        .map { device.getInterface(it) }
+        .filter { it.interfaceClass == UsbConstants.USB_CLASS_CSCID }
+
+    val usbManager = applicationContext.getSystemService(Context.USB_SERVICE) as UsbManager
+    val connection: UsbDeviceConnection? = try {
+        if (usbManager.hasPermission(device)) usbManager.openDevice(device) else null
+    } catch (_: Throwable) { null }
+    val rawDescriptors = try { connection?.rawDescriptors } catch (_: Throwable) { null }
+    try { connection?.close() } catch (_: Throwable) {}
+
+    val candidateNfcInterfaces = ccidInterfaces.filter { !isDefinitelyNotNfc(it, rawDescriptors) }
+    val targetInterfaces = when {
+        candidateNfcInterfaces.isNotEmpty() -> candidateNfcInterfaces
+        ccidInterfaces.isNotEmpty() -> ccidInterfaces
+        else -> listOf(device.getInterface(0))
+    }
+    var lastAddedReader: ExternalNfcReaderUsb? = null
+
     val format = HexFormat {
         number.prefix = "0x"
         number.minLength = 2
     }
-    Logger.i(
-        TAG, "Adding USB-connected external NFC reader '$deviceDisplayName' " +
-                "vid ${device.vendorId.toHexString(format)} pid ${device.productId.toHexString(format)} " +
-                "to persistent ExternalNfcReaderStore")
-    return this.addUsbReader(
-        displayName = deviceDisplayName,
-        vendorId = device.vendorId,
-        productId = device.productId
-    )
+
+    for (iface in targetInterfaces) {
+        val ifaceIndex = iface.id
+
+        val nameSuffix = if (targetInterfaces.size > 1) {
+            val ifaceName = try { iface.name?.trim() ?: "" } catch (_: Throwable) { "" }
+            if (ifaceName.isNotEmpty()) " ($ifaceName)" else " (Interface ${iface.id})"
+        } else ""
+        val displayName = "$deviceDisplayName$nameSuffix"
+
+        Logger.i(
+            TAG, "Adding USB-connected external NFC reader '$displayName' " +
+                    "vid ${device.vendorId.toHexString(format)} pid ${device.productId.toHexString(format)} " +
+                    "interfaceIndex $ifaceIndex to persistent ExternalNfcReaderStore")
+
+        val reader = this.addUsbReader(
+            displayName = displayName,
+            vendorId = device.vendorId,
+            productId = device.productId,
+            interfaceIndex = ifaceIndex
+        )
+        lastAddedReader = reader
+    }
+
+    return lastAddedReader!!
+}
+
+private fun isDefinitelyNotNfc(iface: UsbInterface, rawDescriptors: ByteArray?): Boolean {
+    val ifaceName = try { iface.name?.lowercase()?.trim() ?: "" } catch (_: Throwable) { "" }
+    if (ifaceName.contains("sam") || ifaceName.contains("sim")) {
+        return true
+    }
+    if (ifaceName.contains("contact") && !ifaceName.contains("contactless")) {
+        return true
+    }
+    if (rawDescriptors != null) {
+        val ccidDesc = getCcidDescriptorForInterface(rawDescriptors, iface.id)
+        if (ccidDesc != null && ccidDesc.size >= 40) {
+            val dwMechanical = (ccidDesc[36].toInt() and 0xFF) or
+                    ((ccidDesc[37].toInt() and 0xFF) shl 8) or
+                    ((ccidDesc[38].toInt() and 0xFF) shl 16) or
+                    ((ccidDesc[39].toInt() and 0xFF) shl 24)
+            if (dwMechanical != 0) {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+private fun getCcidDescriptorForInterface(raw: ByteArray, targetIfaceNum: Int): ByteArray? {
+    var idx = 0
+    var currentIfaceNum = -1
+    while (idx < raw.size - 2) {
+        val len = raw[idx].toInt() and 0xFF
+        val type = raw[idx + 1].toInt() and 0xFF
+        if (len <= 0) break
+        if (type == 0x04 && len >= 9 && idx + 9 <= raw.size) {
+            currentIfaceNum = raw[idx + 2].toInt() and 0xFF
+        } else if (type == 0x21 && currentIfaceNum == targetIfaceNum && len >= 0x36 && idx + len <= raw.size) {
+            return raw.copyOfRange(idx, idx + len)
+        }
+        idx += len
+    }
+    return null
 }
 
 private fun UsbDevice.getNiceDisplayName(): String {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderUsb.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderUsb.android.kt
@@ -149,6 +149,7 @@ internal actual suspend fun ExternalNfcReaderUsb.getUsbNfcTagReader(): NfcTagRea
     }
     return NfcTagReaderUsb(
         manager = usbManager,
-        device = device
+        device = device,
+        interfaceIndex = interfaceIndex
     )
 }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
@@ -18,7 +18,7 @@ private class NfcIsoTagUsb(
     private val driver: CcidDriver,
 ): NfcIsoTag() {
     override val maxTransceiveLength: Int
-        get() = 0xfeff
+        get() = driver.maxCommandLength
 
     override suspend fun transceive(command: CommandApdu): ResponseApdu {
         val commandApduBytes = command.encode()
@@ -44,6 +44,7 @@ private class NfcIsoTagUsb(
 internal class NfcTagReaderUsb(
     private val manager: UsbManager,
     private val device: UsbDevice,
+    private val interfaceIndex: Int,
 ): NfcTagReader {
     override val external: Boolean
         get() = true
@@ -62,14 +63,15 @@ internal class NfcTagReaderUsb(
     ): T {
         val driver = CcidDriver(
             usbManager = manager,
-            device = device
+            device = device,
+            interfaceIndex = interfaceIndex
         )
         driver.connect()
         try {
             val result = suspendCancellableCoroutine<T> { continuation ->
                 var readJob: Job? = null
 
-                driver.setListener(listener = object : CcidDriverListener {
+                val listener = object : CcidDriverListener {
                     override fun onCardInserted() {
                         Logger.i(TAG, "Card inserted")
                         if (readJob == null) {
@@ -96,14 +98,24 @@ internal class NfcTagReaderUsb(
                     override fun onCardRemoved() {
                         Logger.i(TAG, "Card removed")
                     }
-                })
+                }
+
+                driver.setListener(listener = listener)
+
+                try {
+                    val status = driver.getCardStatus()
+                    if (status == CardStatus.PRESENT_ACTIVE || status == CardStatus.PRESENT_INACTIVE) {
+                        listener.onCardInserted()
+                    }
+                } catch (e: Exception) {
+                    Logger.w(TAG, "Failed to query initial card status", e)
+                }
 
                 continuation.invokeOnCancellation {
                     readJob?.cancel()
                     driver.disconnect()
                 }
             }
-            driver.disconnect()
             return result
         } catch (e: Exception) {
             if (e is CancellationException) throw e

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcHybridTransportMdocReader.kt
@@ -20,6 +20,7 @@ import org.multipaz.mdoc.nfc.nfcV2Transact
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NfcIsoTag
 import org.multipaz.util.Logger
+import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -170,10 +171,11 @@ class NfcHybridTransportMdocReader(
                     val messageToSend = writingQueue.receive()
                     numSentViaNfc += 1
                     Logger.i(TAG, "Sending message over NFC of length ${messageToSend.size}")
+                    val maxLen = min(nfcTag.maxTransceiveLength, 65530)
                     val responseMessage = nfcTag.nfcV2Transact(
                         message = messageToSend,
-                        commandDataFieldMaxLength = 65530, // TODO
-                        responseDataFieldMaxLength = 65530, // TODO
+                        commandDataFieldMaxLength = maxLen,
+                        responseDataFieldMaxLength = maxLen,
                         onMessageSent = {
                             sentMessagesNumViaNfc += 1
                         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReader.kt
@@ -10,13 +10,25 @@ import kotlin.time.Instant
  * @property id an identifier for the reader.
  * @property addedAt the point in time the reader was added
  * @property displayName a human-readable name for the reader.
+ * @property userDisplayName a user-assigned custom display name for the reader, or null if not set.
  */
 @CborSerializable
 sealed class ExternalNfcReader(
     open val id: String,
     open val addedAt: Instant,
     open val displayName: String,
+    open val userDisplayName: String? = null,
 ) {
+    internal var store: ExternalNfcReaderStore?
+        get() = storeMap[id]
+        set(value) {
+            if (value != null) {
+                storeMap[id] = value
+            } else {
+                storeMap.remove(id)
+            }
+        }
+
     /**
      * Starts observing the state of a reader.
      *
@@ -40,6 +52,14 @@ sealed class ExternalNfcReader(
      */
     abstract suspend fun getNfcTagReader(): NfcTagReader
 
+    /**
+     * Sets a user-customized display name for the reader.
+     *
+     * @param userDisplayName the new user display name, or null to clear it.
+     */
+    abstract suspend fun setUserDisplayName(userDisplayName: String?)
+
     companion object {
+        private val storeMap = mutableMapOf<String, ExternalNfcReaderStore>()
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.kt
@@ -39,12 +39,14 @@ class ExternalNfcReaderStore(
      * @param displayName a human-readable name for the device.
      * @param vendorId the vendor ID of the USB device.
      * @param productId the product ID of the USB device.
+     * @param interfaceIndex the USB interface index for the CCID interface on the device.
      * @return a [ExternalNfcReaderUsb] for the added device.
      */
     suspend fun addUsbReader(
         displayName: String,
         vendorId: Int,
-        productId: Int
+        productId: Int,
+        interfaceIndex: Int
     ): ExternalNfcReaderUsb {
         val id = storageTable.insert(
             key = null,
@@ -56,8 +58,10 @@ class ExternalNfcReaderStore(
             addedAt = Clock.System.now(),
             displayName = displayName,
             vendorId = vendorId,
-            productId = productId
+            productId = productId,
+            interfaceIndex = interfaceIndex
         )
+        reader.store = this
         storageTable.update(
             key = id,
             data = ByteString(Cbor.encode(reader.toDataItem())),
@@ -71,6 +75,34 @@ class ExternalNfcReaderStore(
                 .sortedBy { it.addedAt }
         }
         return reader
+    }
+
+    /**
+     * Sets the user display name for a reader.
+     *
+     * @param reader the reader to update.
+     * @param userDisplayName the new user display name, or null to clear it.
+     */
+    suspend fun setUserDisplayName(reader: ExternalNfcReader, userDisplayName: String?) {
+        val updatedReader = when (reader) {
+            is ExternalNfcReaderUsb -> reader.copy(userDisplayName = userDisplayName)
+        }.apply { store = this@ExternalNfcReaderStore }
+
+        storageTable.update(
+            key = reader.id,
+            data = ByteString(Cbor.encode(updatedReader.toDataItem())),
+            partitionId = partitionId
+        )
+        _readers.update { current ->
+            current.toMutableList()
+                .apply {
+                    val idx = indexOfFirst { it.id == reader.id }
+                    if (idx != -1) {
+                        set(idx, updatedReader)
+                    }
+                }
+                .sortedBy { it.addedAt }
+        }
     }
 
     /**
@@ -97,6 +129,7 @@ class ExternalNfcReaderStore(
         val readers = mutableListOf<ExternalNfcReader>()
         for ((key, encodedData) in storageTable.enumerateWithData(partitionId = partitionId)) {
             val reader = ExternalNfcReader.fromDataItem(Cbor.decode(encodedData.toByteArray()))
+            reader.store = this
             readers.add(reader)
         }
         _readers.update { current ->
@@ -108,7 +141,7 @@ class ExternalNfcReaderStore(
 
     companion object {
         private val tableSpec = StorageTableSpec(
-            name = "ExternalNfcReaderStore",
+            name = "ExternalNfcReaderStore1",
             supportPartitions = true,
             supportExpiration = false,
         )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReaderUsb.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/ExternalNfcReaderUsb.kt
@@ -8,20 +8,27 @@ import kotlin.time.Instant
  *
  * @property vendorId the USB vendor ID for the reader.
  * @property productId the USB product ID for the reader.
+ * @property interfaceIndex the USB interface index for the CCID interface on the reader.
  */
 data class ExternalNfcReaderUsb(
     override val id: String,
     override val addedAt: Instant,
     override val displayName: String,
+    override val userDisplayName: String? = null,
     val vendorId: Int,
-    val productId: Int
-): ExternalNfcReader(id, addedAt, displayName) {
+    val productId: Int,
+    val interfaceIndex: Int
+): ExternalNfcReader(id, addedAt, displayName, userDisplayName) {
 
     override fun observeState(): Flow<ExternalNfcReaderState> = observeUsbState()
 
     override suspend fun requestPermission(): Boolean = requestUsbPermission()
 
     override suspend fun getNfcTagReader(): NfcTagReader = getUsbNfcTagReader()
+
+    override suspend fun setUserDisplayName(userDisplayName: String?) {
+        store?.setUserDisplayName(this, userDisplayName)
+    }
 }
 
 internal expect fun ExternalNfcReaderUsb.observeUsbState(): Flow<ExternalNfcReaderState>

--- a/samples/testapp/src/androidMain/res/xml/usb_nfc_readers.xml
+++ b/samples/testapp/src/androidMain/res/xml/usb_nfc_readers.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <!-- ACR 1252U -->
-    <usb-device vendor-id="0x072f" product-id="0x223b" />
-
-    <!-- ACR WalletMate II -->
-    <usb-device vendor-id="0x072f" product-id="0x2401" />
-
-    <!-- ACR ACR1555 BLE Reader (USB interface) -->
-    <usb-device vendor-id="0x072f" product-id="0x230a" />
+    <!-- Match all USB CCID (Class 11 / 0x0B) Smart Card / NFC readers -->
+    <usb-device class="11" />
 </resources>

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -197,7 +197,7 @@ fun IsoMdocProximityReadingScreen(
         readers.add(NfcReaderInternal("Internal NFC Reader", index))
     }
     app.externalNfcReaderStore.readers.value.forEach { externalReader ->
-        readers.add(NfcReaderExternal(externalReader.displayName, externalReader))
+        readers.add(NfcReaderExternal(externalReader.userDisplayName ?: externalReader.displayName, externalReader))
     }
     if (readers.isEmpty()) {
         readers.add(NfcReaderNoneAvailable())

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReaderScreen.kt
@@ -6,12 +6,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,6 +45,49 @@ fun NfcReaderScreen(
         return
     }
 
+    var showEditDialog by remember { mutableStateOf(false) }
+    var nameInput by remember(reader.userDisplayName) { mutableStateOf(reader.userDisplayName ?: "") }
+
+    if (showEditDialog) {
+        AlertDialog(
+            onDismissRequest = { showEditDialog = false },
+            title = { Text("Edit Reader Name") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "Hardware name: ${reader.displayName}",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    OutlinedTextField(
+                        value = nameInput,
+                        onValueChange = { nameInput = it },
+                        label = { Text("Custom Name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val newName = nameInput.trim().ifEmpty { null }
+                        coroutineScope.launch {
+                            reader.setUserDisplayName(newName)
+                        }
+                        showEditDialog = false
+                    }
+                ) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEditDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     val hexFormat = HexFormat {
         number.prefix = "0x"
         number.minLength = 4
@@ -56,11 +107,15 @@ fun NfcReaderScreen(
             modifier = Modifier.padding(top = 10.dp, bottom = 20.dp),
             title = "External NFC Reader"
         ) {
-            FloatingItemHeadingAndText("Name", reader.displayName)
+            FloatingItemHeadingAndText("Name", reader.userDisplayName ?: reader.displayName)
+            if (reader.userDisplayName != null) {
+                FloatingItemHeadingAndText("Original Name", reader.displayName)
+            }
             if (reader is ExternalNfcReaderUsb) {
                 FloatingItemHeadingAndText("Connection", "USB")
                 FloatingItemHeadingAndText("Vendor ID", reader.vendorId.toHexString(hexFormat))
                 FloatingItemHeadingAndText("Product ID", reader.productId.toHexString(hexFormat))
+                FloatingItemHeadingAndText("Interface Index", reader.interfaceIndex.toString())
             }
             FloatingItemHeadingAndText("State", state.toString())
         }
@@ -69,6 +124,18 @@ fun NfcReaderScreen(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            Button(
+                onClick = {
+                    nameInput = reader.userDisplayName ?: ""
+                    showEditDialog = true
+                }
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    text = "Edit Name"
+                )
+            }
+
             Button(
                 enabled = (state == ExternalNfcReaderState.CONNECTED_NO_PERMISSION),
                 onClick = {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReadersScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcReadersScreen.kt
@@ -48,7 +48,7 @@ fun NfcReadersScreen(
                         modifier = Modifier.clickable {
                             onReaderClicked(reader.id)
                         },
-                        heading = reader.displayName,
+                        heading = reader.userDisplayName ?: reader.displayName,
                         text = "State: ${state.value}"
                     )
                 }
@@ -58,10 +58,8 @@ fun NfcReadersScreen(
         Text(
             text = AnnotatedString.fromMarkdown(
                 """
-                To use an external NFC reader connected via USB, simply plug it in. If the device is supported, a
-                prompt will appear asking for permission to use it with the app. For a list of supported devices see
-                [usb_nfc_readers.xml](https://github.com/openwallet-foundation/multipaz/blob/main/samples/testapp/src/androidMain/res/xml/usb_nfc_readers.xml)
-                file in the Multipaz GitHub repository.
+                To use an external NFC reader connected via USB, simply plug it in. Any USB smart card reader
+                supporting the standard CCID protocol (USB Class 11) will prompt for permission and be detected automatically.
             """.trimIndent().lines().joinToString(" ")
             )
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/NfcScreen.kt
@@ -95,7 +95,7 @@ fun NfcScreen(
         readers.add(NfcReaderInternal("Internal NFC Reader", index))
     }
     externalNfcReaderStore.readers.value.forEach { externalReader ->
-        readers.add(NfcReaderExternal(externalReader.displayName, externalReader))
+        readers.add(NfcReaderExternal(externalReader.userDisplayName ?: externalReader.displayName, externalReader))
     }
     if (readers.isEmpty()) {
         readers.add(NfcReaderNoneAvailable())


### PR DESCRIPTION
Fix external USB CCID reader NFCv2 transport, framing, and interface binding.

- Do not prematurely disconnect CcidDriver at the end of NfcTagReaderUsb.scan() so the tag remains available for ongoing transport operations.
- Parse dwMaxCCIDMessageLength from raw CCID descriptor to determine maxCommandLength and avoid oversized USB bulk transfers.
- Use nfcTag.maxTransceiveLength in NfcHybridTransportMdocReader instead of hardcoding 65530.
- Handle CCID Time Extension (0x80) and SlotStatus (0x81) error frames in CcidDriver.
- Add CCID block chaining support based on dwFeatures in the CCID descriptor for APDU level exchange (0x00040000 / 0x00080000), allowing Extended APDUs up to 65535 bytes to be transmitted seamlessly across multiple CCID blocks.
- Add interfaceIndex property to ExternalNfcReaderUsb, ExternalNfcReaderStore, NfcTagReaderUsb, and CcidDriver to support multi-interface CCID readers (e.g. dual contact/contactless readers or SAM slots).
- Update handleUsbDeviceAttached to enumerate CCID interfaces and automatically filter out non-NFC interfaces (e.g. physical contact slot mechanics dwMechanical != 0, SAM, or SIM slots).
- Add userDisplayName property and setUserDisplayName method to ExternalNfcReader, ExternalNfcReaderUsb, and ExternalNfcReaderStore to allow user-customized display names for external readers, and wire it up to the UI in test app.
- Replace individual vendor/product ID lists in usb_nfc_readers.xml with USB Class 11 (USB_CLASS_CSCID) filter to match all standard CCID smart card readers automatically.

With these fixes, we can now run the entire NFCv2 transaction over NFC only when using an external NFC reader and it also works with any USB CCID compliant reader w/o having to add VID/PID to configuration files.

Fixes #1846.

Test: Manually tested.