### PR TITLE
Improve requester info presentation, logging, and registration.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -288,6 +288,7 @@ fun Consent(
 
                     composable("showRequesterInfo") {
                         ShowRequesterInfoPage(
+                            requester = requester,
                             trustedRequesterIdentity = trustedRequesterIdentity,
                             onBackClicked = {
                                 navController.navigateUp()
@@ -318,6 +319,7 @@ fun Consent(
 
 @Composable
 private fun ShowRequesterInfoPage(
+    requester: Requester,
     trustedRequesterIdentity: TrustedRequesterIdentity?,
     onBackClicked: () -> Unit,
 ) {
@@ -349,7 +351,10 @@ private fun ShowRequesterInfoPage(
             }
         }
 
-        trustedRequesterIdentity?.identity?.certChain?.let { certChain ->
+        val certChainToShow = trustedRequesterIdentity?.identity?.certChain
+            ?: requester.requesterIdentities.firstOrNull()?.certChain
+
+        certChainToShow?.let { certChain ->
             Box(
                 modifier = Modifier.fillMaxHeight()
             ) {
@@ -457,6 +462,7 @@ private fun ConsentPage(
 
     Column {
         RelyingPartySection(
+            requester = requester,
             trustedRequesterIdentity = trustedRequesterIdentity,
             requesterDisplayData = requesterDisplayData,
             imageLoader = imageLoader,
@@ -1208,6 +1214,7 @@ private fun ClaimsView(
 
 @Composable
 private fun RelyingPartySection(
+    requester: Requester,
     requesterDisplayData: RequesterDisplayData,
     trustedRequesterIdentity: TrustedRequesterIdentity?,
     imageLoader: ImageLoader?,
@@ -1230,10 +1237,15 @@ private fun RelyingPartySection(
             // done in the warning text
             ?: stringResource(Res.string.credential_presentment_headline_share_with_unknown_requester)
 
+        // Make the RP requester icon / string clickable if we have a certificate chain
+        val showRequesterInfoEnabled = trustedRequesterIdentity?.identity?.certChain != null ||
+                requester.requesterIdentities.isNotEmpty()
+        println("showRequesterInfoEnabled $showRequesterInfoEnabled")
+
         if (requesterDisplayData.icon != null) {
             Icon(
                 modifier = Modifier.size(80.dp)
-                    .clickable(enabled = trustedRequesterIdentity?.identity?.certChain != null) {
+                    .clickable(enabled = showRequesterInfoEnabled) {
                         onShowRequesterInfo()
                     },
                 bitmap = requesterDisplayData.icon,
@@ -1244,7 +1256,7 @@ private fun RelyingPartySection(
         } else if (requesterDisplayData.iconUrl != null && imageLoader != null) {
             AsyncImage(
                 modifier = Modifier.size(80.dp)
-                    .clickable(enabled = trustedRequesterIdentity?.identity?.certChain != null) {
+                    .clickable(enabled = showRequesterInfoEnabled) {
                         onShowRequesterInfo()
                     },
                 model = requesterDisplayData.iconUrl,
@@ -1256,7 +1268,7 @@ private fun RelyingPartySection(
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             modifier = Modifier
-                .clickable(enabled = trustedRequesterIdentity?.identity?.certChain != null) {
+                .clickable(enabled = showRequesterInfoEnabled) {
                     onShowRequesterInfo()
                 },
             text = requesterName,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -138,7 +138,12 @@ suspend fun Iso18013Presentment(
                 break
             }
 
-            val deviceRequestCbor = Cbor.decode(encodedDeviceRequest!!)
+            if (encodedDeviceRequest == null) {
+                throw IllegalStateException("No data in message from reader")
+            }
+
+            Logger.dCbor(TAG, "DeviceRequest", encodedDeviceRequest)
+            val deviceRequestCbor = Cbor.decode(encodedDeviceRequest)
             val deviceRequest = DeviceRequest.fromDataItem(deviceRequestCbor)
             deviceRequest.verifyReaderAuthentication(sessionTranscript)
             val responseObject = mdocPresentment(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/digitalCredentialsPresentment.kt
@@ -283,7 +283,9 @@ private suspend fun digitalCredentialsMdocApiProtocol(
     }
     Logger.dCbor(TAG, "SessionTranscript", sessionTranscript)
 
-    val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(deviceRequestBase64.fromBase64Url()))
+    val encodedDeviceRequest = deviceRequestBase64.fromBase64Url()
+    Logger.dCbor(TAG, "DeviceRequest", encodedDeviceRequest)
+    val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(encodedDeviceRequest))
     deviceRequest.verifyReaderAuthentication(sessionTranscript)
     val responseObject = mdocPresentment(
         deviceRequest = deviceRequest,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -86,9 +86,6 @@ suspend fun mdocPresentment(
 ): MdocResponse {
     val credentialsPresented = mutableSetOf<SecureAreaBoundCredential>()
     lateinit var eventData: EventPresentmentData
-    if (Logger.isDebugEnabled) {
-        Logger.dCbor(TAG, "DeviceRequest", deviceRequest.toDataItem())
-    }
 
     val deviceResponse = buildDeviceResponse(
         sessionTranscript = sessionTranscript,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/uriSchemePresentment.kt
@@ -287,6 +287,7 @@ private suspend fun mdocUriSchemePresentment(
             throw IllegalStateException("No data in message from reader")
         }
 
+        Logger.dCbor(TAG, "DeviceRequest", messageFromReader)
         val deviceRequest = DeviceRequest.fromDataItem(Cbor.decode(messageFromReader))
         deviceRequest.verifyReaderAuthentication(sessionTranscript)
         val responseObject = mdocPresentment(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -258,7 +258,7 @@ object Logger {
             }
             val sb = "$message: ${bytes.size} bytes of CBOR: " + bytes.toHex() +
                     "\n" +
-                    "In diagnostic notation:\n" +
+                    "In Concise Diagnostic Notation:\n" +
                     cdnString
             printLine(
                 level = level,

--- a/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/SwiftTestApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -95,6 +95,19 @@ struct DocumentProviderExtension: IdentityDocumentProvider {
     }
 
     func performRegistrationUpdates() async {
-        
+        print("In performRegistrationUpdates()")
+        let source = await getPresentmentSource()
+        let dcApi = try! await DigitalCredentialsCompanion.shared.getDefault()
+        if dcApi.registerAvailable {
+            do {
+                try await dcApi.register(
+                    documentStore: source.documentStore,
+                    documentTypeRepository: source.documentTypeRepository,
+                    selectedProtocols: dcApi.supportedProtocols
+                )
+            } catch {
+                print("Error registering with DigitalCredentials API: \(error)")
+            }
+        }
     }
 }

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -224,11 +224,15 @@ class ViewModel {
         
         let dcApi = try! await DigitalCredentialsCompanion.shared.getDefault()
         if dcApi.registerAvailable {
-            try! await dcApi.register(
-                documentStore: documentStore,
-                documentTypeRepository: documentTypeRepository,
-                selectedProtocols: dcApi.supportedProtocols
-            )
+            do {
+                try await dcApi.register(
+                    documentStore: documentStore,
+                    documentTypeRepository: documentTypeRepository,
+                    selectedProtocols: dcApi.supportedProtocols
+                )
+            } catch {
+                print("Error registering with DigitalCredentials API: \(error)")
+            }
             Task {
                 for await _ in documentStore.eventFlow {
                     do {


### PR DESCRIPTION
In `Consent`, enable interaction with relying party requester details when `requesterIdentities` is present, even if `trustedRequesterIdentity` certificate chain is absent. Show the certificate chain from `requesterIdentities` in `ShowRequesterInfoPage` as fallback.

In `Iso18013Presentment`, `digitalCredentialsMdocApiProtocol`, and `mdocUriSchemePresentment`, log raw `DeviceRequest` bytes via `Logger.dCbor()` prior to decoding. Remove redundant `DeviceRequest` logging in `mdocPresentment()`. Check for null encoded `DeviceRequest` in `Iso18013Presentment`.

Update `Logger.dCbor()` output header to "In Concise Diagnostic Notation:".

Additionally, in `DocumentProviderExtension` and `ViewModel` for `SwiftTestApp`, catch errors thrown during `DigitalCredentialsCompanion` registration instead of throwing.

Fixes #1869.

Test: ./gradlew check
