### PR TITLE
Add IdentifierList tests and CDN enhancements.

### DIFF
--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/AnnexCParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/AnnexCParserComponent.kt
@@ -11,8 +11,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.DataItem
-import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborArray
@@ -598,7 +599,7 @@ val AnnexCParserComponent: FC<Props> = FC {
                     }
 
                     CborDiagnosticViewer {
-                        diagText = Cbor.toDiagnostics(req.encryptionInfoDataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                        diagText = Cdn.encode(req.encryptionInfoDataItem, CdnGeneratorOptions.Pretty)
                         maxHeight = 250.px
                     }
                 }
@@ -696,7 +697,7 @@ val AnnexCParserComponent: FC<Props> = FC {
                     }
 
                     CborDiagnosticViewer {
-                        diagText = Cbor.toDiagnostics(req.devReqDataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                        diagText = Cdn.encode(req.devReqDataItem, CdnGeneratorOptions.Pretty)
                         maxHeight = 350.px
                     }
                 }
@@ -780,7 +781,7 @@ val AnnexCParserComponent: FC<Props> = FC {
                     }
 
                     CborDiagnosticViewer {
-                        diagText = Cbor.toDiagnostics(resp.responseDataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                        diagText = Cdn.encode(resp.responseDataItem, CdnGeneratorOptions.Pretty)
                         maxHeight = 350.px
                     }
                 }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDecoderComponent.kt
@@ -37,6 +37,9 @@ val CborDecoderComponent = FC {
     var outputB64Url by useState("")
     var prettyPrint by useState(true)
     var decodeEmbeddedCbor by useState(true)
+    var useEmbeddedCborOpportunistically by useState(true)
+    var useEmbeddedCertsOpportunistically by useState(true)
+    var annotateCoseOpportunistically by useState(true)
     var useAppExtensions by useState(true)
     var sortKeys by useState(false)
     var bstrFormat by useState(ByteStringFormat.HEX)
@@ -56,6 +59,9 @@ val CborDecoderComponent = FC {
                     val options = CdnGeneratorOptions(
                         prettyPrint = prettyPrint,
                         useEmbeddedCborShorthand = decodeEmbeddedCbor,
+                        useEmbeddedCborOpportunistically = useEmbeddedCborOpportunistically,
+                        useEmbeddedCertsOpportunistically = useEmbeddedCertsOpportunistically,
+                        annotateCoseOpportunistically = annotateCoseOpportunistically,
                         useApplicationExtensions = useAppExtensions,
                         sortMapKeys = sortKeys,
                         byteStringFormat = bstrFormat
@@ -301,7 +307,58 @@ val CborDecoderComponent = FC {
                         checked = decodeEmbeddedCbor
                         onChange = { decodeEmbeddedCbor = it.target.checked }
                     }
-                    +"Decode embedded CBOR (<< ... >>)"
+                    +"Tag 24 embedded CBOR (<< ... >>)"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = useEmbeddedCborOpportunistically
+                        onChange = { useEmbeddedCborOpportunistically = it.target.checked }
+                    }
+                    +"Opportunistic embedded CBOR (<< ... >>)"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = useEmbeddedCertsOpportunistically
+                        onChange = { useEmbeddedCertsOpportunistically = it.target.checked }
+                    }
+                    +"Opportunistic X.509 certs (cert'''...''')"
+                }
+
+                label {
+                    css {
+                        display = Display.flex
+                        alignItems = AlignItems.center
+                        gap = 8.px
+                        cursor = Cursor.pointer
+                        color = Color("#cbd5e1")
+                        fontWeight = FontWeight.normal
+                    }
+                    input {
+                        type = "checkbox".unsafeCast<InputType>()
+                        checked = annotateCoseOpportunistically
+                        onChange = { annotateCoseOpportunistically = it.target.checked }
+                    }
+                    +"Opportunistic COSE (/label/, # alg)"
                 }
 
                 label {
@@ -414,7 +471,7 @@ val CborDecoderComponent = FC {
                                 fontWeight = FontWeight.normal
                                 color = Color("#cbd5e1")
                             }
-                            +"Diagnostic Output (CDN):"
+                            +"CDN Output:"
                         }
                         button {
                             css {

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDiagnosticViewer.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/CborDiagnosticViewer.kt
@@ -24,122 +24,185 @@ private data class Token(val text: String, val type: TokenType)
 
 private fun tokenizeCborDiagnostics(diagText: String): List<Token> {
     val tokens = mutableListOf<Token>()
-    val lines = diagText.split("\n")
+    var i = 0
+    val len = diagText.length
 
-    for (lineIdx in lines.indices) {
-        val line = lines[lineIdx]
-        var i = 0
-        val len = line.length
+    while (i < len) {
+        val ch = diagText[i]
 
-        while (i < len) {
-            val ch = line[i]
-
-            // Comment
-            if (ch == '#') {
-                tokens.add(Token(line.substring(i), TokenType.COMMENT))
-                i = len
-                break
+        // Triple-single-quoted string: '''...''' or cert'''...'''
+        if (ch == '\'' && i + 2 < len && diagText[i + 1] == '\'' && diagText[i + 2] == '\'') {
+            val start = i
+            i += 3
+            while (i + 2 < len && !(diagText[i] == '\'' && diagText[i + 1] == '\'' && diagText[i + 2] == '\'')) {
+                i++
             }
+            if (i + 2 < len) i += 3 else i = len
+            tokens.add(Token(diagText.substring(start, i), TokenType.STRING))
+            continue
+        }
 
-            // Hex string: h'...'
-            if (ch == 'h' && i + 1 < len && line[i + 1] == '\'') {
-                val start = i
-                i += 2
-                while (i < len && line[i] != '\'') {
+        // Triple-double-quoted string: """..."""
+        if (ch == '"' && i + 2 < len && diagText[i + 1] == '"' && diagText[i + 2] == '"') {
+            val start = i
+            i += 3
+            while (i + 2 < len && !(diagText[i] == '"' && diagText[i + 1] == '"' && diagText[i + 2] == '"')) {
+                i++
+            }
+            if (i + 2 < len) i += 3 else i = len
+            tokens.add(Token(diagText.substring(start, i), TokenType.STRING))
+            continue
+        }
+
+        // Single-line Comment: // or #
+        if (ch == '#' || (ch == '/' && i + 1 < len && diagText[i + 1] == '/')) {
+            val start = i
+            while (i < len && diagText[i] != '\n') i++
+            tokens.add(Token(diagText.substring(start, i), TokenType.COMMENT))
+            continue
+        }
+
+        // Multi-line Comment: /* ... */
+        if (ch == '/' && i + 1 < len && diagText[i + 1] == '*') {
+            val start = i
+            i += 2
+            while (i + 1 < len && !(diagText[i] == '*' && diagText[i + 1] == '/')) i++
+            if (i + 1 < len) i += 2 else i = len
+            tokens.add(Token(diagText.substring(start, i), TokenType.COMMENT))
+            continue
+        }
+
+        // Hex string: h'...' or b64'...'
+        if ((ch == 'h' || ch == 'b') && i + 1 < len && diagText[i + 1] == '\'') {
+            val start = i
+            i += 2
+            while (i < len && diagText[i] != '\'' && diagText[i] != '\n') i++
+            if (i < len && diagText[i] == '\'') i++
+            tokens.add(Token(diagText.substring(start, i), TokenType.HEX_STRING))
+            continue
+        }
+
+        // Single-quoted byte string: '...'
+        if (ch == '\'') {
+            val start = i
+            i++
+            while (i < len && diagText[i] != '\'' && diagText[i] != '\n') {
+                if (diagText[i] == '\\' && i + 1 < len) i += 2 else i++
+            }
+            if (i < len && diagText[i] == '\'') i++
+            tokens.add(Token(diagText.substring(start, i), TokenType.STRING))
+            continue
+        }
+
+        // Double-quoted text string: "..."
+        if (ch == '"') {
+            val start = i
+            i++
+            while (i < len && diagText[i] != '\n') {
+                if (diagText[i] == '\\' && i + 1 < len) {
+                    i += 2
+                } else if (diagText[i] == '"') {
+                    i++
+                    break
+                } else {
                     i++
                 }
-                if (i < len) i++ // include closing quote
-                tokens.add(Token(line.substring(start, i), TokenType.HEX_STRING))
+            }
+            tokens.add(Token(diagText.substring(start, i), TokenType.STRING))
+            continue
+        }
+
+        // Embedded CBOR: << or >>
+        if (i + 1 < len && ((ch == '<' && diagText[i + 1] == '<') || (ch == '>' && diagText[i + 1] == '>'))) {
+            tokens.add(Token(diagText.substring(i, i + 2), TokenType.EMBEDDED))
+            i += 2
+            continue
+        }
+
+        // Tag: e.g. 18( or 24( or 24_0(
+        if (ch.isDigit()) {
+            var j = i
+            while (j < len && (diagText[j].isDigit() || (diagText[j] == '_' && j + 1 < len && diagText[j + 1].isDigit()))) j++
+            if (j < len && diagText[j] == '(') {
+                tokens.add(Token(diagText.substring(i, j + 1), TokenType.TAG))
+                i = j + 1
                 continue
-            }
-
-            // Text string: "..."
-            if (ch == '"') {
-                val start = i
-                i++
-                while (i < len) {
-                    if (line[i] == '\\' && i + 1 < len) {
-                        i += 2
-                    } else if (line[i] == '"') {
-                        i++
-                        break
-                    } else {
-                        i++
-                    }
-                }
-                tokens.add(Token(line.substring(start, i), TokenType.STRING))
-                continue
-            }
-
-            // Embedded CBOR: << or >>
-            if (i + 1 < len && ((ch == '<' && line[i + 1] == '<') || (ch == '>' && line[i + 1] == '>'))) {
-                tokens.add(Token(line.substring(i, i + 2), TokenType.EMBEDDED))
-                i += 2
-                continue
-            }
-
-            // Tag: 24( or 100(
-            if (ch.isDigit()) {
-                var j = i
-                while (j < len && line[j].isDigit()) j++
-                if (j < len && line[j] == '(') {
-                    tokens.add(Token(line.substring(i, j + 1), TokenType.TAG))
-                    i = j + 1
-                    continue
-                }
-            }
-
-            // Boolean / null / undefined
-            if (ch.isLetter()) {
-                val start = i
-                while (i < len && (line[i].isLetterOrDigit() || line[i] == '_')) i++
-                val word = line.substring(start, i)
-                if (word == "true" || word == "false" || word == "null" || word == "undefined") {
-                    tokens.add(Token(word, TokenType.BOOL))
-                } else {
-                    tokens.add(Token(word, TokenType.PLAIN))
-                }
-                continue
-            }
-
-            // Numbers: -123 or 123
-            if (ch.isDigit() || (ch == '-' && i + 1 < len && line[i + 1].isDigit())) {
-                val start = i
-                if (ch == '-') i++
-                while (i < len && (line[i].isDigit() || line[i] == '.')) i++
-                tokens.add(Token(line.substring(start, i), TokenType.NUMBER))
-                continue
-            }
-
-            // Punctuation
-            if (ch in "{}[],:") {
-                tokens.add(Token(ch.toString(), TokenType.PUNCTUATION))
-                i++
-                continue
-            }
-
-            // Plain whitespace / other characters
-            val start = i
-            while (i < len) {
-                val c = line[i]
-                if (c == '#' || c == '"' || c == '{' || c == '}' || c == '[' || c == ']' || c == ',' || c == ':' ||
-                    c.isLetterOrDigit() || c == '-' || (c == 'h' && i + 1 < len && line[i + 1] == '\'') ||
-                    (i + 1 < len && ((c == '<' && line[i + 1] == '<') || (c == '>' && line[i + 1] == '>')))) {
-                    break
-                }
-                i++
-            }
-            if (i > start) {
-                tokens.add(Token(line.substring(start, i), TokenType.PLAIN))
             }
         }
 
-        if (lineIdx < lines.size - 1) {
+        // Identifiers & Keywords (e.g. cert, dt, ip, true, false, null)
+        if (ch.isLetter() || ch == '_' || ch == '$') {
+            val start = i
+            while (i < len && (diagText[i].isLetterOrDigit() || diagText[i] == '_' || diagText[i] == '-' || diagText[i] == '$')) i++
+            val word = diagText.substring(start, i)
+            if (word == "true" || word == "false" || word == "null" || word == "undefined") {
+                tokens.add(Token(word, TokenType.BOOL))
+            } else {
+                tokens.add(Token(word, TokenType.PLAIN))
+            }
+            continue
+        }
+
+        // Numbers: -123 or 123
+        if (ch.isDigit() || (ch == '-' && i + 1 < len && diagText[i + 1].isDigit())) {
+            val start = i
+            if (ch == '-') i++
+            while (i < len && (diagText[i].isDigit() || diagText[i] == '.' || diagText[i] == 'e' || diagText[i] == 'E')) i++
+            tokens.add(Token(diagText.substring(start, i), TokenType.NUMBER))
+            continue
+        }
+
+        // Punctuation
+        if (ch in "{}[],:()") {
+            tokens.add(Token(ch.toString(), TokenType.PUNCTUATION))
+            i++
+            continue
+        }
+
+        // Newline
+        if (ch == '\n') {
             tokens.add(Token("\n", TokenType.PLAIN))
+            i++
+            continue
+        }
+
+        // Whitespace and other characters
+        val start = i
+        while (i < len) {
+            val c = diagText[i]
+            if (c == '\n' || c == '#' || c == '"' || c == '\'' || c == '{' || c == '}' || c == '[' || c == ']' ||
+                c == '(' || c == ')' || c == ',' || c == ':' || c.isLetterOrDigit() || c == '-' ||
+                (c == 'h' && i + 1 < len && diagText[i + 1] == '\'') ||
+                (i + 1 < len && ((c == '<' && diagText[i + 1] == '<') || (c == '>' && diagText[i + 1] == '>')))) {
+                break
+            }
+            i++
+        }
+        if (i > start) {
+            tokens.add(Token(diagText.substring(start, i), TokenType.PLAIN))
+        } else {
+            tokens.add(Token(diagText[i].toString(), TokenType.PLAIN))
+            i++
         }
     }
 
-    return tokens
+    // Merge adjacent tokens of the same type (except newlines, embedded symbols, or tags) to minimize DOM nodes
+    val merged = mutableListOf<Token>()
+    for (t in tokens) {
+        if (merged.isNotEmpty() &&
+            merged.last().type == t.type &&
+            !merged.last().text.endsWith("\n") &&
+            t.text != "\n" &&
+            t.type != TokenType.EMBEDDED &&
+            t.type != TokenType.TAG
+        ) {
+            merged[merged.lastIndex] = Token(merged.last().text + t.text, t.type)
+        } else {
+            merged.add(t)
+        }
+    }
+
+    return merged
 }
 
 external interface CborDiagnosticViewerProps : Props {

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/DeviceRequestParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/DeviceRequestParserComponent.kt
@@ -10,8 +10,9 @@ import js.typedarrays.toByteArray
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.DataItem
-import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cose.Cose
 import org.multipaz.cose.toCoseLabel
@@ -162,7 +163,7 @@ external interface ItemsRequestViewerBlockProps : Props {
 private val ItemsRequestViewerBlock: FC<ItemsRequestViewerBlockProps> = FC { props ->
     var copyStatus by useState("")
     val itemsReqHex = Cbor.encode(props.itemsReqItem).toHex()
-    val itemsReqDiag = Cbor.toDiagnostics(props.itemsReqItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+    val itemsReqDiag = Cdn.encode(props.itemsReqItem, CdnGeneratorOptions.Pretty)
 
     div {
         css {
@@ -340,12 +341,12 @@ val DeviceRequestParserComponent: FC<Props> = FC {
                             }
                         }
                         onClick = {
-                            val diag = Cbor.toDiagnostics(result.rawDataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                            val diag = Cdn.encode(result.rawDataItem, CdnGeneratorOptions.Pretty)
                             window.navigator.asDynamic().clipboard.writeText(diag)
-                            copyDiagStatus = "Copied Diagnostics!"
+                            copyDiagStatus = "Copied CDN!"
                             window.setTimeout({ copyDiagStatus = "" }, 2000)
                         }
-                        +if (copyDiagStatus.isNotEmpty()) copyDiagStatus else "Copy CBOR Diagnostics"
+                        +if (copyDiagStatus.isNotEmpty()) copyDiagStatus else "Copy CDN"
                     }
                 }
             }
@@ -764,7 +765,7 @@ val DeviceRequestParserComponent: FC<Props> = FC {
                         }
 
                         CborDiagnosticViewer {
-                            diagText = Cbor.toDiagnostics(info.dataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                            diagText = Cdn.encode(info.dataItem, CdnGeneratorOptions.Pretty)
                             maxHeight = 250.px
                         }
                     }
@@ -776,11 +777,11 @@ val DeviceRequestParserComponent: FC<Props> = FC {
 
                     label {
                         css { display = Display.block; fontWeight = FontWeight.bold; color = Color("#cbd5e1"); marginBottom = 8.px }
-                        +"Full DeviceRequest CBOR Diagnostic Notation:"
+                        +"Full DeviceRequest CBOR CDN View:"
                     }
 
                     CborDiagnosticViewer {
-                        diagText = Cbor.toDiagnostics(rawDataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                        diagText = Cdn.encode(rawDataItem, CdnGeneratorOptions.Pretty)
                         maxHeight = 400.px
                     }
                 }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
@@ -10,8 +10,9 @@ import js.typedarrays.toByteArray
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
 import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.DataItem
-import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.eventlogger.Event
@@ -527,7 +528,7 @@ private val CborDataBlock: FC<CborDataBlockProps> = FC { props ->
     var copyHexStatus by useState("")
     val encodedBytes = Cbor.encode(props.dataItem)
     val hexString = encodedBytes.toHex()
-    val diagText = Cbor.toDiagnostics(props.dataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+    val diagText = Cdn.encode(props.dataItem, CdnGeneratorOptions.Pretty)
 
     div {
         css {
@@ -1083,7 +1084,7 @@ private val CredentialCard: FC<CredentialCardProps> = FC { props ->
         // CBOR diagnostic preview if data is valid CBOR
         val diagPreview = try {
             val dataItem = Cbor.decode(bytes)
-            Cbor.toDiagnostics(dataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+            Cdn.encode(dataItem, CdnGeneratorOptions.Pretty)
         } catch (e: Throwable) {
             null
         }
@@ -1617,7 +1618,7 @@ private fun react.ChildrenBuilder.renderEventAppDataSection(appData: Map<String,
                 }
 
                 CborDiagnosticViewer {
-                    diagText = Cbor.toDiagnostics(dataItem, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                    diagText = Cdn.encode(dataItem, CdnGeneratorOptions.Pretty)
                     maxHeight = 200.px
                 }
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Iso180137VerifierComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/Iso180137VerifierComponent.kt
@@ -28,7 +28,8 @@ import org.multipaz.crypto.X509CertChain
 import org.multipaz.mdoc.util.MdocUtil
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.addCborArray
 import org.multipaz.cbor.addCborMap
@@ -2569,9 +2570,9 @@ val Iso180137VerifierComponent: FC<Props> = FC {
             if (generatedDevReqDataItem != null) {
                 div {
                     css { marginTop = 12.px }
-                    h4 { css { fontSize = 13.px; color = Color("#94a3b8"); margin = Margin(0.px, 0.px, 6.px, 0.px) }; +"DeviceRequest CBOR Diagnostic View:" }
+                    h4 { css { fontSize = 13.px; color = Color("#94a3b8"); margin = Margin(0.px, 0.px, 6.px, 0.px) }; +"DeviceRequest CBOR CDN View:" }
                     CborDiagnosticViewer {
-                        diagText = Cbor.toDiagnostics(generatedDevReqDataItem!!, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                        diagText = Cdn.encode(generatedDevReqDataItem!!, CdnGeneratorOptions.Pretty)
                         maxHeight = 220.px
                     }
                 }
@@ -2782,7 +2783,7 @@ val Iso180137VerifierComponent: FC<Props> = FC {
                 }
 
                 CborDiagnosticViewer {
-                    diagText = Cbor.toDiagnostics(resp.deviceResponse, setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                    diagText = Cdn.encode(resp.deviceResponse, CdnGeneratorOptions.Pretty)
                     maxHeight = 300.px
                 }
             }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/KeyGeneratorComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/KeyGeneratorComponent.kt
@@ -21,7 +21,8 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.util.toHex
 
 val KeyGeneratorComponent = FC {
@@ -158,8 +159,8 @@ val KeyGeneratorComponent = FC {
                         cosePrivateText = Cbor.encode(key.toCoseKey().toDataItem()).toHex()
                         cosePublicText = Cbor.encode(key.publicKey.toCoseKey().toDataItem()).toHex()
 
-                        diagPrivateText = Cbor.toDiagnostics(key.toCoseKey().toDataItem(), setOf(DiagnosticOption.PRETTY_PRINT))
-                        diagPublicText = Cbor.toDiagnostics(key.publicKey.toCoseKey().toDataItem(), setOf(DiagnosticOption.PRETTY_PRINT))
+                        diagPrivateText = Cdn.encode(key.toCoseKey().toDataItem(), CdnGeneratorOptions.Pretty)
+                        diagPublicText = Cdn.encode(key.publicKey.toCoseKey().toDataItem(), CdnGeneratorOptions.Pretty)
 
                         pemPrivateText = key.toPem()
                         pemPublicText = key.publicKey.toPem()
@@ -285,7 +286,7 @@ val KeyGeneratorComponent = FC {
                             listOf(
                                 "jwk" to "JWK (JSON)",
                                 "cose" to "COSE Hex (CBOR)",
-                                "diagnostic" to "Diagnostic",
+                                "diagnostic" to "CDN",
                                 "pem" to "PEM"
                             ).forEach { (tabId, tabTitle) ->
                                 button {
@@ -390,7 +391,7 @@ val KeyGeneratorComponent = FC {
                             listOf(
                                 "jwk" to "JWK (JSON)",
                                 "cose" to "COSE Hex (CBOR)",
-                                "diagnostic" to "Diagnostic",
+                                "diagnostic" to "CDN",
                                 "pem" to "PEM"
                             ).forEach { (tabId, tabTitle) ->
                                 button {

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MdocViewerComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MdocViewerComponent.kt
@@ -5,7 +5,8 @@ import emotion.react.css
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.mdoc.response.DeviceResponse
 import org.multipaz.util.toBase64
 import org.multipaz.util.toHex
@@ -617,9 +618,9 @@ val MdocViewerComponent = FC {
                                                                     }
                                                                 }
                                                             } else {
-                                                                +try {
-                                                                    Cbor.toDiagnostics(item.dataElementValue, setOf(DiagnosticOption.EMBEDDED_CBOR))
-                                                                } catch (e: Throwable) {
+                                                                 +try {
+                                                                     Cdn.encode(item.dataElementValue)
+                                                                 } catch (e: Throwable) {
                                                                     "Error formatting item"
                                                                 }
                                                             }
@@ -739,12 +740,12 @@ val MdocViewerComponent = FC {
 
                             label {
                                 css { display = Display.block; fontSize = 12.px; fontWeight = FontWeight.bold; color = Color("#94a3b8"); marginBottom = 6.px }
-                                +"ZkDocument CBOR Diagnostics:"
+                                +"ZkDocument CBOR CDN View:"
                             }
 
                             CborDiagnosticViewer {
                                 diagText = try {
-                                    Cbor.toDiagnostics(zkDoc.toDataItem(), setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR))
+                                    Cdn.encode(zkDoc.toDataItem(), CdnGeneratorOptions.Pretty)
                                 } catch (e: Throwable) {
                                     "Error formatting ZkDocument: ${e.message}"
                                 }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MsoNamespacesViewerComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MsoNamespacesViewerComponent.kt
@@ -35,7 +35,8 @@ import web.html.InputType
 import web.cssom.*
 import kotlinx.coroutines.launch
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Tagged
 import org.multipaz.mdoc.mso.MobileSecurityObject
@@ -488,7 +489,7 @@ private fun react.ChildrenBuilder.renderMsoDetails(mso: MobileSecurityObject) {
                 }
                 code {
                     +try {
-                        Cbor.toDiagnostics(mso.deviceKey.toCoseKey().toDataItem(), setOf(DiagnosticOption.EMBEDDED_CBOR))
+                        Cdn.encode(mso.deviceKey.toCoseKey().toDataItem())
                     } catch (e: Throwable) {
                         "Error formatting device key"
                     }
@@ -538,7 +539,7 @@ private fun react.ChildrenBuilder.renderMsoDetails(mso: MobileSecurityObject) {
                     }
                     code {
                         +try {
-                            Cbor.toDiagnostics(revocationStatus.toDataItem(), setOf(DiagnosticOption.EMBEDDED_CBOR))
+                            Cdn.encode(revocationStatus.toDataItem())
                         } catch (e: Throwable) {
                             "Error formatting revocation status"
                         }
@@ -692,7 +693,7 @@ private fun react.ChildrenBuilder.renderNamespacesDetails(namespaces: IssuerName
                                         }
                                     } else {
                                         +try {
-                                            Cbor.toDiagnostics(item.dataElementValue, setOf(DiagnosticOption.EMBEDDED_CBOR))
+                                            Cdn.encode(item.dataElementValue)
                                         } catch (e: Throwable) {
                                             "Error formatting item"
                                         }

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/X509ParserComponent.kt
@@ -35,7 +35,8 @@ import org.multipaz.asn1.ASN1Integer
 import org.multipaz.asn1.ASN1Sequence
 import org.multipaz.asn1.OID
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
 import org.multipaz.certext.MultipazExtension
 import org.multipaz.certext.fromCbor
 import org.multipaz.util.AndroidAttestationExtensionParser
@@ -760,10 +761,7 @@ private fun formatExtensionValue(cert: X509Cert, extOid: String, extData: ByteAr
             AndroidAttestationExtensionParser(cert).prettyPrint()
 
         OID.X509_EXTENSION_ANDROID_KEYSTORE_PROVISIONING_INFORMATION.oid ->
-            Cbor.toDiagnostics(
-                extData,
-                setOf(DiagnosticOption.PRETTY_PRINT),
-            )
+            Cdn.encode(extData, CdnGeneratorOptions.Pretty)
 
         OID.X509_EXTENSION_MULTIPAZ_EXTENSION.oid ->
             MultipazExtension.fromCbor(extData).prettyPrint()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnExtension.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnExtension.kt
@@ -1,5 +1,7 @@
 package org.multipaz.cbor
 
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.crypto.X509Cert
 import org.multipaz.util.fromBase64
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.fromHex
@@ -26,7 +28,7 @@ interface CdnExtension {
     /**
      * Formats a [DataItem] into CDN extension syntax, or returns `null` if not applicable.
      */
-    fun format(item: DataItem, options: CdnGeneratorOptions): String?
+    fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int = 0): String?
 }
 
 /**
@@ -58,13 +60,14 @@ class CdnExtensionRegistry {
          */
         val Default: CdnExtensionRegistry by lazy {
             CdnExtensionRegistry().apply {
-                register(HexExtension)
-                register(Base64Extension)
+                register(CertExtension)
                 register(DateTimeExtension)
                 register(IpExtension)
                 register(FloatExtension)
                 register(StringConcatByteExtension)
                 register(StringConcatTextExtension)
+                register(HexExtension)
+                register(Base64Extension)
             }
         }
     }
@@ -82,7 +85,7 @@ object HexExtension : CdnExtension {
         return Bstr(bytes)
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
         if (options.byteStringFormat == ByteStringFormat.HEX && item is Bstr) {
             return "h'${item.value.toHex()}'"
         }
@@ -106,7 +109,7 @@ object Base64Extension : CdnExtension {
         return Bstr(bytes)
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
         if (options.byteStringFormat == ByteStringFormat.BASE64 && item is Bstr) {
             return "b64'${item.value.toBase64()}'"
         }
@@ -124,7 +127,7 @@ object DateTimeExtension : CdnExtension {
         return Tagged(Tagged.DATE_TIME_STRING, Tstr(content))
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
         if (!options.useApplicationExtensions) return null
         if (item is Tagged && item.tagNumber == Tagged.DATE_TIME_STRING && item.taggedItem is Tstr) {
             return "dt'${(item.taggedItem as Tstr).value}'"
@@ -163,7 +166,7 @@ object IpExtension : CdnExtension {
         }
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
         if (!options.useApplicationExtensions) return null
         if (item is Tagged) {
             if (item.tagNumber == 52L && item.taggedItem is Bstr && item.taggedItem.asBstr.size == 4) {
@@ -239,7 +242,7 @@ object FloatExtension : CdnExtension {
         throw CdnException("Invalid float extension literal: $content")
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? = null
 
     private fun float16ToFloat(bits: Int): Float {
         val s = (bits shr 15) and 0x01
@@ -275,7 +278,7 @@ object StringConcatByteExtension : CdnExtension {
         return Bstr(content.encodeToByteArray())
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? = null
 }
 
 /**
@@ -288,5 +291,47 @@ object StringConcatTextExtension : CdnExtension {
         return Tstr(content)
     }
 
-    override fun format(item: DataItem, options: CdnGeneratorOptions): String? = null
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? = null
+}
+
+/**
+ * Extension for X.509 certificates: `cert'''-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----'''`.
+ */
+object CertExtension : CdnExtension {
+    override val identifier: String = "cert"
+
+    override fun parseLiteral(content: String, delimiter: Char): DataItem {
+        val cert = X509Cert.fromPem(content)
+        return Bstr(cert.encoded.toByteArray())
+    }
+
+    override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
+        if (!options.useApplicationExtensions || !options.useEmbeddedCertsOpportunistically) return null
+        if (item is Bstr) {
+            val bytes = item.value
+            // Fast path check: X.509 DER certificate MUST start with 0x30 (SEQUENCE) and be >= 64 bytes
+            if (bytes.size < 64 || bytes[0] != 0x30.toByte()) {
+                return null
+            }
+            try {
+                val cert = X509Cert(ByteString(bytes))
+                cert.version // Trigger parsing to ensure valid X.509 structure
+                val pem = cert.toPem().trim()
+                return if (options.prettyPrint) {
+                    val itemIndentStr = " ".repeat(indent)
+                    val pemIndentStr = " ".repeat(indent + options.indentSize)
+                    val subjectLine = "$itemIndentStr# Subject DN: ${cert.subject.name}"
+                    val issuerLine = "$itemIndentStr# Issuer DN: ${cert.issuer.name}"
+                    val indentedPem = pem.lines().joinToString("\n") { "$pemIndentStr$it" }
+                    val block = "$subjectLine\n$issuerLine\n${itemIndentStr}cert'''\n$indentedPem\n$itemIndentStr'''"
+                    if (indent > 0) "\n$block" else block
+                } else {
+                    "cert'''\n# Subject DN: ${cert.subject.name}\n# Issuer DN: ${cert.issuer.name}\n$pem\n'''"
+                }
+            } catch (_: Throwable) {
+                // Not a valid X.509 certificate
+            }
+        }
+        return null
+    }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
@@ -1,5 +1,7 @@
 package org.multipaz.cbor
 
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.EcCurve
 import org.multipaz.util.toHex
 
 internal class CdnGenerator(private val options: CdnGeneratorOptions) {
@@ -10,24 +12,71 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
         return sb.toString()
     }
 
-    private fun generateItem(sb: StringBuilder, indent: Int, item: DataItem) {
+    private fun generateItem(
+        sb: StringBuilder,
+        indent: Int,
+        item: DataItem,
+        isCoseHeaderMap: Boolean = false
+    ) {
         val pretty = options.prettyPrint
         val indentStr = if (pretty) " ".repeat(indent) else ""
 
         if (item is RawCbor) {
             val decoded = Cbor.decode(item.encodedCbor)
-            generateItem(sb, indent, decoded)
+            generateItem(sb, indent, decoded, isCoseHeaderMap)
             return
         }
 
-        // Try application extensions first (e.g. dt'...', ip'...', or custom registered extensions)
+        // Try application extensions first (e.g. cert'''...''', dt'...', ip'...')
         if (options.useApplicationExtensions) {
             for (ext in options.extensionRegistry.all) {
-                val formatted = ext.format(item, options)
+                if (ext is HexExtension || ext is Base64Extension) continue
+                val formatted = ext.format(item, options, indent)
                 if (formatted != null) {
-                    sb.append(formatted)
+                    if (formatted.startsWith("\n")) {
+                        while (sb.isNotEmpty() && sb.last() == ' ') {
+                            sb.deleteAt(sb.length - 1)
+                        }
+                        if (sb.endsWith("\n")) {
+                            sb.append(formatted.substring(1))
+                        } else {
+                            sb.append(formatted)
+                        }
+                    } else {
+                        sb.append(formatted)
+                    }
                     return
                 }
+            }
+        }
+
+        if (item is Bstr && options.useEmbeddedCborOpportunistically) {
+            try {
+                val embedded = Cbor.decode(item.value)
+                if (embedded !is Bstr) {
+                    sb.append("<< ")
+                    generateItem(sb, indent, embedded, isCoseHeaderMap = isCoseHeaderMap)
+                    sb.append(" >>")
+                    return
+                }
+            } catch (_: Throwable) {
+                // Fallback if CBOR decode fails
+            }
+        }
+
+        // Try remaining application extensions (e.g. h'...', b64'...')
+        if (options.useApplicationExtensions) {
+            val hexExt = options.extensionRegistry.get("h")
+            val hexFormatted = hexExt?.format(item, options, indent)
+            if (hexFormatted != null) {
+                sb.append(hexFormatted)
+                return
+            }
+            val b64Ext = options.extensionRegistry.get("b64")
+            val b64Formatted = b64Ext?.format(item, options, indent)
+            if (b64Formatted != null) {
+                sb.append(b64Formatted)
+                return
             }
         }
 
@@ -88,22 +137,45 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
                 val isIndef = item.indefiniteLength
                 val openBracket = if (isIndef) "[_ " else "["
 
+                val coseStructure = if (options.annotateCoseOpportunistically) {
+                    detectCoseArrayStructure(item, isTaggedCose = false)
+                } else null
+
                 if (!pretty || arrayItems.isEmpty()) {
                     sb.append(openBracket)
                     var count = 0
-                    for (elem in arrayItems) {
+                    for ((idx, elem) in arrayItems.withIndex()) {
                         if (count++ > 0) sb.append(", ")
-                        generateItem(sb, indent, elem)
+                        if (coseStructure != null) {
+                            val elementComment = getCoseArrayElementComment(coseStructure, idx)
+                            if (elementComment != null) {
+                                sb.append("/").append(elementComment).append("/ ")
+                            }
+                        }
+                        val isHeaderElem = coseStructure != null && (idx == 0 || idx == 1)
+                        generateItem(sb, indent, elem, isCoseHeaderMap = isHeaderElem)
                     }
                     sb.append("]")
                 } else {
-                    sb.append(if (isIndef) "[_\n" else "[\n")
+                    val structComment = when (coseStructure) {
+                        CoseStructureType.COSE_SIGN1 -> " # COSE_Sign1"
+                        CoseStructureType.COSE_MAC0 -> " # COSE_Mac0"
+                        null -> ""
+                    }
+                    sb.append(if (isIndef) "[_$structComment\n" else "[$structComment\n")
                     val childIndent = indent + options.indentSize
                     val childIndentStr = " ".repeat(childIndent)
                     var count = 0
-                    for (elem in arrayItems) {
+                    for ((idx, elem) in arrayItems.withIndex()) {
                         sb.append(childIndentStr)
-                        generateItem(sb, childIndent, elem)
+                        if (coseStructure != null) {
+                            val elementComment = getCoseArrayElementComment(coseStructure, idx)
+                            if (elementComment != null) {
+                                sb.append("/").append(elementComment).append("/ ")
+                            }
+                        }
+                        val isHeaderElem = coseStructure != null && (idx == 0 || idx == 1)
+                        generateItem(sb, childIndent, elem, isCoseHeaderMap = isHeaderElem)
                         if (++count < arrayItems.size) {
                             sb.append(",")
                         }
@@ -122,28 +194,60 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
                 val isIndef = item.indefiniteLength
                 val openBrace = if (isIndef) "{_ " else "{"
 
+                val isCoseKeyMap = options.annotateCoseOpportunistically && isCoseKey(mapObj)
+                val isCoseHeaderMapToUse = options.annotateCoseOpportunistically && !isCoseKeyMap && (isCoseHeaderMap || (indent == 0 && isCoseHeaderMap(mapObj)))
+                val ktyVal = if (isCoseKeyMap) getKtyValue(mapObj) else null
+
                 if (!pretty || mapEntries.isEmpty()) {
                     sb.append(openBrace)
                     var count = 0
                     for ((key, value) in mapEntries) {
                         if (count++ > 0) sb.append(", ")
+                        val keyInt = getIntegerKey(key)
+                        val labelComment = when {
+                            isCoseKeyMap && keyInt != null -> getCoseKeyLabelComment(keyInt, ktyVal)
+                            isCoseHeaderMapToUse && keyInt != null -> getCoseHeaderLabelComment(keyInt)
+                            else -> null
+                        }
+                        if (labelComment != null) {
+                            sb.append("/").append(labelComment).append("/ ")
+                        }
                         generateItem(sb, indent, key)
                         sb.append(": ")
                         generateItem(sb, indent, value)
+                        val valDesc = if (labelComment != null) getCoseValueDescription(labelComment, value) else null
+                        if (valDesc != null) {
+                            sb.append(" # ").append(valDesc)
+                        }
                     }
                     sb.append("}")
                 } else {
-                    sb.append(if (isIndef) "{_\n" else "{\n")
+                    val keyComment = if (isCoseKeyMap) " # COSE_Key" else ""
+                    sb.append(if (isIndef) "{_$keyComment\n" else "{$keyComment\n")
                     val childIndent = indent + options.indentSize
                     val childIndentStr = " ".repeat(childIndent)
                     var count = 0
                     for ((key, value) in mapEntries) {
                         sb.append(childIndentStr)
+                        val keyInt = getIntegerKey(key)
+                        val labelComment = when {
+                            isCoseKeyMap && keyInt != null -> getCoseKeyLabelComment(keyInt, ktyVal)
+                            isCoseHeaderMapToUse && keyInt != null -> getCoseHeaderLabelComment(keyInt)
+                            else -> null
+                        }
+                        if (labelComment != null) {
+                            sb.append("/").append(labelComment).append("/ ")
+                        }
                         generateItem(sb, childIndent, key)
                         sb.append(": ")
                         generateItem(sb, childIndent, value)
-                        if (++count < mapEntries.size) {
+                        val isLast = (++count == mapEntries.size)
+                        if (!isLast) {
                             sb.append(",")
+                        }
+                        val valDesc = if (labelComment != null) getCoseValueDescription(labelComment, value) else null
+                        if (valDesc != null) {
+                            sb.append(" # ").append(valDesc)
                         }
                         sb.append("\n")
                     }
@@ -155,21 +259,29 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
                 val tagged = item as Tagged
                 val tagNum = tagged.tagNumber
 
-                // Embedded CBOR shorthand << item >> for Tag 24
+                // Embedded CBOR shorthand 24(<< item >>) for Tag 24
                 if (tagNum == Tagged.ENCODED_CBOR && options.useEmbeddedCborShorthand && tagged.taggedItem is Bstr) {
                     try {
                         val embedded = Cbor.decode((tagged.taggedItem as Bstr).value)
-                        sb.append("<< ")
-                        generateItem(sb, indent, embedded)
-                        sb.append(" >>")
+                        sb.append("24(<< ")
+                        generateItem(sb, indent, embedded, isCoseHeaderMap)
+                        sb.append(" >>)")
                         return
-                    } catch (_: Exception) {
+                    } catch (_: Throwable) {
                         // Fallback to tag format if CBOR decode fails
                     }
                 }
 
+                if (options.annotateCoseOpportunistically && (tagNum == Tagged.COSE_SIGN1 || tagNum == Tagged.COSE_MAC0) && tagged.taggedItem is CborArray) {
+                    val coseStructure = if (tagNum == Tagged.COSE_SIGN1) CoseStructureType.COSE_SIGN1 else CoseStructureType.COSE_MAC0
+                    sb.append(tagNum).append("(")
+                    generateCoseArray(sb, indent, tagged.taggedItem as CborArray, coseStructure)
+                    sb.append(")")
+                    return
+                }
+
                 sb.append(tagNum).append("(")
-                generateItem(sb, indent, tagged.taggedItem)
+                generateItem(sb, indent, tagged.taggedItem, isCoseHeaderMap)
                 sb.append(")")
             }
 
@@ -190,6 +302,54 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
                     else -> throw IllegalArgumentException("Unexpected MajorType.SPECIAL item")
                 }
             }
+        }
+    }
+
+    private fun generateCoseArray(
+        sb: StringBuilder,
+        indent: Int,
+        array: CborArray,
+        structure: CoseStructureType
+    ) {
+        val arrayItems = array.items
+        val isIndef = array.indefiniteLength
+        val pretty = options.prettyPrint
+        val indentStr = if (pretty) " ".repeat(indent) else ""
+
+        if (!pretty || arrayItems.isEmpty()) {
+            val openBracket = if (isIndef) "[_ " else "["
+            sb.append(openBracket)
+            var count = 0
+            for ((idx, elem) in arrayItems.withIndex()) {
+                if (count++ > 0) sb.append(", ")
+                val elementComment = getCoseArrayElementComment(structure, idx)
+                if (elementComment != null) {
+                    sb.append("/").append(elementComment).append("/ ")
+                }
+                val isHeaderElem = (idx == 0 || idx == 1)
+                generateItem(sb, indent, elem, isCoseHeaderMap = isHeaderElem)
+            }
+            sb.append("]")
+        } else {
+            val structComment = if (structure == CoseStructureType.COSE_SIGN1) " # COSE_Sign1" else " # COSE_Mac0"
+            sb.append(if (isIndef) "[_$structComment\n" else "[$structComment\n")
+            val childIndent = indent + options.indentSize
+            val childIndentStr = " ".repeat(childIndent)
+            var count = 0
+            for ((idx, elem) in arrayItems.withIndex()) {
+                sb.append(childIndentStr)
+                val elementComment = getCoseArrayElementComment(structure, idx)
+                if (elementComment != null) {
+                    sb.append("/").append(elementComment).append("/ ")
+                }
+                val isHeaderElem = (idx == 0 || idx == 1)
+                generateItem(sb, childIndent, elem, isCoseHeaderMap = isHeaderElem)
+                if (++count < arrayItems.size) {
+                    sb.append(",")
+                }
+                sb.append("\n")
+            }
+            sb.append(indentStr).append("]")
         }
     }
 
@@ -240,5 +400,183 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
             if (v !in 32..126) return false
         }
         return true
+    }
+
+    private enum class CoseStructureType {
+        COSE_SIGN1,
+        COSE_MAC0
+    }
+
+    private fun detectCoseArrayStructure(item: DataItem, isTaggedCose: Boolean): CoseStructureType? {
+        if (item !is CborArray) return null
+        val items = item.items
+        if (items.size != 4) return null
+
+        val p = items[0] as? Bstr ?: return null
+        val uMap = items[1] as? CborMap ?: return null
+        val payload = items[2]
+        if (items[3] !is Bstr) return null
+        if (payload !is Bstr && payload != Simple.NULL && payload != Simple.UNDEFINED) return null
+
+        val pMap: CborMap = if (p.value.isEmpty()) {
+            CborMap(mutableMapOf())
+        } else {
+            try {
+                val decoded = Cbor.decode(p.value)
+                decoded as? CborMap
+            } catch (_: Throwable) {
+                null
+            }
+        } ?: return null
+
+        val hasSign1Headers = hasCoseHeader(pMap, COSE_HEADER_LABELS) || hasCoseHeader(uMap, COSE_HEADER_LABELS)
+        val hasMac0Headers = hasCoseHeader(pMap, COSE_HEADER_LABELS) || hasCoseHeader(uMap, COSE_HEADER_LABELS)
+
+        return when {
+            hasSign1Headers -> CoseStructureType.COSE_SIGN1
+            hasMac0Headers -> CoseStructureType.COSE_MAC0
+            isTaggedCose -> CoseStructureType.COSE_SIGN1
+            else -> null
+        }
+    }
+
+    private fun isCoseHeaderMap(map: CborMap): Boolean {
+        return hasCoseHeader(map, COSE_HEADER_LABELS)
+    }
+
+    private fun hasCoseHeader(map: CborMap, labels: Set<Long>): Boolean {
+        for (key in map.items.keys) {
+            val k = getIntegerKey(key) ?: continue
+            if (k in labels) return true
+        }
+        return false
+    }
+
+    private fun isCoseKey(map: CborMap): Boolean {
+        var hasKty = false
+        var hasOtherKeyParam = false
+
+        for ((key, value) in map.items) {
+            val k = getIntegerKey(key) ?: continue
+            if (k == 1L) {
+                val v = getIntegerValue(value) ?: continue
+                if (v in 1L..4L) {
+                    hasKty = true
+                }
+            } else if (k in COSE_KEY_PARAM_LABELS) {
+                hasOtherKeyParam = true
+            }
+        }
+        return hasKty && hasOtherKeyParam
+    }
+
+    private fun getKtyValue(map: CborMap): Long? {
+        for ((key, value) in map.items) {
+            if (getIntegerKey(key) == 1L) {
+                return getIntegerValue(value)
+            }
+        }
+        return null
+    }
+
+    private fun getIntegerKey(item: DataItem): Long? {
+        return when (item) {
+            is Uint -> item.value.toLong()
+            is Nint -> -item.value.toLong()
+            else -> null
+        }
+    }
+
+    private fun getIntegerValue(item: DataItem): Long? {
+        return when (item) {
+            is Uint -> item.value.toLong()
+            is Nint -> -item.value.toLong()
+            else -> null
+        }
+    }
+
+    private fun getCoseArrayElementComment(structure: CoseStructureType, index: Int): String? {
+        return when (index) {
+            0 -> "protected"
+            1 -> "unprotected"
+            2 -> "payload"
+            3 -> if (structure == CoseStructureType.COSE_SIGN1) "signature" else "tag"
+            else -> null
+        }
+    }
+
+    private fun getCoseHeaderLabelComment(key: Long): String? {
+        return when (key) {
+            1L -> "alg"
+            2L -> "crit"
+            3L -> "content type"
+            4L -> "kid"
+            5L -> "IV"
+            6L -> "Partial IV"
+            33L -> "x5chain"
+            else -> null
+        }
+    }
+
+    private fun getCoseKeyLabelComment(key: Long, ktyVal: Long?): String? {
+        return when (key) {
+            1L -> "kty"
+            2L -> "kid"
+            3L -> "alg"
+            4L -> "key_ops"
+            5L -> "Base IV"
+            -1L -> if (ktyVal == 4L) "k" else "crv"
+            -2L -> "x"
+            -3L -> "y"
+            -4L -> "d"
+            else -> null
+        }
+    }
+
+    private fun getCoseValueDescription(labelComment: String, value: DataItem): String? {
+        val intVal = getIntegerValue(value) ?: return null
+        return when (labelComment) {
+            "kty" -> when (intVal) {
+                1L -> "OKP"
+                2L -> "EC2"
+                3L -> "RSA"
+                4L -> "Symmetric"
+                else -> null
+            }
+
+            "alg" -> {
+                val alg = try {
+                    Algorithm.fromCoseAlgorithmIdentifier(intVal.toInt())
+                } catch (_: Throwable) {
+                    null
+                }
+                if (alg != null) "${alg.name}: ${alg.description}" else null
+            }
+
+            "crv" -> {
+                val curve = EcCurve.entries.firstOrNull { it.coseCurveIdentifier == intVal.toInt() }
+                when (curve) {
+                    EcCurve.P256 -> "P-256"
+                    EcCurve.P384 -> "P-384"
+                    EcCurve.P521 -> "P-521"
+                    EcCurve.ED25519 -> "Ed25519"
+                    EcCurve.ED448 -> "Ed448"
+                    EcCurve.X25519 -> "X25519"
+                    EcCurve.X448 -> "X448"
+                    EcCurve.BRAINPOOLP256R1 -> "brainpoolP256r1"
+                    EcCurve.BRAINPOOLP320R1 -> "brainpoolP320r1"
+                    EcCurve.BRAINPOOLP384R1 -> "brainpoolP384r1"
+                    EcCurve.BRAINPOOLP512R1 -> "brainpoolP512r1"
+                    null -> null
+                }
+            }
+
+            else -> null
+        }
+    }
+
+    companion object {
+        private val COSE_HEADER_LABELS = setOf(1L, 2L, 3L, 4L, 5L, 6L, 33L)
+        private val COSE_KEY_PARAM_LABELS = setOf(2L, 3L, 4L, 5L, -1L, -2L, -3L, -4L)
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnLexer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnLexer.kt
@@ -8,6 +8,7 @@ internal enum class TokenType {
     STRING_RAW_DOUBLE,
     STRING_RAW_SINGLE,
     EXTENSION_LITERAL,
+    EXTENSION_EMBEDDED_CBOR_OPEN, // e.g. b1<<, t1<<, hash<<
     EMBEDDED_CBOR_OPEN,  // <<
     EMBEDDED_CBOR_CLOSE, // >>
     LBRACKET,            // [
@@ -118,6 +119,10 @@ internal class CdnLexer(private val input: String) {
             skipWhitespaceAndComments()
             if (pos < input.length) {
                 val nextCh = input[pos]
+                if (nextCh == '<' && peek(1) == '<') {
+                    advance(2)
+                    return Token(TokenType.EXTENSION_EMBEDDED_CBOR_OPEN, "<<", startLine, startCol, extraData = id)
+                }
                 if (nextCh == '"' && peek(1) == '"' && peek(2) == '"') {
                     val rawToken = readRawString(true, startLine, startCol)
                     return Token(TokenType.EXTENSION_LITERAL, rawToken.text, startLine, startCol, extraData = id)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnOptions.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnOptions.kt
@@ -42,6 +42,16 @@ data class CdnGeneratorOptions(
     val useEmbeddedCborShorthand: Boolean = true,
 
     /**
+     * Whether to format any byte string using `<< ... >>` embedded CBOR notation when it contains valid encoded CBOR.
+     */
+    val useEmbeddedCborOpportunistically: Boolean = true,
+
+    /**
+     * Whether to format byte strings containing valid X.509 certificates using `cert'''...'''` PEM notation.
+     */
+    val useEmbeddedCertsOpportunistically: Boolean = true,
+
+    /**
      * Whether to format tagged items using application extension literals (e.g. `dt'...'`, `ip'...'`).
      */
     val useApplicationExtensions: Boolean = true,
@@ -50,6 +60,26 @@ data class CdnGeneratorOptions(
      * Whether map keys should be sorted.
      */
     val sortMapKeys: Boolean = false,
+
+    /**
+     * Whether to heuristically detect COSE data structures (e.g., COSE_Sign1, COSE_Mac0, COSE_Key)
+     * and annotate their elements, header parameters, key parameters, and algorithms with descriptive comments.
+     *
+     * Following the draft-ietf-cbor-edn-literals convention:
+     * - Structure labels and key names are placed in inline comments (`/ label /`).
+     * - Parameter values and algorithms are annotated with line comments (`# value`).
+     *
+     * ### Supported Structures:
+     * - **COSE_Sign1** (RFC 9052 Section 4.2): 4-element array `[/ protected /, / unprotected /, / payload /, / signature /]`.
+     * - **COSE_Mac0** (RFC 9052 Section 6.2): 4-element array `[/ protected /, / unprotected /, / payload /, / tag /]`.
+     * - **COSE_Key** (RFC 9052 Section 7): Map containing `/ kty / 1` and key parameters (`/ alg /`, `/ crv /`, `/ x /`, `/ y /`, `/ d /`, `/ k /`).
+     *
+     * ### Heuristic Detection:
+     * - **COSE_Sign1**: Tag 18 OR 4-element array `[bstr, map, bstr/null, bstr]` containing recognized COSE header labels.
+     * - **COSE_Mac0**: Tag 17 OR 4-element array `[bstr, map, bstr/null, bstr]` containing recognized MAC algorithm/header labels.
+     * - **COSE_Key**: Map containing integer key `1` (`kty`) matching valid key types (`1` OKP, `2` EC2, `3` RSA, `4` Symmetric).
+     */
+    val annotateCoseOpportunistically: Boolean = true,
 
     /**
      * Extension registry for formatting application extensions.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnParser.kt
@@ -143,7 +143,9 @@ internal class CdnParser(
                 }
             }
 
-            TokenType.EMBEDDED_CBOR_OPEN -> {
+            TokenType.EMBEDDED_CBOR_OPEN, TokenType.EXTENSION_EMBEDDED_CBOR_OPEN -> {
+                val isExtension = token.type == TokenType.EXTENSION_EMBEDDED_CBOR_OPEN
+                val extId = if (isExtension) token.extraData as String else null
                 advance() // consume <<
                 depth++
                 val seq = mutableListOf<DataItem>()
@@ -156,7 +158,33 @@ internal class CdnParser(
                 expect(TokenType.EMBEDDED_CBOR_CLOSE, "Expected '>>' closing embedded CBOR literal")
                 depth--
                 val encodedBytes = seq.fold(byteArrayOf()) { acc, item -> acc + Cbor.encode(item) }
-                Tagged(Tagged.ENCODED_CBOR, Bstr(encodedBytes))
+                if (isExtension) {
+                    when (extId) {
+                        "b1" -> {
+                            val bytes = seq.fold(byteArrayOf()) { acc, item ->
+                                acc + when (item) {
+                                    is Bstr -> item.value
+                                    is Tstr -> item.value.encodeToByteArray()
+                                    else -> throw CdnException("Expected string in b1 sequence", token.line, token.column)
+                                }
+                            }
+                            Bstr(bytes)
+                        }
+                        "t1" -> {
+                            val text = seq.fold("") { acc, item ->
+                                acc + when (item) {
+                                    is Tstr -> item.value
+                                    is Bstr -> item.value.decodeToString()
+                                    else -> throw CdnException("Expected string in t1 sequence", token.line, token.column)
+                                }
+                            }
+                            Tstr(text)
+                        }
+                        else -> throw CdnException("Unrecognized extension literal '$extId<<...>>'", token.line, token.column)
+                    }
+                } else {
+                    Bstr(encodedBytes)
+                }
             }
 
             TokenType.LBRACKET -> parseArray(indefinite = false)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Tagged.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/Tagged.kt
@@ -83,6 +83,13 @@ class Tagged(val tagNumber: Long, val taggedItem: DataItem) : DataItem(MajorType
         const val NEGATIVE_BIGNUM = 3L
 
         /**
+         * Holds COSE MACed message with one recipient.
+         *
+         * Defined in https://www.rfc-editor.org/rfc/rfc9052.html#section-6.2
+         */
+        const val COSE_MAC0 = 17L
+
+        /**
          * Holds COSE signed message with one signer.
          *
          * Defined in https://www.rfc-editor.org/rfc/rfc9052.html#name-signing-with-one-signer

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Signed.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Signed.kt
@@ -214,11 +214,23 @@ sealed class X509Signed() {
 
     companion object {
         @OptIn(ExperimentalEncodingApi::class)
-        internal fun fromPemHelper(pemEncoding: String, name: String): ByteString =
-            ByteString(Base64.Mime.decode(pemEncoding
-                .replace("-----BEGIN $name-----", "")
-                .replace("-----END $name-----", "")
-                .trim()))
+        internal fun fromPemHelper(pemEncoding: String, name: String): ByteString {
+            val beginTag = "-----BEGIN $name-----"
+            val endTag = "-----END $name-----"
+            val startIndex = pemEncoding.indexOf(beginTag)
+            val endIndex = pemEncoding.indexOf(endTag)
+            val base64Content = if (startIndex != -1 && endIndex != -1 && endIndex > startIndex) {
+                pemEncoding.substring(startIndex + beginTag.length, endIndex)
+            } else {
+                pemEncoding.lines()
+                    .map { it.trim() }
+                    .filterNot { it.startsWith("#") }
+                    .joinToString("")
+                    .replace(beginTag, "")
+                    .replace(endTag, "")
+            }
+            return ByteString(Base64.Mime.decode(base64Content.trim()))
+        }
 
         internal fun parseName(obj: ASN1Sequence): X500Name {
             val components = mutableMapOf<String, ASN1String>()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
@@ -132,7 +132,8 @@ suspend fun validateCwt(
                 body[claim]
             }
             if (fieldValue != expectedValue) {
-                throw InvalidRequestException("$cwtName: '${claim.strKey}' is incorrect or missing")
+                throw InvalidRequestException("$cwtName: '${claim.strKey}' is incorrect or missing. " +
+                        "Expected `$expectedValue`, got `$fieldValue`")
             }
         }
     }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
@@ -1,10 +1,20 @@
 package org.multipaz.cbor
 
+import kotlinx.coroutines.test.runTest
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.buildX509Cert
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class CdnTests {
 
@@ -71,7 +81,7 @@ class CdnTests {
 
     @Test
     fun testArrays() {
-        val expected = CborArray.builder().add(1).add(2).add(3).end().build()
+        val expected = buildCborArray { add(1); add(2); add(3) }
         assertEquals(expected, Cdn.parse("[1, 2, 3]"))
 
         val indefExpected = CborArray(mutableListOf<DataItem>(Uint(1UL), Uint(2UL)), indefiniteLength = true)
@@ -83,7 +93,7 @@ class CdnTests {
 
     @Test
     fun testMaps() {
-        val expected = CborMap.builder().put("key", "value").put(1, 2).end().build()
+        val expected = buildCborMap { put("key", "value"); put(1, 2) }
         assertEquals(expected, Cdn.parse("{\"key\": \"value\", 1: 2}"))
         assertEquals(expected, Cdn.parse("{\"key\" => \"value\", 1 => 2}"))
 
@@ -109,10 +119,89 @@ class CdnTests {
         assertEquals(tagged, Cdn.parse("32(\"https://example.com\")"))
 
         val embeddedCbor = Cdn.parse("<< 1234 >>")
-        assertTrue(embeddedCbor is Tagged && embeddedCbor.tagNumber == Tagged.ENCODED_CBOR)
-        assertEquals(Uint(1234UL), Cbor.decode((embeddedCbor.taggedItem as Bstr).value))
+        assertTrue(embeddedCbor is Bstr)
+        assertEquals(Uint(1234UL), Cbor.decode(embeddedCbor.asBstr))
+        assertEquals("<< 1234 >>", Cdn.encode(embeddedCbor, CdnGeneratorOptions(useEmbeddedCborOpportunistically = true)))
 
-        assertEquals("<< 1234 >>", Cdn.encode(embeddedCbor))
+        val taggedEmbeddedCbor = Cdn.parse("24(<< 1234 >>)")
+        assertTrue(taggedEmbeddedCbor is Tagged && taggedEmbeddedCbor.tagNumber == Tagged.ENCODED_CBOR)
+        assertEquals(Uint(1234UL), Cbor.decode((taggedEmbeddedCbor.taggedItem as Bstr).value))
+        assertEquals("24(<< 1234 >>)", Cdn.encode(taggedEmbeddedCbor))
+    }
+
+    @Test
+    fun testUseEmbeddedCborOpportunistically() {
+        val protectedHeader = Cbor.encode(buildCborMap { put(1L, -7L) })
+        val payload = Cbor.encode(buildCborMap { put("foo", "bar") })
+        val coseSign1 = Tagged(
+            18L,
+            buildCborArray {
+                add(protectedHeader)
+                add(buildCborMap {})
+                add(payload)
+                add(byteArrayOf(0x01, 0x02))
+            }
+        )
+
+        val cdnWithEmbedded = Cdn.encode(coseSign1, CdnGeneratorOptions(useEmbeddedCborOpportunistically = true, annotateCoseOpportunistically = false))
+        assertEquals("18([<< {1: -7} >>, {}, << {\"foo\": \"bar\"} >>, h'0102'])", cdnWithEmbedded)
+
+        val cdnWithoutEmbedded = Cdn.encode(coseSign1, CdnGeneratorOptions(useEmbeddedCborOpportunistically = false, annotateCoseOpportunistically = false))
+        assertEquals("18([h'a10126', {}, h'a163666f6f63626172', h'0102'])", cdnWithoutEmbedded)
+
+        val mapWithEmbeddedBstr = buildCborMap {
+            put("plain_bytes", byteArrayOf(0x01, 0x02))
+            put("cbor_bytes", Cbor.encode(Tstr("hello")))
+        }
+        val cdnMapWithEmbedded = Cdn.encode(mapWithEmbeddedBstr, CdnGeneratorOptions(useEmbeddedCborOpportunistically = true))
+        assertEquals("{\"plain_bytes\": h'0102', \"cbor_bytes\": << \"hello\" >>}", cdnMapWithEmbedded)
+
+        // Verify round trip parsing: << ... >> parses into untagged Bstr
+        val parsedBstr = Cdn.parse("<< \"hello\" >>")
+        assertEquals(Bstr(Cbor.encode(Tstr("hello"))), parsedBstr)
+
+        // Verify round trip parsing: 24(<< ... >>) parses into Tagged(24, Bstr)
+        val parsedTagged = Cdn.parse("24(<< \"hello\" >>)")
+        assertEquals(Tagged(Tagged.ENCODED_CBOR, Bstr(Cbor.encode(Tstr("hello")))), parsedTagged)
+    }
+
+    @Test
+    fun testUseEmbeddedCertsOpportunistically() = runTest {
+        val key = Crypto.createEcPrivateKey(EcCurve.P256)
+        val cert = buildX509Cert(
+            publicKey = key.publicKey,
+            signingKey = AsymmetricKey.anonymous(key, Algorithm.ES256),
+            serialNumber = ASN1Integer(1),
+            subject = X500Name.fromName("CN=Test Cert"),
+            issuer = X500Name.fromName("CN=Test Cert"),
+            validFrom = Instant.fromEpochMilliseconds(1000000000000L),
+            validUntil = Instant.fromEpochMilliseconds(2000000000000L)
+        ) {}
+
+        val certBstr = Bstr(cert.encoded.toByteArray())
+        val cdnWithCert = Cdn.encode(certBstr, CdnGeneratorOptions(useEmbeddedCertsOpportunistically = true))
+        assertTrue(cdnWithCert.startsWith("cert'''\n# Subject DN: CN=Test Cert\n# Issuer DN: CN=Test Cert\n-----BEGIN CERTIFICATE-----\n"))
+        assertTrue(cdnWithCert.endsWith("\n-----END CERTIFICATE-----\n'''"))
+
+        val prettyCertCdn = Cdn.encode(buildCborMap { put(33L, certBstr) }, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyCertCdn.contains("33:\n  # Subject DN: CN=Test Cert\n  # Issuer DN: CN=Test Cert\n  cert'''\n    -----BEGIN CERTIFICATE-----\n"))
+
+        val certArrayMap = buildCborMap {
+            put(33L, buildCborArray {
+                add(certBstr)
+                add(certBstr)
+            })
+        }
+        val prettyCertArrayCdn = Cdn.encode(certArrayMap, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyCertArrayCdn.contains("33: [\n    # Subject DN: CN=Test Cert\n    # Issuer DN: CN=Test Cert\n    cert'''\n"))
+        assertFalse(prettyCertArrayCdn.contains("[\n\n"))
+        assertFalse(prettyCertArrayCdn.contains("''',\n\n"))
+
+        val parsedBack = Cdn.parse(cdnWithCert)
+        assertEquals(certBstr, parsedBack)
+
+        val cdnWithoutCert = Cdn.encode(certBstr, CdnGeneratorOptions(useEmbeddedCertsOpportunistically = false))
+        assertTrue(cdnWithoutCert.startsWith("h'"))
     }
 
     @Test
@@ -126,7 +215,7 @@ class CdnTests {
         """.trimIndent()
 
         val parsed = Cdn.parse(cdnWithComments)
-        assertEquals(CborMap.builder().put("foo", "bar").end().build(), parsed)
+        assertEquals(buildCborMap { put("foo", "bar") }, parsed)
     }
 
     @Test
@@ -157,7 +246,7 @@ class CdnTests {
 
     @Test
     fun testPrettyPrintOptions() {
-        val map = CborMap.builder().put("a", 1).put("b", 2).end().build()
+        val map = buildCborMap { put("a", 1); put("b", 2) }
         val prettyCdn = Cdn.encode(map, CdnGeneratorOptions.Pretty)
         assertTrue(prettyCdn.contains("\n"))
         assertTrue(prettyCdn.contains("  \"a\": 1"))
@@ -187,7 +276,7 @@ class CdnTests {
             override fun parseLiteral(content: String, delimiter: Char): DataItem {
                 return Tstr("CUSTOM:$content")
             }
-            override fun format(item: DataItem, options: CdnGeneratorOptions): String? {
+            override fun format(item: DataItem, options: CdnGeneratorOptions, indent: Int): String? {
                 if (item is Tstr && item.value.startsWith("CUSTOM:")) {
                     return "custom'${item.value.removePrefix("CUSTOM:")}'"
                 }
@@ -208,12 +297,20 @@ class CdnTests {
         assertEquals(0.0015, (floatItem as CborDouble).value, 1e-9)
 
         val embeddedSeq = Cdn.parse("<< 10, 20 >>")
-        assertTrue(embeddedSeq is Tagged && embeddedSeq.tagNumber == 24L)
-        val bytes = (embeddedSeq.taggedItem as Bstr).value
+        assertTrue(embeddedSeq is Bstr)
+        val bytes = embeddedSeq.asBstr
         val (offset1, decoded1) = Cbor.decode(bytes, 0)
         val (_, decoded2) = Cbor.decode(bytes, offset1)
         assertEquals(Uint(10UL), decoded1)
         assertEquals(Uint(20UL), decoded2)
+
+        val taggedSeq = Cdn.parse("24(<< 10, 20 >>)")
+        assertTrue(taggedSeq is Tagged && taggedSeq.tagNumber == 24L)
+        val taggedBytes = (taggedSeq.taggedItem as Bstr).value
+        val (tOffset1, tDecoded1) = Cbor.decode(taggedBytes, 0)
+        val (_, tDecoded2) = Cbor.decode(taggedBytes, tOffset1)
+        assertEquals(Uint(10UL), tDecoded1)
+        assertEquals(Uint(20UL), tDecoded2)
     }
 
     @Test
@@ -244,8 +341,8 @@ class CdnTests {
             CborDouble(12.34),
             Tstr("roundtrip test"),
             Bstr(byteArrayOf(0x0a, 0x0b, 0x0c)),
-            CborArray.builder().add("element").add(true).end().build(),
-            CborMap.builder().put("x", 10).put("y", 20).end().build(),
+            buildCborArray { add("element"); add(true) },
+            buildCborMap { put("x", 10); put("y", 20) },
             Tagged(0L, Tstr("2026-07-27T16:00:00Z"))
         )
 
@@ -254,5 +351,100 @@ class CdnTests {
             val decodedItem = Cdn.parse(cdnStr)
             assertEquals(item, decodedItem, "Roundtrip failed for item: $item")
         }
+    }
+
+    @Test
+    fun testOpportunisticCoseSign1() {
+        val protectedMap = buildCborMap {
+            put(1, -7)
+            put(33, Bstr("certData".encodeToByteArray()))
+        }
+        val protectedBytes = Cbor.encode(protectedMap)
+        val coseSign1 = Tagged(
+            18L,
+            buildCborArray {
+                add(Bstr(protectedBytes))
+                add(buildCborMap {})
+                add(Bstr("payload".encodeToByteArray()))
+                add(Bstr("signature".encodeToByteArray()))
+            }
+        )
+
+        val prettyAnnotated = Cdn.encode(coseSign1, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyAnnotated.contains("# COSE_Sign1"))
+        assertTrue(prettyAnnotated.contains("/protected/"))
+        assertTrue(prettyAnnotated.contains("/unprotected/"))
+        assertTrue(prettyAnnotated.contains("/payload/"))
+        assertTrue(prettyAnnotated.contains("/signature/"))
+        assertTrue(prettyAnnotated.contains("/alg/"))
+        assertTrue(prettyAnnotated.contains("# ES256: ECDSA with SHA-256"))
+        assertTrue(prettyAnnotated.contains("/x5chain/"))
+
+        val roundtripItem = Cdn.parse(prettyAnnotated)
+        assertEquals(coseSign1, roundtripItem)
+    }
+
+    @Test
+    fun testOpportunisticCoseMac0() {
+        val protectedMap = buildCborMap {
+            put(1, 5)
+        }
+        val protectedBytes = Cbor.encode(protectedMap)
+        val coseMac0 = Tagged(
+            17L,
+            buildCborArray {
+                add(Bstr(protectedBytes))
+                add(buildCborMap {})
+                add(Bstr("payload".encodeToByteArray()))
+                add(Bstr("macTag".encodeToByteArray()))
+            }
+        )
+
+        val prettyAnnotated = Cdn.encode(coseMac0, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyAnnotated.contains("# COSE_Mac0"))
+        assertTrue(prettyAnnotated.contains("/protected/"))
+        assertTrue(prettyAnnotated.contains("/unprotected/"))
+        assertTrue(prettyAnnotated.contains("/payload/"))
+        assertTrue(prettyAnnotated.contains("/tag/"))
+        assertTrue(prettyAnnotated.contains("/alg/"))
+        assertTrue(prettyAnnotated.contains("# HMAC_SHA256: HMAC with SHA-256"))
+
+        val roundtripItem = Cdn.parse(prettyAnnotated)
+        assertEquals(coseMac0, roundtripItem)
+    }
+
+    @Test
+    fun testOpportunisticCoseKey() {
+        val ecKey = buildCborMap {
+            put(1, 2)
+            put(3, -7)
+            put(-1, 1)
+            put(-2, Bstr(ByteArray(32)))
+            put(-3, Bstr(ByteArray(32)))
+        }
+
+        val prettyAnnotated = Cdn.encode(ecKey, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyAnnotated.contains("# COSE_Key"))
+        assertTrue(prettyAnnotated.contains("/kty/ 1: 2, # EC2"))
+        assertTrue(prettyAnnotated.contains("/alg/ 3: -7, # ES256: ECDSA with SHA-256"))
+        assertTrue(prettyAnnotated.contains("/crv/ -1: 1, # P-256"))
+        assertTrue(prettyAnnotated.contains("/x/ -2"))
+        assertTrue(prettyAnnotated.contains("/y/ -3"))
+
+        val roundtripItem = Cdn.parse(prettyAnnotated)
+        assertEquals(ecKey, roundtripItem)
+    }
+
+    @Test
+    fun testOpportunisticCoseDisabled() {
+        val ecKey = buildCborMap {
+            put(1, 2)
+            put(3, -7)
+            put(-1, 1)
+        }
+        val noCoseOptions = CdnGeneratorOptions(prettyPrint = true, annotateCoseOpportunistically = false)
+        val text = Cdn.encode(ecKey, noCoseOptions)
+        assertTrue(!text.contains("/ kty /"))
+        assertTrue(!text.contains("# EC2"))
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
@@ -1,0 +1,72 @@
+package org.multipaz.revocation
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.bytestring.ByteString
+import kotlin.time.Clock
+import org.multipaz.cbor.Cdn
+import org.multipaz.cbor.CdnGeneratorOptions
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.util.fromHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+class IdentifierListTest {
+    @Test
+    fun roundtripCwt() = runTest {
+        val key = AsymmetricKey.ephemeral()
+        val id1 = ByteString("1122334455667788990011223344556677889900112233445566778899001122".fromHex())
+        val id2 = ByteString("aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".fromHex())
+        val absentId = ByteString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".fromHex())
+
+        val creationTime = Instant.fromEpochSeconds(1686920170)
+        val expirationTime = Instant.fromEpochSeconds(1686920170 + 86400)
+
+        val identifierList = IdentifierList(
+            identifiers = setOf(id1, id2),
+            creationTime = creationTime,
+            expirationTime = expirationTime
+        )
+
+        val cwt = identifierList.serializeAsCwt(key, "https://example.com/identifierlists/1")
+
+        val decodedCwt = Cdn.encode(cwt, CdnGeneratorOptions.Pretty)
+        val lines = decodedCwt.lines().toMutableList()
+        lines[lines.size - 2] = "  /signature/ h'' # Signature redacted"
+        val sanitizedCdn = lines.joinToString("\n")
+
+        val expectedCdn = """
+            18([ # COSE_Sign1
+              /protected/ << {
+                16: "application/identifierlist+cwt",
+                /alg/ 1: -9 # ESP256: ECDSA using P-256 curve and SHA-256
+              } >>,
+              /unprotected/ {},
+              /payload/ << {
+                4: 1687006570,
+                6: 1686920170,
+                2: "https://example.com/identifierlists/1",
+                65530: {
+                  "identifiers": {
+                    h'1122334455667788990011223344556677889900112233445566778899001122': {},
+                    h'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899': {}
+                  }
+                },
+                65534: 86400
+              } >>,
+              /signature/ h'' # Signature redacted
+            ])
+        """.trimIndent()
+
+        assertEquals(expectedCdn, sanitizedCdn)
+
+        val parsedList = IdentifierList.fromCwt(cwt, key.publicKey, atTime = creationTime + 100.seconds)
+
+        assertTrue(parsedList.contains(id1))
+        assertTrue(parsedList.contains(id2))
+        assertFalse(parsedList.contains(absentId))
+    }
+}


### PR DESCRIPTION
- Support opportunistic embedded CBOR formatting (`cbor<< ... >>`) for untagged byte strings in CDN generator.
- Support opportunistic COSE structure annotations (`annotateCoseOpportunistically = true`) for COSE_Sign1, COSE_Mac0, and COSE_Key using draft-ietf-cbor-edn-literals inline (`/label/`) and line (`# value`) comments.
- Support opportunistic X.509 certificate formatting (`cert'''...'''`) with line-level indentation in CDN generator.
- Add Tagged.COSE_MAC0 (tag 17) constant.
- Leverage Algorithm.kt and EcCurve.kt for COSE algorithm and curve identifier annotations (rendering `${alg.name}: ${alg.description}`).
- Handle multi-line raw string literals and token merging in CborDiagnosticViewer to prevent browser rendering freezes.
- Migrate all multipaz-tools web components from Cbor.toDiagnostics() to Cdn.encode().
- Expose new opportunistic embedded CBOR/COSE and X.509 certificate options in multipaz-tools web decoder UI.
- Add unit tests validating opportunistic CBOR, COSE, and certificate formatting and round-trip parsing.

Fixes #1860.