### PR TITLE
Fix multiple NFC taps problem.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/CombinedNfcService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/CombinedNfcService.kt
@@ -53,6 +53,8 @@ abstract class CombinedNfcService: HostApduService() {
     override fun processCommandApdu(encodedCommandApdu: ByteArray?, extras: Bundle?): ByteArray? {
         if (encodedCommandApdu == null) return null
 
+        Logger.dHex(TAG, "Handling Command APDU", encodedCommandApdu)
+
         // With Extended APDUs it's possible we get a partial APDU so gracefully handle if decoding fails. Simply
         // log and discard, we'll likely get hit with an onDeactivated call soon anyway.
         //
@@ -73,12 +75,14 @@ abstract class CombinedNfcService: HostApduService() {
             services[activeAid]?.let { service ->
                 return service.processCommandApdu(encodedCommandApdu, extras)
             }
+            Logger.w(TAG, "No handler for AID ${activeAid.toHex()}, returning 6a82")
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND).encode()
         }
         return null
     }
 
     override fun onDeactivated(reason: Int) {
+        Logger.d(TAG, "onDeactivated reason $reason")
         activeAid?.let { activeAid ->
             services[activeAid]?.let { service ->
                 return service.onDeactivated(reason)

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/MainActivity.kt
@@ -38,6 +38,9 @@ class MainActivity : FragmentActivity() {
         NfcAdapter.getDefaultAdapter(this)?.let { adapter ->
             val cardEmulation = CardEmulation.getInstance(adapter)
             val componentName = ComponentName(this, TestAppCombinedNfcService::class.java)
+            if (!cardEmulation.unsetPreferredService(this)) {
+                Logger.w(TAG, "CardEmulation.unsetPreferredService() returned false")
+            }
             if (!cardEmulation.setPreferredService(this, componentName)) {
                 Logger.w(TAG, "CardEmulation.setPreferredService() returned false")
             }


### PR DESCRIPTION
It turns out that NFC engagment doesn't work twice in a row, but it does work if you switch to another app after the first tap and then back again. Calling CardEmulation.unsetPreferredService() right before CardEmulation.setPreferredService() in the activity's onResume() handler seems to fix the problem. This seems more like a workaround of a bug in the Android OS, will report it to them.

Fixes #1819.

Test: Manually tested, can now present multiple times to NFC readers.
