### PR TITLE
Remove max APDU response size from NFCv2 data transfer options.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfcV2.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodNfcV2.kt
@@ -9,19 +9,13 @@ import org.multipaz.util.Logger
 
 /**
  * Connection method for NFCv2.
- *
- * The [apduResponseMaxSize] parameter is used to tell the mdoc that it needs to send its responses in APDUs no
- * larger than this size and this value must be smaller or equal to 65536, the maximum size of an Extended APDU.
- * Since this class is usually not used in an environment where a 64 KiB buffer is a showstopper we default to the
- * maximum size.
- *
- * @property apduResponseMaxSize the maximum length of the response data field.
  */
-data class MdocConnectionMethodNfcV2(
-    val apduResponseMaxSize: Long = 65536L
-): MdocConnectionMethod() {
-    override fun toString(): String =
-        "nfcv2:apdu_response_max_size=$apduResponseMaxSize"
+class MdocConnectionMethodNfcV2 : MdocConnectionMethod() {
+    override fun equals(other: Any?): Boolean = other is MdocConnectionMethodNfcV2
+
+    override fun hashCode(): Int = MdocConnectionMethodNfcV2::class.hashCode()
+
+    override fun toString(): String = "nfcv2"
 
     override fun toDeviceEngagement(): ByteArray {
         return Cbor.encode(
@@ -29,7 +23,6 @@ data class MdocConnectionMethodNfcV2(
                 add(METHOD_TYPE)
                 add(METHOD_MAX_VERSION)
                 addCborMap {
-                    put(OPTION_KEY_APDU_RESPONSE_MAX_LENGTH, apduResponseMaxSize)
                 }
             }
         )
@@ -68,9 +61,10 @@ data class MdocConnectionMethodNfcV2(
                 return null
             }
             val map = array[2]
-            return MdocConnectionMethodNfcV2(
-                map[OPTION_KEY_APDU_RESPONSE_MAX_LENGTH].asNumber
-            )
+            if (map.asMap.isNotEmpty()) {
+                Logger.w(TAG, "Unexpected non-empty map in DeviceEngagement for NFCv2")
+            }
+            return MdocConnectionMethodNfcV2()
         }
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelperTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcV2EngagementHelperTest.kt
@@ -163,8 +163,8 @@ class MdocNfcV2EngagementHelperTest {
             """
                 CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=a0000002480401), le=0)
                 ResponseApdu(status=36864, payload=ByteString(size=7 hex=a1001a00010000))
-                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=17 hex=530fa100a10281830501a1001a00010000), le=65536)
-                ResponseApdu(status=36864, payload=ByteString(size=112 hex=536ea100a50063312e31018201d818584ba401022001215820711b420f708e686917b799e5991346c318a6bd89ac32d04e78cb537cd89dcaa92258201b99557fca9a63617246669eababc7a36068db058e9c98b067a5eba3233b451c0281830501a1001a00010000058006a203f504f5))
+                CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=11 hex=5309a100a10281830501a0), le=65536)
+                ResponseApdu(status=36864, payload=ByteString(size=106 hex=5368a100a50063312e31018201d818584ba401022001215820711b420f708e686917b799e5991346c318a6bd89ac32d04e78cb537cd89dcaa92258201b99557fca9a63617246669eababc7a36068db058e9c98b067a5eba3233b451c0281830501a0058006a203f504f5))
                 CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=12 hex=530aa1646461746143010203), le=65530)
                 ResponseApdu(status=36864, payload=ByteString(size=13 hex=530ba164646174614401020304))
                 CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=11 hex=5309a16673746174757314), le=65530)


### PR DESCRIPTION
This updates to the latest spec from the the small group in ISO SC17 WG10 working on AP 112.05.

Remove the `apduResponseMaxSize` option parameter from `MdocConnectionMethodNfcV2` as it is unnecessary and not part of the engagement payload options.

Update `toDeviceEngagement()` and `fromDeviceEngagement()` in `MdocConnectionMethodNfcV2` to reflect the removed parameter, logging a warning if unexpected options map entries are present during parsing. Update `MdocNfcV2EngagementHelperTest` to match the expected device engagement APDU payload sizes.

Note: This breaks compatibility with older implementations of NFCv2 in Multipaz, most notable Multipaz Wallet. To mitigate we will update all APKs on https://apps.multipaz.org with new versions using this version of NFCv2.

Fixes #1871.

Test: ./gradlew :multipaz:jvmTest
