### PR TITLE
Add support for JPEG 2000 image decoding.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,8 +62,10 @@ kotlin-wrappers-em = "2025.12.1-11.14.0"
 koog = "0.8.0"
 junit-jupiter = "5.10.0"
 jetbrains-navigationevent = "1.0.1"
+jj2000 = "5.2"
 
 [libraries]
+jj2000 = { module = "edu.ucar:jj2000", version.ref = "jj2000" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/multipaz-compose/build.gradle.kts
+++ b/multipaz-compose/build.gradle.kts
@@ -139,6 +139,7 @@ kotlin {
                 implementation(libs.androidx.credentials.registry.provider)
                 implementation(libs.ktor.client.android)
                 implementation(libs.androidx.browser)
+                implementation(libs.jj2000)
             }
         }
     }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
@@ -21,7 +21,21 @@ import org.multipaz.compose.camera.CameraFrame
 import org.multipaz.context.AndroidUiContext
 import org.multipaz.context.applicationContext
 import org.multipaz.util.Logger
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import jj2000.j2k.codestream.HeaderInfo
+import jj2000.j2k.codestream.reader.BitstreamReaderAgent
+import jj2000.j2k.codestream.reader.HeaderDecoder
+import jj2000.j2k.decoder.Decoder
+import jj2000.j2k.fileformat.reader.FileFormatReader
+import jj2000.j2k.image.BlkImgDataSrc
+import jj2000.j2k.image.DataBlkInt
+import jj2000.j2k.image.ImgDataConverter
+import jj2000.j2k.image.invcomptransf.InvCompTransf
+import jj2000.j2k.io.RandomAccessIO
+import jj2000.j2k.util.ISRandomAccessIO
+import jj2000.j2k.util.ParameterList
+import jj2000.j2k.wavelet.synthesis.InverseWT
 import kotlin.coroutines.CoroutineContext
 
 private const val TAG = "Util"
@@ -41,11 +55,140 @@ actual fun getApplicationInfo(appId: String): ApplicationInfo {
 
 actual fun decodeImage(encodedData: ByteArray): ImageBitmap {
     val bitmap = BitmapFactory.decodeByteArray(encodedData, 0, encodedData.size)
-    if (bitmap == null) {
-        Logger.e(TAG, "Failed to decode image (${encodedData.size} bytes)")
-        return ImageBitmap(1, 1)
+    if (bitmap != null) {
+        return bitmap.asImageBitmap()
     }
-    return bitmap.asImageBitmap()
+    try {
+        val j2kBitmap = decodeJpeg2000ToBitmap(encodedData)
+        if (j2kBitmap != null) {
+            return j2kBitmap.asImageBitmap()
+        }
+    } catch (e: Exception) {
+        Logger.e(TAG, "Failed to decode JPEG 2000 image (${encodedData.size} bytes)", e)
+    }
+    Logger.e(TAG, "Failed to decode image (${encodedData.size} bytes)")
+    return ImageBitmap(1, 1)
+}
+
+private fun decodeJpeg2000ToBitmap(bytes: ByteArray): Bitmap? {
+    val defPl = ParameterList()
+    val pinfo = Decoder.getAllParameters()
+    if (pinfo != null) {
+        for (i in pinfo.indices.reversed()) {
+            if (pinfo[i][3] != null) {
+                defPl.put(pinfo[i][0], pinfo[i][3])
+            }
+        }
+    }
+    val pl = ParameterList(defPl)
+    pl.setProperty("u", "on")
+    val isr = ISRandomAccessIO(ByteArrayInputStream(bytes))
+    val ffr = FileFormatReader(isr)
+    ffr.readFileFormat()
+    val stream: RandomAccessIO = if (ffr.JP2FFUsed) {
+        ISRandomAccessIO(ByteArrayInputStream(bytes, ffr.firstCodeStreamPos, ffr.firstCodeStreamLength))
+    } else {
+        isr
+    }
+
+    val hi = HeaderInfo()
+    val hd = HeaderDecoder(stream, pl, hi)
+    val decSpec = hd.decoderSpecs
+    val nComp = hd.numComps
+    val breader = BitstreamReaderAgent.createInstance(stream, hd, pl, decSpec, false, hi)
+    val depth = IntArray(nComp) { i -> hd.getOriginalBitDepth(i) }
+
+    val entDec = hd.createEntropyDecoder(breader, pl)
+    val roiDecoder = hd.createROIDeScaler(entDec, pl, decSpec)
+    val dequant = hd.createDequantizer(roiDecoder, depth, decSpec)
+    val invWT = InverseWT.createInstance(dequant, decSpec)
+    invWT.setImgResLevel(breader.imgRes)
+
+    val converter = ImgDataConverter(invWT, 0)
+    val icomp = InvCompTransf(converter, decSpec, depth, pl)
+    icomp.setTile(0, 0)
+
+    var src: BlkImgDataSrc = icomp
+    if (ffr.JP2FFUsed && "off" != pl.getParameter("nocolorspace")) {
+        val csMap = colorspace.ColorSpace(isr, hd, pl)
+        src = hd.createChannelDefinitionMapper(src, csMap)
+        src = hd.createResampler(src, csMap)
+        src = hd.createPalettizedColorSpaceMapper(src, csMap)
+        src = hd.createColorSpaceMapper(src, csMap)
+    }
+
+    val width = src.imgWidth
+    val height = src.imgHeight
+
+    val fpR = src.getFixedPoint(0)
+    val fpG = if (nComp >= 3) src.getFixedPoint(1) else fpR
+    val fpB = if (nComp >= 3) src.getFixedPoint(2) else fpR
+
+    val rShift = if (!hd.isOriginalSigned(0)) 1 shl (hd.getOriginalBitDepth(0) - 1) else 0
+    val gShift = if (nComp >= 3 && !hd.isOriginalSigned(1)) 1 shl (hd.getOriginalBitDepth(1) - 1) else rShift
+    val bShift = if (nComp >= 3 && !hd.isOriginalSigned(2)) 1 shl (hd.getOriginalBitDepth(2) - 1) else rShift
+
+    val dataBlkR = DataBlkInt()
+    val dataBlkG = DataBlkInt()
+    val dataBlkB = DataBlkInt()
+
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        dataBlkR.ulx = 0
+        dataBlkR.uly = y
+        dataBlkR.w = width
+        dataBlkR.h = 1
+
+        val blkR = src.getInternCompData(dataBlkR, 0) as DataBlkInt
+        val rData = blkR.data
+        val rOff = blkR.offset
+
+        val blkG: DataBlkInt
+        val gData: IntArray
+        val gOff: Int
+
+        val blkB: DataBlkInt
+        val bData: IntArray
+        val bOff: Int
+
+        if (nComp >= 3) {
+            dataBlkG.ulx = 0
+            dataBlkG.uly = y
+            dataBlkG.w = width
+            dataBlkG.h = 1
+            blkG = src.getInternCompData(dataBlkG, 1) as DataBlkInt
+            gData = blkG.data
+            gOff = blkG.offset
+
+            dataBlkB.ulx = 0
+            dataBlkB.uly = y
+            dataBlkB.w = width
+            dataBlkB.h = 1
+            blkB = src.getInternCompData(dataBlkB, 2) as DataBlkInt
+            bData = blkB.data
+            bOff = blkB.offset
+        } else {
+            blkG = blkR
+            gData = rData
+            gOff = rOff
+
+            blkB = blkR
+            bData = rData
+            bOff = rOff
+        }
+
+        val outRow = y * width
+        for (x in 0 until width) {
+            val rVal = (rData[rOff + x] shr fpR) + rShift
+            val gVal = (gData[gOff + x] shr fpG) + gShift
+            val bVal = (bData[bOff + x] shr fpB) + bShift
+            val r = rVal.coerceIn(0, 255)
+            val g = gVal.coerceIn(0, 255)
+            val b = bVal.coerceIn(0, 255)
+            pixels[outRow + x] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
+        }
+    }
+    return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
 }
 
 actual fun encodeImageToPng(image: ImageBitmap): ByteString {

--- a/multipaz-server/build.gradle.kts
+++ b/multipaz-server/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
     implementation(libs.zxing.core)
+    implementation(libs.jj2000)
     implementation(libs.hsqldb)
     implementation(libs.mysql)
     implementation(libs.postgresql)

--- a/multipaz-server/src/main/java/org/multipaz/server/drawing/Canvas.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/drawing/Canvas.kt
@@ -12,6 +12,21 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.cache
 import org.multipaz.util.findFirstGood
+import colorspace.ColorSpace
+import jj2000.disp.BlkImgDataSrcImageProducer
+import jj2000.j2k.codestream.HeaderInfo
+import jj2000.j2k.codestream.reader.BitstreamReaderAgent
+import jj2000.j2k.codestream.reader.HeaderDecoder
+import jj2000.j2k.decoder.Decoder
+import jj2000.j2k.fileformat.reader.FileFormatReader
+import jj2000.j2k.image.BlkImgDataSrc
+import jj2000.j2k.image.DataBlkInt
+import jj2000.j2k.image.ImgDataConverter
+import jj2000.j2k.image.invcomptransf.InvCompTransf
+import jj2000.j2k.io.RandomAccessIO
+import jj2000.j2k.util.ISRandomAccessIO
+import jj2000.j2k.util.ParameterList
+import jj2000.j2k.wavelet.synthesis.InverseWT
 import java.awt.Color
 import java.awt.Font
 import java.awt.Graphics2D
@@ -21,6 +36,7 @@ import java.awt.geom.AffineTransform
 import java.awt.geom.Rectangle2D
 import java.awt.geom.RoundRectangle2D
 import java.awt.image.BufferedImage
+import java.awt.image.PixelGrabber
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
@@ -365,8 +381,72 @@ class Canvas private constructor(val bufferedImage: BufferedImage) {
                 )
             }
 
-        private fun loadImage(bytes: ByteString): BufferedImage =
-            ImageIO.read(ByteArrayInputStream(bytes.toByteArray()))
+        private fun loadImage(bytes: ByteString): BufferedImage {
+            val byteArray = bytes.toByteArray()
+            val image = ImageIO.read(ByteArrayInputStream(byteArray))
+            if (image != null) {
+                return image
+            }
+            return decodeJpeg2000ToBufferedImage(byteArray)
+        }
+
+        private fun decodeJpeg2000ToBufferedImage(bytes: ByteArray): BufferedImage {
+            val defPl = ParameterList()
+            val pinfo = Decoder.getAllParameters()
+            if (pinfo != null) {
+                for (i in pinfo.indices.reversed()) {
+                    if (pinfo[i][3] != null) {
+                        defPl.put(pinfo[i][0], pinfo[i][3])
+                    }
+                }
+            }
+            val pl = ParameterList(defPl)
+            pl.setProperty("u", "on")
+            val isr = ISRandomAccessIO(ByteArrayInputStream(bytes))
+            val ffr = FileFormatReader(isr)
+            ffr.readFileFormat()
+            val stream: RandomAccessIO = if (ffr.JP2FFUsed) {
+                ISRandomAccessIO(ByteArrayInputStream(bytes, ffr.firstCodeStreamPos, ffr.firstCodeStreamLength))
+            } else {
+                isr
+            }
+
+            val hi = HeaderInfo()
+            val hd = HeaderDecoder(stream, pl, hi)
+            val decSpec = hd.decoderSpecs
+            val nComp = hd.numComps
+            val breader = BitstreamReaderAgent.createInstance(stream, hd, pl, decSpec, false, hi)
+            val depth = IntArray(nComp) { i -> hd.getOriginalBitDepth(i) }
+
+            val entDec = hd.createEntropyDecoder(breader, pl)
+            val roiDecoder = hd.createROIDeScaler(entDec, pl, decSpec)
+            val dequant = hd.createDequantizer(roiDecoder, depth, decSpec)
+            val invWT = InverseWT.createInstance(dequant, decSpec)
+            invWT.setImgResLevel(breader.imgRes)
+
+            val converter = ImgDataConverter(invWT, 0)
+            val icomp = InvCompTransf(converter, decSpec, depth, pl)
+
+            var src: BlkImgDataSrc = icomp
+            if (ffr.JP2FFUsed && "off" != pl.getParameter("nocolorspace")) {
+                val csMap = ColorSpace(isr, hd, pl)
+                src = hd.createChannelDefinitionMapper(src, csMap)
+                src = hd.createResampler(src, csMap)
+                src = hd.createPalettizedColorSpaceMapper(src, csMap)
+                src = hd.createColorSpaceMapper(src, csMap)
+            }
+
+            val producer = BlkImgDataSrcImageProducer(src)
+            val width = src.imgWidth
+            val height = src.imgHeight
+            val pixels = IntArray(width * height)
+            val pg = PixelGrabber(producer, 0, 0, width, height, pixels, 0, width)
+            pg.grabPixels()
+
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+            image.setRGB(0, 0, width, height, pixels, 0, width)
+            return image
+        }
 
         private fun toPaint(argb: UInt): Color {
             return Color(argb.toInt(), true)

--- a/multipaz-server/src/test/java/org/multipaz/server/drawing/CanvasTest.kt
+++ b/multipaz-server/src/test/java/org/multipaz/server/drawing/CanvasTest.kt
@@ -1,0 +1,37 @@
+package org.multipaz.server.drawing
+
+import kotlinx.io.bytestring.ByteString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import jj2000.j2k.encoder.Encoder
+import jj2000.j2k.image.DataBlkInt
+import jj2000.j2k.image.ImgData
+import jj2000.j2k.image.BlkImgDataSrc
+import jj2000.j2k.util.ParameterList
+
+import kotlinx.serialization.json.buildJsonObject
+
+class CanvasTest {
+
+    @Test
+    fun testLoadPngImage() {
+        val img = BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB)
+        val g = img.createGraphics()
+        g.color = Color.BLUE
+        g.fillRect(0, 0, 16, 16)
+        g.dispose()
+
+        val baos = ByteArrayOutputStream()
+        ImageIO.write(img, "png", baos)
+
+        val canvas = Canvas.createBlank(16, 16)
+        canvas.drawImage(ByteString(baos.toByteArray()), buildJsonObject {})
+        assertEquals(16, canvas.width)
+        assertEquals(16, canvas.height)
+    }
+}


### PR DESCRIPTION
Uses [jj2000](https://github.com/Unidata/jj2000) to decode JPEG 2000 images in both multipaz-server (drawing Canvas) and multipaz-compose (Util.android.kt).

Fixes #1856.

Test: Manually tested.
