### PR TITLE
Fix COSE_Mac0 structure detection and force ECDSA for ZKP requests.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/CdnGenerator.kt
@@ -429,15 +429,32 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
             }
         } ?: return null
 
-        val hasSign1Headers = hasCoseHeader(pMap, COSE_HEADER_LABELS) || hasCoseHeader(uMap, COSE_HEADER_LABELS)
-        val hasMac0Headers = hasCoseHeader(pMap, COSE_HEADER_LABELS) || hasCoseHeader(uMap, COSE_HEADER_LABELS)
+        val alg = getCoseAlgorithm(pMap) ?: getCoseAlgorithm(uMap)
+        if (alg != null) {
+            if (alg in COSE_MAC_ALGORITHM_IDS) {
+                return CoseStructureType.COSE_MAC0
+            }
+            return CoseStructureType.COSE_SIGN1
+        }
 
+        if (hasCoseHeader(pMap, setOf(33L)) || hasCoseHeader(uMap, setOf(33L))) {
+            return CoseStructureType.COSE_SIGN1
+        }
+
+        val hasCoseHeaders = hasCoseHeader(pMap, COSE_HEADER_LABELS) || hasCoseHeader(uMap, COSE_HEADER_LABELS)
         return when {
-            hasSign1Headers -> CoseStructureType.COSE_SIGN1
-            hasMac0Headers -> CoseStructureType.COSE_MAC0
-            isTaggedCose -> CoseStructureType.COSE_SIGN1
+            hasCoseHeaders || isTaggedCose -> CoseStructureType.COSE_SIGN1
             else -> null
         }
+    }
+
+    private fun getCoseAlgorithm(map: CborMap): Long? {
+        for ((key, value) in map.items) {
+            if (getIntegerKey(key) == 1L) {
+                return getIntegerValue(value)
+            }
+        }
+        return null
     }
 
     private fun isCoseHeaderMap(map: CborMap): Boolean {
@@ -578,5 +595,6 @@ internal class CdnGenerator(private val options: CdnGeneratorOptions) {
     companion object {
         private val COSE_HEADER_LABELS = setOf(1L, 2L, 3L, 4L, 5L, 6L, 33L)
         private val COSE_KEY_PARAM_LABELS = setOf(2L, 3L, 4L, 5L, -1L, -2L, -3L, -4L)
+        private val COSE_MAC_ALGORITHM_IDS = setOf(4L, 5L, 6L, 7L, 14L, 15L, 25L, 26L)
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -631,6 +631,13 @@ data class DeviceRequest private constructor(
             }
         }
 
+        // Zero-Knowledge Proofs (via Longfellow) currently only support ECDSA, so key agreement (MACing) cannot be used.
+        val effectiveKeyAgreementPossible = if (docRequest.docRequestInfo?.zkRequest != null) {
+            emptyList()
+        } else {
+            keyAgreementPossible
+        }
+
         val matches = mutableListOf<DocRequestMatch>()
         // Sort by displayName to ensure deterministic order
         for (cred in candidates.sortedBy { it.document.displayName }) {
@@ -638,7 +645,7 @@ data class DeviceRequest private constructor(
                 cred = cred,
                 docRequest = docRequest,
                 presentmentSource = presentmentSource,
-                keyAgreementPossible = keyAgreementPossible,
+                keyAgreementPossible = effectiveKeyAgreementPossible,
             )
             if (bestMatch != null) {
                 matches.add(bestMatch)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/dcql/DcqlQuery.kt
@@ -146,6 +146,13 @@ data class DcqlQuery(
                 else -> emptyList()
             }
 
+            // Zero-Knowledge Proofs (via Longfellow) currently only support ECDSA, so key agreement (MACing) cannot be used.
+            val effectiveKeyAgreementPossible = if (credentialQuery.format == "mso_mdoc_zk") {
+                emptyList()
+            } else {
+                keyAgreementPossible
+            }
+
             val matches = mutableListOf<QueryResponseMatch>()
             // We sort on displayName b/c otherwise it's sorted on Document.identifier which can be unpredictable
             for (cred in credsSatisfyingMeta.sortedBy { it.document.displayName }) {
@@ -181,7 +188,7 @@ data class DcqlQuery(
                         val credential = presentmentSource.selectCredential(
                             document = cred.document,
                             requestedClaims = credentialQuery.claims,
-                            keyAgreementPossible = keyAgreementPossible
+                            keyAgreementPossible = effectiveKeyAgreementPossible
                         )
                         if (credential == null) {
                             throw DcqlCredentialQueryException("Error selecting credential with id ${credentialQuery.id}")
@@ -229,7 +236,7 @@ data class DcqlQuery(
                                     credential = presentmentSource.selectCredential(
                                         document = cred.document,
                                         requestedClaims = credentialQuery.claims,
-                                        keyAgreementPossible = keyAgreementPossible
+                                        keyAgreementPossible = effectiveKeyAgreementPossible
                                     )!!,
                                     claims = matchingClaimValues,
                                     transactionData = transactionData

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -184,6 +184,9 @@ suspend fun mdocPresentment(
                     )
 
                     if (zkSystemMatch != null) {
+                        if (Logger.isDebugEnabled) {
+                            Logger.dCbor(TAG, "Generating ZKP proof for document", document.toDataItem())
+                        }
                         val zkDocument = zkSystemMatch.generateProof(
                             zkSystemSpec = zkSystemSpec!!,
                             document = document,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cbor/CdnTests.kt
@@ -406,6 +406,32 @@ class CdnTests {
     }
 
     @Test
+    fun testOpportunisticUntaggedCoseMac0() {
+        val protectedMap = buildCborMap {
+            put(1, 5)
+        }
+        val protectedBytes = Cbor.encode(protectedMap)
+        val untaggedCoseMac0 = buildCborArray {
+            add(Bstr(protectedBytes))
+            add(buildCborMap {})
+            add(Bstr("payload".encodeToByteArray()))
+            add(Bstr("macTag".encodeToByteArray()))
+        }
+
+        val prettyAnnotated = Cdn.encode(untaggedCoseMac0, CdnGeneratorOptions.Pretty)
+        assertTrue(prettyAnnotated.contains("# COSE_Mac0"))
+        assertTrue(prettyAnnotated.contains("/protected/"))
+        assertTrue(prettyAnnotated.contains("/unprotected/"))
+        assertTrue(prettyAnnotated.contains("/payload/"))
+        assertTrue(prettyAnnotated.contains("/tag/"))
+        assertTrue(prettyAnnotated.contains("/alg/"))
+        assertTrue(prettyAnnotated.contains("# HMAC_SHA256: HMAC with SHA-256"))
+
+        val roundtripItem = Cdn.parse(prettyAnnotated)
+        assertEquals(untaggedCoseMac0, roundtripItem)
+    }
+
+    @Test
     fun testOpportunisticCoseKey() {
         val ecKey = buildCborMap {
             put(1, 2)


### PR DESCRIPTION
In `CdnGenerator`, update `detectCoseArrayStructure()` to inspect the `alg` header parameter against known COSE MAC algorithm identifiers to correctly distinguish `COSE_Mac0` from `COSE_Sign1`.

In `DeviceRequest` and `DcqlQuery`, update `execute()` to set `keyAgreementPossible` to an empty list when Zero-Knowledge Proofs are requested (`zkRequest != null` or `mso_mdoc_zk`), because Longfellow ZKP currently only supports ECDSA signatures.

Add `testOpportunisticUntaggedCoseMac0()` in `CdnTests` to verify untagged `COSE_Mac0` detection.

Fixes #1828.

Test: Manually tested by presenting Age Verification credential in proximity using ZKP.
Test: ./gradlew :multipaz:jvmTest
