### PR TITLE
Have NfcTagReaderUsb stop scanning when completed or card is removed.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
@@ -80,7 +80,9 @@ internal class NfcTagReaderUsb(
                                 try {
                                     val funcResult = tagInteractionFunc(tag)
                                     if (funcResult != null) {
-                                        continuation.resume(funcResult)
+                                        if (continuation.isActive) {
+                                            continuation.resume(funcResult)
+                                        }
                                     }
                                 } catch (e: NfcTagLostException) {
                                     // This is to properly handle emulated tags - such as on Android - which may be showing
@@ -88,7 +90,9 @@ internal class NfcTagReaderUsb(
                                     Logger.w(TAG, "Tag lost", e)
                                 } catch (e: Exception) {
                                     if (e is CancellationException) throw e
-                                    continuation.resumeWithException(e)
+                                    if (continuation.isActive) {
+                                        continuation.resumeWithException(e)
+                                    }
                                 }
                                 readJob = null
                             }
@@ -97,6 +101,8 @@ internal class NfcTagReaderUsb(
 
                     override fun onCardRemoved() {
                         Logger.i(TAG, "Card removed")
+                        readJob?.cancel()
+                        readJob = null
                     }
                 }
 
@@ -121,6 +127,8 @@ internal class NfcTagReaderUsb(
             if (e is CancellationException) throw e
             driver.disconnect()
             throw e
+        } finally {
+            driver.setListener(null)
         }
     }
 }


### PR DESCRIPTION
- Unregister CcidDriverListener when scan completes (in finally block of scan()) so background CCID interrupt events do not attempt to resume an already completed continuation if the tag is re-entered into the NFC field.
- Cancel readJob on card removal in CcidDriverListener.
- Add defensive continuation.isActive checks before calling continuation.resume() or continuation.resumeWithException().

Fixes #1851.

Test: Manually tested by tapping a device on an external NFC reader and then entering/removing the field while the consent prompt was active.
