### PR TITLE
Fix empty certificate list issue and add server debug log option.

### DIFF
--- a/multipaz-server/src/main/java/org/multipaz/server/common/ServerConfiguration.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/ServerConfiguration.kt
@@ -4,8 +4,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.multipaz.rpc.backend.Configuration
+import org.multipaz.util.Logger
 import java.io.File
 import kotlin.collections.iterator
+
+private const val TAG = "ServerConfiguration"
 
 /**
  * Server-side configuration implementation.
@@ -32,6 +35,10 @@ class ServerConfiguration(args: Array<String>) : Configuration {
                         throw IllegalArgumentException("No '=' in param: '$value'")
                     }
                     map[value.take(index)] = value.substring(index + 1)
+                }
+                "-debug" -> {
+                    Logger.isDebugEnabled = true
+                    Logger.i(TAG, "Enabled debug logging level")
                 }
                 else -> {
                     println("Unknown command-line argument: $arg")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
@@ -46,18 +46,13 @@ data class X509CertChain(
     /**
      * Encodes the certificate as JSON Array according to RFC 7515 Section 4.1.6.
      *
-     * Current draft of HAIP spec states "The X.509 certificate of the trust anchor MUST NOT be
-     * included in the x5c JOSE header of the Status List Token. The X.509 certificate signing
-     * the request MUST NOT be self-signed.". [excludeRoot] parameter helps to enforce this.
-     * Note that including trust root is always redundant, as both the key and the issuer identity
-     * must be known to the party that validates the certificate chain.
-     *
-     * @param excludeRoot if the last certificate is root (self-signed), exclude it
+     * @param excludeRoot if the certificate chain has more than one certificate and the last certificate is a root
+     *   certificate (self-signed), exclude it.
      * @return a [JsonElement].
      */
     fun toX5c(excludeRoot: Boolean = true): JsonElement {
         val last = certificates.last()
-        val certs = if (excludeRoot && last.subject == last.issuer) {
+        val certs = if (excludeRoot && certificates.size > 1 && last.subject == last.issuer) {
             certificates.subList(0, certificates.size - 1)
         } else {
             certificates

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertChainTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertChainTests.kt
@@ -1,11 +1,13 @@
 package org.multipaz.crypto
 
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.truncateToWholeSeconds
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -460,5 +462,85 @@ class X509CertChainTests {
             ))
         )
         multipazOrgCertChain.validate(Instant.parse("2026-03-09T00:00:00Z"))
+    }
+
+    @Test
+    fun testToX5cAndFromX5c() = runTest {
+        initKeys()
+        val rootCert = buildX509Cert(
+            publicKey = rootKey.publicKey,
+            signingKey = rootKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Root"),
+            issuer = X500Name.fromName("CN=Root"),
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(ca = true, pathLenConstraint = 1)
+            includeSubjectKeyIdentifier()
+            includeAuthorityKeyIdentifierAsSubjectKeyIdentifier()
+        }
+        val intermediateCert = buildX509Cert(
+            publicKey = intermediateKey.publicKey,
+            signingKey = rootKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Intermediate"),
+            issuer = rootCert.subject,
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(ca = true, pathLenConstraint = 0)
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(rootCert)
+        }
+        val leafCert = buildX509Cert(
+            publicKey = leafKey.publicKey,
+            signingKey = intermediateKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Leaf"),
+            issuer = intermediateCert.subject,
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(intermediateCert)
+        }
+
+        // 1. Single self-signed root certificate chain (size == 1)
+        val singleRootChain = X509CertChain(listOf(rootCert))
+        val singleRootX5cDefault = singleRootChain.toX5c() // excludeRoot = true by default
+        assertEquals(1, (singleRootX5cDefault as JsonArray).size)
+        assertEquals(singleRootChain, X509CertChain.fromX5c(singleRootX5cDefault))
+
+        val singleRootX5cExplicit = singleRootChain.toX5c(excludeRoot = false)
+        assertEquals(1, (singleRootX5cExplicit as JsonArray).size)
+        assertEquals(singleRootChain, X509CertChain.fromX5c(singleRootX5cExplicit))
+
+        // 2. Single non-self-signed certificate chain (size == 1)
+        val singleLeafChain = X509CertChain(listOf(leafCert))
+        val singleLeafX5c = singleLeafChain.toX5c(excludeRoot = true)
+        assertEquals(1, (singleLeafX5c as JsonArray).size)
+        assertEquals(singleLeafChain, X509CertChain.fromX5c(singleLeafX5c))
+
+        // 3. Multi-certificate chain ending in a self-signed root (size == 3)
+        val fullChain = X509CertChain(listOf(leafCert, intermediateCert, rootCert))
+        val fullChainX5cExcluded = fullChain.toX5c(excludeRoot = true) as JsonArray
+        assertEquals(2, fullChainX5cExcluded.size)
+        assertEquals(
+            X509CertChain(listOf(leafCert, intermediateCert)),
+            X509CertChain.fromX5c(fullChainX5cExcluded)
+        )
+
+        val fullChainX5cIncluded = fullChain.toX5c(excludeRoot = false) as JsonArray
+        assertEquals(3, fullChainX5cIncluded.size)
+        assertEquals(fullChain, X509CertChain.fromX5c(fullChainX5cIncluded))
+
+        // 4. Multi-certificate chain ending in a non-self-signed certificate (size == 2)
+        val partialChain = X509CertChain(listOf(leafCert, intermediateCert))
+        val partialChainX5c = partialChain.toX5c(excludeRoot = true) as JsonArray
+        assertEquals(2, partialChainX5c.size)
+        assertEquals(partialChain, X509CertChain.fromX5c(partialChainX5c))
     }
 }


### PR DESCRIPTION
When toX5c() was called with excludeRoot = true (the default) on a single-element `X509CertChain` containing a self-signed root certificate, the method attempted to trim the root certificate by taking a subList(0, size - 1). For a 1-element chain, this evaluated to subList(0, 0), returning an empty certificate list. Per RFC 7515 Section 4.1.6, an x5c JOSE header parameter must contain at least one certificate.

Update toX5c() in `X509CertChain` so that root certificates are only excluded if the certificate chain contains more than one certificate (size > 1).

Add unit test testToX5cAndFromX5c() in `X509CertChainTests` to verify single-certificate chains (both self-signed and non-self-signed) and multi-certificate chains with and without root certificate exclusion.

We also recently turned off debug logging by default so add handling for the `-debug` command-line option in `ServerConfiguration` to set `Logger.isDebugEnabled` to true.

Fixes #1881.

Test: Ran ./gradlew :multipaz:jvmTest --tests "org.multipaz.crypto.X509CertChainTests" and ./gradlew :multipaz-backend-server:assemble.
