### PR TITLE
Add Concise Diagnostic Notation (CDN) parser, generator, and web tool

### DIFF
--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
@@ -11,19 +11,37 @@ import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.pre
 import react.dom.html.ReactHTML.code
 import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.select
+import react.dom.html.ReactHTML.option
 import react.useState
 import web.cssom.*
+import web.file.File
+import web.file.FileReader
 import web.html.InputType
 import kotlinx.browser.window
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.cbor.ByteStringFormat
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.util.toHex
+import org.multipaz.util.toBase64Url
 
 val CborDecoderComponent = FC {
+    var mode by useState("decode") // "decode" (CBOR -> CDN) or "encode" (CDN -> CBOR)
     var rawInput by useState("")
     var outputDiagnostics by useState("")
+    var outputHex by useState("")
+    var outputB64Url by useState("")
     var prettyPrint by useState(true)
     var decodeEmbeddedCbor by useState(true)
+    var useAppExtensions by useState(true)
+    var sortKeys by useState(false)
+    var bstrFormat by useState(ByteStringFormat.HEX)
     var copyStatus by useState("")
+    var copyHexStatus by useState("")
+    var copyB64Status by useState("")
 
     div {
         css {
@@ -40,7 +58,7 @@ val CborDecoderComponent = FC {
                 margin = Margin(0.px, 0.px, 16.px, 0.px)
                 color = Color("#f8fafc")
             }
-            +"CBOR Decoder"
+            +"CBOR & Concise Diagnostic Notation (CDN) Tool"
         }
 
         p {
@@ -48,187 +66,611 @@ val CborDecoderComponent = FC {
                 color = Color("#94a3b8")
                 marginBottom = 24.px
             }
-            +"Decode raw CBOR bytes (represented as Hex or Base64 / Base64Url) to standard CBOR Diagnostic notation."
+            +"Convert raw CBOR bytes (Hex or Base64) to Concise Diagnostic Notation (CDN), or compile CDN text literals to CBOR bytes."
         }
 
-        label {
-            css {
-                display = Display.block
-                fontWeight = FontWeight.normal
-                marginBottom = 8.px
-                color = Color("#cbd5e1")
-            }
-            +"CBOR Raw Data (Hex, Base64 or Base64Url):"
-        }
-
-        textarea {
-            css {
-                width = 100.pct
-                height = 150.px
-                background = Color("#0f172a")
-                border = Border(1.px, LineStyle.solid, Color("#475569"))
-                borderRadius = 8.px
-                color = Color("#f1f5f9")
-                fontFamily = FontFamily.monospace
-                padding = 12.px
-                resize = "none".unsafeCast<Resize>()
-                marginBottom = 16.px
-                focus {
-                    outline = None.none
-                    borderColor = Color("#3b82f6")
-                }
-            }
-            value = rawInput
-            placeholder = "Paste CBOR hex (e.g. A26776657273696F6E63312E30...) or Base64 here"
-            onChange = { rawInput = it.target.value }
-        }
-
+        // Mode switch tabs
         div {
             css {
                 display = Display.flex
-                gap = 24.px
-                alignItems = AlignItems.center
+                gap = 12.px
                 marginBottom = 24.px
             }
 
-            label {
+            button {
                 css {
-                    display = Display.flex
-                    alignItems = AlignItems.center
-                    gap = 8.px
+                    padding = Padding(8.px, 16.px)
+                    borderRadius = 8.px
+                    border = None.none
+                    fontWeight = FontWeight.bold
+                    fontSize = 14.px
                     cursor = Cursor.pointer
-                    color = Color("#cbd5e1")
-                    fontWeight = FontWeight.normal
-                }
-                input {
-                    type = "checkbox".unsafeCast<InputType>()
-                    checked = prettyPrint
-                    onChange = { prettyPrint = it.target.checked }
-                }
-                +"Pretty print"
-            }
-
-            label {
-                css {
-                    display = Display.flex
-                    alignItems = AlignItems.center
-                    gap = 8.px
-                    cursor = Cursor.pointer
-                    color = Color("#cbd5e1")
-                    fontWeight = FontWeight.normal
-                }
-                input {
-                    type = "checkbox".unsafeCast<InputType>()
-                    checked = decodeEmbeddedCbor
-                    onChange = { decodeEmbeddedCbor = it.target.checked }
-                }
-                +"Decode embedded CBOR"
-            }
-        }
-
-        button {
-            css {
-                padding = Padding(12.px, 24.px)
-                fontSize = 16.px
-                fontWeight = FontWeight.bold
-                backgroundColor = Color("#3b82f6")
-                color = Color("#ffffff")
-                border = None.none
-                borderRadius = 8.px
-                cursor = Cursor.pointer
-                transition = "all 0.2s".unsafeCast<Transition>()
-                hover {
-                    backgroundColor = Color("#2563eb")
-                }
-                disabled {
-                    backgroundColor = Color("#475569")
-                    cursor = Cursor.notAllowed
-                }
-            }
-            disabled = rawInput.trim().isEmpty()
-            onClick = {
-                try {
-                    val bytes = decodeInputToBytes(rawInput)
-                    if (bytes.isEmpty()) {
-                        outputDiagnostics = "Input is empty"
+                    if (mode == "decode") {
+                        backgroundColor = Color("#3b82f6")
+                        color = Color("#ffffff")
                     } else {
-                        val options = mutableSetOf<DiagnosticOption>()
-                        if (prettyPrint) options.add(DiagnosticOption.PRETTY_PRINT)
-                        if (decodeEmbeddedCbor) options.add(DiagnosticOption.EMBEDDED_CBOR)
-                        
-                        outputDiagnostics = Cbor.toDiagnostics(bytes, options)
+                        backgroundColor = Color("#334155")
+                        color = Color("#94a3b8")
                     }
-                } catch (e: Exception) {
-                    outputDiagnostics = "Error decoding: " + (e.message ?: "Unknown decoding error")
                 }
+                onClick = {
+                    mode = "decode"
+                    rawInput = ""
+                    outputDiagnostics = ""
+                    outputHex = ""
+                    outputB64Url = ""
+                }
+                +"Decode (CBOR Bytes → CDN)"
             }
-            +"Decode CBOR"
+
+            button {
+                css {
+                    padding = Padding(8.px, 16.px)
+                    borderRadius = 8.px
+                    border = None.none
+                    fontWeight = FontWeight.bold
+                    fontSize = 14.px
+                    cursor = Cursor.pointer
+                    if (mode == "encode") {
+                        backgroundColor = Color("#3b82f6")
+                        color = Color("#ffffff")
+                    } else {
+                        backgroundColor = Color("#334155")
+                        color = Color("#94a3b8")
+                    }
+                }
+                onClick = {
+                    mode = "encode"
+                    rawInput = ""
+                    outputDiagnostics = ""
+                    outputHex = ""
+                    outputB64Url = ""
+                }
+                +"Encode (CDN Text → CBOR Bytes)"
+            }
         }
 
-        if (outputDiagnostics.isNotEmpty()) {
+        if (mode == "decode") {
             div {
                 css {
-                    marginTop = 32.px
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
+                    marginBottom = 8.px
                 }
+
+                label {
+                    css {
+                        fontWeight = FontWeight.normal
+                        color = Color("#cbd5e1")
+                    }
+                    +"CBOR Raw Data (Hex, Base64 or Base64Url):"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".cbor,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                    outputDiagnostics = ""
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
+            }
+
+            textarea {
+                css {
+                    width = 100.pct
+                    height = 140.px
+                    background = Color("#0f172a")
+                    border = Border(1.px, LineStyle.solid, Color("#475569"))
+                    borderRadius = 8.px
+                    color = Color("#f1f5f9")
+                    fontFamily = FontFamily.monospace
+                    padding = 12.px
+                    resize = "none".unsafeCast<Resize>()
+                    marginBottom = 16.px
+                    focus {
+                        outline = None.none
+                        borderColor = Color("#3b82f6")
+                    }
+                }
+                value = rawInput
+                placeholder = "Paste CBOR hex (e.g. A26776657273696F6E63312E30...) or Base64 here"
+                onChange = { rawInput = it.target.value }
+            }
+
+            // Formatting options
+            div {
+                css {
+                    display = Display.flex
+                    flexWrap = FlexWrap.wrap
+                    gap = 20.px
+                    alignItems = AlignItems.center
+                    marginBottom = 24.px
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = prettyPrint
+                        onChange = { prettyPrint = it.target.checked }
+                    }
+                    +"Pretty print"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = decodeEmbeddedCbor
+                        onChange = { decodeEmbeddedCbor = it.target.checked }
+                    }
+                    +"Decode embedded CBOR (<< ... >>)"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = useAppExtensions
+                        onChange = { useAppExtensions = it.target.checked }
+                    }
+                    +"Application extensions (dt'...', ip'...')"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = sortKeys
+                        onChange = { sortKeys = it.target.checked }
+                    }
+                    +"Sort map keys"
+                }
+
                 div {
                     css {
                         display = Display.flex
-                        justifyContent = JustifyContent.spaceBetween
                         alignItems = AlignItems.center
-                        marginBottom = 8.px
+                        gap = 8.px
                     }
                     label {
                         css {
-                            fontWeight = FontWeight.normal
                             color = Color("#cbd5e1")
-                        }
-                        +"Diagnostic Output:"
-                    }
-                    button {
-                        css {
-                            background = Color("#334155")
-                            border = None.none
-                            color = Color("#f1f5f9")
-                            padding = Padding(6.px, 12.px)
-                            borderRadius = 6.px
-                            cursor = Cursor.pointer
-                            fontSize = 13.px
                             fontWeight = FontWeight.normal
-                            hover {
-                                background = Color("#475569")
-                            }
                         }
-                        onClick = {
-                            window.navigator.asDynamic().clipboard.writeText(outputDiagnostics)
-                            copyStatus = "Copied!"
-                            window.setTimeout({ copyStatus = "" }, 2000)
+                        +"Byte format:"
+                    }
+                    select {
+                        css {
+                            background = Color("#0f172a")
+                            color = Color("#f1f5f9")
+                            border = Border(1.px, LineStyle.solid, Color("#475569"))
+                            borderRadius = 6.px
+                            padding = Padding(4.px, 8.px)
                         }
-                        if (copyStatus.isNotEmpty()) +copyStatus else +"Copy to Clipboard"
+                        value = bstrFormat.name
+                        onChange = { e ->
+                            bstrFormat = ByteStringFormat.valueOf(e.target.asDynamic().value as String)
+                        }
+                        option { value = ByteStringFormat.HEX.name; +"Hex (h'...')" }
+                        option { value = ByteStringFormat.BASE64.name; +"Base64 (b64'...')" }
+                        option { value = ByteStringFormat.ASCII_SINGLE_QUOTE.name; +"ASCII ('...')" }
+                        option { value = ByteStringFormat.LENGTH_ONLY.name; +"Length Summary" }
                     }
                 }
-                if (outputDiagnostics.startsWith("Error")) {
-                    pre {
-                        css {
-                            background = Color("#020617")
-                            border = Border(1.px, LineStyle.solid, Color("#334155"))
-                            borderRadius = 8.px
-                            padding = 16.px
-                            overflow = "auto".unsafeCast<Overflow>()
-                            maxHeight = 500.px
+            }
+
+            button {
+                css {
+                    padding = Padding(12.px, 24.px)
+                    fontSize = 16.px
+                    fontWeight = FontWeight.bold
+                    backgroundColor = Color("#3b82f6")
+                    color = Color("#ffffff")
+                    border = None.none
+                    borderRadius = 8.px
+                    cursor = Cursor.pointer
+                    transition = "all 0.2s".unsafeCast<Transition>()
+                    hover {
+                        backgroundColor = Color("#2563eb")
+                    }
+                    disabled {
+                        backgroundColor = Color("#475569")
+                        cursor = Cursor.notAllowed
+                    }
+                }
+                disabled = rawInput.trim().isEmpty()
+                onClick = {
+                    try {
+                        val bytes = decodeInputToBytes(rawInput)
+                        if (bytes.isEmpty()) {
+                            outputDiagnostics = "Input is empty"
+                        } else {
+                            val options = CdnGeneratorOptions(
+                                prettyPrint = prettyPrint,
+                                useEmbeddedCborShorthand = decodeEmbeddedCbor,
+                                useApplicationExtensions = useAppExtensions,
+                                sortMapKeys = sortKeys,
+                                byteStringFormat = bstrFormat
+                            )
+                            outputDiagnostics = Cdn.encode(bytes, options)
                         }
-                        code {
+                    } catch (e: Exception) {
+                        outputDiagnostics = "Error decoding: " + (e.message ?: "Unknown decoding error")
+                    }
+                }
+                +"Decode to CDN"
+            }
+
+            if (outputDiagnostics.isNotEmpty()) {
+                div {
+                    css {
+                        marginTop = 32.px
+                    }
+                    div {
+                        css {
+                            display = Display.flex
+                            justifyContent = JustifyContent.spaceBetween
+                            alignItems = AlignItems.center
+                            marginBottom = 8.px
+                        }
+                        label {
                             css {
-                                fontFamily = FontFamily.monospace
-                                color = Color("#ef4444")
-                                fontSize = 14.px
+                                fontWeight = FontWeight.normal
+                                color = Color("#cbd5e1")
                             }
-                            +outputDiagnostics
+                            +"Diagnostic Output (CDN):"
+                        }
+                        button {
+                            css {
+                                background = Color("#334155")
+                                border = None.none
+                                color = Color("#f1f5f9")
+                                padding = Padding(6.px, 12.px)
+                                borderRadius = 6.px
+                                cursor = Cursor.pointer
+                                fontSize = 13.px
+                                fontWeight = FontWeight.normal
+                                hover {
+                                    background = Color("#475569")
+                                }
+                            }
+                            onClick = {
+                                window.navigator.asDynamic().clipboard.writeText(outputDiagnostics)
+                                copyStatus = "Copied!"
+                                window.setTimeout({ copyStatus = "" }, 2000)
+                            }
+                            if (copyStatus.isNotEmpty()) +copyStatus else +"Copy to Clipboard"
                         }
                     }
-                } else {
-                    CborDiagnosticViewer {
-                        diagText = outputDiagnostics
-                        maxHeight = 500.px
+                    if (outputDiagnostics.startsWith("Error")) {
+                        pre {
+                            css {
+                                background = Color("#020617")
+                                border = Border(1.px, LineStyle.solid, Color("#334155"))
+                                borderRadius = 8.px
+                                padding = 16.px
+                                overflow = "auto".unsafeCast<Overflow>()
+                                maxHeight = 500.px
+                            }
+                            code {
+                                css {
+                                    fontFamily = FontFamily.monospace
+                                    color = Color("#ef4444")
+                                    fontSize = 14.px
+                                }
+                                +outputDiagnostics
+                            }
+                        }
+                    } else {
+                        CborDiagnosticViewer {
+                            diagText = outputDiagnostics
+                            maxHeight = 500.px
+                        }
+                    }
+                }
+            }
+        } else {
+            // Encode Mode (CDN -> CBOR Bytes)
+            div {
+                css {
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
+                    marginBottom = 8.px
+                }
+
+                label {
+                    css {
+                        fontWeight = FontWeight.normal
+                        color = Color("#cbd5e1")
+                    }
+                    +"CDN Text Literal (e.g. [1, 2, \"hello\", dt'2026-07-27T16:00:00Z', << {\"ver\": \"1.0\"} >>]):"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".cdn,.cbor-diag,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val text = reader.result.toString()
+                                    rawInput = text
+                                    outputHex = ""
+                                    outputB64Url = ""
+                                    outputDiagnostics = ""
+                                }
+                                reader.readAsText(file)
+                            }
+                        }
+                    }
+                }
+            }
+
+            textarea {
+                css {
+                    width = 100.pct
+                    height = 140.px
+                    background = Color("#0f172a")
+                    border = Border(1.px, LineStyle.solid, Color("#475569"))
+                    borderRadius = 8.px
+                    color = Color("#f1f5f9")
+                    fontFamily = FontFamily.monospace
+                    padding = 12.px
+                    resize = "none".unsafeCast<Resize>()
+                    marginBottom = 16.px
+                    focus {
+                        outline = None.none
+                        borderColor = Color("#3b82f6")
+                    }
+                }
+                value = rawInput
+                placeholder = "Paste Concise Diagnostic Notation (CDN) text here..."
+                onChange = { rawInput = it.target.value }
+            }
+
+            button {
+                css {
+                    padding = Padding(12.px, 24.px)
+                    fontSize = 16.px
+                    fontWeight = FontWeight.bold
+                    backgroundColor = Color("#3b82f6")
+                    color = Color("#ffffff")
+                    border = None.none
+                    borderRadius = 8.px
+                    cursor = Cursor.pointer
+                    transition = "all 0.2s".unsafeCast<Transition>()
+                    hover {
+                        backgroundColor = Color("#2563eb")
+                    }
+                    disabled {
+                        backgroundColor = Color("#475569")
+                        cursor = Cursor.notAllowed
+                    }
+                }
+                disabled = rawInput.trim().isEmpty()
+                onClick = {
+                    try {
+                        val item = Cdn.parse(rawInput)
+                        val encodedBytes = Cbor.encode(item)
+                        outputHex = encodedBytes.toHex()
+                        outputB64Url = encodedBytes.toBase64Url()
+                        outputDiagnostics = ""
+                    } catch (e: Exception) {
+                        outputDiagnostics = "Error parsing CDN: " + (e.message ?: "Unknown syntax error")
+                        outputHex = ""
+                        outputB64Url = ""
+                    }
+                }
+                +"Encode to CBOR"
+            }
+
+            if (outputDiagnostics.isNotEmpty()) {
+                pre {
+                    css {
+                        marginTop = 24.px
+                        background = Color("#020617")
+                        border = Border(1.px, LineStyle.solid, Color("#334155"))
+                        borderRadius = 8.px
+                        padding = 16.px
+                    }
+                    code {
+                        css {
+                            fontFamily = FontFamily.monospace
+                            color = Color("#ef4444")
+                            fontSize = 14.px
+                        }
+                        +outputDiagnostics
+                    }
+                }
+            }
+
+            if (outputHex.isNotEmpty()) {
+                div {
+                    css {
+                        marginTop = 24.px
+                        display = Display.flex
+                        flexDirection = FlexDirection.column
+                        gap = 16.px
+                    }
+
+                    div {
+                        div {
+                            css {
+                                display = Display.flex
+                                justifyContent = JustifyContent.spaceBetween
+                                alignItems = AlignItems.center
+                                marginBottom = 6.px
+                            }
+                            label {
+                                css { color = Color("#cbd5e1"); fontWeight = FontWeight.normal }
+                                +"CBOR Hex:"
+                            }
+                            button {
+                                css {
+                                    background = Color("#334155")
+                                    border = None.none
+                                    color = Color("#f1f5f9")
+                                    padding = Padding(4.px, 10.px)
+                                    borderRadius = 6.px
+                                    cursor = Cursor.pointer
+                                    fontSize = 12.px
+                                }
+                                onClick = {
+                                    window.navigator.asDynamic().clipboard.writeText(outputHex)
+                                    copyHexStatus = "Copied!"
+                                    window.setTimeout({ copyHexStatus = "" }, 2000)
+                                }
+                                if (copyHexStatus.isNotEmpty()) +copyHexStatus else +"Copy Hex"
+                            }
+                        }
+                        textarea {
+                            css {
+                                width = 100.pct
+                                height = 80.px
+                                background = Color("#0f172a")
+                                border = Border(1.px, LineStyle.solid, Color("#475569"))
+                                borderRadius = 8.px
+                                color = Color("#38bdf8")
+                                fontFamily = FontFamily.monospace
+                                padding = 8.px
+                                resize = "none".unsafeCast<Resize>()
+                            }
+                            readOnly = true
+                            value = outputHex
+                        }
+                    }
+
+                    div {
+                        div {
+                            css {
+                                display = Display.flex
+                                justifyContent = JustifyContent.spaceBetween
+                                alignItems = AlignItems.center
+                                marginBottom = 6.px
+                            }
+                            label {
+                                css { color = Color("#cbd5e1"); fontWeight = FontWeight.normal }
+                                +"CBOR Base64Url:"
+                            }
+                            button {
+                                css {
+                                    background = Color("#334155")
+                                    border = None.none
+                                    color = Color("#f1f5f9")
+                                    padding = Padding(4.px, 10.px)
+                                    borderRadius = 6.px
+                                    cursor = Cursor.pointer
+                                    fontSize = 12.px
+                                }
+                                onClick = {
+                                    window.navigator.asDynamic().clipboard.writeText(outputB64Url)
+                                    copyB64Status = "Copied!"
+                                    window.setTimeout({ copyB64Status = "" }, 2000)
+                                }
+                                if (copyB64Status.isNotEmpty()) +copyB64Status else +"Copy Base64Url"
+                            }
+                        }
+                        textarea {
+                            css {
+                                width = 100.pct
+                                height = 80.px
+                                background = Color("#0f172a")
+                                border = Border(1.px, LineStyle.solid, Color("#475569"))
+                                borderRadius = 8.px
+                                color = Color("#38bdf8")
+                                fontFamily = FontFamily.monospace
+                                padding = 8.px
+                                resize = "none".unsafeCast<Resize>()
+                            }
+                            readOnly = true
+                            value = outputB64Url
+                        }
                     }
                 }
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
@@ -161,7 +161,7 @@ val App = FC {
 
             val categories = listOf(
                 Category("decoders", "Decoders & Parsers", listOf(
-                    "cbor-decode" to "CBOR Decoder",
+                    "cbor-decode" to "CBOR and CDN",
                     "asn1" to "ASN.1 Decoder",
                     "ndef-parse" to "NDEF Parser"
                 )),

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Cdn.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Cdn.kt
@@ -1,0 +1,121 @@
+package org.multipaz.cbor
+
+/**
+ * Main entry point for Concise Diagnostic Notation (CDN) parsing and generation.
+ *
+ * CDN is specified by IETF `draft-ietf-cbor-edn-literals` and updates RFC 8949 / RFC 8610 Appendix G.
+ */
+object Cdn {
+    /**
+     * Parses a CDN text string into a single [DataItem].
+     *
+     * @param cdnText The Concise Diagnostic Notation text to parse.
+     * @param options Options for parsing CDN.
+     * @return The parsed [DataItem].
+     * @throws CdnException If a syntax or token error occurs during parsing.
+     */
+    fun parse(
+        cdnText: String,
+        options: CdnParserOptions = CdnParserOptions.Default
+    ): DataItem {
+        val parser = CdnParser(cdnText, options)
+        return parser.parseSingle()
+    }
+
+    /**
+     * Parses a CDN text string containing zero or more data items (a CBOR sequence) into a [List] of [DataItem]s.
+     *
+     * @param cdnText The Concise Diagnostic Notation sequence text to parse.
+     * @param options Options for parsing CDN.
+     * @return A list of parsed [DataItem]s.
+     * @throws CdnException If a syntax or token error occurs during parsing.
+     */
+    fun parseSequence(
+        cdnText: String,
+        options: CdnParserOptions = CdnParserOptions.Default
+    ): List<DataItem> {
+        val parser = CdnParser(cdnText, options)
+        return parser.parseSequence()
+    }
+
+    /**
+     * Serializes a [DataItem] into its Concise Diagnostic Notation text representation.
+     *
+     * @param item The [DataItem] to encode.
+     * @param options Options controlling formatting (e.g. pretty printing, byte string format).
+     * @return The formatted CDN string.
+     */
+    fun encode(
+        item: DataItem,
+        options: CdnGeneratorOptions = CdnGeneratorOptions.Default
+    ): String {
+        val generator = CdnGenerator(options)
+        return generator.generate(item)
+    }
+
+    /**
+     * Decodes encoded CBOR bytes and serializes them into Concise Diagnostic Notation text.
+     *
+     * @param encodedCbor The raw CBOR bytes.
+     * @param options Options controlling formatting.
+     * @return The formatted CDN string.
+     */
+    fun encode(
+        encodedCbor: ByteArray,
+        options: CdnGeneratorOptions = CdnGeneratorOptions.Default
+    ): String {
+        val decoded = Cbor.decode(encodedCbor)
+        return encode(decoded, options)
+    }
+
+    /**
+     * Registers a custom [CdnExtension] with the default extension registry.
+     */
+    fun registerExtension(extension: CdnExtension) {
+        CdnExtensionRegistry.Default.register(extension)
+    }
+
+    /**
+     * Parses a CDN text string into a single [DataItem] using a custom extension registry.
+     */
+    fun parse(
+        cdnText: String,
+        extensionRegistry: CdnExtensionRegistry
+    ): DataItem = parse(cdnText, CdnParserOptions(extensionRegistry = extensionRegistry))
+
+    /**
+     * Parses a CDN text string containing zero or more data items into a [List] of [DataItem]s using a custom extension registry.
+     */
+    fun parseSequence(
+        cdnText: String,
+        extensionRegistry: CdnExtensionRegistry
+    ): List<DataItem> = parseSequence(cdnText, CdnParserOptions(extensionRegistry = extensionRegistry))
+
+    /**
+     * Serializes a [DataItem] into its CDN text representation using a custom extension registry.
+     */
+    fun encode(
+        item: DataItem,
+        extensionRegistry: CdnExtensionRegistry
+    ): String = encode(item, CdnGeneratorOptions(extensionRegistry = extensionRegistry))
+
+    /**
+     * Decodes CBOR bytes and serializes them into CDN text representation using a custom extension registry.
+     */
+    fun encode(
+        encodedCbor: ByteArray,
+        extensionRegistry: CdnExtensionRegistry
+    ): String = encode(encodedCbor, CdnGeneratorOptions(extensionRegistry = extensionRegistry))
+}
+
+/**
+ * Extension function to convert a [DataItem] to a CDN string representation.
+ */
+fun DataItem.toCdn(options: CdnGeneratorOptions = CdnGeneratorOptions.Default): String =
+    Cdn.encode(this, options)
+
+/**
+ * Extension function to parse a CDN string representation into a [DataItem].
+ */
+fun String.toDataItemFromCdn(options: CdnParserOptions = CdnParserOptions.Default): DataItem =
+    Cdn.parse(this, options)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnException.kt
@@ -1,0 +1,14 @@
+package org.multipaz.cbor
+
+/**
+ * Exception thrown when parsing Concise Diagnostic Notation (CDN) fails.
+ *
+ * @param message Description of the syntax error.
+ * @param line Line number in the CDN text where the error occurred (1-indexed).
+ * @param column Column number in the CDN text where the error occurred (1-indexed).
+ */
+class CdnException(
+    message: String,
+    val line: Int = 1,
+    val column: Int = 1
+) : IllegalArgumentException("CDN parse error at $line:$column: $message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnExtension.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnExtension.kt
@@ -1,0 +1,292 @@
+package org.multipaz.cbor
+
+import org.multipaz.util.fromBase64
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.fromHex
+import org.multipaz.util.toBase64
+import org.multipaz.util.toHex
+
+/**
+ * Interface for CDN application-oriented extension literals (e.g. `dt'2026-07-27T16:00:00Z'`).
+ */
+interface CdnExtension {
+    /**
+     * The extension identifier, e.g., "dt", "ip", "h", "b64", "hash", "b1", "t1", "float".
+     */
+    val identifier: String
+
+    /**
+     * Parses the string content of an extension literal into a [DataItem].
+     *
+     * @param content The text within the quotes or delimiters of the extension.
+     * @param delimiter The delimiter character used (' or " or `).
+     */
+    fun parseLiteral(content: String, delimiter: Char): DataItem
+
+    /**
+     * Formats a [DataItem] into CDN extension syntax, or returns `null` if not applicable.
+     */
+    fun format(item: DataItem, options: CdnGeneratorOptions): String?
+}
+
+/**
+ * Registry for CDN application-oriented extensions.
+ */
+class CdnExtensionRegistry {
+    private val extensions = mutableMapOf<String, CdnExtension>()
+
+    /**
+     * Registers a [CdnExtension] with this registry.
+     */
+    fun register(extension: CdnExtension) {
+        extensions[extension.identifier] = extension
+    }
+
+    /**
+     * Gets a registered [CdnExtension] by its identifier.
+     */
+    fun get(identifier: String): CdnExtension? = extensions[identifier]
+
+    /**
+     * All registered [CdnExtension] instances.
+     */
+    val all: Collection<CdnExtension> get() = extensions.values
+
+    companion object {
+        /**
+         * Default extension registry populated with standard extension handlers.
+         */
+        val Default: CdnExtensionRegistry by lazy {
+            CdnExtensionRegistry().apply {
+                register(HexExtension)
+                register(Base64Extension)
+                register(DateTimeExtension)
+                register(IpExtension)
+                register(FloatExtension)
+                register(StringConcatByteExtension)
+                register(StringConcatTextExtension)
+            }
+        }
+    }
+}
+
+/**
+ * Extension for Hexadecimal byte strings: `h'01020304'` or `h"01020304"`.
+ */
+object HexExtension : CdnExtension {
+    override val identifier: String = "h"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        val cleanContent = content.filterNot { it.isWhitespace() }
+        val bytes = cleanContent.fromHex()
+        return Bstr(bytes)
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+        if (options.byteStringFormat == ByteStringFormat.HEX && item is Bstr) {
+            return "h'${item.value.toHex()}'"
+        }
+        return null
+    }
+}
+
+/**
+ * Extension for Base64 byte strings: `b64'AQIDBA=='`.
+ */
+object Base64Extension : CdnExtension {
+    override val identifier: String = "b64"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        val cleanContent = content.filterNot { it.isWhitespace() }
+        val bytes = try {
+            cleanContent.fromBase64Url()
+        } catch (e: Exception) {
+            cleanContent.fromBase64()
+        }
+        return Bstr(bytes)
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+        if (options.byteStringFormat == ByteStringFormat.BASE64 && item is Bstr) {
+            return "b64'${item.value.toBase64()}'"
+        }
+        return null
+    }
+}
+
+/**
+ * Extension for RFC 3339 Date/Time: `dt'2026-07-27T16:00:00Z'`.
+ */
+object DateTimeExtension : CdnExtension {
+    override val identifier: String = "dt"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        return Tagged(Tagged.DATE_TIME_STRING, Tstr(content))
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+        if (!options.useApplicationExtensions) return null
+        if (item is Tagged && item.tagNumber == Tagged.DATE_TIME_STRING && item.taggedItem is Tstr) {
+            return "dt'${(item.taggedItem as Tstr).value}'"
+        }
+        return null
+    }
+}
+
+/**
+ * Extension for IP addresses: `ip'192.168.1.1'` or `ip'2001:db8::1'`.
+ */
+object IpExtension : CdnExtension {
+    override val identifier: String = "ip"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        if (content.contains(":")) {
+            // IPv6 address parsing
+            val bytes = parseIpv6(content)
+            return Tagged(54L, Bstr(bytes))
+        } else {
+            // IPv4 address parsing
+            val parts = content.split(".")
+            if (parts.size != 4) {
+                throw CdnException("Invalid IPv4 address in ip extension: $content")
+            }
+            val bytes = ByteArray(4)
+            for (i in 0 until 4) {
+                val byteVal = parts[i].toIntOrNull()
+                    ?: throw CdnException("Invalid component in IPv4 address: $content")
+                if (byteVal !in 0..255) {
+                    throw CdnException("IPv4 byte value out of range: $byteVal")
+                }
+                bytes[i] = byteVal.toByte()
+            }
+            return Tagged(52L, Bstr(bytes))
+        }
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+        if (!options.useApplicationExtensions) return null
+        if (item is Tagged) {
+            if (item.tagNumber == 52L && item.taggedItem is Bstr && item.taggedItem.asBstr.size == 4) {
+                val bytes = item.taggedItem.asBstr
+                val ipStr = bytes.joinToString(".") { (it.toInt() and 0xff).toString() }
+                return "ip'$ipStr'"
+            }
+            if (item.tagNumber == 54L && item.taggedItem is Bstr && item.taggedItem.asBstr.size == 16) {
+                val bytes = item.taggedItem.asBstr
+                val words = IntArray(8)
+                for (i in 0 until 8) {
+                    words[i] = ((bytes[i * 2].toInt() and 0xff) shl 8) or (bytes[i * 2 + 1].toInt() and 0xff)
+                }
+                val ipStr = words.joinToString(":") { it.toString(16) }
+                return "ip'$ipStr'"
+            }
+        }
+        return null
+    }
+
+    private fun parseIpv6(ipStr: String): ByteArray {
+        val bytes = ByteArray(16)
+        val parts = ipStr.split("::")
+        if (parts.size > 2) throw CdnException("Invalid IPv6 address: $ipStr")
+        
+        fun parseHexWords(section: String): List<Int> {
+            if (section.isEmpty()) return emptyList()
+            return section.split(":").map { word ->
+                word.toIntOrNull(16) ?: throw CdnException("Invalid hex in IPv6: $ipStr")
+            }
+        }
+
+        val head = parseHexWords(parts[0])
+        val tail = if (parts.size == 2) parseHexWords(parts[1]) else emptyList()
+        val totalWords = head.size + tail.size
+        if (parts.size == 1 && totalWords != 8) throw CdnException("IPv6 must contain 8 words: $ipStr")
+        if (totalWords > 8) throw CdnException("Too many words in IPv6 address: $ipStr")
+
+        val words = IntArray(8)
+        for (i in head.indices) words[i] = head[i]
+        val tailStart = 8 - tail.size
+        for (i in tail.indices) words[tailStart + i] = tail[i]
+
+        for (i in 0 until 8) {
+            bytes[i * 2] = (words[i] shr 8).toByte()
+            bytes[i * 2 + 1] = words[i].toByte()
+        }
+        return bytes
+    }
+}
+
+/**
+ * Extension for explicit floating point precision bit-widths: `float'16(0x7c00)'`.
+ */
+object FloatExtension : CdnExtension {
+    override val identifier: String = "float"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        val trimmed = content.trim()
+        if (trimmed.startsWith("16(")) {
+            val hex = trimmed.removePrefix("16(").removeSuffix(")").removePrefix("0x").filterNot { it.isWhitespace() }
+            val bits = hex.toInt(16)
+            return CborFloat(float16ToFloat(bits))
+        } else if (trimmed.startsWith("32(")) {
+            val hex = trimmed.removePrefix("32(").removeSuffix(")").removePrefix("0x").filterNot { it.isWhitespace() }
+            val bits = hex.toLong(16).toInt()
+            return CborFloat(Float.fromBits(bits))
+        } else if (trimmed.startsWith("64(")) {
+            val hex = trimmed.removePrefix("64(").removeSuffix(")").removePrefix("0x").filterNot { it.isWhitespace() }
+            val bits = hex.toULong(16).toLong()
+            return CborDouble(Double.fromBits(bits))
+        }
+        throw CdnException("Invalid float extension literal: $content")
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+
+    private fun float16ToFloat(bits: Int): Float {
+        val s = (bits shr 15) and 0x01
+        val e = (bits shr 10) and 0x1f
+        val m = bits and 0x03ff
+        if (e == 0) {
+            if (m == 0) return if (s == 1) -0.0f else 0.0f
+            val f = (m / 1024.0f) * (1.0f / 16384.0f)
+            return if (s == 1) -f else f
+        } else if (e == 31) {
+            if (m == 0) return if (s == 1) Float.NEGATIVE_INFINITY else Float.POSITIVE_INFINITY
+            return Float.NaN
+        }
+        var exp = e - 15
+        var mult = 1.0f
+        if (exp >= 0) {
+            for (i in 0 until exp) mult *= 2.0f
+        } else {
+            for (i in 0 until -exp) mult /= 2.0f
+        }
+        val f = (1.0f + m / 1024.0f) * mult
+        return if (s == 1) -f else f
+    }
+}
+
+/**
+ * Extension for Byte String Concatenation: `b1'...'`.
+ */
+object StringConcatByteExtension : CdnExtension {
+    override val identifier: String = "b1"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        return Bstr(content.encodeToByteArray())
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+}
+
+/**
+ * Extension for Text String Concatenation: `t1'...'`.
+ */
+object StringConcatTextExtension : CdnExtension {
+    override val identifier: String = "t1"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        return Tstr(content)
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
@@ -1,0 +1,244 @@
+package org.multipaz.cbor
+
+import org.multipaz.util.toHex
+
+internal class CdnGenerator(private val options: CdnGeneratorOptions) {
+
+    fun generate(item: DataItem): String {
+        val sb = StringBuilder()
+        generateItem(sb, 0, item)
+        return sb.toString()
+    }
+
+    private fun generateItem(sb: StringBuilder, indent: Int, item: DataItem) {
+        val pretty = options.prettyPrint
+        val indentStr = if (pretty) " ".repeat(indent) else ""
+
+        if (item is RawCbor) {
+            val decoded = Cbor.decode(item.encodedCbor)
+            generateItem(sb, indent, decoded)
+            return
+        }
+
+        // Try application extensions first (e.g. dt'...', ip'...', or custom registered extensions)
+        if (options.useApplicationExtensions) {
+            for (ext in options.extensionRegistry.all) {
+                val formatted = ext.format(item, options)
+                if (formatted != null) {
+                    sb.append(formatted)
+                    return
+                }
+            }
+        }
+
+        when (item.majorType) {
+            MajorType.UNSIGNED_INTEGER -> sb.append((item as Uint).value)
+
+            MajorType.NEGATIVE_INTEGER -> {
+                sb.append('-')
+                sb.append((item as Nint).value)
+            }
+
+            MajorType.BYTE_STRING -> {
+                when (item) {
+                    is IndefLengthBstr -> {
+                        if (options.byteStringFormat == ByteStringFormat.LENGTH_ONLY) {
+                            sb.append("indefinite-size byte-string")
+                        } else {
+                            sb.append("(_ ")
+                            var count = 0
+                            for (chunk in item.chunks) {
+                                if (count++ > 0) sb.append(", ")
+                                generateByteStringLiteral(sb, chunk)
+                            }
+                            sb.append(")")
+                        }
+                    }
+
+                    is Bstr -> {
+                        generateByteStringLiteral(sb, item.value)
+                    }
+
+                    else -> throw IllegalStateException("Unexpected Bstr type")
+                }
+            }
+
+            MajorType.UNICODE_STRING -> {
+                when (item) {
+                    is IndefLengthTstr -> {
+                        sb.append("(_ ")
+                        var count = 0
+                        for (chunk in item.chunks) {
+                            if (count++ > 0) sb.append(", ")
+                            generateTextStringLiteral(sb, chunk)
+                        }
+                        sb.append(")")
+                    }
+
+                    is Tstr -> {
+                        generateTextStringLiteral(sb, item.value)
+                    }
+
+                    else -> throw IllegalStateException("Unexpected Tstr type")
+                }
+            }
+
+            MajorType.ARRAY -> {
+                val arrayItems = (item as CborArray).items
+                val isIndef = item.indefiniteLength
+                val openBracket = if (isIndef) "[_ " else "["
+
+                if (!pretty || arrayItems.isEmpty()) {
+                    sb.append(openBracket)
+                    var count = 0
+                    for (elem in arrayItems) {
+                        if (count++ > 0) sb.append(", ")
+                        generateItem(sb, indent, elem)
+                    }
+                    sb.append("]")
+                } else {
+                    sb.append(if (isIndef) "[_\n" else "[\n")
+                    val childIndent = indent + options.indentSize
+                    val childIndentStr = " ".repeat(childIndent)
+                    var count = 0
+                    for (elem in arrayItems) {
+                        sb.append(childIndentStr)
+                        generateItem(sb, childIndent, elem)
+                        if (++count < arrayItems.size) {
+                            sb.append(",")
+                        }
+                        sb.append("\n")
+                    }
+                    sb.append(indentStr).append("]")
+                }
+            }
+
+            MajorType.MAP -> {
+                val mapObj = item as CborMap
+                var mapEntries: List<Map.Entry<DataItem, DataItem>> = mapObj.items.entries.toList()
+                if (options.sortMapKeys) {
+                    mapEntries = mapEntries.sortedBy { (k, _) -> k.toString() }
+                }
+                val isIndef = item.indefiniteLength
+                val openBrace = if (isIndef) "{_ " else "{"
+
+                if (!pretty || mapEntries.isEmpty()) {
+                    sb.append(openBrace)
+                    var count = 0
+                    for ((key, value) in mapEntries) {
+                        if (count++ > 0) sb.append(", ")
+                        generateItem(sb, indent, key)
+                        sb.append(": ")
+                        generateItem(sb, indent, value)
+                    }
+                    sb.append("}")
+                } else {
+                    sb.append(if (isIndef) "{_\n" else "{\n")
+                    val childIndent = indent + options.indentSize
+                    val childIndentStr = " ".repeat(childIndent)
+                    var count = 0
+                    for ((key, value) in mapEntries) {
+                        sb.append(childIndentStr)
+                        generateItem(sb, childIndent, key)
+                        sb.append(": ")
+                        generateItem(sb, childIndent, value)
+                        if (++count < mapEntries.size) {
+                            sb.append(",")
+                        }
+                        sb.append("\n")
+                    }
+                    sb.append(indentStr).append("}")
+                }
+            }
+
+            MajorType.TAG -> {
+                val tagged = item as Tagged
+                val tagNum = tagged.tagNumber
+
+                // Embedded CBOR shorthand << item >> for Tag 24
+                if (tagNum == Tagged.ENCODED_CBOR && options.useEmbeddedCborShorthand && tagged.taggedItem is Bstr) {
+                    try {
+                        val embedded = Cbor.decode((tagged.taggedItem as Bstr).value)
+                        sb.append("<< ")
+                        generateItem(sb, indent, embedded)
+                        sb.append(" >>")
+                        return
+                    } catch (_: Exception) {
+                        // Fallback to tag format if CBOR decode fails
+                    }
+                }
+
+                sb.append(tagNum).append("(")
+                generateItem(sb, indent, tagged.taggedItem)
+                sb.append(")")
+            }
+
+            MajorType.SPECIAL -> {
+                when (item) {
+                    is Simple -> {
+                        when (item) {
+                            Simple.TRUE -> sb.append("true")
+                            Simple.FALSE -> sb.append("false")
+                            Simple.NULL -> sb.append("null")
+                            Simple.UNDEFINED -> sb.append("undefined")
+                            else -> sb.append("simple(").append(item.value).append(")")
+                        }
+                    }
+
+                    is CborFloat -> sb.append(item.value)
+                    is CborDouble -> sb.append(item.value)
+                    else -> throw IllegalArgumentException("Unexpected MajorType.SPECIAL item")
+                }
+            }
+        }
+    }
+
+    private fun generateByteStringLiteral(sb: StringBuilder, bytes: ByteArray) {
+        when (options.byteStringFormat) {
+            ByteStringFormat.LENGTH_ONLY -> {
+                val label = if (bytes.size == 1) "1 byte" else "${bytes.size} bytes"
+                sb.append(label)
+            }
+
+            ByteStringFormat.ASCII_SINGLE_QUOTE -> {
+                if (isPrintableAscii(bytes)) {
+                    sb.append("'").append(bytes.decodeToString().replace("'", "\\'")).append("'")
+                } else {
+                    sb.append("h'").append(bytes.toHex()).append("'")
+                }
+            }
+
+            ByteStringFormat.BASE64 -> {
+                val ext = options.extensionRegistry.get("b64")
+                val formatted = ext?.format(Bstr(bytes), options)
+                if (formatted != null) {
+                    sb.append(formatted)
+                } else {
+                    sb.append("h'").append(bytes.toHex()).append("'")
+                }
+            }
+
+            ByteStringFormat.HEX -> {
+                sb.append("h'").append(bytes.toHex()).append("'")
+            }
+        }
+    }
+
+    private fun generateTextStringLiteral(sb: StringBuilder, text: String) {
+        val escaped = text
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        sb.append("\"").append(escaped).append("\"")
+    }
+
+    private fun isPrintableAscii(bytes: ByteArray): Boolean {
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            if (v !in 32..126) return false
+        }
+        return true
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnLexer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnLexer.kt
@@ -1,0 +1,398 @@
+package org.multipaz.cbor
+
+internal enum class TokenType {
+    INTEGER,
+    FLOAT,
+    STRING_DOUBLE,
+    STRING_SINGLE,
+    STRING_RAW_DOUBLE,
+    STRING_RAW_SINGLE,
+    EXTENSION_LITERAL,
+    EMBEDDED_CBOR_OPEN,  // <<
+    EMBEDDED_CBOR_CLOSE, // >>
+    LBRACKET,            // [
+    RBRACKET,            // ]
+    LBRACE,              // {
+    RBRACE,              // }
+    LPAREN,              // (
+    RPAREN,              // )
+    COLON,               // :
+    ARROW,               // =>
+    COMMA,               // ,
+    SEMICOLON,           // ;
+    INDEF_ARRAY_OPEN,    // [_
+    INDEF_MAP_OPEN,      // {_
+    INDEF_STRING_OPEN,   // (_
+    IDENTIFIER,          // true, false, null, undefined, extension id, tag number
+    EOF
+}
+
+internal data class Token(
+    val type: TokenType,
+    val text: String,
+    val line: Int,
+    val column: Int,
+    val extraData: String? = null // e.g. extension identifier or raw string contents
+)
+
+internal class CdnLexer(private val input: String) {
+    private var pos = 0
+    private var line = 1
+    private var col = 1
+
+    fun nextToken(): Token {
+        skipWhitespaceAndComments()
+
+        if (pos >= input.length) {
+            return Token(TokenType.EOF, "", line, col)
+        }
+
+        val startLine = line
+        val startCol = col
+        val ch = input[pos]
+
+        // Compound open delimiters: [_ {_ (_
+        if (ch == '[' && peek(1) == '_') {
+            advance(2)
+            return Token(TokenType.INDEF_ARRAY_OPEN, "[_", startLine, startCol)
+        }
+        if (ch == '{' && peek(1) == '_') {
+            advance(2)
+            return Token(TokenType.INDEF_MAP_OPEN, "{_", startLine, startCol)
+        }
+        if (ch == '(' && peek(1) == '_') {
+            advance(2)
+            return Token(TokenType.INDEF_STRING_OPEN, "(_", startLine, startCol)
+        }
+
+        // Embedded CBOR: << and >>
+        if (ch == '<' && peek(1) == '<') {
+            advance(2)
+            return Token(TokenType.EMBEDDED_CBOR_OPEN, "<<", startLine, startCol)
+        }
+        if (ch == '>' && peek(1) == '>') {
+            advance(2)
+            return Token(TokenType.EMBEDDED_CBOR_CLOSE, ">>", startLine, startCol)
+        }
+
+        // Arrow =>
+        if (ch == '=' && peek(1) == '>') {
+            advance(2)
+            return Token(TokenType.ARROW, "=>", startLine, startCol)
+        }
+
+        // Single character tokens
+        when (ch) {
+            '[' -> { advance(); return Token(TokenType.LBRACKET, "[", startLine, startCol) }
+            ']' -> { advance(); return Token(TokenType.RBRACKET, "]", startLine, startCol) }
+            '{' -> { advance(); return Token(TokenType.LBRACE, "{", startLine, startCol) }
+            '}' -> { advance(); return Token(TokenType.RBRACE, "}", startLine, startCol) }
+            '(' -> { advance(); return Token(TokenType.LPAREN, "(", startLine, startCol) }
+            ')' -> { advance(); return Token(TokenType.RPAREN, ")", startLine, startCol) }
+            ':' -> { advance(); return Token(TokenType.COLON, ":", startLine, startCol) }
+            ',' -> { advance(); return Token(TokenType.COMMA, ",", startLine, startCol) }
+            ';' -> { advance(); return Token(TokenType.SEMICOLON, ";", startLine, startCol) }
+        }
+
+        // Raw strings: """...""" or '''...'''
+        if (ch == '"' && peek(1) == '"' && peek(2) == '"') {
+            return readRawString(true, startLine, startCol)
+        }
+        if (ch == '\'' && peek(1) == '\'' && peek(2) == '\'') {
+            return readRawString(false, startLine, startCol)
+        }
+
+        // Double quoted text string
+        if (ch == '"') {
+            return readQuotedString('"', TokenType.STRING_DOUBLE, startLine, startCol)
+        }
+
+        // Single quoted byte string
+        if (ch == '\'') {
+            return readQuotedString('\'', TokenType.STRING_SINGLE, startLine, startCol)
+        }
+
+        // Identifiers & Application extensions: e.g., dt'...', ip'...', h'...', b64'...'
+        if (ch.isLetter() || ch == '_' || ch == '$') {
+            val id = readIdentifierName()
+            skipWhitespaceAndComments()
+            if (pos < input.length) {
+                val nextCh = input[pos]
+                if (nextCh == '"' && peek(1) == '"' && peek(2) == '"') {
+                    val rawToken = readRawString(true, startLine, startCol)
+                    return Token(TokenType.EXTENSION_LITERAL, rawToken.text, startLine, startCol, extraData = id)
+                }
+                if (nextCh == '\'' && peek(1) == '\'' && peek(2) == '\'') {
+                    val rawToken = readRawString(false, startLine, startCol)
+                    return Token(TokenType.EXTENSION_LITERAL, rawToken.text, startLine, startCol, extraData = id)
+                }
+                if (nextCh == '"') {
+                    val strToken = readQuotedString('"', TokenType.STRING_DOUBLE, startLine, startCol)
+                    return Token(TokenType.EXTENSION_LITERAL, strToken.text, startLine, startCol, extraData = id)
+                }
+                if (nextCh == '\'') {
+                    val strToken = readQuotedString('\'', TokenType.STRING_SINGLE, startLine, startCol)
+                    return Token(TokenType.EXTENSION_LITERAL, strToken.text, startLine, startCol, extraData = id)
+                }
+            }
+            return Token(TokenType.IDENTIFIER, id, startLine, startCol)
+        }
+
+        // Numbers: positive or negative, hex, octal, binary, float, Infinity, NaN
+        if (ch.isDigit() || ch == '+' || ch == '-') {
+            return readNumber(startLine, startCol)
+        }
+
+        throw CdnException("Unexpected character '$ch'", startLine, startCol)
+    }
+
+    private fun readIdentifierName(): String {
+        val sb = StringBuilder()
+        while (pos < input.length) {
+            val c = input[pos]
+            if (c.isLetterOrDigit() || c == '_' || c == '$' || c == '-') {
+                sb.append(c)
+                advance()
+            } else {
+                break
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun readQuotedString(
+        quote: Char,
+        type: TokenType,
+        startLine: Int,
+        startCol: Int
+    ): Token {
+        advance() // Consume opening quote
+        val sb = StringBuilder()
+        while (pos < input.length) {
+            val c = input[pos]
+            if (c == quote) {
+                advance() // Consume closing quote
+                return Token(type, sb.toString(), startLine, startCol)
+            }
+            if (c == '\\') {
+                advance()
+                if (pos >= input.length) {
+                    throw CdnException("Unterminated escape sequence in string", line, col)
+                }
+                val escChar = input[pos]
+                advance()
+                when (escChar) {
+                    '"' -> sb.append('"')
+                    '\'' -> sb.append('\'')
+                    '\\' -> sb.append('\\')
+                    '/' -> sb.append('/')
+                    'b' -> sb.append('\b')
+                    'f' -> sb.append('\u000C')
+                    'n' -> sb.append('\n')
+                    'r' -> sb.append('\r')
+                    't' -> sb.append('\t')
+                    'u' -> {
+                        // \uXXXX or \u{X...}
+                        if (pos < input.length && input[pos] == '{') {
+                            advance()
+                            val hexSb = StringBuilder()
+                            while (pos < input.length && input[pos] != '}') {
+                                hexSb.append(input[pos])
+                                advance()
+                            }
+                            if (pos < input.length && input[pos] == '}') {
+                                advance()
+                            }
+                            val codePoint = hexSb.toString().toIntOrNull(16)
+                                ?: throw CdnException("Invalid unicode escape: \\u{${hexSb}}", line, col)
+                            sb.appendCodePoint(codePoint)
+                        } else {
+                            if (pos + 4 > input.length) {
+                                throw CdnException("Unterminated \\u escape sequence", line, col)
+                            }
+                            val hexStr = input.substring(pos, pos + 4)
+                            advance(4)
+                            val codePoint = hexStr.toIntOrNull(16)
+                                ?: throw CdnException("Invalid unicode escape: \\u$hexStr", line, col)
+                            sb.append(codePoint.toChar())
+                        }
+                    }
+                    else -> sb.append(escChar)
+                }
+            } else {
+                sb.append(c)
+                advance()
+            }
+        }
+        throw CdnException("Unterminated string literal starting at $startLine:$startCol", line, col)
+    }
+
+    private fun readRawString(
+        isDoubleQuote: Boolean,
+        startLine: Int,
+        startCol: Int
+    ): Token {
+        advance(3) // Consume initial triple quotes
+        val sb = StringBuilder()
+        while (pos < input.length) {
+            if (input[pos] == (if (isDoubleQuote) '"' else '\'') &&
+                peek(1) == (if (isDoubleQuote) '"' else '\'') &&
+                peek(2) == (if (isDoubleQuote) '"' else '\'')
+            ) {
+                advance(3)
+                val type = if (isDoubleQuote) TokenType.STRING_RAW_DOUBLE else TokenType.STRING_RAW_SINGLE
+                return Token(type, sb.toString(), startLine, startCol)
+            }
+            sb.append(input[pos])
+            advance()
+        }
+        throw CdnException("Unterminated raw string literal starting at $startLine:$startCol", line, col)
+    }
+
+    private fun readNumber(startLine: Int, startCol: Int): Token {
+        val sb = StringBuilder()
+        if (input[pos] == '+' || input[pos] == '-') {
+            sb.append(input[pos])
+            advance()
+        }
+
+        // Check for named float literals like Infinity, -Infinity, NaN
+        if (pos < input.length && input[pos].isLetter()) {
+            val word = readIdentifierName()
+            val full = sb.toString() + word
+            if (full == "Infinity" || full == "+Infinity" || full == "-Infinity" || full == "NaN" || full == "-NaN") {
+                return Token(TokenType.FLOAT, full, startLine, startCol)
+            }
+            throw CdnException("Invalid numeric token '$full'", startLine, startCol)
+        }
+
+        // Hex / Octal / Binary prefixed numbers: 0x, 0o, 0b
+        if (pos + 1 < input.length && input[pos] == '0') {
+            val next = input[pos + 1]
+            if (next == 'x' || next == 'X' || next == 'o' || next == 'O' || next == 'b' || next == 'B') {
+                sb.append(input[pos])
+                sb.append(next)
+                advance(2)
+                while (pos < input.length && (input[pos].isLetterOrDigit() || input[pos] == '_')) {
+                    if (input[pos] != '_') {
+                        sb.append(input[pos])
+                    }
+                    advance()
+                }
+                return Token(TokenType.INTEGER, sb.toString(), startLine, startCol)
+            }
+        }
+
+        var isFloat = false
+        var hasExp = false
+        while (pos < input.length) {
+            val c = input[pos]
+            if (c.isDigit()) {
+                sb.append(c)
+                advance()
+            } else if (c == '.' && !isFloat && !hasExp) {
+                isFloat = true
+                sb.append(c)
+                advance()
+            } else if ((c == 'e' || c == 'E') && !hasExp) {
+                hasExp = true
+                isFloat = true
+                sb.append(c)
+                advance()
+                if (pos < input.length && (input[pos] == '+' || input[pos] == '-')) {
+                    sb.append(input[pos])
+                    advance()
+                }
+            } else if (c == '_') {
+                // Ignore underscores in numeric literals per CDN spec
+                advance()
+            } else {
+                break
+            }
+        }
+
+        val text = sb.toString()
+        if (text == "NaN" || text == "Infinity" || text == "-Infinity" || text == "+Infinity" || isFloat) {
+            return Token(TokenType.FLOAT, text, startLine, startCol)
+        }
+        return Token(TokenType.INTEGER, text, startLine, startCol)
+    }
+
+    private fun skipWhitespaceAndComments() {
+        while (pos < input.length) {
+            val c = input[pos]
+            if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+                advance()
+            } else if (c == '#') {
+                // Line comment starting with #
+                advance()
+                while (pos < input.length && input[pos] != '\n') {
+                    advance()
+                }
+            } else if (c == '/' && peek(1) == '/') {
+                // Line comment starting with //
+                advance(2)
+                while (pos < input.length && input[pos] != '\n') {
+                    advance()
+                }
+            } else if (c == '/' && peek(1) == '*') {
+                // Block comment starting with /*
+                advance(2)
+                while (pos < input.length) {
+                    if (input[pos] == '*' && peek(1) == '/') {
+                        advance(2)
+                        break
+                    }
+                    advance()
+                }
+            } else if (c == '/') {
+                // EDN Slash comment starting with /
+                advance()
+                while (pos < input.length) {
+                    val sc = input[pos]
+                    if (sc == '/') {
+                        advance()
+                        break
+                    }
+                    if (sc == '\\' && peek(1) == '/') {
+                        advance(2)
+                    } else {
+                        advance()
+                    }
+                }
+            } else {
+                break
+            }
+        }
+    }
+
+    private fun advance(count: Int = 1) {
+        for (i in 0 until count) {
+            if (pos < input.length) {
+                if (input[pos] == '\n') {
+                    line++
+                    col = 1
+                } else {
+                    col++
+                }
+                pos++
+            }
+        }
+    }
+
+    private fun peek(offset: Int): Char? {
+        val index = pos + offset
+        return if (index < input.length) input[index] else null
+    }
+
+    private fun StringBuilder.appendCodePoint(codePoint: Int) {
+        if (codePoint <= 0xFFFF) {
+            append(codePoint.toChar())
+        } else {
+            val high = ((codePoint - 0x10000) shr 10) + 0xD800
+            val low = ((codePoint - 0x10000) and 0x3FF) + 0xDC00
+            append(high.toChar())
+            append(low.toChar())
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnOptions.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnOptions.kt
@@ -1,0 +1,93 @@
+package org.multipaz.cbor
+
+/**
+ * Format preferred for byte strings when generating CDN text.
+ */
+enum class ByteStringFormat {
+    /** Output byte strings as hex, e.g., `h'010203'`. */
+    HEX,
+
+    /** Output byte strings as Base64, e.g., `b64'AQID'`. */
+    BASE64,
+
+    /** Output byte strings as single-quoted ASCII strings when printable, e.g., `'hello'`. */
+    ASCII_SINGLE_QUOTE,
+
+    /** Output `<N bytes>` summary instead of literal byte contents. */
+    LENGTH_ONLY
+}
+
+/**
+ * Options for CDN text generation (serializing [DataItem] to CDN string).
+ */
+data class CdnGeneratorOptions(
+    /**
+     * Whether to insert line breaks and indentation for readability.
+     */
+    val prettyPrint: Boolean = false,
+
+    /**
+     * Number of spaces per indentation level when [prettyPrint] is true.
+     */
+    val indentSize: Int = 2,
+
+    /**
+     * Preferred formatting style for byte strings.
+     */
+    val byteStringFormat: ByteStringFormat = ByteStringFormat.HEX,
+
+    /**
+     * Whether to use `<< ... >>` shorthand notation for Tag 24 encoded CBOR byte strings.
+     */
+    val useEmbeddedCborShorthand: Boolean = true,
+
+    /**
+     * Whether to format tagged items using application extension literals (e.g. `dt'...'`, `ip'...'`).
+     */
+    val useApplicationExtensions: Boolean = true,
+
+    /**
+     * Whether map keys should be sorted.
+     */
+    val sortMapKeys: Boolean = false,
+
+    /**
+     * Extension registry for formatting application extensions.
+     */
+    val extensionRegistry: CdnExtensionRegistry = CdnExtensionRegistry.Default
+) {
+    companion object {
+        /**
+         * Default CDN generator options.
+         */
+        val Default = CdnGeneratorOptions()
+
+        /**
+         * Options configured for pretty printing.
+         */
+        val Pretty = CdnGeneratorOptions(prettyPrint = true)
+    }
+}
+
+/**
+ * Options for CDN text parsing (parsing CDN text to [DataItem]).
+ */
+data class CdnParserOptions(
+    /**
+     * Extension registry for parsing application extensions.
+     */
+    val extensionRegistry: CdnExtensionRegistry = CdnExtensionRegistry.Default,
+
+    /**
+     * Maximum allowed nesting depth for compound structures (arrays/maps/tags).
+     */
+    val maxDepth: Int = 100
+) {
+    companion object {
+        /**
+         * Default CDN parser options.
+         */
+        val Default = CdnParserOptions()
+    }
+}
+

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnParser.kt
@@ -1,0 +1,265 @@
+package org.multipaz.cbor
+
+internal class CdnParser(
+    input: String,
+    private val options: CdnParserOptions = CdnParserOptions.Default
+) {
+    private val lexer = CdnLexer(input)
+    private var currentToken: Token = lexer.nextToken()
+    private var depth = 0
+
+    fun parseSingle(): DataItem {
+        if (currentToken.type == TokenType.EOF) {
+            throw CdnException("Unexpected EOF when parsing CDN data item", currentToken.line, currentToken.column)
+        }
+        val item = parseDataItem()
+        return item
+    }
+
+    fun parseSequence(): List<DataItem> {
+        val items = mutableListOf<DataItem>()
+        while (currentToken.type != TokenType.EOF) {
+            items.add(parseDataItem())
+            // Optional separator between sequence items
+            if (currentToken.type == TokenType.COMMA || currentToken.type == TokenType.SEMICOLON) {
+                advance()
+            }
+        }
+        return items
+    }
+
+    private fun parseDataItem(): DataItem {
+        if (depth > options.maxDepth) {
+            throw CdnException("Exceeded maximum nesting depth of ${options.maxDepth}", currentToken.line, currentToken.column)
+        }
+
+        val token = currentToken
+        return when (token.type) {
+            TokenType.INTEGER -> {
+                advance()
+                val text = token.text
+                val isNegative = text.startsWith("-")
+                val cleanText = if (isNegative) text.substring(1) else text
+
+                val value = when {
+                    cleanText.startsWith("0x", ignoreCase = true) -> cleanText.substring(2).toLong(16)
+                    cleanText.startsWith("0o", ignoreCase = true) -> cleanText.substring(2).toLong(8)
+                    cleanText.startsWith("0b", ignoreCase = true) -> cleanText.substring(2).toLong(2)
+                    else -> cleanText.toLong()
+                }
+
+                val item = if (isNegative) {
+                    Nint(value.toULong())
+                } else {
+                    Uint(value.toULong())
+                }
+
+                // Check for tagged value: e.g. 0("2026-07-27...") or 32("https://...")
+                if (currentToken.type == TokenType.LPAREN) {
+                    advance() // consume (
+                    depth++
+                    val taggedItem = parseDataItem()
+                    expect(TokenType.RPAREN, "Expected ')' after tagged item")
+                    depth--
+                    val tagNum = if (isNegative) -value else value
+                    Tagged(tagNum, taggedItem)
+                } else {
+                    item
+                }
+            }
+
+            TokenType.FLOAT -> {
+                advance()
+                val d = when (token.text) {
+                    "Infinity", "+Infinity" -> Double.POSITIVE_INFINITY
+                    "-Infinity" -> Double.NEGATIVE_INFINITY
+                    "NaN" -> Double.NaN
+                    else -> token.text.toDouble()
+                }
+                CborDouble(d)
+            }
+
+            TokenType.STRING_DOUBLE -> {
+                advance()
+                Tstr(token.text)
+            }
+
+            TokenType.STRING_SINGLE -> {
+                advance()
+                Bstr(token.text.encodeToByteArray())
+            }
+
+            TokenType.STRING_RAW_DOUBLE -> {
+                advance()
+                Tstr(token.text)
+            }
+
+            TokenType.STRING_RAW_SINGLE -> {
+                advance()
+                Bstr(token.text.encodeToByteArray())
+            }
+
+            TokenType.EXTENSION_LITERAL -> {
+                advance()
+                val extensionId = token.extraData
+                    ?: throw CdnException("Missing extension identifier", token.line, token.column)
+                val ext = options.extensionRegistry.get(extensionId)
+                    ?: throw CdnException("Unknown application extension '$extensionId'", token.line, token.column)
+                val delimiter = if (token.text.startsWith("\"")) '"' else '\''
+                ext.parseLiteral(token.text, delimiter)
+            }
+
+            TokenType.IDENTIFIER -> {
+                advance()
+                when (token.text) {
+                    "true" -> Simple.TRUE
+                    "false" -> Simple.FALSE
+                    "null" -> Simple.NULL
+                    "undefined" -> Simple.UNDEFINED
+                    "Infinity", "+Infinity" -> CborDouble(Double.POSITIVE_INFINITY)
+                    "-Infinity" -> CborDouble(Double.NEGATIVE_INFINITY)
+                    "NaN" -> CborDouble(Double.NaN)
+                    "simple" -> {
+                        expect(TokenType.LPAREN, "Expected '(' after 'simple'")
+                        val numToken = expect(TokenType.INTEGER, "Expected simple value integer")
+                        val simpleValue = numToken.text.toInt()
+                        expect(TokenType.RPAREN, "Expected ')' after simple value")
+                        Simple(simpleValue.toUInt())
+                    }
+                    else -> {
+                        // Identifier tag e.g. tag(value)
+                        val tagNum = token.text.toLongOrNull()
+                        if (tagNum != null && currentToken.type == TokenType.LPAREN) {
+                            advance() // consume (
+                            depth++
+                            val taggedItem = parseDataItem()
+                            expect(TokenType.RPAREN, "Expected ')' after tagged item")
+                            depth--
+                            Tagged(tagNum, taggedItem)
+                        } else {
+                            throw CdnException("Unrecognized identifier '${token.text}'", token.line, token.column)
+                        }
+                    }
+                }
+            }
+
+            TokenType.EMBEDDED_CBOR_OPEN -> {
+                advance() // consume <<
+                depth++
+                val seq = mutableListOf<DataItem>()
+                while (currentToken.type != TokenType.EMBEDDED_CBOR_CLOSE && currentToken.type != TokenType.EOF) {
+                    seq.add(parseDataItem())
+                    if (currentToken.type == TokenType.COMMA || currentToken.type == TokenType.SEMICOLON) {
+                        advance()
+                    }
+                }
+                expect(TokenType.EMBEDDED_CBOR_CLOSE, "Expected '>>' closing embedded CBOR literal")
+                depth--
+                val encodedBytes = seq.fold(byteArrayOf()) { acc, item -> acc + Cbor.encode(item) }
+                Tagged(Tagged.ENCODED_CBOR, Bstr(encodedBytes))
+            }
+
+            TokenType.LBRACKET -> parseArray(indefinite = false)
+            TokenType.INDEF_ARRAY_OPEN -> parseArray(indefinite = true)
+
+            TokenType.LBRACE -> parseMap(indefinite = false)
+            TokenType.INDEF_MAP_OPEN -> parseMap(indefinite = true)
+
+            TokenType.INDEF_STRING_OPEN -> parseIndefiniteLengthString()
+
+            else -> throw CdnException("Unexpected token '${token.text}' (${token.type})", token.line, token.column)
+        }
+    }
+
+    private fun parseArray(indefinite: Boolean): DataItem {
+        advance() // consume [ or [_
+        depth++
+        val items = mutableListOf<DataItem>()
+        while (currentToken.type != TokenType.RBRACKET && currentToken.type != TokenType.EOF) {
+            items.add(parseDataItem())
+            if (currentToken.type == TokenType.COMMA) {
+                advance()
+            } else if (currentToken.type != TokenType.RBRACKET) {
+                // Optional trailing comma or whitespace separator
+            }
+        }
+        expect(TokenType.RBRACKET, "Expected ']' closing array")
+        depth--
+        return CborArray(items, indefiniteLength = indefinite)
+    }
+
+    private fun parseMap(indefinite: Boolean): DataItem {
+        advance() // consume { or {_
+        depth++
+        val mapItems = LinkedHashMap<DataItem, DataItem>()
+        while (currentToken.type != TokenType.RBRACE && currentToken.type != TokenType.EOF) {
+            val key = parseDataItem()
+            if (currentToken.type == TokenType.COLON || currentToken.type == TokenType.ARROW) {
+                advance()
+            } else {
+                throw CdnException("Expected ':' or '=>' after map key", currentToken.line, currentToken.column)
+            }
+            val value = parseDataItem()
+            mapItems[key] = value
+
+            if (currentToken.type == TokenType.COMMA) {
+                advance()
+            } else if (currentToken.type != TokenType.RBRACE) {
+                // Optional trailing comma
+            }
+        }
+        expect(TokenType.RBRACE, "Expected '}' closing map")
+        depth--
+        return CborMap(mapItems, indefiniteLength = indefinite)
+    }
+
+    private fun parseIndefiniteLengthString(): DataItem {
+        advance() // consume (_
+        depth++
+        val chunks = mutableListOf<DataItem>()
+        var isByteString = false
+        var isTextString = false
+
+        while (currentToken.type != TokenType.RPAREN && currentToken.type != TokenType.EOF) {
+            val chunk = parseDataItem()
+            if (chunk is Bstr) {
+                isByteString = true
+                chunks.add(chunk)
+            } else if (chunk is Tstr) {
+                isTextString = true
+                chunks.add(chunk)
+            } else {
+                throw CdnException("Indefinite-length string chunk must be a string", currentToken.line, currentToken.column)
+            }
+
+            if (currentToken.type == TokenType.COMMA) {
+                advance()
+            }
+        }
+        expect(TokenType.RPAREN, "Expected ')' closing indefinite string")
+        depth--
+
+        return if (isByteString && !isTextString) {
+            val bstrChunks = chunks.map { (it as Bstr).value }
+            IndefLengthBstr(bstrChunks)
+        } else if (isTextString && !isByteString) {
+            val tstrChunks = chunks.map { (it as Tstr).value }
+            IndefLengthTstr(tstrChunks)
+        } else {
+            throw CdnException("Indefinite string cannot mix text and byte string chunks", currentToken.line, currentToken.column)
+        }
+    }
+
+    private fun expect(type: TokenType, errorMessage: String): Token {
+        if (currentToken.type != type) {
+            throw CdnException("$errorMessage (found '${currentToken.text}')", currentToken.line, currentToken.column)
+        }
+        val token = currentToken
+        advance()
+        return token
+    }
+
+    private fun advance() {
+        currentToken = lexer.nextToken()
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -17,7 +17,8 @@ package org.multipaz.util
 
 import kotlinx.coroutines.CancellationException
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import kotlin.time.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -241,51 +242,73 @@ object Logger {
         hex(Level.ERROR, tag, message, data)
     }
 
-    private fun cbor(level: Level, tag: String, message: String, encodedCbor: ByteArray) {
-        val sb = "$message: ${encodedCbor.size} bytes of CBOR: " + encodedCbor.toHex() +
+    private fun cbor(
+        level: Level,
+        tag: String,
+        message: String,
+        encodedCbor: ByteArray? = null,
+        dataItem: DataItem? = null
+    ) {
+        val bytes = encodedCbor ?: Cbor.encode(dataItem!!)
+        val cdnString = try {
+            if (dataItem != null) {
+                Cdn.encode(dataItem, CdnGeneratorOptions.Pretty)
+            } else {
+                Cdn.encode(bytes, CdnGeneratorOptions.Pretty)
+            }
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            if (encodedCbor != null) {
+                printLine(
+                    Level.WARNING,
+                    tag,
+                    "$message: ${encodedCbor.size} bytes of invalid CBOR: ${encodedCbor.toHex()}",
+                    e
+                )
+            }
+            throw e
+        }
+        val sb = "$message: ${bytes.size} bytes of CBOR: " + bytes.toHex() +
                 "\n" +
                 "In diagnostic notation:\n" +
-                Cbor.toDiagnostics(
-                    encodedCbor,
-                    setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR)
-                )
+                cdnString
         printLine(level, tag, sb, null)
     }
 
     fun dCbor(tag: String, message: String, encodedCbor: ByteArray) {
         if (isDebugEnabled) {
-            cbor(Level.DEBUG, tag, message, encodedCbor)
+            cbor(Level.DEBUG, tag, message, encodedCbor = encodedCbor)
         }
     }
 
     fun iCbor(tag: String, message: String, encodedCbor: ByteArray) {
-        cbor(Level.INFO, tag, message, encodedCbor)
+        cbor(Level.INFO, tag, message, encodedCbor = encodedCbor)
     }
 
     fun wCbor(tag: String, message: String, encodedCbor: ByteArray) {
-        cbor(Level.WARNING, tag, message, encodedCbor)
+        cbor(Level.WARNING, tag, message, encodedCbor = encodedCbor)
     }
 
     fun eCbor(tag: String, message: String, encodedCbor: ByteArray) {
-        cbor(Level.ERROR, tag, message, encodedCbor)
+        cbor(Level.ERROR, tag, message, encodedCbor = encodedCbor)
     }
 
     fun dCbor(tag: String, message: String, dataItem: DataItem) {
         if (isDebugEnabled) {
-            cbor(Level.DEBUG, tag, message, Cbor.encode(dataItem))
+            cbor(Level.DEBUG, tag, message, dataItem = dataItem)
         }
     }
 
     fun iCbor(tag: String, message: String, dataItem: DataItem) {
-        cbor(Level.INFO, tag, message, Cbor.encode(dataItem))
+        cbor(Level.INFO, tag, message, dataItem = dataItem)
     }
 
     fun wCbor(tag: String, message: String, dataItem: DataItem) {
-        cbor(Level.WARNING, tag, message, Cbor.encode(dataItem))
+        cbor(Level.WARNING, tag, message, dataItem = dataItem)
     }
 
     fun eCbor(tag: String, message: String, dataItem: DataItem) {
-        cbor(Level.ERROR, tag, message, Cbor.encode(dataItem))
+        cbor(Level.ERROR, tag, message, dataItem = dataItem)
     }
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
@@ -1,0 +1,258 @@
+package org.multipaz.cbor
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CdnTests {
+
+    @Test
+    fun testIntegers() {
+        assertEquals(Uint(12345UL), Cdn.parse("12345"))
+        assertEquals(Nint(12345UL), Cdn.parse("-12345"))
+        assertEquals(Uint(0UL), Cdn.parse("0"))
+        assertEquals(Uint(255UL), Cdn.parse("0xff"))
+        assertEquals(Uint(511UL), Cdn.parse("0o777"))
+        assertEquals(Uint(10UL), Cdn.parse("0b1010"))
+
+        assertEquals("12345", Cdn.encode(Uint(12345UL)))
+        assertEquals("-12345", Cdn.encode(Nint(12345UL)))
+    }
+
+    @Test
+    fun testFloats() {
+        assertEquals(CborDouble(3.14159), Cdn.parse("3.14159"))
+        assertEquals(CborDouble(-0.5), Cdn.parse("-0.5"))
+        assertEquals(CborDouble(Double.POSITIVE_INFINITY), Cdn.parse("Infinity"))
+        assertEquals(CborDouble(Double.NEGATIVE_INFINITY), Cdn.parse("-Infinity"))
+
+        val nanParsed = Cdn.parse("NaN")
+        assertTrue(nanParsed is CborDouble && nanParsed.value.isNaN())
+    }
+
+    @Test
+    fun testSimpleValues() {
+        assertEquals(Simple.TRUE, Cdn.parse("true"))
+        assertEquals(Simple.FALSE, Cdn.parse("false"))
+        assertEquals(Simple.NULL, Cdn.parse("null"))
+        assertEquals(Simple.UNDEFINED, Cdn.parse("undefined"))
+        assertEquals(Simple(23U), Cdn.parse("simple(23)"))
+
+        assertEquals("true", Cdn.encode(Simple.TRUE))
+        assertEquals("false", Cdn.encode(Simple.FALSE))
+        assertEquals("null", Cdn.encode(Simple.NULL))
+        assertEquals("undefined", Cdn.encode(Simple.UNDEFINED))
+    }
+
+    @Test
+    fun testTextStrings() {
+        assertEquals(Tstr("hello world"), Cdn.parse("\"hello world\""))
+        assertEquals(Tstr("hello\nworld"), Cdn.parse("\"hello\\nworld\""))
+        assertEquals(Tstr("A"), Cdn.parse("\"\\u0041\""))
+        assertEquals(Tstr("multi\nline"), Cdn.parse("\"\"\"multi\nline\"\"\""))
+
+        assertEquals("\"hello world\"", Cdn.encode(Tstr("hello world")))
+    }
+
+    @Test
+    fun testByteStrings() {
+        assertEquals(Bstr(byteArrayOf(0x01, 0x02, 0x03, 0x04)), Cdn.parse("h'01020304'"))
+        assertEquals(Bstr(byteArrayOf(0x01, 0x02, 0x03, 0x04)), Cdn.parse("b64'AQIDBA=='"))
+        assertEquals(Bstr("hello".encodeToByteArray()), Cdn.parse("'hello'"))
+        assertEquals(Bstr("raw bytes".encodeToByteArray()), Cdn.parse("'''raw bytes'''"))
+
+        val bstr = Bstr(byteArrayOf(0x01, 0x02))
+        assertEquals("h'0102'", Cdn.encode(bstr, CdnGeneratorOptions(byteStringFormat = ByteStringFormat.HEX)))
+        val encodedB64 = Cdn.encode(bstr, CdnGeneratorOptions(byteStringFormat = ByteStringFormat.BASE64))
+        assertTrue(encodedB64.startsWith("b64'AQI"))
+    }
+
+    @Test
+    fun testArrays() {
+        val expected = CborArray.builder().add(1).add(2).add(3).end().build()
+        assertEquals(expected, Cdn.parse("[1, 2, 3]"))
+
+        val indefExpected = CborArray(mutableListOf<DataItem>(Uint(1UL), Uint(2UL)), indefiniteLength = true)
+        assertEquals(indefExpected, Cdn.parse("[_ 1, 2]"))
+
+        assertEquals("[1, 2, 3]", Cdn.encode(expected))
+        assertEquals("[_ 1, 2]", Cdn.encode(indefExpected))
+    }
+
+    @Test
+    fun testMaps() {
+        val expected = CborMap.builder().put("key", "value").put(1, 2).end().build()
+        assertEquals(expected, Cdn.parse("{\"key\": \"value\", 1: 2}"))
+        assertEquals(expected, Cdn.parse("{\"key\" => \"value\", 1 => 2}"))
+
+        val indefExpected = CborMap(mutableMapOf<DataItem, DataItem>(Tstr("a") to Uint(1UL)), indefiniteLength = true)
+        assertEquals(indefExpected, Cdn.parse("{_ \"a\": 1}"))
+    }
+
+    @Test
+    fun testIndefiniteLengthStrings() {
+        val parsedBstr = Cdn.parse("(_ h'0102', h'0304')")
+        assertTrue(parsedBstr is IndefLengthBstr)
+        assertEquals(2, parsedBstr.chunks.size)
+        assertContentEquals(byteArrayOf(1, 2), parsedBstr.chunks[0])
+        assertContentEquals(byteArrayOf(3, 4), parsedBstr.chunks[1])
+
+        val tstrIndef = IndefLengthTstr(listOf("hello ", "world"))
+        assertEquals(tstrIndef, Cdn.parse("(_ \"hello \", \"world\")"))
+    }
+
+    @Test
+    fun testTaggedAndEmbeddedCbor() {
+        val tagged = Tagged(32L, Tstr("https://example.com"))
+        assertEquals(tagged, Cdn.parse("32(\"https://example.com\")"))
+
+        val embeddedCbor = Cdn.parse("<< 1234 >>")
+        assertTrue(embeddedCbor is Tagged && embeddedCbor.tagNumber == Tagged.ENCODED_CBOR)
+        assertEquals(Uint(1234UL), Cbor.decode((embeddedCbor.taggedItem as Bstr).value))
+
+        assertEquals("<< 1234 >>", Cdn.encode(embeddedCbor))
+    }
+
+    @Test
+    fun testComments() {
+        val cdnWithComments = """
+            // This is a line comment
+            {
+                /* block comment */
+                "foo": /* inside map */ "bar" // trailing comment
+            }
+        """.trimIndent()
+
+        val parsed = Cdn.parse(cdnWithComments)
+        assertEquals(CborMap.builder().put("foo", "bar").end().build(), parsed)
+    }
+
+    @Test
+    fun testApplicationExtensions() {
+        val dtParsed = Cdn.parse("dt'2026-07-27T16:00:00Z'")
+        assertEquals(Tagged(Tagged.DATE_TIME_STRING, Tstr("2026-07-27T16:00:00Z")), dtParsed)
+
+        val ipv4Parsed = Cdn.parse("ip'192.168.1.1'")
+        assertEquals(Tagged(52L, Bstr(byteArrayOf(192.toByte(), 168.toByte(), 1, 1))), ipv4Parsed)
+
+        val ipv6Parsed = Cdn.parse("ip'2001:db8::1'")
+        assertTrue(ipv6Parsed is Tagged && ipv6Parsed.tagNumber == 54L)
+
+        assertEquals("dt'2026-07-27T16:00:00Z'", Cdn.encode(dtParsed))
+        assertEquals("ip'192.168.1.1'", Cdn.encode(ipv4Parsed))
+    }
+
+    @Test
+    fun testSequenceParsing() {
+        val seqText = "1, 2, \"hello\", true"
+        val sequence = Cdn.parseSequence(seqText)
+        assertEquals(4, sequence.size)
+        assertEquals(Uint(1UL), sequence[0])
+        assertEquals(Uint(2UL), sequence[1])
+        assertEquals(Tstr("hello"), sequence[2])
+        assertEquals(Simple.TRUE, sequence[3])
+    }
+
+    @Test
+    fun testPrettyPrintOptions() {
+        val map = CborMap.builder().put("a", 1).put("b", 2).end().build()
+        val prettyCdn = Cdn.encode(map, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyCdn.contains("\n"))
+        assertTrue(prettyCdn.contains("  \"a\": 1"))
+    }
+
+    @Test
+    fun testSyntaxErrors() {
+        val ex = assertFailsWith<CdnException> {
+            Cdn.parse("{ invalid json }")
+        }
+        assertTrue(ex.message!!.contains("CDN parse error"))
+    }
+
+    @Test
+    fun testLoggerInvalidCbor() {
+        val invalidCborBytes = byteArrayOf(0xff.toByte(), 0xfe.toByte())
+        assertFailsWith<Throwable> {
+            org.multipaz.util.Logger.iCbor("TestTag", "Testing invalid CBOR", invalidCborBytes)
+        }
+    }
+
+    @Test
+    fun testCustomExtensionRegistryPassing() {
+        val customRegistry = CdnExtensionRegistry()
+        customRegistry.register(object : CdnExtension {
+            override val identifier: String = "custom"
+            override fun parseLiteral(content: String, delimiter: Char): DataItem {
+                return Tstr("CUSTOM:$content")
+            }
+            override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+                if (item is Tstr && item.value.startsWith("CUSTOM:")) {
+                    return "custom'${item.value.removePrefix("CUSTOM:")}'"
+                }
+                return null
+            }
+        })
+
+        val item = Cdn.parse("custom'hello'", customRegistry)
+        assertEquals(Tstr("CUSTOM:hello"), item)
+        val formatted = Cdn.encode(item, customRegistry)
+        assertEquals("custom'hello'", formatted)
+    }
+
+    @Test
+    fun testFloatExponentAndEmbeddedSequence() {
+        val floatItem = Cdn.parse("1.5e-3")
+        assertTrue(floatItem is CborDouble)
+        assertEquals(0.0015, (floatItem as CborDouble).value, 1e-9)
+
+        val embeddedSeq = Cdn.parse("<< 10, 20 >>")
+        assertTrue(embeddedSeq is Tagged && embeddedSeq.tagNumber == 24L)
+        val bytes = (embeddedSeq.taggedItem as Bstr).value
+        val (offset1, decoded1) = Cbor.decode(bytes, 0)
+        val (_, decoded2) = Cbor.decode(bytes, offset1)
+        assertEquals(Uint(10UL), decoded1)
+        assertEquals(Uint(20UL), decoded2)
+    }
+
+    @Test
+    fun testUserCoseKeySnippetWithSlashAndHashComments() {
+        val snippet = """
+            {
+             /kty/ 1 : 4, # Symmetric
+             /alg/ 3 : 5, # HMAC 256-256
+              /k/ -1 : h'6684523ab17337f173500e5728c628547cb37df
+                         e68449c65f885d1b73b49eae1'
+            }
+        """.trimIndent()
+        val item = Cdn.parse(snippet)
+        assertTrue(item is CborMap)
+        val map = item as CborMap
+        assertEquals(Uint(4UL), map[Uint(1UL)])
+        assertEquals(Uint(5UL), map[Uint(3UL)])
+        assertTrue(map[Nint(1UL)] is Bstr)
+        val kBytes = (map[Nint(1UL)] as Bstr).value
+        assertEquals(32, kBytes.size)
+    }
+
+    @Test
+    fun testRoundtrip() {
+        val items = listOf(
+            Uint(42UL),
+            Nint(99UL),
+            CborDouble(12.34),
+            Tstr("roundtrip test"),
+            Bstr(byteArrayOf(0x0a, 0x0b, 0x0c)),
+            CborArray.builder().add("element").add(true).end().build(),
+            CborMap.builder().put("x", 10).put("y", 20).end().build(),
+            Tagged(0L, Tstr("2026-07-27T16:00:00Z"))
+        )
+
+        for (item in items) {
+            val cdnStr = Cdn.encode(item)
+            val decodedItem = Cdn.parse(cdnStr)
+            assertEquals(item, decodedItem, "Roundtrip failed for item: $item")
+        }
+    }
+}


### PR DESCRIPTION
Implement Concise Diagnostic Notation (CDN) support as defined in [draft-ietf-cbor-edn-literals](https://cbor-wg.github.io/edn/draft-ietf-cbor-edn-literals.html).

Key features:
- Lexer & Parser (CdnLexer, CdnParser): Full support for CDN tokens, integers (dec, hex, octal, binary, underscores), floats (scientific exponents, NaN, Infinity), text/byte strings (double/single quotes, raw multiline triple-quotes, hex h'...', base64 b64'...'), embedded CBOR (<< ... >> sequences), indefinite-length arrays/maps/strings, tags, comments (slash comments / ... /, hash comments # ..., line comments //, block comments /* ... */).
- Generator (CdnGenerator): Serializes DataItem to CDN string with formatting options (pretty printing, key sorting, byte string format choices).
- Application Extensions (CdnExtension): Extensible registry supporting dt'...' (Tag 0), ip'...' (Tag 54), float'...' (Tag 35), b1'...' (Tag 1001), h'...' and b64'...' byte strings.
- Logger Integration: Updated Logger.cbor() to format CBOR data using Cdn.encode, with optimized handling to avoid redundant encode/decode operations when DataItem or ByteArray are provided, and logging a warning with size & hex bytes if invalid CBOR is encountered.
- Web Frontend: Updated CborDecoderComponent and Main.kt to support bi-directional CBOR decoding/encoding, formatting option controls, file chooser ("Load data"), and renamed tab to "CBOR and CDN".
- Unit Tests: Added comprehensive test suite in CdnTests.kt covering CDN literals, extensions, sequences, embedded CBOR, COSE key snippets, syntax errors, and invalid CBOR logging.

Fixes #1848.

Test: Unit tests and tools.multipaz.org.
