### PR TITLE
A way to access Ktor `ApplicationCall` from the handler.

### DIFF
--- a/multipaz-server/src/main/java/org/multipaz/server/common/KtorCall.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/KtorCall.kt
@@ -1,0 +1,33 @@
+package org.multipaz.server.common
+
+import io.ktor.server.application.ApplicationCall
+import kotlinx.coroutines.currentCoroutineContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provides access to ktor [ApplicationCall] object.
+ *
+ * @param call Ktor [ApplicationCall] which is being handled.
+ */
+class KtorCall internal constructor(
+    val call: ApplicationCall
+): CoroutineContext.Element {
+    object Key:CoroutineContext.Key<KtorCall>
+
+    override val key: CoroutineContext.Key<KtorCall>
+        get() = Key
+
+    companion object {
+        /**
+         * Finds ktor [ApplicationCall] which is being handled by this coroutine.
+         *
+         * This can be called only when it is known that the code is invoked by a ktor handler
+         * which was set up using [runServer].
+         *
+         * @return [ApplicationCall] which is being handled
+         */
+        suspend fun getCall(): ApplicationCall =
+            (currentCoroutineContext()[Key]
+                ?: throw IllegalStateException("Not in ktor handler")).call
+    }
+}

--- a/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/runServer.kt
@@ -103,7 +103,7 @@ fun Application.installServerEnvironment(
 ) {
     intercept(ApplicationCallPipeline.Plugins) {
         // Inject server environment
-        withContext(serverEnvironment.await()) {
+        withContext(serverEnvironment.await() + KtorCall(call)) {
             // Standard error handling; if this is not desired, individual handlers
             // must do their own.
             try {

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
@@ -7,6 +7,7 @@ import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.parameters
+import io.ktor.server.plugins.origin
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -42,6 +43,7 @@ import org.multipaz.rpc.handler.RpcAuthInspectorSignature
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureAreaProvider
 import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.server.common.KtorCall
 import org.multipaz.server.common.baseUrl
 import org.multipaz.server.common.getBaseUrl
 import org.multipaz.server.common.enrollmentServerUrl
@@ -116,7 +118,12 @@ class EnrollmentImpl: Enrollment, RpcAuthInspector by serverAuth {
         if (requestId != null && enrollmentsMap[identity]?.requestId != requestId) {
             throw InvalidRequestException("Enrollment was not requested")
         }
-        Logger.i(TAG, "Received enrollment for '$identity'")
+        try {
+            val call = KtorCall.getCall()
+            Logger.i(TAG, "Received enrollment for '$identity' from '${call.request.origin.remoteAddress}'")
+        } catch (_: IllegalStateException) {
+            Logger.i(TAG, "Received enrollment for '$identity'")
+        }
         val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
         // Set up expiration to re-enroll ahead of the certificate expiration
         val expiration = certChain.certificates.first().validityNotAfter - MIN_VALIDITY_DURATION

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/backend/BackendEnvironment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/backend/BackendEnvironment.kt
@@ -1,7 +1,7 @@
 package org.multipaz.rpc.backend
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 
 /**
@@ -30,6 +30,6 @@ interface BackendEnvironment: CoroutineContext.Element {
         }
 
         suspend fun <T: Any> getInterface(clazz: KClass<T>): T? =
-            get(coroutineContext).getInterface(clazz)
+            get(currentCoroutineContext()).getInterface(clazz)
     }
 }


### PR DESCRIPTION
Test: unit tests, manual test with a local podman container.

Fixes #1884
