### PR TITLE
Skip network calls during credential refresh if no refresh is needed.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
@@ -106,4 +106,14 @@ interface AbstractDocumentProvisioningHandler {
      * @param err provisioning error
      */
     suspend fun cleanupCredentialsOnError(pendingCredentials: List<Credential>, err: Throwable)
+
+    /**
+     * Checks if there are credentials that should be fetched/refreshed for the document.
+     *
+     * This is useful for checking if network I/O should be performed during credential refresh.
+     *
+     * @param document [Document] for which credentials are being checked.
+     * @return `true` if there are credentials to refresh, `false` otherwise.
+     */
+    suspend fun haveCredentialsToRefresh(document: Document): Boolean
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
@@ -66,8 +66,8 @@ open class DocumentProvisioningHandler(
      */
     open suspend fun getDocumentProvisioningSettings(
         document: Document,
-        credentialMetadata: CredentialMetadata,
-        issuerMetadata: ProvisioningMetadata
+        credentialMetadata: CredentialMetadata?,
+        issuerMetadata: ProvisioningMetadata?
     ): DocumentProvisioningSettings = defaultDocumentProvisioningSettings
 
     override suspend fun createDocument(
@@ -245,6 +245,45 @@ open class DocumentProvisioningHandler(
             dryRun = false
         )
         return document.getPendingCredentials()
+    }
+
+    override suspend fun haveCredentialsToRefresh(document: Document): Boolean {
+        if (!document.provisioned || document.getCredentials().isEmpty()) {
+            return true
+        }
+        val pending = document.getPendingCredentials()
+        if (pending.isNotEmpty()) {
+            return true
+        }
+        val settings = getDocumentProvisioningSettings(document, null, null)
+        val now = Clock.System.now()
+        val credentials = document.getCredentials()
+        val domains = credentials.map { it.domain }.toSet()
+        for (domain in domains) {
+            val certifiedInDomain = document.getCertifiedCredentialsForDomain(domain)
+            if (certifiedInDomain.isEmpty()) {
+                continue
+            }
+            val maxUses = if (domain == settings.sdJwtKeylessDomain) {
+                settings.keylessCredentialMaxUses
+            } else {
+                settings.keyBoundCredentialMaxUses
+            }
+            val count = DocumentUtil.managedCredentialHelper(
+                document = document,
+                domain = domain,
+                createCredential = null,
+                now = now,
+                numCredentials = certifiedInDomain.size,
+                maxUsesPerCredential = maxUses,
+                minValidTime = settings.minValidTime,
+                dryRun = true
+            )
+            if (count > 0) {
+                return true
+            }
+        }
+        return false
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -150,16 +150,19 @@ class ProvisioningModel(
      *
      * Note that this bypasses the model and throws an exception if something goes wrong.
      *
+     * It is guaranteed that no network I/O to the issuer will be performed unless there are credentials
+     * that actually need to be fetched (as determined by
+     * [AbstractDocumentProvisioningHandler.haveCredentialsToRefresh]).
+     *
      * @param document [Document] where credentials should be provisioned
      * @param authorizationData authorization data from a previous provisioning session (see
      *  [DocumentProvisioningHandler.AbstractDocumentMetadataHandler.updateDocumentMetadata]
      *  `authorizationData` parameter)
      * @param clientPreferences configuration parameters for OpenID4VCI client
      * @param backend interface to the wallet back-end service
-     * @return deferred [Document] value, resolved when credentials are provisioned
+     * @return number of credentials fetched
      * @throws Exception if an error occurred
      */
-    // TODO: be more specific with what exceptions are thrown
     @Throws(
         CancellationException::class,
         Exception::class
@@ -170,6 +173,9 @@ class ProvisioningModel(
         clientPreferences: OpenID4VCIClientPreferences,
         backend: OpenID4VCIBackend,
     ): Int {
+        if (!documentProvisioningHandler.haveCredentialsToRefresh(document)) {
+            return 0
+        }
         val numCredentialsFetched = CoroutineScope(createCoroutineContext(clientPreferences, backend)).async {
             val provisioningClient = Provisioning.createClientFromAuthorizationData(authorizationData)
             requestCredentials(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
@@ -38,6 +38,10 @@ import org.multipaz.mdoc.mso.MobileSecurityObjectGenerator
 import org.multipaz.mdoc.mso.StaticAuthDataGenerator
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.prompt.PromptModel
+import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
+import org.multipaz.provisioning.openid4vci.OpenID4VCIClientPreferences
+import org.multipaz.securearea.KeyAttestation
+import org.multipaz.securearea.SecureArea
 import org.multipaz.securearea.SecureAreaRepository
 import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.Storage
@@ -57,7 +61,7 @@ import kotlin.time.Duration.Companion.days
 class ProvisioningModelTest {
     private lateinit var storage: Storage
     private lateinit var secureAreaRepository: SecureAreaRepository
-
+    private lateinit var secureArea: SecureArea
     private lateinit var documentStore: DocumentStore
 
     private val mockHttpEngine = MockEngine { request ->
@@ -70,7 +74,7 @@ class ProvisioningModelTest {
     @BeforeTest
     fun setup() = runTest {
         storage = EphemeralStorage()
-        val secureArea = SoftwareSecureArea.create(storage)
+        secureArea = SoftwareSecureArea.create(storage)
         secureAreaRepository = SecureAreaRepository.Builder()
             .add(secureArea)
             .build()
@@ -216,6 +220,47 @@ class ProvisioningModelTest {
         }
         // Initial provisioning failed, document must be cleaned up
         assertTrue(documentStore.listDocumentIds().isEmpty())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun refreshNoOpWhenNoCredentialsToFetch() = runTest {
+        val doc = model.launch(UnconfinedTestDispatcher(testScheduler)) {
+            TestProvisioningClient()
+        }.await()
+        assertTrue(doc.provisioned)
+
+        val handler = DocumentProvisioningHandler(
+            documentStore = documentStore,
+            secureArea = secureArea
+        )
+        // With all credentials certified and up to date, no credentials need refresh
+        assertFalse(handler.haveCredentialsToRefresh(doc))
+
+        // openID4VCIRefreshCredentials should immediately return 0 without attempting network I/O
+        // (Invalid authorizationData would throw an exception if network I/O / client creation was attempted)
+        val numRefreshed = model.openID4VCIRefreshCredentials(
+            document = doc,
+            authorizationData = ByteString(byteArrayOf(0x00)),
+            clientPreferences = OpenID4VCIClientPreferences(
+                clientId = "test",
+                redirectUrl = "https://example.com/redirect",
+                locales = listOf("en-US"),
+                signingAlgorithms = listOf(Algorithm.ES256)
+            ),
+            backend = object : OpenID4VCIBackend {
+                override suspend fun getClientId(): String = "test"
+                override suspend fun createJwtClientAssertion(authorizationServerIdentifier: String): String = ""
+                override suspend fun createJwtWalletAttestation(keyAttestation: KeyAttestation): String = ""
+                override suspend fun createJwtKeyAttestation(
+                    credentialKeyAttestations: List<CredentialKeyAttestation>,
+                    challenge: String,
+                    userAuthentication: List<String>?,
+                    keyStorage: List<String>?
+                ): String = ""
+            }
+        )
+        assertEquals(0, numRefreshed)
     }
 
     class TestProvisioningClient(


### PR DESCRIPTION
Introduce `haveCredentialsToRefresh()` on `AbstractDocumentProvisioningHandler` and check it in `ProvisioningModel.openID4VCIRefreshCredentials()` to guarantee that no network I/O is performed to the credential issuer unless there are credentials that actually require fetching or replacement.

Implemented `haveCredentialsToRefresh()` in `DocumentProvisioningHandler` to inspect the document's credentials across active domains using dry runs of `DocumentUtil.managedCredentialHelper()` to check for expired credentials, credentials exceeding usage limits, or uncertified pending credentials.

Fixes #1873.

Test: Unit tests pass (`./gradlew :multipaz:jvmTest`).

