### PR TITLE
High-level revocation check utility.

### DIFF
--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/handleRevocationDataNotModified.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/handleRevocationDataNotModified.kt
@@ -1,0 +1,41 @@
+package org.multipaz.openid4vci.request
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fromHttpToGmtDate
+import io.ktor.http.toHttpDate
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.header
+import io.ktor.server.response.etag
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
+import io.ktor.util.date.GMTDate
+import org.multipaz.revocation.RevocationData
+import org.multipaz.util.Logger
+
+internal suspend fun handleRevocationDataNotModified(
+    call: ApplicationCall,
+    revocationData: RevocationData
+): Boolean {
+    val creationMillis = revocationData.creationTime.toEpochMilliseconds()
+    val eTag = "W/\"$creationMillis\""
+    if (call.request.header(HttpHeaders.IfNoneMatch) == eTag) {
+        call.respond(HttpStatusCode.NotModified)
+        return true
+    }
+    try {
+        call.request.header(HttpHeaders.IfModifiedSince)?.fromHttpToGmtDate()?.let {
+            if (it.timestamp >= creationMillis) {
+                call.respond(HttpStatusCode.NotModified)
+                return true
+            }
+        }
+    } catch (err: Exception) {
+        Logger.e(TAG, "Error parsing If-Modified-Since header", err)
+    }
+    call.response.header(HttpHeaders.LastModified, GMTDate(creationMillis).toHttpDate())
+    call.response.etag(eTag)
+    return false
+}
+
+private const val TAG = "identifierList"

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/identifierList.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/identifierList.kt
@@ -1,12 +1,8 @@
 package org.multipaz.openid4vci.request
 
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.toHttpDate
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.response.header
 import io.ktor.server.response.respondBytes
-import io.ktor.util.date.GMTDate
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.multipaz.openid4vci.util.CredentialState
@@ -57,16 +53,15 @@ suspend fun identifierList(call: ApplicationCall, bucket: String) {
         }
     }
 
-    val creation = identifierList.creationTime.toEpochMilliseconds()
-    call.response.header(HttpHeaders.LastModified, GMTDate(creation).toHttpDate())
-    call.response.header(HttpHeaders.ETag, "W/$creation")
-    call.respondBytes(
-        bytes = identifierList.serializeAsCwt(
-            key = getServerIdentity(ServerIdentity.CREDENTIAL_SIGNING),
-            subject = BackendEnvironment.getBaseUrl() + "/identifier_list/$bucket"
-        ),
-        contentType = IDENTIFIER_LIST_CWT
-    )
+    if (!handleRevocationDataNotModified(call, identifierList)) {
+        call.respondBytes(
+            bytes = identifierList.serializeAsCwt(
+                key = getServerIdentity(ServerIdentity.CREDENTIAL_SIGNING),
+                subject = BackendEnvironment.getBaseUrl() + "/identifier_list/$bucket"
+            ),
+            contentType = IDENTIFIER_LIST_CWT
+        )
+    }
 }
 
 private val IDENTIFIER_LIST_CWT = ContentType("application", "identifierlist+cwt")

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/statusList.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/statusList.kt
@@ -2,12 +2,9 @@ package org.multipaz.openid4vci.request
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.http.toHttpDate
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.response.header
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
-import io.ktor.util.date.GMTDate
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.multipaz.openid4vci.util.CredentialState
@@ -73,26 +70,25 @@ suspend fun statusList(call: ApplicationCall, bucket: String) {
         }
     }
 
-    val creation = statusList.creationTime.toEpochMilliseconds()
-    call.response.header(HttpHeaders.LastModified, GMTDate(creation).toHttpDate())
-    call.response.header(HttpHeaders.ETag, "W/$creation")
-    val serverKey = getServerIdentity(ServerIdentity.CREDENTIAL_SIGNING)
-    if (useCwt) {
-        call.respondBytes(
-            bytes = statusList.serializeAsCwt(
-                key = serverKey,
-                subject = BackendEnvironment.getBaseUrl() + "/status_list/$bucket"
-            ),
-            contentType = STATUSLIST_CWT
-        )
-    } else {
-        call.respondText(
-            text = statusList.serializeAsJwt(
-                key = serverKey,
-                subject = BackendEnvironment.getBaseUrl() + "/status_list/$bucket"
-            ),
-            contentType = STATUSLIST_JWT
-        )
+    if (!handleRevocationDataNotModified(call, statusList)) {
+        val serverKey = getServerIdentity(ServerIdentity.CREDENTIAL_SIGNING)
+        if (useCwt) {
+            call.respondBytes(
+                bytes = statusList.serializeAsCwt(
+                    key = serverKey,
+                    subject = BackendEnvironment.getBaseUrl() + "/status_list/$bucket"
+                ),
+                contentType = STATUSLIST_CWT
+            )
+        } else {
+            call.respondText(
+                text = statusList.serializeAsJwt(
+                    key = serverKey,
+                    subject = BackendEnvironment.getBaseUrl() + "/status_list/$bucket"
+                ),
+                contentType = STATUSLIST_JWT
+            )
+        }
     }
 }
 

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/CredentialState.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/CredentialState.kt
@@ -262,6 +262,14 @@ class CredentialState(
             }
         }
 
+        fun identifierToIndex(identifier: ByteString): Int {
+            var value = 0
+            for (byte in identifier.toByteArray()) {
+                value = (value shl 8) or (byte.toInt() and 0xFF)
+            }
+            return value
+        }
+
         /**
          * Sets the credential status.
          *
@@ -321,7 +329,7 @@ class CredentialState(
 
         /** Inverse of [encodeIndexToKey] */
         private fun decodeKeyToIndex(key: String): Int {
-            check(key.substring(0, 1).toInt() + 1 == key.length)
+            check(key.take(1).toInt() + 1 == key.length)
             return key.substring(1).toInt(36)
         }
     }

--- a/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -33,25 +33,44 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
 import org.multipaz.asn1.OID
+import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.X509Cert
+import org.multipaz.document.DocumentStore
+import org.multipaz.document.buildDocumentStore
+import org.multipaz.documenttype.knowntypes.DrivingLicense
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredential
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredentialSdJwt
 import org.multipaz.openid4vci.credential.CredentialFactoryMdl
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
 import org.multipaz.openid4vci.credential.CredentialFactoryUtopiaNaturalization
+import org.multipaz.openid4vci.request.invalidateIdentifierList
+import org.multipaz.openid4vci.request.invalidateStatusList
+import org.multipaz.openid4vci.util.CredentialId
+import org.multipaz.openid4vci.util.CredentialState
 import org.multipaz.provisioning.AuthorizationChallenge
 import org.multipaz.provisioning.AuthorizationResponse
+import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.provisioning.KeyBindingInfo
 import org.multipaz.provisioning.Provisioning
 import org.multipaz.provisioning.CredentialKeyAttestation
+import org.multipaz.provisioning.CredentialMetadata
+import org.multipaz.provisioning.Display
+import org.multipaz.provisioning.DocumentProvisioningHandler
+import org.multipaz.provisioning.KeyBindingType
+import org.multipaz.provisioning.ProvisioningMetadata
 import org.multipaz.provisioning.openid4vci.OpenID4VCI
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackend
 import org.multipaz.provisioning.openid4vci.OpenID4VCIBackendUtil
 import org.multipaz.provisioning.openid4vci.OpenID4VCIClientPreferences
+import org.multipaz.revocation.CachingRevocationChecker
+import org.multipaz.revocation.RevocationCheckState
+import org.multipaz.revocation.RevocationStatus
+import org.multipaz.revocation.check
+import org.multipaz.revocation.getRevocationInfo
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.KeyAttestation
@@ -62,9 +81,17 @@ import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.server.common.ServerConfiguration
 import org.multipaz.server.common.ServerEnvironment
 import org.multipaz.server.common.installServerEnvironment
+import org.multipaz.server.enrollment.ServerIdentity
+import org.multipaz.server.enrollment.getServerIdentity
 import org.multipaz.storage.Storage
 import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.trustmanagement.ConfigurableTrustManager
+import org.multipaz.trustmanagement.TrustEntryX509Cert
+import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.util.toBase64Url
+import org.multipaz.utopia.knowntypes.DigitalPaymentCredential
+import org.multipaz.utopia.knowntypes.DigitalPaymentCredentialSdJwt
+import org.multipaz.utopia.knowntypes.UtopiaNaturalization
 import kotlin.IllegalStateException
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
@@ -84,6 +111,10 @@ class ProvisioningClientTest {
 
     lateinit var credentalFactoryRegistry: CredentialFactoryRegistry
 
+    lateinit var documentStore: DocumentStore
+
+    lateinit var documentProvisioningHandler: DocumentProvisioningHandler
+
     @Before
     fun setup() = runTest {
         storage = EphemeralStorage()
@@ -92,6 +123,8 @@ class ProvisioningClientTest {
         secureAreaProvider = SecureAreaProvider<SecureArea>(Dispatchers.Default) {
             secureArea
         }
+        documentStore = buildDocumentStore(storage, secureAreaRepository) {}
+        documentProvisioningHandler = DocumentProvisioningHandler(secureArea, documentStore)
         credentalFactoryRegistry = CredentialFactoryRegistry(
             listOf(
                 CredentialFactoryMdl(),
@@ -107,6 +140,7 @@ class ProvisioningClientTest {
     fun authorizationCodeWithScope() {
         runWithAuthorizationCode(
             offer = OFFER_MDL,
+            credentialFormat = CredentialFormat.Mdoc(DrivingLicense.MDL_DOCTYPE),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -116,9 +150,24 @@ class ProvisioningClientTest {
     }
 
     @Test
+    fun authorizationCodeWithScopeWithIdentifierListRevocation() {
+        runWithAuthorizationCode(
+            offer = OFFER_MDL,
+            credentialFormat = CredentialFormat.Mdoc(DrivingLicense.MDL_DOCTYPE),
+            serverArgs = arrayOf(
+                "-param", "base_url=http://localhost",
+                "-param", "database_engine=ephemeral",
+                "-param", "use_scopes=true"
+            ),
+            extraTests = ::runRevocationTests
+        )
+    }
+
+    @Test
     fun authorizationCodeWithScopeNoClientAttestationChallenge() {
         runWithAuthorizationCode(
             offer = OFFER_MDL,
+            credentialFormat = CredentialFormat.Mdoc(DrivingLicense.MDL_DOCTYPE),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -132,6 +181,7 @@ class ProvisioningClientTest {
     fun authorizationCodeWithScopeWithClientAssertion() {
         runWithAuthorizationCode(
             offer = OFFER_NATURALIZATION,
+            credentialFormat = CredentialFormat.SdJwt(UtopiaNaturalization.VCT),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -146,6 +196,7 @@ class ProvisioningClientTest {
     fun authorizationCodeWithAuthorizationDetails() {
         runWithAuthorizationCode(
             offer = OFFER_MDL,
+            credentialFormat = CredentialFormat.Mdoc(DrivingLicense.MDL_DOCTYPE),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -158,6 +209,7 @@ class ProvisioningClientTest {
     fun authorizationCodeWithPaymentCredential() {
         runWithAuthorizationCode(
             offer = OFFER_PAYMENT,
+            credentialFormat = CredentialFormat.Mdoc(DigitalPaymentCredential.CARD_DOCTYPE),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -170,6 +222,7 @@ class ProvisioningClientTest {
     fun authorizationCodeWithPaymentCredentialSdJwt() {
         runWithAuthorizationCode(
             offer = OFFER_PAYMENT_SD_JWT,
+            credentialFormat = CredentialFormat.SdJwt(DigitalPaymentCredentialSdJwt.CARD_VCT),
             serverArgs = arrayOf(
                 "-param", "base_url=http://localhost",
                 "-param", "database_engine=ephemeral",
@@ -178,9 +231,25 @@ class ProvisioningClientTest {
         )
     }
 
+    @Test
+    fun authorizationCodeWithPaymentCredentialSdJwtWithStatusListRevocation() {
+        runWithAuthorizationCode(
+            offer = OFFER_PAYMENT_SD_JWT,
+            credentialFormat = CredentialFormat.SdJwt(DigitalPaymentCredentialSdJwt.CARD_VCT),
+            serverArgs = arrayOf(
+                "-param", "base_url=http://localhost",
+                "-param", "database_engine=ephemeral",
+                "-param", "use_scopes=true"
+            ),
+            extraTests = ::runRevocationTests
+        )
+    }
+
     fun runWithAuthorizationCode(
         offer: String,
-        serverArgs: Array<String>
+        credentialFormat: CredentialFormat,
+        serverArgs: Array<String>,
+        extraTests: suspend (httpClient: HttpClient, credential: Credential) -> Unit = { _, _ -> }
     ) = testApplication {
         val configuration = ServerConfiguration(serverArgs)
         val serverEnvironment = ServerEnvironment.create(configuration) {
@@ -248,16 +317,37 @@ class ProvisioningClientTest {
                 parameterizedRedirectUrl = location
             ))
 
-            val secureArea = secureAreaProvider.get()
+            // Our test backend does not verify key attestation, so the result can be ignored
+            provisioningClient.getKeyBindingChallenge()
 
-            provisioningClient.getKeyBindingChallenge()  // Our test backend does not verify key attestation
+            val document = documentStore.createDocument()
+            val display = Display("test")
+            val credential = documentProvisioningHandler.getPendingKeyBoundCredentials(
+                document = document,
+                credentialMetadata = CredentialMetadata(
+                    display = display,
+                    format = credentialFormat,
+                    keyBindingType = KeyBindingType.Attestation(Algorithm.ES256),
+                    maxBatchSize = 1
+                ),
+                issuerMetadata = ProvisioningMetadata("http://testul", display, mapOf()),
+                createKeySettings = CreateKeySettings()
+            ).first()
 
-            val keyInfo = secureArea.createKey(null, CreateKeySettings())
+            val credentialData = provisioningClient.obtainCredentials(KeyBindingInfo.Attestation(
+                listOf(CredentialKeyAttestation(
+                    credentialId = credential.identifier,
+                    keyAttestation = credential.getAttestation()
+                ))))
 
-            val credentials = provisioningClient.obtainCredentials(KeyBindingInfo.Attestation(
-                listOf(CredentialKeyAttestation("foo", keyInfo.attestation))))
+            Assert.assertEquals(1, credentialData.certifications.size)
 
-            Assert.assertEquals(1, credentials.certifications.size)
+            credential.certify(credentialData.certifications.first().issuerData)
+
+            withContext(serverEnvironment.await()) {
+                // Run this in server environment!
+                extraTests.invoke(httpClient, credential)
+            }
         }
     }
 
@@ -360,6 +450,134 @@ class ProvisioningClientTest {
             // Exception is thrown because key could not be found
             assertIs<IllegalArgumentException>(exception)
         }
+    }
+
+    private suspend fun runRevocationTests(
+        httpClient: HttpClient,
+        credential: Credential
+    ) {
+        runRevocationTest(
+            httpClient = httpClient,
+            credential = credential,
+            useLastModified = true,
+            useETag = false,
+            bypassCache = false,
+            preferJwt = true
+        )
+        runRevocationTest(
+            httpClient = httpClient,
+            credential = credential,
+            useLastModified = false,
+            useETag = true,
+            bypassCache = false
+        )
+        runRevocationTest(
+            httpClient = httpClient,
+            credential = credential,
+            useLastModified = false,
+            useETag = false,
+            bypassCache = true
+        )
+        /*
+            // This should fail since without conditional HTTP request cache becomes stale:
+            runRevocationTest(
+                httpClient = httpClient,
+                credential = credential,
+                useLastModified = false,
+                useETag = false,
+                bypassCache = false
+            )
+        */
+    }
+
+    private suspend fun runRevocationTest(
+        httpClient: HttpClient,
+        credential: Credential,
+        useETag: Boolean,
+        useLastModified: Boolean,
+        bypassCache: Boolean,
+        preferJwt: Boolean = false
+    ) {
+        val serverKey = getServerIdentity(ServerIdentity.CREDENTIAL_SIGNING) as AsymmetricKey.X509Certified
+        val rootCert = serverKey.certChain.certificates.last()
+        val trustManager = ConfigurableTrustManager(
+            identifier = "builtInIssuerTrustManager",
+            entries = buildList {
+                add(
+                    TrustEntryX509Cert(
+                        identifier = "test_issuer",
+                        metadata = TrustMetadata(
+                            displayName = rootCert.subject.components["CN"]?.value ?: "test",
+                        ),
+                        certificate = rootCert
+                    )
+                )
+            }
+        )
+
+        val revocationChecker = CachingRevocationChecker(
+            storage = storage,
+            httpClient = httpClient,
+            useETag = useETag,
+            useLastModified = useLastModified
+        )
+        val revocationInfo = credential.getRevocationInfo(trustManager)!!
+        val credentialId = when (val status = revocationInfo.revocationStatus) {
+            is RevocationStatus.IdentifierList ->
+                CredentialId(
+                    bucket = status.uri.substring(status.uri.lastIndexOf('/') + 1),
+                    index = CredentialState.identifierToIndex(status.id)
+                )
+            is RevocationStatus.StatusList ->
+                CredentialId(
+                    bucket = status.uri.substring(status.uri.lastIndexOf('/') + 1),
+                    index = status.idx
+                )
+            else -> throw IllegalStateException()
+        }
+
+        val result1 = revocationChecker.check(
+            credential = credential,
+            trustManager = trustManager,
+            bypassCache = bypassCache,
+            preferJwt = preferJwt
+        )
+        Assert.assertNull(result1.error)
+        Assert.assertEquals(RevocationCheckState.VALID, result1.state)
+
+        CredentialState.setCredentialStatus(
+            credentialId = credentialId,
+            status = CredentialState.Status.INVALID,
+            expiration = CredentialState.getCredentialState(credentialId)!!.expiration
+        )
+        invalidateStatusList(credentialId.bucket)
+        invalidateIdentifierList(credentialId.bucket)
+
+        val result2 = revocationChecker.check(
+            credential = credential,
+            trustManager = trustManager,
+            bypassCache = bypassCache,
+            preferJwt = preferJwt
+        )
+        Assert.assertNull(result2.error)
+        Assert.assertEquals(RevocationCheckState.INVALID, result2.state)
+
+        CredentialState.setCredentialStatus(
+            credentialId = credentialId,
+            status = CredentialState.Status.VALID,
+            expiration = CredentialState.getCredentialState(credentialId)!!.expiration
+        )
+        invalidateStatusList(credentialId.bucket)
+        invalidateIdentifierList(credentialId.bucket)
+
+        val result3 = revocationChecker.check(
+            credential = credential,
+            trustManager = trustManager,
+            bypassCache = bypassCache,
+            preferJwt = preferJwt
+        )
+        Assert.assertNull(result3.error)
+        Assert.assertEquals(RevocationCheckState.VALID, result3.state)
     }
 
     object TestBackend: OpenID4VCIBackend {
@@ -472,23 +690,7 @@ class ProvisioningClientTest {
             }            
         """.trimIndent()
 
-        private val attestationJwk = """
-            {
-                "kty": "EC",
-                "alg": "ESP256",
-                "crv": "P-256",
-                "x": "CoLFZ9sJfTqax-GarKIyw7_fX8-L446AoCTSHKJnZGs",
-                "y": "ALEJB1_YQMO_0qSFQb3urFTxRfANN8-MSeWLHYU7MVI",
-                "d": "nJXw7FqLff14yQLBEAwu70mu1gzlfOONh9UuealdsVM",
-                "x5c": [
-                    "MIIBtDCCATugAwIBAgIJAPosC/l8rotwMAoGCCqGSM49BAMCMDgxNjA0BgNVBAMTLXVybjp1dWlkOjYwZjhjMTE3LWI2OTItNGRlOC04ZjdmLTYzNmZmODUyYmFhNjAeFw0yNTA5MzAwMjUxNDRaFw0zNTA5MjgwMjUxNDRaMDgxNjA0BgNVBAMMLXVybjp1dWlkOjRjNDY0NzJiLTdlYjItNDRiNi04NTNhLWY3ZGZlMTEzYzU3NTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAqCxWfbCX06msfhmqyiMsO/31/Pi+OOgKAk0hyiZ2RrALEJB1/YQMO/0qSFQb3urFTxRfANN8+MSeWLHYU7MVKjLjAsMB8GA1UdIwQYMBaAFPqAK5EjiQbxFAeWt//DCaWtC57aMAkGA1UdEwQCMAAwCgYIKoZIzj0EAwIDZwAwZAIwfDEviit5J188zK5qKjkzFWkPy3ljshUg650p2kNuQq7CiQvbKyVDIlCGgOhMZyy+AjBm6ehDicFMPVBEHLUEiXO4cHw7Ed6dFpPm/6GknWcADhax62KN1tIzExo6T1l06G4=",
-                    "MIIBxTCCAUugAwIBAgIJAOQTL9qcQopZMAoGCCqGSM49BAMDMDgxNjA0BgNVBAMTLXVybjp1dWlkOjYwZjhjMTE3LWI2OTItNGRlOC04ZjdmLTYzNmZmODUyYmFhNjAeFw0yNDA5MjMyMjUxMzFaFw0zNDA5MjMyMjUxMzFaMDgxNjA0BgNVBAMTLXVybjp1dWlkOjYwZjhjMTE3LWI2OTItNGRlOC04ZjdmLTYzNmZmODUyYmFhNjB2MBAGByqGSM49AgEGBSuBBAAiA2IABN4D7fpNMAv4EtxyschbITpZ6iNH90rGapa6YEO/uhKnC6VpPt5RUrJyhbvwAs0edCPthRfIZwfwl5GSEOS0mKGCXzWdRv4GGX/Y0m7EYypox+tzfnRTmoVX3v6OxQiapKMhMB8wHQYDVR0OBBYEFPqAK5EjiQbxFAeWt//DCaWtC57aMAoGCCqGSM49BAMDA2gAMGUCMEO01fJKCy+iOTpaVp9LfO7jiXcXksn2BA22reiR9ahDRdGNCrH1E3Q2umQAssSQbQIxAIz1FTHbZPcEbA5uE5lCZlRG/DQxlZhk/rZrkPyXFhqEgfMnQ45IJ6f8Utlg+4Wiiw=="
-                ]
-            }
-           """.trimIndent()
-
         private val clientAssertionKey = AsymmetricKey.parseExplicit(clientAssertionJwk)
-        private val attestationKey = AsymmetricKey.parseExplicit(attestationJwk)
         const val CLIENT_ID = "urn:uuid:418745b8-78a3-4810-88df-7898aff3ffb4"
 
 
@@ -546,6 +748,5 @@ class ProvisioningClientTest {
             locales = listOf("en-US"),
             signingAlgorithms = listOf(Algorithm.ESP256)
         )
-
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CachingRevocationChecker.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CachingRevocationChecker.kt
@@ -1,0 +1,370 @@
+package org.multipaz.revocation
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.readRawBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.etag
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.X509Cert
+import org.multipaz.rpc.handler.InvalidRequestException
+import org.multipaz.storage.KeyExistsStorageException
+import org.multipaz.storage.NoRecordStorageException
+import org.multipaz.storage.Storage
+import org.multipaz.storage.StorageTable
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.util.Logger
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+/**
+ * Storage-backed implementation of [RevocationChecker] that caches downloaded data (status and
+ * identifier lists) in a [StorageTable].
+ *
+ * Revocation data is validated at download time, when loaded from cache it is not re-validated.
+ * When revocation data is found in cache, it is checked for freshness in the following manner:
+ * - if revocation data server has used `ETag` or `Last-Modified` headers, a conditional HTTP GET
+ *   request is sent to the server; HTTP status `304 Not Modified` means that cached data is
+ *   fresh to be used, otherwise fresh data is sent from the server and replaces cached one.
+ * - if revocation data server has not sent these headers, cached data is assumed fresh for its
+ *   specified TTL time, or, absent that, expiration time.
+ * - if HTTP update fails, cached data is used, even if it is expired; stale data is assumed
+ *   to be better than no data; cache entries are purged after the time specified by
+ *   [cachingDuration], which should be longer than a typical credential validity period.
+ *
+ * @param storage Storage instance used to persist revocation list caches.
+ * @param httpClient Ktor [HttpClient] used to fetch revocation status and identifier lists over HTTP/HTTPS.
+ * @param httpTimeout Timeout duration for network requests fetching revocation lists.
+ * @param cachingDuration how long to keep revocation data in cache
+ * @param useETag allow `ETag` header use, mostly exposed for testing only
+ * @param useETag allow `Last-Modified` header use, mostly exposed for testing only
+ */
+class CachingRevocationChecker(
+    private val storage: Storage,
+    private val httpClient: HttpClient = HttpClient(),
+    private val httpTimeout: Duration = 10.seconds,
+    private val cachingDuration: Duration = 60.days,
+    private val useETag: Boolean = true,
+    private val useLastModified: Boolean = true
+) : RevocationChecker {
+
+    private suspend fun getCacheTable(): StorageTable {
+        return storage.getTable(cacheTableSpec)
+    }
+
+    override suspend fun clearCache() {
+        try {
+            getCacheTable().deleteAll()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Logger.w(TAG, "Failed to clear revocation cache", e)
+        }
+    }
+
+    override suspend fun check(
+        revocationStatus: RevocationStatus,
+        issuerCert: X509Cert?,
+        onlyTrusted: Boolean,
+        atTime: Instant,
+        bypassCache: Boolean,
+        preferJwt: Boolean
+    ): RevocationCheckResult = when (revocationStatus) {
+            is RevocationStatus.StatusList ->
+                checkStatusList(revocationStatus, issuerCert, onlyTrusted, atTime, bypassCache, preferJwt)
+            is RevocationStatus.IdentifierList ->
+                checkIdentifierList(revocationStatus, issuerCert, onlyTrusted, atTime, bypassCache)
+            is RevocationStatus.Unknown -> RevocationCheckResult(
+                state = RevocationCheckState.UNKNOWN,
+                isTrusted = false,
+                error = IllegalStateException("Unknown revocation status format")
+            )
+        }
+
+    private suspend fun fetchOrGetCached(
+        uri: String,
+        acceptHeader: String? = null,
+        bypassCache: Boolean = false,
+        parser: suspend (bytes: ByteArray, contentType: ContentType?) -> Pair<RevocationData, Boolean>
+    ): Pair<StoredRevocationData?, Exception?> {
+        val table = getCacheTable()
+        val rawCachedData = if (bypassCache) {
+            null
+        } else {
+            try {
+                table.get(uri)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e(TAG, "Error checking revocation cache for $uri", e)
+                null
+            }
+        }
+
+        val cachedData = rawCachedData?.let {
+            try {
+                StoredRevocationData.fromCbor(it.toByteArray())
+            } catch (e: Exception) {
+                Logger.e(TAG, "Error parsing revocation cache for $uri", e)
+                null
+            }
+        }
+
+        if (cachedData != null
+            && (!useLastModified || cachedData.lastModified == null)
+            && (!useETag || cachedData.etag == null)) {
+            // We have cached data, but the server does not support conditional fetches or they
+            // are disabled in settings. Unconditional fetch on every check can be too expensive,
+            // so just work off the expiration/ttl time in the revocation data.
+            if (cachedData.data.expirationTime > Clock.System.now()) {
+                return Pair(cachedData, null)
+            }
+        }
+
+        val response = try {
+            httpClient.get(uri) {
+                timeout {
+                    requestTimeoutMillis = httpTimeout.inWholeMilliseconds
+                }
+                if (cachedData != null) {
+                    if (useETag && cachedData.etag != null) {
+                        headers.append(HttpHeaders.IfNoneMatch, cachedData.etag)
+                    } else if (useLastModified && cachedData.lastModified != null) {
+                        headers.append(HttpHeaders.IfModifiedSince, cachedData.lastModified)
+                    }
+                }
+                if (acceptHeader != null) {
+                    headers.append(HttpHeaders.Accept, acceptHeader)
+                }
+            }
+        } catch (err: CancellationException) {
+            throw err
+        } catch (err: Exception) {
+            return Pair(cachedData, err)
+        }
+
+        if (response.status == HttpStatusCode.NotModified) {
+            return if (cachedData != null) {
+                Pair(cachedData, null)
+            } else {
+                Pair(null, IllegalStateException("Unexpected HTTP Status ${response.status}"))
+            }
+        }
+
+        if (response.status != HttpStatusCode.OK) {
+            return Pair(cachedData, IllegalStateException("HTTP Status ${response.status}"))
+        }
+
+        try {
+            val (data, isTrusted) = parser.invoke(response.readRawBytes(), response.contentType())
+            val updatedCacheEntry = StoredRevocationData(
+                lastModified = response.headers[HttpHeaders.LastModified],
+                etag = response.etag(),
+                isTrusted = isTrusted,
+                data = data
+            )
+            val serialized = ByteString(updatedCacheEntry.toCbor())
+            val expiration = Clock.System.now() + cachingDuration
+            if (rawCachedData == null) {
+                try {
+                    table.insert(uri, serialized, expiration = expiration)
+                } catch (err: KeyExistsStorageException) {
+                    // another thread might have written it meanwhile
+                    Logger.w(TAG, "Cache entry already exists: possible access from multiple coroutines", err)
+                }
+            } else {
+                try {
+                    table.update(uri, serialized, expiration = expiration)
+                } catch (err: NoRecordStorageException) {
+                    // cache might have been cleared
+                    Logger.w(TAG, "Cache entry was cleared from a different coroutine", err)
+                }
+            }
+            return Pair(updatedCacheEntry, null)
+        } catch (err: CancellationException) {
+            throw err
+        } catch (err: Exception) {
+            return Pair(cachedData, err)
+        }
+    }
+
+    private suspend fun checkStatusList(
+        status: RevocationStatus.StatusList,
+        issuerCert: X509Cert?,
+        onlyTrusted: Boolean,
+        atTime: Instant,
+        bypassCache: Boolean,
+        preferJwt: Boolean
+    ): RevocationCheckResult {
+        val cert = status.certificate ?: issuerCert
+        return fetchOrGetCached(
+            uri = status.uri,
+            acceptHeader = if (preferJwt) {
+                "$STATUSLIST_JWT, $STATUSLIST_CWT;q=0.9"
+            } else {
+                "$STATUSLIST_CWT, $STATUSLIST_JWT;q=0.9"
+            },
+            bypassCache = bypassCache
+        ) { bytes, contentType ->
+            if (contentType != STATUSLIST_JWT) {
+                try {
+                    Logger.dCbor(TAG, "Status list (CWT) for ${status.uri}", bytes)
+                    return@fetchOrGetCached Pair(
+                        first = CompressedStatusList.fromCwt(
+                            cwt = bytes,
+                            publicKey = cert?.ecPublicKey,
+                            atTime = atTime
+                        ),
+                        second = true
+                    )
+                } catch (err: InvalidRequestException) {
+                    if (onlyTrusted) {
+                        throw err
+                    }
+                    // Untrusted path
+                    Logger.w(TAG, "Status list (CWT) could not be validated, attempt using it anyway", err)
+                    return@fetchOrGetCached Pair(
+                        first = CompressedStatusList.fromCwtNoTrust(bytes),
+                        second = false
+                    )
+                } catch (err: IllegalArgumentException) {
+                    if (contentType == STATUSLIST_CWT) {
+                        throw err
+                    }
+                }
+            }
+            val jwtString = bytes.decodeToString()
+            Logger.d(TAG, "Status list (JWT) for ${status.uri}: $jwtString")
+            try {
+                Pair(
+                    first = CompressedStatusList.fromJwt(
+                        jwt = jwtString,
+                        publicKey = cert?.ecPublicKey,
+                        atTime = atTime
+                    ),
+                    second = true
+                )
+            } catch (err: InvalidRequestException) {
+                if (onlyTrusted) {
+                    throw err
+                }
+                // Untrusted path
+                Logger.w(TAG, "Status list (JWT) could not be validated, attempt using it anyway", err)
+                Pair(first = CompressedStatusList.fromJwtNoTrust(jwtString), second = false)
+            }
+        }.let { (item, error) ->
+            if (item == null) {
+                RevocationCheckResult(RevocationCheckState.UNKNOWN, false, error)
+            } else if (onlyTrusted && !item.isTrusted) {
+                RevocationCheckResult(
+                    state = RevocationCheckState.UNKNOWN,
+                    isTrusted = false,
+                    error = InvalidRequestException("Status list signature could not be verified")
+                )
+            } else {
+                try {
+                    val statusList = (item.data as CompressedStatusList).decompress()
+                    when (val code = statusList[status.idx]) {
+                        0 -> RevocationCheckResult(RevocationCheckState.VALID, item.isTrusted, error)
+                        1 -> RevocationCheckResult(RevocationCheckState.INVALID, item.isTrusted, error)
+                        2 -> RevocationCheckResult(RevocationCheckState.SUSPENDED, item.isTrusted, error)
+                        else -> RevocationCheckResult(
+                            state = RevocationCheckState.UNKNOWN,
+                            isTrusted = false,
+                            error = IllegalStateException("Unknown revocation code $code")
+                        )
+                    }
+                } catch (err: CancellationException) {
+                    throw err
+                } catch (err: Exception) {
+                    RevocationCheckResult(RevocationCheckState.UNKNOWN, false, err)
+                }
+            }
+        }
+    }
+
+    private suspend fun checkIdentifierList(
+        status: RevocationStatus.IdentifierList,
+        issuerCert: X509Cert?,
+        onlyTrusted: Boolean,
+        atTime: Instant,
+        bypassCache: Boolean
+    ): RevocationCheckResult {
+        if (onlyTrusted && issuerCert == null) {
+            // This call can only succeed for credentials that carry certificate in their identifier
+            // list, which is not common and should not be relied upon.
+            Logger.e(TAG, "suspicious checkIdentifierList")
+        }
+        val cert = status.certificate ?: issuerCert
+        return fetchOrGetCached(
+            uri = status.uri,
+            bypassCache = bypassCache
+        ) { bytes, _ ->
+            Logger.dCbor(TAG, "Identifier list (CWT) for ${status.uri}", bytes)
+            try {
+                Pair(
+                    first = IdentifierList.fromCwt(
+                        cwt = bytes,
+                        publicKey = cert?.ecPublicKey,
+                        atTime = atTime
+                    ),
+                    second = true
+                )
+            } catch (err: InvalidRequestException) {
+                if (onlyTrusted) {
+                    throw err
+                }
+                Logger.w(TAG, "Identifier list could not be validated, attempt using it anyway", err)
+                // Trust cannot be verified
+                Pair(first = IdentifierList.fromCwtNoTrust(bytes), second = false)
+            }
+        }.let { (item, error) ->
+            if (item == null) {
+                RevocationCheckResult(RevocationCheckState.UNKNOWN, false, error)
+            } else if (onlyTrusted && !item.isTrusted) {
+                RevocationCheckResult(
+                    state = RevocationCheckState.UNKNOWN,
+                    isTrusted = false,
+                    error = InvalidRequestException("Identifier list signature could not be verified")
+                )
+            } else {
+                val identifierList = item.data as IdentifierList
+                if (identifierList.contains(status.id)) {
+                    RevocationCheckResult(RevocationCheckState.INVALID, item.isTrusted, error)
+                } else {
+                    RevocationCheckResult(RevocationCheckState.VALID, item.isTrusted, error)
+                }
+            }
+        }
+    }
+
+    @CborSerializable
+    internal data class StoredRevocationData(
+        val lastModified: String?,
+        val etag: String?,
+        val isTrusted: Boolean,
+        val data: RevocationData,
+    ) {
+        companion object
+    }
+
+    companion object {
+        private const val TAG = "CachingRevocationChecker"
+        private val STATUSLIST_JWT = ContentType("application", "statuslist+jwt")
+        private val STATUSLIST_CWT = ContentType("application", "statuslist+cwt")
+
+        private val cacheTableSpec = StorageTableSpec(
+            name = "RevocationCache",
+            supportExpiration = true,
+            supportPartitions = false
+        )
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
@@ -1,5 +1,7 @@
 package org.multipaz.revocation
 
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
@@ -8,9 +10,12 @@ import kotlinx.serialization.json.long
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.Uint
+import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.putCborMap
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.crypto.EcPublicKey
@@ -48,12 +53,13 @@ import kotlin.time.Instant
  *        the status list is served through HTTP in one of its serialized forms.
  * @param expirationTime when this status list expires
  */
+@CborSerializable(typeId = "statusList")
 class CompressedStatusList(
     val bitsPerItem: Int,
-    private val compressedStatusList: ByteArray,
-    val creationTime: Instant = Clock.System.now(),
-    val expirationTime: Instant = creationTime + 20.minutes
-) {
+    internal val compressedStatusList: ByteString,
+    override val creationTime: Instant = Clock.System.now(),
+    override val expirationTime: Instant = creationTime + 20.minutes
+): RevocationData() {
     init {
         require(bitsPerItem == 1 || bitsPerItem == 2 || bitsPerItem == 4 || bitsPerItem == 8)
     }
@@ -77,7 +83,7 @@ class CompressedStatusList(
         put("sub", subject)
         putJsonObject("status_list") {
             put("bits", bitsPerItem)
-            put("lst", compressedStatusList.toBase64Url())
+            put("lst", compressedStatusList.toByteArray().toBase64Url())
         }
         put("ttl", (expirationTime - creationTime).inWholeSeconds)
     }
@@ -101,7 +107,7 @@ class CompressedStatusList(
         put(WebTokenClaim.Sub, subject)
         putCborMap(STATUS_LIST_CLAIM) {
             put("bits", bitsPerItem)
-            put("lst", compressedStatusList)
+            put("lst", compressedStatusList.toByteArray())
         }
         put(TTL_CLAIM, (expirationTime - creationTime).inWholeSeconds)
     }
@@ -110,7 +116,7 @@ class CompressedStatusList(
      * Creates decompressed form of this status list.
      */
     suspend fun decompress(): StatusList {
-        return StatusList(bitsPerItem, compressedStatusList.zlibInflate())
+        return StatusList(bitsPerItem, compressedStatusList.toByteArray().zlibInflate())
     }
 
     companion object {
@@ -150,6 +156,28 @@ class CompressedStatusList(
                 atTime = atTime,
                 maxValidity = maxValidity
             )
+            return fromJwtBody(body)
+        }
+
+        /**
+         * Parses and validates JWT that holds the status list without validating its signature.
+         *
+         * @param jwt status list JWT representation
+         * @return parsed [CompressedStatusList]
+         * @throws IllegalArgumentException when [jwt] cannot be parsed as JWT status list
+         */
+        fun fromJwtNoTrust(jwt: String): CompressedStatusList {
+            val parts = jwt.split('.')
+            if (parts.size != 3) {
+                throw InvalidRequestException("Status List: invalid")
+            }
+            val body = Json.parseToJsonElement(
+                parts[1].fromBase64Url().decodeToString()
+            ).jsonObject
+            return fromJwtBody(body)
+        }
+
+        private fun fromJwtBody(body: JsonObject): CompressedStatusList {
             val expirationTime = body["exp"]?.let {
                 Instant.fromEpochSeconds(it.jsonPrimitive.long)
             } ?: body["ttl"]?.let { ttl ->
@@ -180,7 +208,7 @@ class CompressedStatusList(
             return CompressedStatusList(
                 bitsPerItem = json["bits"]?.jsonPrimitive?.intOrNull
                     ?: throw IllegalArgumentException("missing 'bits' in 'status_list' claim"),
-                compressedStatusList = lst.jsonPrimitive.content.fromBase64Url(),
+                compressedStatusList = ByteString(lst.jsonPrimitive.content.fromBase64Url()),
                 expirationTime = expirationTime
             )
         }
@@ -193,7 +221,7 @@ class CompressedStatusList(
          *
          * @param cwt status list CWT representation
          * @param publicKey public key of the issuance server signing key (optional)
-         * @param checks additional checks for JWT validation
+         * @param checks additional checks for CWT validation
          * @param atTime time instant to check for expiration
          * @param maxValidity maximum CWT validity duration to accept
          * @return parsed [CompressedStatusList]
@@ -218,6 +246,32 @@ class CompressedStatusList(
                 atTime = atTime,
                 maxValidity = maxValidity
             )
+            return fromCborMap(body)
+        }
+
+        /**
+         * Parses and validates CWT that holds the status list without validating its signature.
+         *
+         * @param cwt status list CWT representation
+         * @return parsed [CompressedStatusList]
+         * @throws IllegalArgumentException when [cwt] cannot be parsed as CWT status list
+         */
+        fun fromCwtNoTrust(cwt: ByteArray): CompressedStatusList {
+            val cbor = Cbor.decode(cwt)
+            val unwrapped = if (cbor is Tagged && cbor.tagNumber == Tagged.COSE_SIGN1) {
+                cbor.taggedItem
+            } else {
+                cbor
+            }
+            val sign1 = unwrapped.asCoseSign1
+
+            val body = Cbor.decode(sign1.payload!!) as? CborMap
+                ?: throw IllegalArgumentException("Status List: not a valid CWT")
+
+            return fromCborMap(body)
+        }
+
+        private fun fromCborMap(body: CborMap): CompressedStatusList {
             if (!body.hasKey(STATUS_LIST_CLAIM)) {
                 throw IllegalArgumentException("not a valid status list CWT")
             }
@@ -228,7 +282,7 @@ class CompressedStatusList(
             } else {
                 Clock.System.now() + 20.minutes
             }
-            return fromDataItem(body[STATUS_LIST_CLAIM], expirationTime)
+            return fromStatusListClaim(body[STATUS_LIST_CLAIM], expirationTime)
         }
 
         /**
@@ -241,7 +295,7 @@ class CompressedStatusList(
          * @return parsed [CompressedStatusList]
          * @throws IllegalArgumentException when [dataItem] does not represent status list
          */
-        fun fromDataItem(dataItem: DataItem, expirationTime: Instant): CompressedStatusList {
+        fun fromStatusListClaim(dataItem: DataItem, expirationTime: Instant): CompressedStatusList {
             val map = dataItem as? CborMap
                 ?: throw IllegalArgumentException("invalid 'status_list' claim")
             val lst = map["lst"] as? Bstr
@@ -250,7 +304,7 @@ class CompressedStatusList(
                 ?: throw IllegalArgumentException("missing 'bits' in 'status_list' claim")
             return CompressedStatusList(
                 bitsPerItem = bits.value.toInt(),
-                compressedStatusList = lst.value,
+                compressedStatusList = ByteString(lst.value),
                 expirationTime = expirationTime
             )
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
@@ -2,7 +2,10 @@ package org.multipaz.revocation
 
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
+import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborMap
+import org.multipaz.cbor.Tagged
+import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.AsymmetricKey
@@ -30,11 +33,12 @@ import kotlin.time.Instant
  * @param [creationTime] time when this object was created
  * @param [expirationTime] time when this object expires and should be refreshed
  */
+@CborSerializable(typeId = "identifierList")
 class IdentifierList(
-    private val identifiers: Set<ByteString>,
-    val creationTime: Instant = Clock.System.now(),
-    val expirationTime: Instant = creationTime + 20.minutes
-) {
+    internal val identifiers: Set<ByteString>,
+    override val creationTime: Instant = Clock.System.now(),
+    override val expirationTime: Instant = creationTime + 20.minutes
+): RevocationData() {
     /**
      * Serializes this list as CWT.
      *
@@ -138,6 +142,32 @@ class IdentifierList(
                 atTime = atTime,
                 maxValidity = maxValidity
             )
+            return fromCwtBody(body)
+        }
+
+        /**
+         * Parses and validates CWT that holds the identifier list without validating its signature.
+         *
+         * @param cwt identifier list CWT representation
+         * @return parsed [IdentifierList]
+         * @throws IllegalArgumentException when [cwt] cannot be parsed as CWT identifier list
+         */
+        fun fromCwtNoTrust(cwt: ByteArray): IdentifierList {
+            val cbor = Cbor.decode(cwt)
+            val unwrapped = if (cbor is Tagged && cbor.tagNumber == Tagged.COSE_SIGN1) {
+                cbor.taggedItem
+            } else {
+                cbor
+            }
+            val sign1 = unwrapped.asCoseSign1
+
+            val body = Cbor.decode(sign1.payload!!) as? CborMap
+                ?: throw IllegalArgumentException("Identifier List: not a valid CWT")
+
+            return fromCwtBody(body)
+        }
+
+        private fun fromCwtBody(body: CborMap): IdentifierList {
             if (!body.hasKey(IDENTIFIER_LIST_CLAIM)) {
                 throw IllegalArgumentException("not a valid identifier list CWT")
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationCheckResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationCheckResult.kt
@@ -1,0 +1,17 @@
+package org.multipaz.revocation
+
+/**
+ * Result of checking a document's revocation status.
+ *
+ * @property state high-level state of the revocation status check.
+ * @param isTrusted indicates if revocation data was validated to be trusted (including signature
+ *  verification), for non-[RevocationCheckState.UNKNOWN] state this can only be `false` when
+ *  `onlyTrusted` [RevocationChecker.check] parameter was set to `false`
+ * @property error when non-`null` explains why the check failed (when [state]
+ *  is [RevocationCheckState.UNKNOWN]) or stale (for other [state] values).
+ */
+data class RevocationCheckResult(
+    val state: RevocationCheckState,
+    val isTrusted: Boolean,
+    val error: Throwable? = null
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationCheckState.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationCheckState.kt
@@ -1,0 +1,15 @@
+package org.multipaz.revocation
+
+/**
+ * Represents the state of a document revocation check.
+ */
+enum class RevocationCheckState {
+    /** The credential/identifier is valid and not revoked or suspended. */
+    VALID,
+    /** The credential/identifier is explicitly revoked. */
+    INVALID,
+    /** The credential/identifier is currently suspended. */
+    SUSPENDED,
+    /** The revocation status is unknown, not provided, or could not be verified/downloaded. */
+    UNKNOWN
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationChecker.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationChecker.kt
@@ -1,0 +1,84 @@
+package org.multipaz.revocation
+
+import kotlinx.coroutines.CancellationException
+import org.multipaz.credential.Credential
+import org.multipaz.crypto.X509Cert
+import org.multipaz.trustmanagement.TrustManagerInterface
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Interface for checking and managing the revocation status of digital credentials.
+ *
+ * Handles downloading, caching, and verifying ISO/IEC 18013-5 or IETF SD-JWT revocation payloads
+ * such as status lists and identifier lists.
+ */
+interface RevocationChecker {
+    /**
+     * Checks the revocation state for a given non-null [RevocationStatus] payload.
+     *
+     * This method **never throws** exceptions for non-cancellation errors (such as network, HTTP,
+     * timeout, parsing, or signature verification failures). Instead, those errors are caught
+     * internally and returned as a [RevocationCheckResult] with state
+     * [RevocationCheckState.UNKNOWN] and the underlying exception in [RevocationCheckResult.error].
+     * Standard coroutine [CancellationException]s are preserved and rethrown.
+     *
+     * @param revocationStatus The revocation status object (StatusList or IdentifierList) extracted
+     *  from the presentation.
+     * @param issuerCert The top-level certificate chain of the issuer / document signer, used for
+     *  signature verification if not included in the status payload.
+     * @param atTime The point in time at which to evaluate revocation status validity. Defaults
+     *  to current system time.
+     * @param bypassCache If true, forces downloading a fresh status/identifier list payload from
+     *  the network rather than using cached data.
+     * @param preferJwt Prefer status list data in JWT format, rather than more compact CWT; mostly
+     *  exposed for testing
+     * @return [RevocationCheckResult] indicating whether the credential is valid, revoked,
+     *  suspended, or unknown.
+     */
+    suspend fun check(
+        revocationStatus: RevocationStatus,
+        issuerCert: X509Cert? = null,
+        onlyTrusted: Boolean = true,
+        atTime: Instant = Clock.System.now(),
+        bypassCache: Boolean = false,
+        preferJwt: Boolean = false
+    ): RevocationCheckResult
+
+    /**
+     * Clears all cached revocation status and identifier list entries from storage.
+     */
+    suspend fun clearCache()
+}
+
+/**
+ * Convenience extension to check the revocation state for a given [Credential].
+ *
+ * @see RevocationChecker.check for details.
+ *
+ * @param credential credential for which the revocation state should .
+ * @param trustManager trust manager to find the root certificate for the credential issuer.
+ * @param onlyTrusted only use revocation data which could be validated (including signature check)
+ * @param atTime The point in time at which to evaluate revocation status validity. Defaults
+ *  to current system time.
+ * @param bypassCache If true, forces downloading a fresh status/identifier list payload from
+ *  the network rather than using cached data.
+ * @param preferJwt Prefer status list data in JWT format, rather than more compact CWT; mostly
+ *  exposed for testing
+ * @return [RevocationCheckResult] indicating whether the credential is valid, revoked,
+ *  suspended, or unknown.
+ */
+suspend fun RevocationChecker.check(
+    credential: Credential,
+    trustManager: TrustManagerInterface,
+    onlyTrusted: Boolean = true,
+    atTime: Instant = Clock.System.now(),
+    bypassCache: Boolean = false,
+    preferJwt: Boolean = false
+): RevocationCheckResult = credential.getRevocationInfo(trustManager)?.let {
+    check(it.revocationStatus, it.certificate, onlyTrusted, atTime, bypassCache, preferJwt)
+} ?: RevocationCheckResult(
+    state = RevocationCheckState.UNKNOWN,
+    isTrusted = false,
+    error = IllegalStateException("No revocation data in the credential")
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationData.kt
@@ -1,0 +1,19 @@
+package org.multipaz.revocation
+
+import org.multipaz.cbor.annotation.CborSerializable
+import kotlin.time.Instant
+
+
+/**
+ * Abstract class that represents some kind of revocation data
+ *
+ * @property [creationTime] time when this object was created
+ * @property [expirationTime] time when this object expires and should be refreshed
+ */
+@CborSerializable
+sealed class RevocationData {
+    abstract val creationTime: Instant
+    abstract val expirationTime: Instant
+
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationInfo.kt
@@ -1,0 +1,56 @@
+package org.multipaz.revocation
+
+import kotlinx.io.bytestring.decodeToString
+import org.multipaz.cbor.Cbor
+import org.multipaz.cose.Cose
+import org.multipaz.cose.CoseNumberLabel
+import org.multipaz.credential.Credential
+import org.multipaz.crypto.X509Cert
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.sdjwt.SdJwt
+import org.multipaz.sdjwt.credential.SdJwtVcCredential
+import org.multipaz.trustmanagement.TrustManagerInterface
+import kotlin.time.Clock
+
+/**
+ * Information needed to perform a revocation check for a credential or a credential presentation.
+ *
+ * @property revocationStatus revocation status from the credential
+ * @property certificate top-level certificate that should be used to check revocation data
+ *  signature; may or may not be needed (as certificate might be embedded in [revocationStatus]
+ *  itself)
+ */
+data class RevocationInfo(
+    val revocationStatus: RevocationStatus,
+    val certificate: X509Cert?
+)
+
+/**
+ * Convenience method to extract [RevocationInfo] from a [Credential].
+ *
+ * Note: [RevocationInfo.certificate] can be successfully obtained only when the credential
+ * is issued by an issuer that is trusted by [trustManager].
+ *
+ * @param trustManager trust manager that is searched for an issuer's root certificate
+ * @return [RevocationInfo] for this credential
+ */
+suspend fun Credential.getRevocationInfo(trustManager: TrustManagerInterface): RevocationInfo? {
+    return when (this) {
+        is MdocCredential -> {
+            val issuerSigned = Cbor.decode(issuerProvidedData.toByteArray())
+            val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
+            val certChain = issuerAuth.unprotectedHeaders[
+                CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN)
+            ]!!.asX509CertChain.certificates
+            val trustResult = trustManager.verify(certChain, mso.validFrom)
+            mso.revocationStatus?.let { RevocationInfo(it, trustResult.trustChain?.certificates?.last()) }
+        }
+        is SdJwtVcCredential -> {
+            val sdjwt = SdJwt.fromCompactSerialization(issuerProvidedData.decodeToString())
+            val certChain = sdjwt.x5c ?: return null
+            val trustResult = trustManager.verify(certChain.certificates, sdjwt.validFrom ?: Clock.System.now())
+            sdjwt.revocationStatus?.let { RevocationInfo(it, trustResult.trustChain?.certificates?.last()) }
+        }
+        else -> null
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
@@ -1,6 +1,7 @@
 package org.multipaz.revocation
 
 import kotlinx.io.Buffer
+import kotlinx.io.bytestring.ByteString
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.JsonObject
 import org.multipaz.cbor.DataItem
@@ -64,7 +65,7 @@ class StatusList(
         val creationTime = Clock.System.now()
         return CompressedStatusList(
             bitsPerItem = bitsPerItem,
-            compressedStatusList = statusList.zlibDeflate(9),
+            compressedStatusList = ByteString( statusList.zlibDeflate(9)),
             creationTime = creationTime,
             expirationTime = creationTime + timeToLive
         )
@@ -205,6 +206,6 @@ class StatusList(
          * @throws IllegalArgumentException when [dataItem] does not represent status list
          */
         suspend fun fromDataItem(dataItem: DataItem, expirationTime: Instant): StatusList =
-            CompressedStatusList.fromDataItem(dataItem, expirationTime).decompress()
+            CompressedStatusList.fromStatusListClaim(dataItem, expirationTime).decompress()
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateCwt.kt
@@ -152,8 +152,17 @@ suspend fun validateCwt(
 
     val caName = checks[WebTokenCheck.TRUST]
     val key = if (caName == null) {
-        require(publicKey != null || caValidated)
-        publicKey ?: certificateChain!!.certificates.first().ecPublicKey
+        if (publicKey == null && !caValidated) {
+            throw InvalidRequestException("$cwtName: could not check signature, no public key found")
+        }
+        if (certificateChain == null|| certificateChain.certificates.isEmpty()) {
+            publicKey!!
+        } else {
+            if (publicKey != null) {
+                certificateChain.certificates.last().verify(publicKey)
+            }
+            certificateChain.certificates.first().ecPublicKey
+        }
     } else {
         val issuer = body[WebTokenClaim.Iss]
         if (certificateChain != null) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
@@ -153,8 +153,17 @@ suspend fun validateJwt(
 
     val caName = checks[WebTokenCheck.TRUST]
     val key = if (caName == null) {
-        require(publicKey != null || caValidated)
-        publicKey ?: certificateChain!!.certificates.first().ecPublicKey
+        if (publicKey == null && !caValidated) {
+            throw InvalidRequestException("$jwtName: could not check signature, no public key found")
+        }
+        if (certificateChain == null || certificateChain.certificates.isEmpty()) {
+            publicKey!!
+        } else {
+            if (publicKey != null) {
+                certificateChain.certificates.last().verify(publicKey)
+            }
+            certificateChain.certificates.first().ecPublicKey
+        }
     } else {
         val issuer = body["iss"]?.jsonPrimitive?.content
         if (certificateChain != null) {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -109,6 +109,8 @@ import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.request.Requester
 import org.multipaz.request.RequesterIdentity
 import org.multipaz.request.TrustedRequesterIdentity
+import org.multipaz.revocation.CachingRevocationChecker
+import org.multipaz.revocation.RevocationChecker
 import org.multipaz.secure_area_test_app.ui.CloudSecureAreaScreen
 import org.multipaz.securearea.SecureAreaRepository
 import org.multipaz.securearea.cloud.CloudSecureArea
@@ -199,6 +201,8 @@ class App private constructor (val promptModel: PromptModel) {
     lateinit var softwareSecureArea: SoftwareSecureArea
     lateinit var documentStore: DocumentStore
     lateinit var documentModel: DocumentModel
+
+    lateinit var revocationChecker: RevocationChecker
 
     lateinit var iacaKey: AsymmetricKey.X509Certified
 
@@ -320,6 +324,7 @@ class App private constructor (val promptModel: PromptModel) {
                 Pair(::documentTypeRepositoryInit, "documentTypeRepositoryInit"),
                 Pair(::documentStoreInit, "documentStoreInit"),
                 Pair(::documentModelInit, "documentModelInit"),
+                Pair(::revocationCheckerInit, "revocationCheckerInit"),
                 Pair(::keyStorageInit, "keyStorageInit"),
                 Pair(::iacaInit, "iacaInit"),
                 Pair(::readerRootInit, "readerRootInit"),
@@ -402,6 +407,13 @@ class App private constructor (val promptModel: PromptModel) {
             documentStore = documentStore,
             documentTypeRepository = documentTypeRepository,
             badgeFunction = ::getBadgesForDocument
+        )
+    }
+
+    private suspend fun revocationCheckerInit() {
+        revocationChecker = CachingRevocationChecker(
+            storage = TestAppConfiguration.storage,
+            httpClient = HttpClient(TestAppConfiguration.httpClientEngineFactory)
         )
     }
 
@@ -1284,6 +1296,8 @@ class App private constructor (val promptModel: PromptModel) {
                         val destination = backStackEntry.toRoute<CredentialViewerDestination>()
                         CredentialViewerScreen(
                             documentModel = documentModel,
+                            revocationChecker = revocationChecker,
+                            issuerTrustManager = issuerTrustManager,
                             documentId = destination.documentId,
                             credentialId = destination.credentialId,
                             showToast = ::showToast,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CredentialViewerScreen.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.launch
 import org.multipaz.compose.datetime.formattedDateTime
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import org.multipaz.revocation.RevocationChecker
+import org.multipaz.trustmanagement.TrustManagerInterface
 import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 
@@ -42,6 +44,8 @@ private const val TAG = "CredentialViewerScreen"
 @Composable
 fun CredentialViewerScreen(
     documentModel: DocumentModel,
+    revocationChecker: RevocationChecker,
+    issuerTrustManager: TrustManagerInterface,
     documentId: String,
     credentialId: String,
     showToast: (message: String) -> Unit,
@@ -96,7 +100,7 @@ fun CredentialViewerScreen(
                     }
                 )
                 KeyValuePairText("Usage Count", credentialInfo.credential.usageCount.toString())
-                RevocationStatusSection(credentialInfo.credential)
+                RevocationStatusSection(revocationChecker, issuerTrustManager, credentialInfo.credential)
                 when (credentialInfo.credential) {
                     is MdocCredential -> {
                         val issuerSigned = Cbor.decode(credentialInfo.credential.issuerProvidedData.toByteArray())

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/RevocationStatusSection.kt
@@ -1,6 +1,5 @@
 package org.multipaz.testapp.ui
 
-import kotlinx.coroutines.CancellationException
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,96 +12,46 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import io.ktor.client.HttpClient
-import io.ktor.client.request.get
-import io.ktor.client.statement.readRawBytes
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
 import kotlinx.coroutines.launch
-import kotlinx.io.bytestring.decodeToString
-import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.Tagged
-import org.multipaz.cose.Cose
-import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.credential.Credential
-import org.multipaz.crypto.X509CertChain
-import org.multipaz.mdoc.credential.MdocCredential
-import org.multipaz.mdoc.mso.MobileSecurityObject
-import org.multipaz.revocation.IdentifierList
+import org.multipaz.revocation.RevocationCheckState
+import org.multipaz.revocation.RevocationChecker
+import org.multipaz.revocation.RevocationInfo
 import org.multipaz.revocation.RevocationStatus
-import org.multipaz.revocation.StatusList
-import org.multipaz.sdjwt.SdJwt
-import org.multipaz.sdjwt.credential.SdJwtVcCredential
-import org.multipaz.testapp.TestAppConfiguration
-import org.multipaz.util.Logger
+import org.multipaz.revocation.getRevocationInfo
+import org.multipaz.trustmanagement.TrustManagerInterface
 import org.multipaz.util.toHex
 
 @Composable
-fun RevocationStatusSection(credential: Credential) {
+fun RevocationStatusSection(
+    revocationChecker: RevocationChecker,
+    issuerTrustManager: TrustManagerInterface,
+    credential: Credential
+) {
     val coroutineScope = rememberCoroutineScope()
-    val revocationData = remember { mutableStateOf<RevocationData?>(null) }
+    val revocationData = remember { mutableStateOf<RevocationInfo?>(null) }
 
     LaunchedEffect(Unit) {
         coroutineScope.launch {
-            revocationData.value = extractRevocationData(credential)
+            revocationData.value = credential.getRevocationInfo(issuerTrustManager)
         }
     }
-
-    when (val status = revocationData.value?.revocationStatus) {
-        is RevocationStatus.Unknown -> {
-            Text(
-                text = "Revocation Info Not Parsed",
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.titleMedium
-            )
-        }
-        is RevocationStatus.StatusList -> StatusListCheckSection(status, revocationData.value!!.certChain)
-        is RevocationStatus.IdentifierList -> IdentifierListCheckSection(status, revocationData.value!!.certChain)
-        else -> {
-            Text(
-                text = "Revocation Info Not Found",
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.titleMedium
-            )
-        }
+    val value = revocationData.value
+    if (value != null) {
+        RevocationCheckSection(revocationChecker, value)
+    } else {
+        Text(
+            text = "Revocation Info Not Found",
+            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleMedium
+        )
     }
 }
-
-private suspend fun extractRevocationData(credential: Credential): RevocationData? {
-    return when (credential) {
-        is MdocCredential -> {
-            val issuerSigned = Cbor.decode(credential.issuerProvidedData.toByteArray())
-            val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
-            val certChain = issuerAuth.unprotectedHeaders[
-                CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN)
-            ]!!.asX509CertChain
-            val tagged = Cbor.decode(issuerAuth.payload!!)
-            val mso = MobileSecurityObject.fromDataItem(Cbor.decode((tagged as Tagged).taggedItem.asBstr))
-            mso.revocationStatus?.let { RevocationData(it, certChain) }
-        }
-        is SdJwtVcCredential -> {
-            val sdjwt = SdJwt.fromCompactSerialization(credential.issuerProvidedData.decodeToString())
-            val certChain = sdjwt.x5c ?: return null
-            sdjwt.revocationStatus?.let { RevocationData(it, certChain) }
-        }
-        else -> null
-    }
-}
-
-private class RevocationData(
-    val revocationStatus: RevocationStatus,
-    val certChain: X509CertChain
-)
-
-private val STATUSLIST_JWT = ContentType("application", "statuslist+jwt")
-private val STATUSLIST_CWT = ContentType("application", "statuslist+cwt")
 
 @Composable
-private fun StatusListCheckSection(
-    status: RevocationStatus.StatusList,
-    certChain: X509CertChain
+private fun RevocationCheckSection(
+    revocationChecker: RevocationChecker,
+    revocationData: RevocationInfo
 ) {
     val coroutineScope = rememberCoroutineScope()
     val statusText = remember { mutableStateOf("Click to check status") }
@@ -110,42 +59,22 @@ private fun StatusListCheckSection(
         modifier = Modifier.fillMaxWidth()
             .clickable {
                 coroutineScope.launch {
-                    val client = HttpClient(TestAppConfiguration.httpClientEngineFactory)
-                    val response = client.get(status.uri) {
-                        // CWT is more compact, so prefer that
-                        headers.append(
-                            name = HttpHeaders.Accept,
-                            value = "$STATUSLIST_CWT, $STATUSLIST_JWT;q=0.9"
-                        )
+                    val result = revocationChecker.check(
+                        revocationStatus = revocationData.revocationStatus,
+                        issuerCert = revocationData.certificate,
+                        onlyTrusted = false  // Only for use in testing!
+                    )
+                    val state = when (result.state) {
+                        RevocationCheckState.VALID -> "Valid"
+                        RevocationCheckState.INVALID -> "Invalid"
+                        RevocationCheckState.SUSPENDED -> "Suspended"
+                        RevocationCheckState.UNKNOWN -> "Unknown"
                     }
-                    if (response.status != HttpStatusCode.OK) {
-                        statusText.value = "HTTP Status: ${response.status}"
+                    val trust = if (result.isTrusted) "Trusted" else "Not trusted"
+                    statusText.value = if (result.error == null) {
+                        "$state ($trust)"
                     } else {
-                        try {
-                            val cert = status.certificate ?: certChain.certificates.first()
-                            val statusList = when (val type = response.contentType()) {
-                                STATUSLIST_JWT -> StatusList.fromJwt(
-                                    jwt = response.readRawBytes().decodeToString(),
-                                    publicKey = cert.ecPublicKey
-                                )
-                                STATUSLIST_CWT -> StatusList.fromCwt(
-                                    cwt = response.readRawBytes(),
-                                    publicKey = cert.ecPublicKey
-                                )
-                                else -> throw IllegalStateException("Unknown type: $type")
-                            }
-
-                            statusText.value = when (val code = statusList[status.idx]) {
-                                0 -> "Valid"
-                                1 -> "Invalid"
-                                2 -> "Suspended"
-                                else -> "Unexpected status $code"
-                            }
-                        } catch (err: Exception) {
-                            if (err is CancellationException) throw err
-                            Logger.e(TAG, "Failed to parse status list", err)
-                            statusText.value = "Failed to parse status list"
-                        }
+                        "$state ($trust) [${result.error!!::class.simpleName}]"
                     }
                 }
             }
@@ -155,75 +84,33 @@ private fun StatusListCheckSection(
             fontWeight = FontWeight.Bold,
             style = MaterialTheme.typography.titleMedium
         )
-        Text(
-            text = "Index: ${status.idx}",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary
-        )
-        Text(
-            text = "Url: ${status.uri}",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary
-        )
-        Text(
-            text = statusText.value,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary
-        )
-    }
-}
-
-@Composable
-fun IdentifierListCheckSection(
-    status: RevocationStatus.IdentifierList,
-    certChain: X509CertChain
-) {
-    val coroutineScope = rememberCoroutineScope()
-    val statusText = remember { mutableStateOf("Click to check status") }
-    Column(
-        modifier = Modifier.fillMaxWidth()
-            .clickable {
-                coroutineScope.launch {
-                    val client = HttpClient(TestAppConfiguration.httpClientEngineFactory)
-                    val response = client.get(status.uri)
-                    if (response.status != HttpStatusCode.OK) {
-                        statusText.value = "HTTP Status: ${response.status}"
-                    } else {
-                        val cert = status.certificate ?: certChain.certificates.first()
-                        try {
-                            val identifierList = IdentifierList.fromCwt(
-                                cwt = response.readRawBytes(),
-                                publicKey = cert.ecPublicKey
-                            )
-                            statusText.value = if (identifierList.contains(status.id)) {
-                                "Invalid"
-                            } else {
-                                "Valid"
-                            }
-                        } catch (err: Exception) {
-                            if (err is CancellationException) throw err
-                            Logger.e(TAG, "Failed to parse identifier list", err)
-                            statusText.value = "Failed to parse identifier list"
-                        }
-                    }
-                }
+        when (val status = revocationData.revocationStatus) {
+            is RevocationStatus.StatusList -> {
+                Text(
+                    text = "Index: ${status.idx}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+                Text(
+                    text = "Url: ${status.uri}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary
+                )
             }
-    ) {
-        Text(
-            text = "Identifier List Revocation",
-            fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.titleMedium
-        )
-        Text(
-            text = "Identifier: ${status.id.toByteArray().toHex()}",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary
-        )
-        Text(
-            text = "Url: ${status.uri}",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary
-        )
+            is RevocationStatus.IdentifierList -> {
+                Text(
+                    text = "Identifier: ${status.id.toByteArray().toHex()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+                Text(
+                    text = "Url: ${status.uri}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+            else -> Text("Unknown revocation data format")
+        }
         Text(
             text = statusText.value,
             style = MaterialTheme.typography.bodyMedium,
@@ -231,5 +118,3 @@ fun IdentifierListCheckSection(
         )
     }
 }
-
-private const val TAG = "RevocationStatusSection"


### PR DESCRIPTION
Added `RevocationChecker` interface and `CachingRevocationChecker` implementation to perform revocation checks efficiently.

Updated testapp to use new API.

Also fixed a bug in revocation data signature check.

Test: added several integration tests that cover various revocation data formats and caching modes.

Fixes #1864
