### PR TITLE
multipaz-tools: Add URL hash payload deep-linking and file load buttons.

### DIFF
--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/AnnexCParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/AnnexCParserComponent.kt
@@ -40,7 +40,14 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 import kotlin.random.Random
 
@@ -124,6 +131,96 @@ val AnnexCParserComponent: FC<Props> = FC {
 
     var copyRespHexStatus by useState("")
     var copyEncPayloadHexStatus by useState("")
+
+    fun parseInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val jsonObj = Json.parseToJsonElement(cleanInput).jsonObject
+                if (mode == "request") {
+                    val devReqB64 = jsonObj["deviceRequest"]?.jsonPrimitive?.content
+                        ?: error("Missing 'deviceRequest' field in JSON")
+                    val encInfoB64 = jsonObj["encryptionInfo"]?.jsonPrimitive?.content
+                        ?: error("Missing 'encryptionInfo' field in JSON")
+
+                    val devReqBytes = devReqB64.fromBase64Url()
+                    val devReqDataItem = Cbor.decode(devReqBytes)
+                    val devReq = DeviceRequest.fromDataItem(devReqDataItem)
+
+                    val encInfoBytes = encInfoB64.fromBase64Url()
+                    val encInfoDataItem = Cbor.decode(encInfoBytes)
+
+                    var nonceHex: String? = null
+                    var recipientPublicKeyPem: String? = null
+                    var recipientPublicKeyCurve: String? = null
+
+                    try {
+                        val paramsMap = encInfoDataItem.asArray[1].asMap
+                        paramsMap[Tstr("nonce")]?.let {
+                            nonceHex = it.asBstr.toHex()
+                        }
+                        paramsMap[Tstr("recipientPublicKey")]?.let { coseKeyItem ->
+                            val ecPublicKey = coseKeyItem.asCoseKey.ecPublicKey
+                            recipientPublicKeyPem = ecPublicKey.toPem()
+                            recipientPublicKeyCurve = ecPublicKey.curve.name
+                        }
+                    } catch (e: Throwable) {
+                        // optional field extraction fallback
+                    }
+
+                    parsedRequest = ParsedRequestData(
+                        deviceRequest = devReq,
+                        devReqHex = devReqBytes.toHex(),
+                        devReqDataItem = devReqDataItem,
+                        encryptionInfoDataItem = encInfoDataItem,
+                        encInfoHex = encInfoBytes.toHex(),
+                        nonceHex = nonceHex,
+                        recipientPublicKeyPem = recipientPublicKeyPem,
+                        recipientPublicKeyCurve = recipientPublicKeyCurve
+                    )
+                    parseError = ""
+                    updateUrlHashPayload(cleanInput)
+                } else {
+                    val respB64 = jsonObj["response"]?.jsonPrimitive?.content
+                        ?: error("Missing 'response' field in JSON")
+
+                    val respBytes = respB64.fromBase64Url()
+                    val respDataItem = Cbor.decode(respBytes)
+
+                    var encryptedPayloadHex: String? = null
+                    try {
+                        val paramsMap = respDataItem.asArray[1].asMap
+                        paramsMap[Tstr("enc")]?.let {
+                            encryptedPayloadHex = it.asBstr.toHex()
+                        }
+                    } catch (e: Throwable) {
+                        // optional payload extraction fallback
+                    }
+
+                    parsedResponse = ParsedResponseData(
+                        responseDataItem = respDataItem,
+                        responseHex = respBytes.toHex(),
+                        encryptedPayloadHex = encryptedPayloadHex
+                    )
+                    parseError = ""
+                    updateUrlHashPayload(cleanInput)
+                }
+            } catch (e: Throwable) {
+                parseError = "Error parsing W3C Digital Credentials JSON: " + (e.message ?: "Invalid JSON / Base64Url / CBOR structure")
+                parsedRequest = null
+                parsedResponse = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseInput(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -232,6 +329,8 @@ val AnnexCParserComponent: FC<Props> = FC {
                     parsedRequest = null
                     parsedResponse = null
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Decode Another"
             }
@@ -251,14 +350,59 @@ val AnnexCParserComponent: FC<Props> = FC {
                 }
             }
         } else {
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +if (mode == "request") "Paste W3C Digital Credentials Request JSON:" else "Paste W3C Digital Credentials Response JSON:"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +if (mode == "request") "Paste W3C Digital Credentials Request JSON:" else "Paste W3C Digital Credentials Response JSON:"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".json,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    rawInput = text.trim()
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             div {
@@ -335,81 +479,7 @@ val AnnexCParserComponent: FC<Props> = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val jsonObj = Json.parseToJsonElement(rawInput.trim()).jsonObject
-                            if (mode == "request") {
-                                val devReqB64 = jsonObj["deviceRequest"]?.jsonPrimitive?.content
-                                    ?: error("Missing 'deviceRequest' field in JSON")
-                                val encInfoB64 = jsonObj["encryptionInfo"]?.jsonPrimitive?.content
-                                    ?: error("Missing 'encryptionInfo' field in JSON")
-
-                                val devReqBytes = devReqB64.fromBase64Url()
-                                val devReqDataItem = Cbor.decode(devReqBytes)
-                                val devReq = DeviceRequest.fromDataItem(devReqDataItem)
-
-                                val encInfoBytes = encInfoB64.fromBase64Url()
-                                val encInfoDataItem = Cbor.decode(encInfoBytes)
-
-                                var nonceHex: String? = null
-                                var recipientPublicKeyPem: String? = null
-                                var recipientPublicKeyCurve: String? = null
-
-                                try {
-                                    val paramsMap = encInfoDataItem.asArray[1].asMap
-                                    paramsMap[Tstr("nonce")]?.let {
-                                        nonceHex = it.asBstr.toHex()
-                                    }
-                                    paramsMap[Tstr("recipientPublicKey")]?.let { coseKeyItem ->
-                                        val ecPublicKey = coseKeyItem.asCoseKey.ecPublicKey
-                                        recipientPublicKeyPem = ecPublicKey.toPem()
-                                        recipientPublicKeyCurve = ecPublicKey.curve.name
-                                    }
-                                } catch (e: Throwable) {
-                                    // optional field extraction fallback
-                                }
-
-                                parsedRequest = ParsedRequestData(
-                                    deviceRequest = devReq,
-                                    devReqHex = devReqBytes.toHex(),
-                                    devReqDataItem = devReqDataItem,
-                                    encryptionInfoDataItem = encInfoDataItem,
-                                    encInfoHex = encInfoBytes.toHex(),
-                                    nonceHex = nonceHex,
-                                    recipientPublicKeyPem = recipientPublicKeyPem,
-                                    recipientPublicKeyCurve = recipientPublicKeyCurve
-                                )
-                                parseError = ""
-                            } else {
-                                val respB64 = jsonObj["response"]?.jsonPrimitive?.content
-                                    ?: error("Missing 'response' field in JSON")
-
-                                val respBytes = respB64.fromBase64Url()
-                                val respDataItem = Cbor.decode(respBytes)
-
-                                var encryptedPayloadHex: String? = null
-                                try {
-                                    val paramsMap = respDataItem.asArray[1].asMap
-                                    paramsMap[Tstr("enc")]?.let {
-                                        encryptedPayloadHex = it.asBstr.toHex()
-                                    }
-                                } catch (e: Throwable) {
-                                    // optional payload extraction fallback
-                                }
-
-                                parsedResponse = ParsedResponseData(
-                                    responseDataItem = respDataItem,
-                                    responseHex = respBytes.toHex(),
-                                    encryptedPayloadHex = encryptedPayloadHex
-                                )
-                                parseError = ""
-                            }
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing W3C Digital Credentials JSON: " + (e.message ?: "Invalid JSON / Base64Url / CBOR structure")
-                            parsedRequest = null
-                            parsedResponse = null
-                        }
-                    }
+                    parseInput(rawInput)
                 }
                 +if (mode == "request") "Decode Request JSON" else "Decode Response JSON"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Asn1DecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Asn1DecoderComponent.kt
@@ -10,7 +10,15 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.pre
 import react.dom.html.ReactHTML.code
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.util.toHex
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 import kotlinx.browser.window
 import org.multipaz.asn1.ASN1
@@ -19,6 +27,35 @@ val Asn1DecoderComponent = FC {
     var rawInput by useState("")
     var outputText by useState("")
     var copyStatus by useState("")
+
+    fun decodeInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        try {
+            val bytes = decodeInputToBytes(cleanInput)
+            if (bytes.isEmpty()) {
+                outputText = "Input is empty"
+            } else {
+                val objects = ASN1.decodeMultiple(bytes)
+                if (objects.isEmpty()) {
+                    outputText = "No ASN.1 objects decoded."
+                } else {
+                    outputText = objects.joinToString("\n") { ASN1.print(it) }
+                    updateUrlHashPayload(cleanInput)
+                }
+            }
+        } catch (e: Exception) {
+            outputText = "Error decoding: " + (e.message ?: "Unknown decoding error")
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            decodeInput(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -46,14 +83,64 @@ val Asn1DecoderComponent = FC {
             +"Decode raw ASN.1 DER bytes (represented as Hex or Base64 / Base64Url) to a human-readable structure tree."
         }
 
-        label {
+        div {
             css {
-                display = Display.block
-                fontWeight = FontWeight.normal
+                display = Display.flex
+                justifyContent = JustifyContent.spaceBetween
+                alignItems = AlignItems.center
                 marginBottom = 8.px
-                color = Color("#cbd5e1")
             }
-            +"ASN.1 Raw Data (Hex, Base64 or Base64Url):"
+
+            label {
+                css {
+                    fontWeight = FontWeight.normal
+                    color = Color("#cbd5e1")
+                }
+                +"ASN.1 Raw Data (Hex, Base64 or Base64Url):"
+            }
+
+            label {
+                css {
+                    background = Color("#334155")
+                    border = None.none
+                    color = Color("#f1f5f9")
+                    padding = Padding(4.px, 12.px)
+                    borderRadius = 6.px
+                    cursor = Cursor.pointer
+                    fontSize = 13.px
+                    fontWeight = FontWeight.normal
+                    hover {
+                        background = Color("#475569")
+                    }
+                }
+                +"📁 Load data"
+                input {
+                    type = "file".unsafeCast<InputType>()
+                    accept = ".asn1,.der,.bin,.hex,.txt,*/*"
+                    css {
+                        display = None.none
+                    }
+                    onChange = { event ->
+                        val fileList = event.target.asDynamic().files
+                        if (fileList != null && fileList.length > 0) {
+                            val file = fileList[0].unsafeCast<File>()
+                            val reader = FileReader()
+                            reader.asDynamic().onload = {
+                                val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                val bytes = Int8Array(arrayBuffer).toByteArray()
+                                val text = bytes.decodeToString()
+                                if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                    rawInput = text.trim()
+                                } else {
+                                    rawInput = bytes.toHex()
+                                }
+                                outputText = ""
+                            }
+                            reader.readAsArrayBuffer(file)
+                        }
+                    }
+                }
+            }
         }
 
         textarea {
@@ -99,21 +186,7 @@ val Asn1DecoderComponent = FC {
             }
             disabled = rawInput.trim().isEmpty()
             onClick = {
-                try {
-                    val bytes = decodeInputToBytes(rawInput)
-                    if (bytes.isEmpty()) {
-                        outputText = "Input is empty"
-                    } else {
-                        val objects = ASN1.decodeMultiple(bytes)
-                        if (objects.isEmpty()) {
-                            outputText = "No ASN.1 objects decoded."
-                        } else {
-                            outputText = objects.joinToString("\n") { ASN1.print(it) }
-                        }
-                    }
-                } catch (e: Exception) {
-                    outputText = "Error decoding: " + (e.message ?: "Unknown decoding error")
-                }
+                decodeInput(rawInput)
             }
             +"Decode ASN.1"
         }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
@@ -14,6 +14,7 @@ import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.select
 import react.dom.html.ReactHTML.option
 import react.useState
+import react.useEffectOnce
 import web.cssom.*
 import web.file.File
 import web.file.FileReader
@@ -42,6 +43,52 @@ val CborDecoderComponent = FC {
     var copyStatus by useState("")
     var copyHexStatus by useState("")
     var copyB64Status by useState("")
+
+    fun processInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        if (mode == "decode") {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                if (bytes.isEmpty()) {
+                    outputDiagnostics = "Input is empty"
+                } else {
+                    val options = CdnGeneratorOptions(
+                        prettyPrint = prettyPrint,
+                        useEmbeddedCborShorthand = decodeEmbeddedCbor,
+                        useApplicationExtensions = useAppExtensions,
+                        sortMapKeys = sortKeys,
+                        byteStringFormat = bstrFormat
+                    )
+                    outputDiagnostics = Cdn.encode(bytes, options)
+                    updateUrlHashPayload(cleanInput)
+                }
+            } catch (e: Exception) {
+                outputDiagnostics = "Error decoding: " + (e.message ?: "Unknown decoding error")
+            }
+        } else {
+            try {
+                val item = Cdn.parse(cleanInput)
+                val encodedBytes = Cbor.encode(item)
+                outputHex = encodedBytes.toHex()
+                outputB64Url = encodedBytes.toBase64Url()
+                outputDiagnostics = ""
+                updateUrlHashPayload(cleanInput)
+            } catch (e: Exception) {
+                outputDiagnostics = "Error parsing CDN: " + (e.message ?: "Unknown syntax error")
+                outputHex = ""
+                outputB64Url = ""
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            processInput(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -345,23 +392,7 @@ val CborDecoderComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    try {
-                        val bytes = decodeInputToBytes(rawInput)
-                        if (bytes.isEmpty()) {
-                            outputDiagnostics = "Input is empty"
-                        } else {
-                            val options = CdnGeneratorOptions(
-                                prettyPrint = prettyPrint,
-                                useEmbeddedCborShorthand = decodeEmbeddedCbor,
-                                useApplicationExtensions = useAppExtensions,
-                                sortMapKeys = sortKeys,
-                                byteStringFormat = bstrFormat
-                            )
-                            outputDiagnostics = Cdn.encode(bytes, options)
-                        }
-                    } catch (e: Exception) {
-                        outputDiagnostics = "Error decoding: " + (e.message ?: "Unknown decoding error")
-                    }
+                    processInput(rawInput)
                 }
                 +"Decode to CDN"
             }
@@ -535,17 +566,7 @@ val CborDecoderComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    try {
-                        val item = Cdn.parse(rawInput)
-                        val encodedBytes = Cbor.encode(item)
-                        outputHex = encodedBytes.toHex()
-                        outputB64Url = encodedBytes.toBase64Url()
-                        outputDiagnostics = ""
-                    } catch (e: Exception) {
-                        outputDiagnostics = "Error parsing CDN: " + (e.message ?: "Unknown syntax error")
-                        outputHex = ""
-                        outputB64Url = ""
-                    }
+                    processInput(rawInput)
                 }
                 +"Encode to CBOR"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CompressionComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CompressionComponent.kt
@@ -10,7 +10,13 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.select
 import react.dom.html.ReactHTML.option
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import web.file.File
+import web.file.FileReader
 import web.cssom.*
 import web.html.InputType
 import kotlinx.coroutines.launch
@@ -31,6 +37,67 @@ val CompressionComponent = FC {
     var operation by useState("compress") // "compress" or "decompress"
     var inputFormat by useState("hex") // "hex" or "base64" or "utf8"
     var outputFormat by useState("hex") // "hex" or "base64" or "utf8"
+
+    fun processCompression(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val inputBytes = when (inputFormat) {
+                    "utf8" -> cleanInput.encodeToByteArray()
+                    "base64" -> cleanInput.fromBase64()
+                    else -> {
+                        try {
+                            decodeInputToBytes(cleanInput)
+                        } catch (e: Exception) {
+                            cleanInput.encodeToByteArray()
+                        }
+                    }
+                }
+
+                if (inputBytes.isEmpty()) {
+                    parseError = "Input data is empty"
+                    outputResult = ""
+                    return@launch
+                }
+
+                val processedBytes = if (operation == "compress") {
+                    if (method == "zlib") {
+                        inputBytes.zlibDeflate()
+                    } else {
+                        inputBytes.deflate()
+                    }
+                } else {
+                    if (method == "zlib") {
+                        inputBytes.zlibInflate()
+                    } else {
+                        inputBytes.inflate()
+                    }
+                }
+
+                val resultStr = when (outputFormat) {
+                    "utf8" -> processedBytes.decodeToString()
+                    "base64" -> processedBytes.toBase64()
+                    else -> processedBytes.toHex()
+                }
+
+                outputResult = resultStr
+                parseError = ""
+                updateUrlHashPayload(cleanInput)
+            } catch (e: Throwable) {
+                parseError = "Processing error: " + (e.message ?: "Unknown error")
+                outputResult = ""
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            processCompression(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -69,6 +136,8 @@ val CompressionComponent = FC {
                 onClick = {
                     outputResult = ""
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -130,14 +199,63 @@ val CompressionComponent = FC {
                 +"Compress or decompress binary payloads using DEFLATE (RFC 1951) or zlib (RFC 1950) wrappers. Input can be parsed from hex or base64, and output is generated in your preferred format."
             }
 
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +"Input Payload:"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +"Input Payload:"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             textarea {
@@ -325,54 +443,7 @@ val CompressionComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val cleanInput = rawInput.trim()
-                            val inputBytes = when (inputFormat) {
-                                "utf8" -> cleanInput.encodeToByteArray()
-                                "base64" -> cleanInput.fromBase64()
-                                else -> {
-                                    try {
-                                        decodeInputToBytes(cleanInput)
-                                    } catch (e: Exception) {
-                                        cleanInput.encodeToByteArray()
-                                    }
-                                }
-                            }
-
-                            if (inputBytes.isEmpty()) {
-                                parseError = "Input data is empty"
-                                outputResult = ""
-                                return@launch
-                            }
-
-                            val processedBytes = if (operation == "compress") {
-                                if (method == "zlib") {
-                                    inputBytes.zlibDeflate()
-                                } else {
-                                    inputBytes.deflate()
-                                }
-                            } else {
-                                if (method == "zlib") {
-                                    inputBytes.zlibInflate()
-                                } else {
-                                    inputBytes.inflate()
-                                }
-                            }
-
-                            val resultStr = when (outputFormat) {
-                                "utf8" -> processedBytes.decodeToString()
-                                "base64" -> processedBytes.toBase64()
-                                else -> processedBytes.toHex()
-                            }
-
-                            outputResult = resultStr
-                            parseError = ""
-                        } catch (e: Throwable) {
-                            parseError = "Processing error: " + (e.message ?: "Unknown error")
-                            outputResult = ""
-                        }
-                    }
+                    processCompression(rawInput)
                 }
                 +(if (operation == "compress") "Compress Payload" else "Decompress Payload")
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/DeviceRequestParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/DeviceRequestParserComponent.kt
@@ -37,6 +37,7 @@ import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
 import react.useState
+import react.useEffectOnce
 import web.cssom.*
 import web.file.File
 import web.file.FileReader
@@ -223,6 +224,33 @@ val DeviceRequestParserComponent: FC<Props> = FC {
     var copyHexStatus by useState("")
     var copyDiagStatus by useState("")
 
+    fun parseInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                val dataItem = Cbor.decode(bytes)
+                val devReq = DeviceRequest.fromDataItem(dataItem)
+                parsedResult = ParsedRequestResult(devReq, dataItem, bytes.toHex())
+                parseError = ""
+                if (fileName.isEmpty()) fileName = "Input Payload"
+                updateUrlHashPayload(cleanInput)
+            } catch (e: Throwable) {
+                parseError = "Error parsing DeviceRequest: " + (e.message ?: "Invalid structure")
+                parsedResult = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseInput(hashPayload)
+        }
+    }
+
     div {
         css {
             background = Color("#1e293b")
@@ -267,6 +295,8 @@ val DeviceRequestParserComponent: FC<Props> = FC {
                         parsedResult = null
                         parseError = ""
                         fileName = ""
+                        rawInput = ""
+                        updateUrlHashPayload("")
                     }
                     +"← Clear and Decode Another Request"
                 }
@@ -493,19 +523,7 @@ val DeviceRequestParserComponent: FC<Props> = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val bytes = decodeInputToBytes(rawInput)
-                            val dataItem = Cbor.decode(bytes)
-                            val devReq = DeviceRequest.fromDataItem(dataItem)
-                            parsedResult = ParsedRequestResult(devReq, dataItem, bytes.toHex())
-                            parseError = ""
-                            if (fileName.isEmpty()) fileName = "Pasted Input"
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing DeviceRequest: " + (e.message ?: "Invalid structure")
-                            parsedResult = null
-                        }
-                    }
+                    parseInput(rawInput)
                 }
                 +"Decode DeviceRequest"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
@@ -58,6 +58,7 @@ import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
 import react.useState
+import react.useEffectOnce
 import web.cssom.*
 import web.file.File
 import web.file.FileReader
@@ -87,6 +88,34 @@ val EventDecoderComponent: FC<Props> = FC {
     var parseError by useState("")
     var fileName by useState("")
     var copyEventHexStatus by useState("")
+
+    fun decodeInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                val res = parseEventFromBytes(bytes)
+                parsedEventHolder = res.first?.let { EventHolder(it) }
+                parseError = res.second
+                if (fileName.isEmpty()) fileName = "Input Payload"
+                if (res.first != null) {
+                    updateUrlHashPayload(cleanInput)
+                }
+            } catch (e: Throwable) {
+                parseError = "Error reading input: " + (e.message ?: "Invalid format")
+                parsedEventHolder = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            decodeInput(hashPayload)
+        }
+    }
 
     val parsedEvent = parsedEventHolder?.event
 
@@ -134,6 +163,8 @@ val EventDecoderComponent: FC<Props> = FC {
                         parsedEventHolder = null
                         parseError = ""
                         fileName = ""
+                        rawInput = ""
+                        updateUrlHashPayload("")
                     }
                     +"← Clear and Decode Another Event"
                 }
@@ -299,18 +330,7 @@ val EventDecoderComponent: FC<Props> = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val bytes = decodeInputToBytes(rawInput)
-                            val res = parseEventFromBytes(bytes)
-                            parsedEventHolder = res.first?.let { EventHolder(it) }
-                            parseError = res.second
-                            fileName = "Pasted Input"
-                        } catch (e: Throwable) {
-                            parseError = "Error reading input: " + (e.message ?: "Invalid format")
-                            parsedEventHolder = null
-                        }
-                    }
+                    decodeInput(rawInput)
                 }
                 +"Decode Event"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Main.kt
@@ -272,6 +272,10 @@ val App = FC {
                                         }
                                     }
                                     onClick = {
+                                        val targetPath = tabToPath(tabId)
+                                        if (window.location.pathname != targetPath || window.location.hash.isNotEmpty()) {
+                                            window.history.pushState(null, "", targetPath)
+                                        }
                                         activeTab = tabId
                                         activeDropdown = null
                                     }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MdocViewerComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MdocViewerComponent.kt
@@ -27,9 +27,15 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
+import react.dom.html.ReactHTML.input
 import react.useEffectOnce
 import react.useState
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
 import web.cssom.*
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 
 val MdocViewerComponent = FC {
     var rawInput by useState("")
@@ -69,23 +75,42 @@ val MdocViewerComponent = FC {
         }
     }
 
-    useEffectOnce {
-        val pendingHex = window.localStorage.getItem("pending_mdoc_hex")
-        if (!pendingHex.isNullOrBlank()) {
-            window.localStorage.removeItem("pending_mdoc_hex")
-            rawInput = pendingHex
-            mainScope.launch {
-                try {
-                    val bytes = decodeInputToBytes(pendingHex)
-                    if (bytes.isNotEmpty()) {
-                        val dataItem = Cbor.decode(bytes)
-                        val response = DeviceResponse.fromDataItem(dataItem)
-                        processResponse(response)
-                    }
-                } catch (e: Throwable) {
-                    parseError = "Error parsing DeviceResponse: " + (e.message ?: e.toString())
+    fun parseInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                if (bytes.isEmpty()) {
+                    parseError = "Input is empty"
+                    parsedResponse = null
+                } else {
+                    val dataItem = Cbor.decode(bytes)
+                    val response = DeviceResponse.fromDataItem(dataItem)
+                    processResponse(response)
+                    updateUrlHashPayload(cleanInput)
                 }
+            } catch (e: Throwable) {
+                parseError = "Error parsing DeviceResponse: " + (e.message ?: e.toString())
+                parsedResponse = null
             }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        val pendingHex = window.localStorage.getItem("pending_mdoc_hex")
+        val inputToParse = if (hashPayload.isNotEmpty()) {
+            hashPayload
+        } else if (!pendingHex.isNullOrBlank()) {
+            window.localStorage.removeItem("pending_mdoc_hex")
+            pendingHex
+        } else {
+            ""
+        }
+        if (inputToParse.isNotEmpty()) {
+            rawInput = inputToParse
+            parseInput(inputToParse)
         }
     }
 
@@ -127,6 +152,8 @@ val MdocViewerComponent = FC {
                     parsedResponse = null
                     decompressedOtherDocs = emptyMap()
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -150,14 +177,63 @@ val MdocViewerComponent = FC {
                 +"Inspect a raw DeviceResponse CBOR structure (Hex or Base64 format). Decodes version, status, mdoc documents, SD-JWT / OtherDocuments, ZK documents, and EncryptedDocuments."
             }
 
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +"DeviceResponse (Hex or Base64):"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +"DeviceResponse (Hex or Base64):"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".cbor,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             textarea {
@@ -203,22 +279,7 @@ val MdocViewerComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val bytes = decodeInputToBytes(rawInput)
-                            if (bytes.isEmpty()) {
-                                parseError = "Input is empty"
-                                parsedResponse = null
-                            } else {
-                                val dataItem = Cbor.decode(bytes)
-                                val response = DeviceResponse.fromDataItem(dataItem)
-                                processResponse(response)
-                            }
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing DeviceResponse: " + (e.message ?: e.toString())
-                            parsedResponse = null
-                        }
-                    }
+                    parseInput(rawInput)
                 }
                 +"Parse DeviceResponse"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MsoNamespacesViewerComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MsoNamespacesViewerComponent.kt
@@ -23,7 +23,15 @@ import react.dom.html.ReactHTML.select
 import react.dom.html.ReactHTML.option
 import react.dom.html.ReactHTML.pre
 import react.dom.html.ReactHTML.code
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.util.toHex
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 import kotlinx.coroutines.launch
 import org.multipaz.cbor.Cbor
@@ -123,6 +131,35 @@ val MsoNamespacesViewerComponent = FC {
         throw IllegalArgumentException("Could not identify or parse the input data structure. Try selecting the format explicitly.")
     }
 
+    fun parseRawInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                if (bytes.isEmpty()) {
+                    parseError = "Input is empty"
+                    parsedResult = null
+                } else {
+                    parsedResult = parseInput(bytes, selectedType)
+                    parseError = ""
+                    updateUrlHashPayload(cleanInput)
+                }
+            } catch (e: Throwable) {
+                parseError = "Error parsing: " + (e.message ?: "Unknown error")
+                parsedResult = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseRawInput(hashPayload)
+        }
+    }
+
     div {
         css {
             background = Color("#1e293b")
@@ -160,6 +197,8 @@ val MsoNamespacesViewerComponent = FC {
                 onClick = {
                     parsedResult = null
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -282,15 +321,64 @@ val MsoNamespacesViewerComponent = FC {
                 }
 
                 div {
-                    label {
+                    div {
                         css {
-                            display = Display.block
-                            fontWeight = FontWeight.bold
+                            display = Display.flex
+                            justifyContent = JustifyContent.spaceBetween
+                            alignItems = AlignItems.center
                             marginBottom = 6.px
-                            color = Color("#cbd5e1")
-                            fontSize = 14.px
                         }
-                        +"Input Data (Hex or Base64):"
+
+                        label {
+                            css {
+                                fontWeight = FontWeight.bold
+                                color = Color("#cbd5e1")
+                                fontSize = 14.px
+                            }
+                            +"Input Data (Hex or Base64):"
+                        }
+
+                        label {
+                            css {
+                                background = Color("#334155")
+                                border = None.none
+                                color = Color("#f1f5f9")
+                                padding = Padding(4.px, 12.px)
+                                borderRadius = 6.px
+                                cursor = Cursor.pointer
+                                fontSize = 13.px
+                                fontWeight = FontWeight.normal
+                                hover {
+                                    background = Color("#475569")
+                                }
+                            }
+                            +"📁 Load data"
+                            input {
+                                type = "file".unsafeCast<InputType>()
+                                accept = ".cbor,.bin,.hex,.txt,*/*"
+                                css {
+                                    display = None.none
+                                }
+                                onChange = { event ->
+                                    val fileList = event.target.asDynamic().files
+                                    if (fileList != null && fileList.length > 0) {
+                                        val file = fileList[0].unsafeCast<File>()
+                                        val reader = FileReader()
+                                        reader.asDynamic().onload = {
+                                            val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                            val bytes = Int8Array(arrayBuffer).toByteArray()
+                                            val text = bytes.decodeToString()
+                                            if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                                rawInput = text.trim()
+                                            } else {
+                                                rawInput = bytes.toHex()
+                                            }
+                                        }
+                                        reader.readAsArrayBuffer(file)
+                                    }
+                                }
+                            }
+                        }
                     }
                     textarea {
                         css {
@@ -336,21 +424,7 @@ val MsoNamespacesViewerComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val bytes = decodeInputToBytes(rawInput)
-                            if (bytes.isEmpty()) {
-                                parseError = "Input is empty"
-                                parsedResult = null
-                            } else {
-                                parsedResult = parseInput(bytes, selectedType)
-                                parseError = ""
-                            }
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing: " + (e.message ?: "Unknown error")
-                            parsedResult = null
-                        }
-                    }
+                    parseRawInput(rawInput)
                 }
                 +"Parse"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/NdefParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/NdefParserComponent.kt
@@ -11,7 +11,15 @@ import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.util.toHex
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.decodeToString
@@ -29,6 +37,30 @@ val NdefParserComponent = FC {
     var rawInput by useState("")
     var parsedMessage by useState<NdefMessage?>(null)
     var parseError by useState("")
+
+    fun parseNdef(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val bytes = decodeInputToBytes(cleanInput)
+                parsedMessage = NdefMessage.fromEncoded(bytes)
+                parseError = ""
+                updateUrlHashPayload(cleanInput)
+            } catch (e: Throwable) {
+                parseError = "Error parsing NDEF message: " + (e.message ?: "Unknown error")
+                parsedMessage = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseNdef(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -67,6 +99,8 @@ val NdefParserComponent = FC {
                 onClick = {
                     parsedMessage = null
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -288,14 +322,63 @@ val NdefParserComponent = FC {
                 +"Decode raw NFC NDEF messages. Paste encoded bytes in Hex format or Base64 notation to unpack all records, TNFs, types, and embedded metadata."
             }
 
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +"NDEF Encoded Payload (Hex or Base64):"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +"NDEF Encoded Payload (Hex or Base64):"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".ndef,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             textarea {
@@ -341,17 +424,7 @@ val NdefParserComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val cleanInput = rawInput.trim()
-                            val bytes = decodeInputToBytes(cleanInput)
-                            parsedMessage = NdefMessage.fromEncoded(bytes)
-                            parseError = ""
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing NDEF message: " + (e.message ?: "Unknown error")
-                            parsedMessage = null
-                        }
-                    }
+                    parseNdef(rawInput)
                 }
                 +"Parse NDEF Message"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/SdJwtInspectorComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/SdJwtInspectorComponent.kt
@@ -34,7 +34,15 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.th
 import react.dom.html.ReactHTML.thead
 import react.dom.html.ReactHTML.tr
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.util.toHex
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 
 val SdJwtInspectorComponent = FC {
@@ -42,6 +50,69 @@ val SdJwtInspectorComponent = FC {
     var parsedSdJwt by useState<SdJwt?>(null)
     var parsedSdJwtKb by useState<SdJwtKb?>(null)
     var parseError by useState("")
+
+    fun parseInput(inputStr: String) {
+        val cleanInput = inputStr.trim()
+        if (cleanInput.isEmpty()) return
+        mainScope.launch {
+            try {
+                val token = if (cleanInput.contains(".") || cleanInput.contains("~")) {
+                    cleanInput
+                } else {
+                    val bytes = decodeInputToBytes(cleanInput)
+                    val decompressedBytes = try {
+                        bytes.zlibInflate()
+                    } catch (e: Throwable) {
+                        bytes
+                    }
+                    decompressedBytes.decodeToString().trim()
+                }
+
+                if (!token.endsWith("~")) {
+                    // Attempt parsing as SD-JWT+KB first
+                    try {
+                        val sdJwtKb = SdJwtKb.fromCompactSerialization(token)
+                        parsedSdJwtKb = sdJwtKb
+                        parsedSdJwt = sdJwtKb.sdJwt
+                        parseError = ""
+                        updateUrlHashPayload(cleanInput)
+                    } catch (e1: Throwable) {
+                        // Fallback to standard SD-JWT with appended trailing tilde
+                        try {
+                            val sdjwt = SdJwt.fromCompactSerialization("$token~")
+                            parsedSdJwtKb = null
+                            parsedSdJwt = sdjwt
+                            parseError = ""
+                            updateUrlHashPayload(cleanInput)
+                        } catch (e2: Throwable) {
+                            parseError = "Error parsing SD-JWT / SD-JWT+KB: ${e1.message ?: e1.toString()}"
+                            parsedSdJwtKb = null
+                            parsedSdJwt = null
+                        }
+                    }
+                } else {
+                    // Standard SD-JWT ending in '~'
+                    val sdjwt = SdJwt.fromCompactSerialization(token)
+                    parsedSdJwtKb = null
+                    parsedSdJwt = sdjwt
+                    parseError = ""
+                    updateUrlHashPayload(cleanInput)
+                }
+            } catch (e: Throwable) {
+                parseError = "Error parsing SD-JWT: " + (e.message ?: e.toString())
+                parsedSdJwtKb = null
+                parsedSdJwt = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseInput(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -81,6 +152,8 @@ val SdJwtInspectorComponent = FC {
                     parsedSdJwt = null
                     parsedSdJwtKb = null
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -104,14 +177,63 @@ val SdJwtInspectorComponent = FC {
                 +"Decode and inspect SD-JWT and SD-JWT+KB tokens (compact serialization). Parses Issuer-Signed JWT header/body, individual claim Disclosures, and Key Binding JWTs (KB-JWT)."
             }
 
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +"SD-JWT / SD-JWT+KB Token:"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +"SD-JWT / SD-JWT+KB Token:"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".vc,.jwt,.sdjwt,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.contains(".") || text.contains("~") || text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             textarea {
@@ -157,54 +279,7 @@ val SdJwtInspectorComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val inputStr = rawInput.trim()
-                            val token = if (inputStr.contains(".") || inputStr.contains("~")) {
-                                inputStr
-                            } else {
-                                val bytes = decodeInputToBytes(inputStr)
-                                val decompressedBytes = try {
-                                    bytes.zlibInflate()
-                                } catch (e: Throwable) {
-                                    bytes
-                                }
-                                decompressedBytes.decodeToString().trim()
-                            }
-
-                            if (!token.endsWith("~")) {
-                                // Attempt parsing as SD-JWT+KB first
-                                try {
-                                    val sdJwtKb = SdJwtKb.fromCompactSerialization(token)
-                                    parsedSdJwtKb = sdJwtKb
-                                    parsedSdJwt = sdJwtKb.sdJwt
-                                    parseError = ""
-                                } catch (e1: Throwable) {
-                                    // Fallback to standard SD-JWT with appended trailing tilde
-                                    try {
-                                        val sdjwt = SdJwt.fromCompactSerialization("$token~")
-                                        parsedSdJwtKb = null
-                                        parsedSdJwt = sdjwt
-                                        parseError = ""
-                                    } catch (e2: Throwable) {
-                                        parseError = "Error parsing SD-JWT / SD-JWT+KB: ${e1.message ?: e1.toString()}"
-                                        parsedSdJwtKb = null
-                                        parsedSdJwt = null
-                                    }
-                                }
-                            } else {
-                                // Standard SD-JWT ending in '~'
-                                val sdjwt = SdJwt.fromCompactSerialization(token)
-                                parsedSdJwtKb = null
-                                parsedSdJwt = sdjwt
-                                parseError = ""
-                            }
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing SD-JWT: " + (e.message ?: e.toString())
-                            parsedSdJwtKb = null
-                            parsedSdJwt = null
-                        }
-                    }
+                    parseInput(rawInput)
                 }
                 +"Inspect SD-JWT / SD-JWT+KB"
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Utils.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Utils.kt
@@ -29,3 +29,37 @@ fun decodeInputToBytes(input: String): ByteArray {
     
     throw IllegalArgumentException("Could not decode input as Hex, Base64Url or Base64")
 }
+
+fun getUrlHashPayload(): String {
+    val hash = kotlinx.browser.window.location.hash
+    if (hash.startsWith("#") && hash.length > 1) {
+        val raw = hash.substring(1)
+        return try {
+            js("decodeURIComponent(raw)").unsafeCast<String>()
+        } catch (e: Throwable) {
+            raw
+        }
+    }
+    return ""
+}
+
+fun updateUrlHashPayload(payload: String) {
+    val currentPath = tabToPath(pathToTab(kotlinx.browser.window.location.pathname))
+    val clean = payload.trim()
+    if (clean.isNotEmpty()) {
+        val encoded = try {
+            js("encodeURIComponent(clean)").unsafeCast<String>()
+        } catch (e: Throwable) {
+            clean
+        }
+        val targetUrl = "$currentPath#$encoded"
+        if (kotlinx.browser.window.location.pathname + kotlinx.browser.window.location.hash != targetUrl) {
+            kotlinx.browser.window.history.replaceState(null, "", targetUrl)
+        }
+    } else {
+        if (kotlinx.browser.window.location.hash.isNotEmpty()) {
+            kotlinx.browser.window.history.replaceState(null, "", currentPath)
+        }
+    }
+}
+

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
@@ -12,7 +12,15 @@ import react.dom.html.ReactHTML.textarea
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.pre
+import react.dom.html.ReactHTML.input
 import react.useState
+import react.useEffectOnce
+import js.typedarrays.Int8Array
+import js.typedarrays.toByteArray
+import org.multipaz.util.toHex
+import web.file.File
+import web.file.FileReader
+import web.html.InputType
 import web.cssom.*
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
@@ -36,6 +44,43 @@ val X509ParserComponent = FC {
     var rawInput by useState("")
     var parsedCert by useState<X509Cert?>(null)
     var parseError by useState("")
+
+    fun parseCert(inputStr: String) {
+        mainScope.launch {
+            try {
+                val cleanInput = inputStr.trim()
+                val cert = if (cleanInput.contains("-----BEGIN")) {
+                    X509Cert.fromPem(cleanInput)
+                } else {
+                    val bytes = decodeInputToBytes(cleanInput)
+                    X509Cert(ByteString(bytes))
+                }
+                
+                // Eagerly evaluate core fields to check parsing success
+                cert.subject.name
+                cert.issuer.name
+                cert.serialNumber
+                cert.version
+                cert.validityNotBefore
+                cert.validityNotAfter
+                
+                parsedCert = cert
+                parseError = ""
+                updateUrlHashPayload(cleanInput)
+            } catch (e: Throwable) {
+                parseError = "Error parsing certificate: " + (e.message ?: "Unknown error")
+                parsedCert = null
+            }
+        }
+    }
+
+    useEffectOnce {
+        val hashPayload = getUrlHashPayload()
+        if (hashPayload.isNotEmpty()) {
+            rawInput = hashPayload
+            parseCert(hashPayload)
+        }
+    }
 
     div {
         css {
@@ -74,6 +119,8 @@ val X509ParserComponent = FC {
                 onClick = {
                     parsedCert = null
                     parseError = ""
+                    rawInput = ""
+                    updateUrlHashPayload("")
                 }
                 +"← Clear and Go Back"
             }
@@ -574,14 +621,63 @@ val X509ParserComponent = FC {
                 +"Decode and view metadata of an X.509 Certificate. Supports PEM format (carrying BEGIN/END headers), raw base64 or hex encoded certificate bytes."
             }
 
-            label {
+            div {
                 css {
-                    display = Display.block
-                    fontWeight = FontWeight.bold
+                    display = Display.flex
+                    justifyContent = JustifyContent.spaceBetween
+                    alignItems = AlignItems.center
                     marginBottom = 8.px
-                    color = Color("#cbd5e1")
                 }
-                +"X.509 Certificate (PEM, Base64, or Hex):"
+
+                label {
+                    css {
+                        fontWeight = FontWeight.bold
+                        color = Color("#cbd5e1")
+                    }
+                    +"X.509 Certificate (PEM, Base64, or Hex):"
+                }
+
+                label {
+                    css {
+                        background = Color("#334155")
+                        border = None.none
+                        color = Color("#f1f5f9")
+                        padding = Padding(4.px, 12.px)
+                        borderRadius = 6.px
+                        cursor = Cursor.pointer
+                        fontSize = 13.px
+                        fontWeight = FontWeight.normal
+                        hover {
+                            background = Color("#475569")
+                        }
+                    }
+                    +"📁 Load data"
+                    input {
+                        type = "file".unsafeCast<InputType>()
+                        accept = ".der,.cer,.crt,.pem,.bin,.hex,.txt,*/*"
+                        css {
+                            display = None.none
+                        }
+                        onChange = { event ->
+                            val fileList = event.target.asDynamic().files
+                            if (fileList != null && fileList.length > 0) {
+                                val file = fileList[0].unsafeCast<File>()
+                                val reader = FileReader()
+                                reader.asDynamic().onload = {
+                                    val arrayBuffer = reader.result.unsafeCast<js.buffer.ArrayBuffer>()
+                                    val bytes = Int8Array(arrayBuffer).toByteArray()
+                                    val text = bytes.decodeToString()
+                                    if (text.contains("-----BEGIN") || text.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' || it.isWhitespace() }) {
+                                        rawInput = text.trim()
+                                    } else {
+                                        rawInput = bytes.toHex()
+                                    }
+                                }
+                                reader.readAsArrayBuffer(file)
+                            }
+                        }
+                    }
+                }
             }
 
             textarea {
@@ -627,31 +723,7 @@ val X509ParserComponent = FC {
                 }
                 disabled = rawInput.trim().isEmpty()
                 onClick = {
-                    mainScope.launch {
-                        try {
-                            val cleanInput = rawInput.trim()
-                            val cert = if (cleanInput.contains("-----BEGIN")) {
-                                X509Cert.fromPem(cleanInput)
-                            } else {
-                                val bytes = decodeInputToBytes(cleanInput)
-                                X509Cert(ByteString(bytes))
-                            }
-                            
-                            // Eagerly evaluate core fields to check parsing success
-                            cert.subject.name
-                            cert.issuer.name
-                            cert.serialNumber
-                            cert.version
-                            cert.validityNotBefore
-                            cert.validityNotAfter
-                            
-                            parsedCert = cert
-                            parseError = ""
-                        } catch (e: Throwable) {
-                            parseError = "Error parsing certificate: " + (e.message ?: "Unknown error")
-                            parsedCert = null
-                        }
-                    }
+                    parseCert(rawInput)
                 }
                 +"Parse Certificate"
             }


### PR DESCRIPTION
- Support reading and deep-linking input payloads via URL hash fragment (#<payload>) across all tools components.
- Automatically update window.location.hash on payload decode and clear hash on clear/back.
- Add 'Load data' file input buttons across all text/binary payload input fields.
- Fix tab navigation issue by updating location history synchronously before mounting target component.

Fixes #1853.

Test: Manually tested and unit tests.
