### PR TITLE
Logger.cbor() fixes.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -250,29 +250,35 @@ object Logger {
         dataItem: DataItem? = null
     ) {
         val bytes = encodedCbor ?: Cbor.encode(dataItem!!)
-        val cdnString = try {
-            if (dataItem != null) {
+        try {
+            val cdnString = if (dataItem != null) {
                 Cdn.encode(dataItem, CdnGeneratorOptions.Pretty)
             } else {
                 Cdn.encode(bytes, CdnGeneratorOptions.Pretty)
             }
-        } catch (e: Throwable) {
+            val sb = "$message: ${bytes.size} bytes of CBOR: " + bytes.toHex() +
+                    "\n" +
+                    "In diagnostic notation:\n" +
+                    cdnString
+            printLine(
+                level = level,
+                tag = tag,
+                msg = sb,
+                throwable = null
+            )
+        } catch (e: Exception) {
             if (e is CancellationException) throw e
             if (encodedCbor != null) {
                 printLine(
-                    Level.WARNING,
-                    tag,
-                    "$message: ${encodedCbor.size} bytes of invalid CBOR: ${encodedCbor.toHex()}",
-                    e
+                    level = level,
+                    tag = tag,
+                    msg = "$message: ${encodedCbor.size} bytes of invalid CBOR: ${encodedCbor.toHex()}",
+                    throwable = null
                 )
+            } else {
+                throw e
             }
-            throw e
         }
-        val sb = "$message: ${bytes.size} bytes of CBOR: " + bytes.toHex() +
-                "\n" +
-                "In diagnostic notation:\n" +
-                cdnString
-        printLine(level, tag, sb, null)
     }
 
     fun dCbor(tag: String, message: String, encodedCbor: ByteArray) {

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
@@ -172,14 +172,6 @@ class CdnTests {
     }
 
     @Test
-    fun testLoggerInvalidCbor() {
-        val invalidCborBytes = byteArrayOf(0xff.toByte(), 0xfe.toByte())
-        assertFailsWith<Throwable> {
-            org.multipaz.util.Logger.iCbor("TestTag", "Testing invalid CBOR", invalidCborBytes)
-        }
-    }
-
-    @Test
     fun testCustomExtensionRegistryPassing() {
         val customRegistry = CdnExtensionRegistry()
         customRegistry.register(object : CdnExtension {


### PR DESCRIPTION
In PR #1849 we extended Logger.cbor() to be smart about when the CBOR to log isn't valid CBOR. However we sorta kinda got it wrong, for example we ended up throwing the exception for when decoding failed.

Fix this by not throwing an exception, just print the "N bytes of invalid CBOR: <hexbytes>" without throwing. This is preferable because the caller might want to deal with invalid CBOR themselves.

Fixes #1858.

Test: Manually tested.
