### PR TITLE
Pass Instant instead of Clock in webtoken validation methods

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
@@ -126,6 +126,8 @@ class CompressedStatusList(
          * @param jwt status list JWT representation
          * @param publicKey public key of the issuance server signing key (optional)
          * @param checks additional checks for JWT validation
+         * @param atTime time instant to check for expiration
+         * @param maxValidity maximum JWT validity duration to accept
          * @return parsed [CompressedStatusList]
          * @throws IllegalArgumentException when [jwt] cannot be parsed as JWT status list
          * @throws InvalidRequestException when JWT validation fails
@@ -134,6 +136,7 @@ class CompressedStatusList(
             jwt: String,
             publicKey: EcPublicKey? = null,
             checks: Map<WebTokenCheck, String> = mapOf(),
+            atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
         ): CompressedStatusList {
             val body = validateJwt(
@@ -144,6 +147,7 @@ class CompressedStatusList(
                     putAll(checks)
                 },
                 publicKey = publicKey,
+                atTime = atTime,
                 maxValidity = maxValidity
             )
             val expirationTime = body["exp"]?.let {
@@ -190,6 +194,7 @@ class CompressedStatusList(
          * @param cwt status list CWT representation
          * @param publicKey public key of the issuance server signing key (optional)
          * @param checks additional checks for JWT validation
+         * @param atTime time instant to check for expiration
          * @param maxValidity maximum CWT validity duration to accept
          * @return parsed [CompressedStatusList]
          * @throws IllegalArgumentException when [cwt] cannot be parsed as CWT status list
@@ -199,6 +204,7 @@ class CompressedStatusList(
             cwt: ByteArray,
             publicKey: EcPublicKey? = null,
             checks: Map<WebTokenCheck, String> = mapOf(),
+            atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
         ): CompressedStatusList {
             val body = validateCwt(
@@ -209,6 +215,7 @@ class CompressedStatusList(
                     putAll(checks)
                 },
                 publicKey = publicKey,
+                atTime = atTime,
                 maxValidity = maxValidity
             )
             if (!body.hasKey(STATUS_LIST_CLAIM)) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
@@ -7,12 +7,14 @@ import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.webtoken.WebTokenCheck
 import org.multipaz.webtoken.WebTokenClaim
 import org.multipaz.webtoken.WebTokenClaim.Companion.put
 import org.multipaz.webtoken.buildCwt
 import org.multipaz.webtoken.validateCwt
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
@@ -103,10 +105,27 @@ class IdentifierList(
         private const val IDENTIFIER_LIST_CLAIM = 65530L
         private const val TTL_CLAIM = 65534L
 
+        /**
+         * Parses and validates CWT that holds the identifier list.
+         *
+         * CWT signature can be validated either by passing [WebTokenCheck.TRUST] key in
+         * the [checks] map or using non-null [publicKey] (see [validateCwt]).
+         *
+         * @param cwt identifier list CWT representation
+         * @param publicKey public key of the issuance server signing key (optional)
+         * @param checks additional checks for JWT validation
+         * @param atTime time instant to check for expiration
+         * @param maxValidity maximum CWT validity duration to accept
+         * @return parsed [IdentifierList]
+         * @throws IllegalArgumentException when [cwt] cannot be parsed as CWT identifier list
+         * @throws InvalidRequestException when CWT validation fails
+         */
         suspend fun fromCwt(
             cwt: ByteArray,
             publicKey: EcPublicKey? = null,
-            checks: Map<WebTokenCheck, String> = mapOf()
+            checks: Map<WebTokenCheck, String> = mapOf(),
+            atTime: Instant = Clock.System.now(),
+            maxValidity: Duration = 365.days
         ): IdentifierList {
             val body = validateCwt(
                 cwt = cwt,
@@ -116,7 +135,8 @@ class IdentifierList(
                     putAll(checks)
                 },
                 publicKey = publicKey,
-                maxValidity = 365.days
+                atTime = atTime,
+                maxValidity = maxValidity
             )
             if (!body.hasKey(IDENTIFIER_LIST_CLAIM)) {
                 throw IllegalArgumentException("not a valid identifier list CWT")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
@@ -189,9 +189,10 @@ class StatusList(
             cwt: ByteArray,
             publicKey: EcPublicKey? = null,
             checks: Map<WebTokenCheck, String> = mapOf(),
+            atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
         ): StatusList =
-            CompressedStatusList.fromCwt(cwt, publicKey, checks, maxValidity).decompress()
+            CompressedStatusList.fromCwt(cwt, publicKey, checks, atTime, maxValidity).decompress()
 
         /**
          * Parses CBOR as status list.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
@@ -66,7 +66,7 @@ import kotlin.time.Instant
  *  the certificate chain is not valid it should throw [InvalidRequestException] exception,
  *  the returned value should indicate if the chain is trusted (in which case
  *  [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
- * @param clock clock that determines current time to check for expiration.
+ * @param atTime time instant for expiration check.
  * @param nonceValidator function that must throw [ChallengeInvalidException] if nonce/challenge
  *  is not valid; this is used with [WebTokenCheck.CHALLENGE] check.
  * @throws ChallengeInvalidException when nonce or challenge check fails (see [WebTokenCheck.CHALLENGE])
@@ -79,7 +79,7 @@ suspend fun validateCwt(
     checks: Map<WebTokenCheck, String> = mapOf(),
     maxValidity: Duration = 10.hours,
     certificateChainValidator: (suspend (chain: X509CertChain, atTime: Instant) -> Boolean)? = null,
-    clock: Clock = Clock.System,
+    atTime: Instant = Clock.System.now(),
     nonceValidator: suspend (nonce: String) -> Unit = Challenge::validateAndConsume
 ): CborMap {
     val cbor = Cbor.decode(cwt)
@@ -93,30 +93,28 @@ suspend fun validateCwt(
     val body = Cbor.decode(sign1.payload!!) as? CborMap
         ?: throw IllegalArgumentException("$cwtName: not a valid CWT")
 
-    val now = clock.now()
-
     val expiration = body[WebTokenClaim.Exp] ?: run {
         if (maxValidity == Duration.INFINITE) {
-            now + 1.seconds
+            atTime + 1.seconds
         } else {
             val iat = body[WebTokenClaim.Iat]
                 ?: throw InvalidRequestException("$cwtName: either 'exp' or 'iat' is required")
-            if (iat > now) {
+            if (iat > atTime) {
                 // Allow no more than 5 seconds clock mismatch
-                if (iat > now + 5.seconds) {
+                if (iat > atTime + 5.seconds) {
                     throw InvalidRequestException("$cwtName: 'iat' is in future")
                 }
-                now + maxValidity
+                atTime + maxValidity
             } else {
                 iat + maxValidity
             }
         }
     }
 
-    if (expiration < now) {
+    if (expiration < atTime) {
         throw InvalidRequestException("$cwtName: expired")
     }
-    if (maxValidity != Duration.INFINITE && expiration > now + maxValidity) {
+    if (maxValidity != Duration.INFINITE && expiration > atTime + maxValidity) {
         throw InvalidRequestException("$cwtName: expiration is too far in the future")
     }
 
@@ -146,7 +144,7 @@ suspend fun validateCwt(
     val caValidated = try {
         certificateChain != null &&
             (certificateChainValidator ?: ::basicCertificateChainValidator)
-                .invoke(certificateChain, now)
+                .invoke(certificateChain, atTime)
     } catch (err: InvalidRequestException) {
         throw InvalidRequestException("$cwtName: ${err.message}")
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
@@ -72,7 +72,7 @@ import kotlin.time.Instant
  *  the certificate chain is not valid it should throw [InvalidRequestException] exception,
  *  the returned value should indicate if the chain is trusted (in which case
  *  [WebTokenCheck.TRUST] check is not performed) or not ([WebTokenCheck.TRUST] still applies).
- * @param clock clock that determines current time to check for expiration.
+ * @param atTime time instant for expiration check.
  * @param nonceValidator function that must throw [ChallengeInvalidException] if nonce/challenge
  *  is not valid; this is used with [WebTokenCheck.CHALLENGE] check.
  * @throws ChallengeInvalidException when nonce or challenge check fails (see [WebTokenCheck.CHALLENGE])
@@ -87,7 +87,7 @@ suspend fun validateJwt(
     checks: Map<WebTokenCheck, String> = mapOf(),
     maxValidity: Duration = 10.hours,
     certificateChainValidator: (suspend (chain: X509CertChain, atTime: Instant) -> Boolean)? = null,
-    clock: Clock = Clock.System,
+    atTime: Instant = Clock.System.now(),
     nonceValidator: suspend (nonce: String) -> Unit = Challenge::validateAndConsume
 ): JsonObject {
     require(publicKey == null || certificateChainValidator == null)
@@ -102,34 +102,32 @@ suspend fun validateJwt(
         parts[1].fromBase64Url().decodeToString()
     ).jsonObject
 
-    val now = clock.now()
-
     val algorithm = header["alg"]?.jsonPrimitive?.content?.let {
         Algorithm.fromJoseAlgorithmIdentifier(it)
     }
 
     val expiration = body[WebTokenClaim.Exp] ?: run {
         if (maxValidity == Duration.INFINITE) {
-            now + 1.seconds
+            atTime + 1.seconds
         } else {
             val iat = body[WebTokenClaim.Iat]
                 ?: throw InvalidRequestException("$jwtName: either 'exp' or 'iat' is required")
-            if (iat > now) {
+            if (iat > atTime) {
                 // Allow no more than 5 seconds clock mismatch
-                if (iat > now + 5.seconds) {
+                if (iat > atTime + 5.seconds) {
                     throw InvalidRequestException("$jwtName: 'iat' is in future")
                 }
-                now + maxValidity
+                atTime + maxValidity
             } else {
                 iat + maxValidity
             }
         }
     }
 
-    if (expiration < now) {
+    if (expiration < atTime) {
         throw InvalidRequestException("$jwtName: expired")
     }
-    if (maxValidity != Duration.INFINITE && expiration > now + maxValidity) {
+    if (maxValidity != Duration.INFINITE && expiration > atTime + maxValidity) {
         throw InvalidRequestException("$jwtName: expiration is too far in the future")
     }
 
@@ -148,7 +146,7 @@ suspend fun validateJwt(
     val caValidated = try {
         certificateChain != null &&
             (certificateChainValidator ?: ::basicCertificateChainValidator)
-                .invoke(certificateChain, now)
+                .invoke(certificateChain, atTime)
     } catch (err: InvalidRequestException) {
         throw InvalidRequestException("$jwtName: ${err.message}")
     }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/CwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/CwtTest.kt
@@ -96,7 +96,7 @@ class CwtTest {
                 WebTokenCheck.IDENT to "foo"
             ),
             maxValidity = 48.hours,
-            clock = clock
+            atTime = clock.now()
         )
     }
 
@@ -104,7 +104,7 @@ class CwtTest {
     fun testSimple() = runBackendTest {
         val cwt = makeCwt(privateTrustedKey)
         validateCwt(
-            cwt, "test", privateTrustedKey.publicKey, clock = clock, checks = mapOf(
+            cwt, "test", privateTrustedKey.publicKey, atTime = clock.now(), checks = mapOf(
                 WebTokenCheck.SUB to TEST_SUB,
                 WebTokenCheck.ISS to TEST_ISS,
                 WebTokenCheck.AUD to TEST_AUD,
@@ -119,7 +119,7 @@ class CwtTest {
         val cwt = makeCwt(privateTrustedKey)
         clock.advance(2.minutes)
         try {
-            validateCwt(cwt, "test", privateTrustedKey.publicKey, clock = clock)
+            validateCwt(cwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
             fail()
         } catch (err: InvalidRequestException) {
             assertTrue(err.message!!.lowercase().contains("expired"))
@@ -133,7 +133,7 @@ class CwtTest {
         try {
             validateCwt(
                 cwt, "test", privateTrustedKey.publicKey,
-                clock = clock, maxValidity = 1.minutes
+                atTime = clock.now(), maxValidity = 1.minutes
             )
             fail()
         } catch (err: InvalidRequestException) {
@@ -147,7 +147,7 @@ class CwtTest {
         try {
             validateCwt(
                 cwt, "test", privateTrustedKey.publicKey,
-                clock = clock, maxValidity = 1.minutes
+                atTime = clock.now(), maxValidity = 1.minutes
             )
             fail()
         } catch (err: InvalidRequestException) {
@@ -158,19 +158,19 @@ class CwtTest {
     @Test
     fun testClockSkewSmall() = runBackendTest {
         val cwt = makeCwt(privateTrustedKey, exp = null, iat = clock.now() + 1.seconds)
-        validateCwt(cwt, "test", privateTrustedKey.publicKey, clock = clock)
+        validateCwt(cwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
     }
 
     @Test
     fun testReplay() = runBackendTest {
         val cwt = makeCwt(privateTrustedKey)
         validateCwt(
-            cwt, "test", privateTrustedKey.publicKey, clock = clock,
+            cwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "cti-space1")
         )
         try {
             validateCwt(
-                cwt, "test", privateTrustedKey.publicKey, clock = clock,
+                cwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
                 checks = mapOf(WebTokenCheck.IDENT to "cti-space1")
             )
             fail()
@@ -178,13 +178,13 @@ class CwtTest {
             assertTrue(err.message!!.lowercase().contains("cti"))
         }
         validateCwt(
-            cwt, "test", privateTrustedKey.publicKey, clock = clock,
+            cwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "cti-space2")
         )
         clock.advance(2.minutes)
         val newCwt = makeCwt(privateTrustedKey)
         validateCwt(
-            newCwt, "test", privateTrustedKey.publicKey, clock = clock,
+            newCwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "cti-space1")
         )
     }
@@ -193,7 +193,7 @@ class CwtTest {
     fun testTrustIssKid() = runBackendTest {
         val cwt = makeCwt(privateTrustedKey, iss = "test-iss", kid = "test-kid")
         validateCwt(
-            cwt, "test", publicKey = null, clock = clock,
+            cwt, "test", publicKey = null, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.TRUST to "iss_kid")
         )
     }
@@ -218,7 +218,7 @@ class CwtTest {
         val chain = X509CertChain(listOf(cert))
         val cwt = makeCwt(x5cKey, iss = "test-x5c-leaf", x5c = chain)
         validateCwt(
-            cwt, "test", publicKey = null, clock = clock,
+            cwt, "test", publicKey = null, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.TRUST to "x5c")
         )
     }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/JwtTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/webtoken/JwtTest.kt
@@ -69,7 +69,7 @@ class JwtTest {
     fun testSimple() = runBackendTest {
         val jwt = makeJwt(privateTrustedKey)
         validateJwt(
-            jwt, "test", privateTrustedKey.publicKey, clock = clock, checks = mapOf(
+            jwt, "test", privateTrustedKey.publicKey, atTime = clock.now(), checks = mapOf(
                 WebTokenCheck.IDENT to TEST_JTI,
                 WebTokenCheck.SUB to TEST_SUB,
                 WebTokenCheck.ISS to TEST_ISS,
@@ -85,7 +85,7 @@ class JwtTest {
         val jwt = makeJwt(privateTrustedKey)
         clock.advance(2.minutes)
         try {
-            validateJwt(jwt, "test", privateTrustedKey.publicKey, clock = clock)
+            validateJwt(jwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
             fail()
         } catch (err: InvalidRequestException) {
             assertTrue(err.message!!.lowercase().contains("expired"))
@@ -95,13 +95,13 @@ class JwtTest {
     @Test
     fun testExpirationIat() = runBackendTest {
         val jwt = makeJwt(privateTrustedKey, exp = null, iat = clock.now())
-        validateJwt(jwt, "test", privateTrustedKey.publicKey, clock = clock)
+        validateJwt(jwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
         clock.advance(2.minutes)
-        validateJwt(jwt, "test", privateTrustedKey.publicKey, clock = clock)
+        validateJwt(jwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
         try {
             validateJwt(
                 jwt, "test", privateTrustedKey.publicKey,
-                clock = clock, maxValidity = 1.minutes
+                atTime = clock.now(), maxValidity = 1.minutes
             )
             fail()
         } catch (err: InvalidRequestException) {
@@ -115,7 +115,7 @@ class JwtTest {
         try {
             validateJwt(
                 jwt, "test", privateTrustedKey.publicKey,
-                clock = clock, maxValidity = 1.minutes
+                atTime = clock.now(), maxValidity = 1.minutes
             )
             fail()
         } catch (err: InvalidRequestException) {
@@ -126,19 +126,19 @@ class JwtTest {
     @Test
     fun testClockSkewSmall() = runBackendTest {
         val jwt = makeJwt(privateTrustedKey, exp = null, iat = clock.now() + 1.seconds)
-        validateJwt(jwt, "test", privateTrustedKey.publicKey, clock = clock)
+        validateJwt(jwt, "test", privateTrustedKey.publicKey, atTime = clock.now())
     }
 
     @Test
     fun testReplay() = runBackendTest {
         val jwt = makeJwt(privateTrustedKey)
         validateJwt(
-            jwt, "test", privateTrustedKey.publicKey, clock = clock,
+            jwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "jti-space1")
         )
         try {
             validateJwt(
-                jwt, "test", privateTrustedKey.publicKey, clock = clock,
+                jwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
                 checks = mapOf(WebTokenCheck.IDENT to "jti-space1")
             )
             fail()
@@ -146,13 +146,13 @@ class JwtTest {
             assertTrue(err.message!!.lowercase().contains("jti"))
         }
         validateJwt(
-            jwt, "test", privateTrustedKey.publicKey, clock = clock,
+            jwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "jti-space2")
         )
         clock.advance(2.minutes)
         val newJwt = makeJwt(privateTrustedKey)
         validateJwt(
-            newJwt, "test", privateTrustedKey.publicKey, clock = clock,
+            newJwt, "test", privateTrustedKey.publicKey, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.IDENT to "jti-space1")
         )
     }
@@ -161,7 +161,7 @@ class JwtTest {
     fun testTrustIssKid() = runBackendTest {
         val jwt = makeJwt(privateTrustedKey, iss = "test-iss", kid = "test-kid")
         validateJwt(
-            jwt, "test", publicKey = null, clock = clock,
+            jwt, "test", publicKey = null, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.TRUST to "iss_kid")
         )
     }
@@ -196,7 +196,7 @@ class JwtTest {
         val chain = X509CertChain(listOf(cert, root))
         val jwt = makeJwt(x5cKey, iss = "test-x5c-leaf", x5c = chain)
         validateJwt(
-            jwt, "test", publicKey = null, clock = clock,
+            jwt, "test", publicKey = null, atTime = clock.now(),
             checks = mapOf(WebTokenCheck.TRUST to "x5c")
         )
     }


### PR DESCRIPTION
Also add atTime parameter to revocation data validation methods

Fixes #1862

Tested with unit tests.