### PR TITLE
Adjusted `RevocationChecker` API to work off root (e.g. AICA) certificate.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CachingRevocationChecker.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CachingRevocationChecker.kt
@@ -217,24 +217,24 @@ class CachingRevocationChecker(
             if (contentType != STATUSLIST_JWT) {
                 try {
                     Logger.dCbor(TAG, "Status list (CWT) for ${status.uri}", bytes)
-                    return@fetchOrGetCached Pair(
-                        first = CompressedStatusList.fromCwt(
-                            cwt = bytes,
-                            publicKey = cert?.ecPublicKey,
-                            atTime = atTime
-                        ),
-                        second = true
-                    )
-                } catch (err: InvalidRequestException) {
-                    if (onlyTrusted) {
-                        throw err
+                    return@fetchOrGetCached if (cert != null) {
+                        Pair(
+                            first = CompressedStatusList.fromCwt(
+                                cwt = bytes,
+                                trustedRootCert = cert,
+                                atTime = atTime
+                            ),
+                            second = true
+                        )
+                    } else if (onlyTrusted) {
+                        throw InvalidRequestException("Status list (CWT) could not be validated, no trusted root")
+                    } else {
+                        Logger.w(TAG, "Status list (CWT) could not be validated, attempt using it anyway")
+                        Pair(
+                            first = CompressedStatusList.fromCwtNoTrust(bytes),
+                            second = false
+                        )
                     }
-                    // Untrusted path
-                    Logger.w(TAG, "Status list (CWT) could not be validated, attempt using it anyway", err)
-                    return@fetchOrGetCached Pair(
-                        first = CompressedStatusList.fromCwtNoTrust(bytes),
-                        second = false
-                    )
                 } catch (err: IllegalArgumentException) {
                     if (contentType == STATUSLIST_CWT) {
                         throw err
@@ -244,14 +244,24 @@ class CachingRevocationChecker(
             val jwtString = bytes.decodeToString()
             Logger.d(TAG, "Status list (JWT) for ${status.uri}: $jwtString")
             try {
-                Pair(
-                    first = CompressedStatusList.fromJwt(
-                        jwt = jwtString,
-                        publicKey = cert?.ecPublicKey,
-                        atTime = atTime
-                    ),
-                    second = true
-                )
+                if (cert != null) {
+                    Pair(
+                        first = CompressedStatusList.fromJwt(
+                            jwt = jwtString,
+                            trustedRootCert = cert,
+                            atTime = atTime
+                        ),
+                        second = true
+                    )
+                } else if (onlyTrusted) {
+                    throw InvalidRequestException("Status list (JWT) could not be validated, no trusted root")
+                } else {
+                    Logger.w(TAG, "Status list (JWT) could not be validated, attempt using it anyway")
+                    Pair(
+                        first = CompressedStatusList.fromJwtNoTrust(jwtString),
+                        second = false
+                    )
+                }
             } catch (err: InvalidRequestException) {
                 if (onlyTrusted) {
                     throw err
@@ -309,20 +319,19 @@ class CachingRevocationChecker(
             bypassCache = bypassCache
         ) { bytes, _ ->
             Logger.dCbor(TAG, "Identifier list (CWT) for ${status.uri}", bytes)
-            try {
+            if (cert != null) {
                 Pair(
                     first = IdentifierList.fromCwt(
                         cwt = bytes,
-                        publicKey = cert?.ecPublicKey,
+                        trustedRootCert = cert,
                         atTime = atTime
                     ),
                     second = true
                 )
-            } catch (err: InvalidRequestException) {
-                if (onlyTrusted) {
-                    throw err
-                }
-                Logger.w(TAG, "Identifier list could not be validated, attempt using it anyway", err)
+            } else if (onlyTrusted) {
+                throw InvalidRequestException("Identifier list could not be validated, no trusted root")
+            } else {
+                Logger.w(TAG, "Identifier list could not be validated, attempt using it anyway")
                 // Trust cannot be verified
                 Pair(first = IdentifierList.fromCwtNoTrust(bytes), second = false)
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/CompressedStatusList.kt
@@ -18,7 +18,7 @@ import org.multipaz.cbor.Uint
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.putCborMap
 import org.multipaz.crypto.AsymmetricKey
-import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.X509Cert
 import org.multipaz.webtoken.WebTokenCheck
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.webtoken.validateJwt
@@ -31,6 +31,7 @@ import org.multipaz.webtoken.validateCwt
 import org.multipaz.webtoken.WebTokenClaim
 import org.multipaz.webtoken.WebTokenClaim.Companion.get
 import org.multipaz.webtoken.WebTokenClaim.Companion.put
+import org.multipaz.webtoken.trustedRootCertificateChainValidator
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -126,11 +127,8 @@ class CompressedStatusList(
         /**
          * Parses and validates JWT that holds the status list.
          *
-         * JWT signature can be validated either by passing [WebTokenCheck.TRUST] key in the [checks]
-         * map or using non-null [publicKey] (see [validateJwt]).
-         *
          * @param jwt status list JWT representation
-         * @param publicKey public key of the issuance server signing key (optional)
+         * @param trustedRootCert root certificate to check JWT signature
          * @param checks additional checks for JWT validation
          * @param atTime time instant to check for expiration
          * @param maxValidity maximum JWT validity duration to accept
@@ -140,7 +138,7 @@ class CompressedStatusList(
          */
         suspend fun fromJwt(
             jwt: String,
-            publicKey: EcPublicKey? = null,
+            trustedRootCert: X509Cert,
             checks: Map<WebTokenCheck, String> = mapOf(),
             atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
@@ -152,7 +150,8 @@ class CompressedStatusList(
                     put(WebTokenCheck.TYP, "statuslist+jwt")
                     putAll(checks)
                 },
-                publicKey = publicKey,
+                publicKey = null,
+                certificateChainValidator = trustedRootCertificateChainValidator(trustedRootCert),
                 atTime = atTime,
                 maxValidity = maxValidity
             )
@@ -216,11 +215,8 @@ class CompressedStatusList(
         /**
          * Parses and validates CWT that holds the status list.
          *
-         * CWT signature can be validated either by passing [WebTokenCheck.TRUST] key in
-         * the [checks] map or using non-null [publicKey] (see [validateCwt]).
-         *
          * @param cwt status list CWT representation
-         * @param publicKey public key of the issuance server signing key (optional)
+         * @param trustedRootCert root certificate to check CWT signature
          * @param checks additional checks for CWT validation
          * @param atTime time instant to check for expiration
          * @param maxValidity maximum CWT validity duration to accept
@@ -230,7 +226,7 @@ class CompressedStatusList(
          */
         suspend fun fromCwt(
             cwt: ByteArray,
-            publicKey: EcPublicKey? = null,
+            trustedRootCert: X509Cert,
             checks: Map<WebTokenCheck, String> = mapOf(),
             atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
@@ -242,7 +238,8 @@ class CompressedStatusList(
                     put(WebTokenCheck.TYP, "application/statuslist+cwt")
                     putAll(checks)
                 },
-                publicKey = publicKey,
+                publicKey = null,
+                certificateChainValidator = trustedRootCertificateChainValidator(trustedRootCert),
                 atTime = atTime,
                 maxValidity = maxValidity
             )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/IdentifierList.kt
@@ -9,12 +9,13 @@ import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.putCborMap
 import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.AsymmetricKey
-import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.X509Cert
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.webtoken.WebTokenCheck
 import org.multipaz.webtoken.WebTokenClaim
 import org.multipaz.webtoken.WebTokenClaim.Companion.put
 import org.multipaz.webtoken.buildCwt
+import org.multipaz.webtoken.trustedRootCertificateChainValidator
 import org.multipaz.webtoken.validateCwt
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -112,11 +113,8 @@ class IdentifierList(
         /**
          * Parses and validates CWT that holds the identifier list.
          *
-         * CWT signature can be validated either by passing [WebTokenCheck.TRUST] key in
-         * the [checks] map or using non-null [publicKey] (see [validateCwt]).
-         *
          * @param cwt identifier list CWT representation
-         * @param publicKey public key of the issuance server signing key (optional)
+         * @param trustedRootCert root certificate to check CWT signature
          * @param checks additional checks for JWT validation
          * @param atTime time instant to check for expiration
          * @param maxValidity maximum CWT validity duration to accept
@@ -126,7 +124,7 @@ class IdentifierList(
          */
         suspend fun fromCwt(
             cwt: ByteArray,
-            publicKey: EcPublicKey? = null,
+            trustedRootCert: X509Cert,
             checks: Map<WebTokenCheck, String> = mapOf(),
             atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
@@ -138,7 +136,8 @@ class IdentifierList(
                     put(WebTokenCheck.TYP, "application/identifierlist+cwt")
                     putAll(checks)
                 },
-                publicKey = publicKey,
+                publicKey = null,
+                certificateChainValidator = trustedRootCertificateChainValidator(trustedRootCert),
                 atTime = atTime,
                 maxValidity = maxValidity
             )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationChecker.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/RevocationChecker.kt
@@ -25,8 +25,12 @@ interface RevocationChecker {
      *
      * @param revocationStatus The revocation status object (StatusList or IdentifierList) extracted
      *  from the presentation.
-     * @param issuerCert The top-level certificate chain of the issuer / document signer, used for
-     *  signature verification if not included in the status payload.
+     * @param issuerCert The top-level certificate chain of the issuer / document signer (e.g. AICA
+     *  certificate for ISO mdoc credentials); it is used for signature verification unless it is
+     *  included in the [revocationStatus] (uncommon); if this is `null`, and certificate in the
+     *  [revocationStatus] is `null`, [onlyTrusted] should be false, or the check will always
+     *  return [RevocationCheckState.UNKNOWN] in [RevocationCheckResult.state]
+     * @param onlyTrusted Only accept trusted revocation data (valid and correctly signed)
      * @param atTime The point in time at which to evaluate revocation status validity. Defaults
      *  to current system time.
      * @param bypassCache If true, forces downloading a fresh status/identifier list payload from

--- a/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/revocation/StatusList.kt
@@ -5,12 +5,10 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.JsonObject
 import org.multipaz.cbor.DataItem
-import org.multipaz.crypto.EcPublicKey
+import org.multipaz.crypto.X509Cert
 import org.multipaz.webtoken.WebTokenCheck
-import org.multipaz.webtoken.validateJwt
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.util.zlibDeflate
-import org.multipaz.webtoken.validateCwt
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -142,11 +140,8 @@ class StatusList(
         /**
          * Parses and validates JWT that holds the status list.
          *
-         * JWT signature can be validated either by passing [WebTokenCheck.TRUST] key in the [checks]
-         * map or using non-null [publicKey] (see [validateJwt]).
-         *
          * @param jwt status list JWT representation
-         * @param publicKey public key of the issuance server signing key (optional)
+         * @param trustedRootCert root certificate to check CWT signature
          * @param checks additional checks for JWT validation
          * @return parsed [StatusList]
          * @throws IllegalArgumentException when [jwt] cannot be parsed as JWT status list
@@ -154,10 +149,10 @@ class StatusList(
          */
         suspend fun fromJwt(
             jwt: String,
-            publicKey: EcPublicKey? = null,
+            trustedRootCert: X509Cert,
             checks: Map<WebTokenCheck, String> = mapOf()
         ): StatusList =
-            CompressedStatusList.fromJwt(jwt, publicKey, checks).decompress()
+            CompressedStatusList.fromJwt(jwt, trustedRootCert, checks).decompress()
 
         /**
          * Parses JSON as status list.
@@ -175,11 +170,8 @@ class StatusList(
         /**
          * Parses and validates CWT that holds the status list.
          *
-         * CWT signature can be validated either by passing [WebTokenCheck.TRUST] key in
-         * the [checks] map or using non-null [publicKey] (see [validateCwt]).
-         *
          * @param cwt status list CWT representation
-         * @param publicKey public key of the issuance server signing key (optional)
+         * @param trustedRootCert root certificate to check CWT signature
          * @param checks additional checks for JWT validation
          * @param maxValidity maximum CWT validity duration to accept
          * @return parsed [StatusList]
@@ -188,12 +180,12 @@ class StatusList(
          */
         suspend fun fromCwt(
             cwt: ByteArray,
-            publicKey: EcPublicKey? = null,
+            trustedRootCert: X509Cert,
             checks: Map<WebTokenCheck, String> = mapOf(),
             atTime: Instant = Clock.System.now(),
             maxValidity: Duration = 365.days
         ): StatusList =
-            CompressedStatusList.fromCwt(cwt, publicKey, checks, atTime, maxValidity).decompress()
+            CompressedStatusList.fromCwt(cwt, trustedRootCert, checks, atTime, maxValidity).decompress()
 
         /**
          * Parses CBOR as status list.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/validateJwt.kt
@@ -298,6 +298,27 @@ suspend fun basicCertificateChainValidator(
     return false  // Certificate chain is valid, but no trust is established
 }
 
+/**
+ * Creates certificate chain validator that checks if the given certificate chain can be validated
+ * using given trusted root certificate.
+ *
+ * @param trustedRootCert trusted root certificate
+ * @return validator which is appropriate for use with [validateJwt] and [validateCwt]
+ *  functions as `certificateChainValidator` parameter
+ */
+fun trustedRootCertificateChainValidator(
+    trustedRootCert: X509Cert
+): suspend (certificateChain: X509CertChain, atTime: Instant) -> Boolean =
+    { certificateChain, atTime ->
+        val combinedChain = if (certificateChain.certificates.last() == trustedRootCert) {
+            certificateChain
+        } else {
+            X509CertChain(certificateChain.certificates + trustedRootCert)
+        }
+        basicCertificateChainValidator(combinedChain, atTime)
+        true  // valid and trusted
+    }
+
 private val jtiTableSpec = StorageTableSpec(
     name = "UsedJti",
     supportPartitions = true,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
@@ -2,28 +2,27 @@ package org.multipaz.revocation
 
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.ByteString
-import kotlin.time.Clock
 import org.multipaz.cbor.Cdn
 import org.multipaz.cbor.CdnGeneratorOptions
-import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.util.fromHex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 class IdentifierListTest {
     @Test
     fun roundtripCwt() = runTest {
-        val key = AsymmetricKey.ephemeral()
+        val dsKey = createTestDsKey()
+        val iacaCert = dsKey.certChain.certificates.last()
+        val dsCert = dsKey.certChain.certificates.first()
         val id1 = ByteString("1122334455667788990011223344556677889900112233445566778899001122".fromHex())
         val id2 = ByteString("aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".fromHex())
         val absentId = ByteString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".fromHex())
 
-        val creationTime = Instant.fromEpochSeconds(1686920170)
-        val expirationTime = Instant.fromEpochSeconds(1686920170 + 86400)
+        val creationTime = dsCert.validityNotBefore
+        val expirationTime = dsCert.validityNotAfter
 
         val identifierList = IdentifierList(
             identifiers = setOf(id1, id2),
@@ -31,7 +30,7 @@ class IdentifierListTest {
             expirationTime = expirationTime
         )
 
-        val cwt = identifierList.serializeAsCwt(key, "https://example.com/identifierlists/1")
+        val cwt = identifierList.serializeAsCwt(dsKey, "https://example.com/identifierlists/1")
 
         val decodedCwt = Cdn.encode(cwt, CdnGeneratorOptions.Pretty)
         val lines = decodedCwt.lines().toMutableList()
@@ -42,12 +41,22 @@ class IdentifierListTest {
             18([ # COSE_Sign1
               /protected/ << {
                 16: "application/identifierlist+cwt",
+                /x5chain/ 33: [
+                  # Subject DN: C=US,CN=DS test key
+                  # Issuer DN: C=US,CN=IACA test key
+                  cert'''${"\n" + dsCert.toPem().trimEnd().prependIndent("                    ")}
+                  ''',
+                  # Subject DN: C=US,CN=IACA test key
+                  # Issuer DN: C=US,CN=IACA test key
+                  cert'''${"\n" + iacaCert.toPem().trimEnd().prependIndent("                    ")}
+                  '''
+                ],
                 /alg/ 1: -9 # ESP256: ECDSA using P-256 curve and SHA-256
               } >>,
               /unprotected/ {},
               /payload/ << {
-                4: 1687006570,
-                6: 1686920170,
+                4: ${expirationTime.epochSeconds},
+                6: ${creationTime.epochSeconds},
                 2: "https://example.com/identifierlists/1",
                 65530: {
                   "identifiers": {
@@ -63,7 +72,7 @@ class IdentifierListTest {
 
         assertEquals(expectedCdn, sanitizedCdn)
 
-        val parsedList = IdentifierList.fromCwt(cwt, key.publicKey, atTime = creationTime + 100.seconds)
+        val parsedList = IdentifierList.fromCwt(cwt, iacaCert, atTime = creationTime + 100.seconds)
 
         assertTrue(parsedList.contains(id1))
         assertTrue(parsedList.contains(id2))

--- a/multipaz/src/commonTest/kotlin/org/multipaz/revocation/StatusListTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/revocation/StatusListTest.kt
@@ -4,18 +4,25 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.multipaz.cbor.Cbor
-import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.X509Cert
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.fromHex
 import org.multipaz.webtoken.WebTokenCheck
 import kotlin.collections.component1
 import kotlin.collections.component2
+import kotlin.io.encoding.Base64
 import kotlin.random.Random
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 import kotlin.time.Instant
 
 class StatusListTest {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
     // testSpecVectorN tests use datasets from the spec (see "Test vectors for Status List encoding"
     // section in https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/)
     @Test
@@ -547,6 +554,20 @@ class StatusListTest {
     @Test
     fun roundtripCwt8() = runTest { testRoundtrip(5000, 8, false) }
 
+    @Test
+    fun testSignature() = runTest {
+        if (!Crypto.supportedCurves.contains(testIacaCert.ecPublicKey.curve)) {
+            println("Curve ${testIacaCert.ecPublicKey.curve} not supported on platform")
+            return@runTest
+        }
+        val time = Instant.parse("2026-08-07T22:11:30Z")
+        CompressedStatusList.fromCwt(
+            cwt = testCwtStatusList,
+            trustedRootCert = testIacaCert,
+            atTime = time
+        )
+    }
+
     suspend fun testRoundtrip(size: Int, bits: Int, useJwt: Boolean) {
         val map = mutableMapOf<Int, Int>()
         val statusCount = (1 shl bits)  // number of distinct status values
@@ -558,17 +579,18 @@ class StatusListTest {
         for ((index, status) in map.entries.sortedWith { (i1, _), (i2, _) -> i1 - i2 }) {
             builder.addStatus(index, status)
         }
-        val key = AsymmetricKey.ephemeral()
+        val dsKey = createTestDsKey()
+        val iacaCert = dsKey.certChain.certificates.last()
         val compressed = builder.build().compress()
         if (useJwt) {
-            val jwt = compressed.serializeAsJwt(key, "foo")
+            val jwt = compressed.serializeAsJwt(dsKey, "foo")
             val statusList =
-                StatusList.fromJwt(jwt, key.publicKey, mapOf(WebTokenCheck.SUB to "foo"))
+                StatusList.fromJwt(jwt, iacaCert, mapOf(WebTokenCheck.SUB to "foo"))
             assertStatusList(map, statusList)
         } else {
-            val cwt = compressed.serializeAsCwt(key, "foo")
+            val cwt = compressed.serializeAsCwt(dsKey, "foo")
             val statusList =
-                StatusList.fromCwt(cwt, key.publicKey, mapOf(WebTokenCheck.SUB to "foo"))
+                StatusList.fromCwt(cwt, iacaCert, mapOf(WebTokenCheck.SUB to "foo"))
             assertStatusList(map, statusList)
         }
     }
@@ -586,5 +608,48 @@ class StatusListTest {
                 assertEquals(0, statusList[index])
             }
         }
+    }
+
+    companion object {
+        val testCwtStatusList = Base64.Mime.decode("""
+            0oRZAyOjASYQeBphcHBsaWNhdGlvbi9zdGF0dXNsaXN0K2N3dBghWQL+MIIC+jCCAqGgAwIBAgIQDTtk
+            40HHu09NJhVKiQJCrDAKBggqhkjOPQQDAjB7MTUwMwYDVQQDEyxJQUNBIENlcnRpZmljYXRlIERlZmF1
+            bHQgSXNzdWVyIEJhbmdrb2sgMjAyNjELMAkGA1UEBhMCVEgxFTATBgNVBAoTDEJhbmdrb2sgMjAyNjEe
+            MBwGA1UECxMVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTI2MDYxMTExMjMwN1oXDTI5MDkxMDExMjMw
+            N1owgY0xRzBFBgNVBAMTPlJldm9jYXRpb24gTGlzdCBTaWduZXIgQ2VydGlmaWNhdGUgRGVmYXVsdCBJ
+            c3N1ZXIgQmFuZ2tvayAyMDI2MQswCQYDVQQGEwJUSDEVMBMGA1UEChMMQmFuZ2tvayAyMDI2MR4wHAYD
+            VQQLExVDZXJ0aWZpY2F0ZSBBdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASqXiY0Jrk+
+            CMuTzCeoLEOgCcEum28xjHf8oQoWG7j8ZGiWJT+reKfJT0FaGpOqDJD4x588Mi2UVkkDS5xpXqrgo4Hz
+            MIHwMB0GA1UdDgQWBBTEk/h+I/JPldq5gDnrMfjZYJG3zTAOBgNVHQ8BAf8EBAMCB4AwUwYDVR0fBEww
+            SjBIoEagRIZCaHR0cHM6Ly9iYW5na29rMjAyNi5tZG9jLm9ubGluZS9DZXJ0aWZpY2F0ZXMvMS9JYWNh
+            Q2VydGlmaWNhdGUuY3JsMB8GA1UdIwQYMBaAFDvS3rYOZTPLX3EicErMLO5SOs7rMEkGA1UdEgRCMECG
+            IGh0dHBzOi8vYmFuZ2tvazIwMjYubWRvYy5vbmxpbmUvgRxpYWNhQGJhbmdrb2syMDI2Lm1kb2Mub25s
+            aW5lMAoGCCqGSM49BAMCA0cAMEQCIHr2u6rnWeaNaqMoZWDlQiN2LRdykAmokCtRGy4kZHShAiBv4doJ
+            kKBPd3Q+iwsCn6HFpSpvsW0uF8Ac73ymltgJNqBZAT+jAnhnaHR0cHM6Ly9iYW5na29rMjAyNi5tZG9j
+            Lm9ubGluZS9SZXZvY2F0aW9uTGlzdHMvM0JEMkRFQjYwRTY1MzNDQjVGNzEyMjcwNEFDQzJDRUU1MjNB
+            Q0VFQi9zdGF0dXNsaXN0LmN3dAYaaml/1Rn//aNkYml0cwFjbHN0WEV42uzaMQ0AIAxFwbIxIgEpSEM6
+            wQArNNwNFfC2nzQCAMigSwAA/ykSnAwJAAAAW+FVUwIAAAivKGnUfZoOAPcsAAAA//9vYWdncmVnYXRp
+            b25fdXJpeGdodHRwczovL2Jhbmdrb2syMDI2Lm1kb2Mub25saW5lL1Jldm9jYXRpb25MaXN0cy8zQkQy
+            REVCNjBFNjUzM0NCNUY3MTIyNzA0QUNDMkNFRTUyM0FDRUVCL3N0YXR1c2xpc3QuY3d0WEDPdczqCYdy
+            IoFYpM32GiQBcfq7HzDwidSKiFQeudpxG45HYwPGaIHH48jlqahvtH9DoKVs+LtyN6Kppv3lXtkL
+        """.trimIndent())
+
+        val testIacaCert = X509Cert.fromPem("""
+            -----BEGIN CERTIFICATE-----
+            MIIC2jCCAn+gAwIBAgIQBn47HNeX5RrJwddevXOhsDAKBggqhkjOPQQDAjB7MTUwMwYDVQQDEyxJQUNBI
+            ENlcnRpZmljYXRlIERlZmF1bHQgSXNzdWVyIEJhbmdrb2sgMjAyNjELMAkGA1UEBhMCVEgxFTATBgNVBA
+            oTDEJhbmdrb2sgMjAyNjEeMBwGA1UECxMVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTI2MDYxMTExMjM
+            wN1oXDTQ2MDYxMTExMjMwN1owezE1MDMGA1UEAxMsSUFDQSBDZXJ0aWZpY2F0ZSBEZWZhdWx0IElzc3Vl
+            ciBCYW5na29rIDIwMjYxCzAJBgNVBAYTAlRIMRUwEwYDVQQKEwxCYW5na29rIDIwMjYxHjAcBgNVBAsTF
+            UNlcnRpZmljYXRlIEF1dGhvcml0eTBaMBQGByqGSM49AgEGCSskAwMCCAEBBwNCAAR7oaJvNGwl/URUWf
+            STilYwyrodGNGOsG1DvZ7tc4A1aAwwA1fZJgBSFuCLkksC+xglCO0xt2bqqW4q4PVhyVRno4HjMIHgMB0
+            GA1UdDgQWBBQ70t62DmUzy19xInBKzCzuUjrO6zAOBgNVHQ8BAf8EBAMCAQYwSQYDVR0SBEIwQIYgaHR0
+            cHM6Ly9iYW5na29rMjAyNi5tZG9jLm9ubGluZS+BHGlhY2FAYmFuZ2tvazIwMjYubWRvYy5vbmxpbmUwD
+            wYDVR0TAQH/BAUwAwEB/zBTBgNVHR8ETDBKMEigRqBEhkJodHRwczovL2Jhbmdrb2syMDI2Lm1kb2Mub2
+            5saW5lL0NlcnRpZmljYXRlcy8xL0lhY2FDZXJ0aWZpY2F0ZS5jcmwwCgYIKoZIzj0EAwIDSQAwRgIhAIB
+            uSUkaNPXgZAiwWHfksJZ6H4hJPBZgQ/lq+pJm2kt+AiEAjOZ4cr55j7aoS8GLc0m2z4qY3gHQLo7p7mfV
+            k43daP0=
+            -----END CERTIFICATE-----
+        """.trimIndent())
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/revocation/createTestDsKey.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/revocation/createTestDsKey.kt
@@ -1,0 +1,53 @@
+package org.multipaz.revocation
+
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.AsymmetricKey.AnonymousExplicit
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.mdoc.util.MdocUtil
+import org.multipaz.util.truncateToWholeSeconds
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Generates a simple test DS private key with certificate chain attached.
+ *
+ * Certificate chain always has 2 elements:
+ * - the first certificate in the certificate chain is DS certificate,
+ * - the second one is IACA certificate
+ *
+ * @return new test DS private key
+ */
+suspend fun createTestDsKey(): AsymmetricKey.X509Certified {
+    val iacaRawKey = AsymmetricKey.ephemeral() as AnonymousExplicit
+    val validFrom = Clock.System.now().truncateToWholeSeconds() - 10.seconds
+    val validUntil = validFrom + 24.hours
+    val iacaCert = MdocUtil.generateIacaCertificate(
+        iacaKey = iacaRawKey,
+        subject = X500Name.fromName("C=US,CN=IACA test key"),
+        serial = ASN1Integer.fromRandom(128),
+        validFrom = validFrom,
+        validUntil = validUntil,
+        issuerAltNameUrl = "https://example.com",
+        crlUrl = "https://example.com/crl"
+    )
+    val iacaKey = AsymmetricKey.X509CertifiedExplicit(
+        certChain = X509CertChain(listOf(iacaCert)),
+        privateKey = iacaRawKey.privateKey
+    )
+    val dsRawKey = AsymmetricKey.ephemeral() as AnonymousExplicit
+    val dsCert = MdocUtil.generateDsCertificate(
+        iacaKey = iacaKey,
+        dsKey = dsRawKey.publicKey,
+        subject = X500Name.fromName("C=US,CN=DS test key"),
+        serial = ASN1Integer.fromRandom(128),
+        validFrom = validFrom,
+        validUntil = validUntil,
+    )
+    return AsymmetricKey.X509CertifiedExplicit(
+        certChain = X509CertChain(listOf(dsCert, iacaCert)),
+        privateKey = dsRawKey.privateKey
+    )
+}


### PR DESCRIPTION
Adjusted `RevocationChecker` API to work off root (e.g. AICA) certificate.

When root certificate is available, always perform revocation data validation, even if `onlyTrusted` parameter is false.

Added a signature test for a non-Multipaz generated status list

Test: unit tests

Fixes #1883
