### PR TITLE
Support user authentication for software keys and improve presentment.

### DIFF
--- a/mpzpass/README.md
+++ b/mpzpass/README.md
@@ -48,17 +48,25 @@ CredentialDataBytes = bstr .cbor CredentialData
 ; secret which can be used to check for updates. A pass also has a version field which is a
 ; monotonically increasing number starting at 0 and represents the version of the pass.
 ;
-; The issuer may also include a URL to update for the wallet to check for updates. The
-; wallet can use a HTTP POST to check for update with the body `update <uniqueId> <version>`.
-; If HTTP status code 204 is returned it means no update is available and if HTTP status
-; code 200 is returned, the bytes of the updated pass will be included in the HTTP response.
+; The issuer may also include a URL in `updateUrl` for the wallet to check for updates. The
+; wallet can issue an HTTP GET request to `updateUrl` with an `If-None-Match: "<version>"`
+; header set to the current version. If no update is available, the server responds with
+; HTTP status code 304 (Not Modified). If an update is available, the server responds with
+; HTTP status code 200 (OK) containing the bytes of the updated pass in the response body.
+;
+; The issuer may also indicate that user authentication using the platform (e.g. passcode
+; or biometrics) must be performed in order to present the pass by setting
+; `userAuthenticationRequired` to `true`.
 ;
 CredentialData = {
   "uniqueId": tstr,          ; Unique identifier for the pass, containing only alphanumerical
                              ; and underscore and hyphen characters and contains at least 128
                              ; bit of entropy.
   "version": uint,           ; Version of the pass, monotonically increasing starting at 0.
-  ? "updateUrl": tstr        ; If set, an URL where the wallet can download updates.
+  ? "updateUrl": tstr,       ; If set, an URL where the wallet can download updates.
+  ? "userAuthenticationRequired": bool,  ; If set and true, user authentication using the platform
+                                         ; (e.g. passcode or biometrics) must be performed in
+                                         ; order to present the pass.
   "display": Display,
   "credential": Credential,
 }

--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
@@ -28,6 +28,7 @@ import org.multipaz.securearea.cloud.CloudSecureAreaServer
 import org.multipaz.securearea.cloud.SimplePassphraseFailureEnforcer
 import org.multipaz.server.request.certificateAuthority
 import org.multipaz.server.request.push
+import org.multipaz.util.Logger
 import java.security.Security
 import kotlin.time.Duration.Companion.seconds
 
@@ -35,7 +36,9 @@ import kotlin.time.Duration.Companion.seconds
  * Defines server endpoints for HTTP GET and POST.
  */
 fun Application.configureRouting(serverEnvironment: Deferred<ServerEnvironment>) {
-    Security.addProvider(BouncyCastleProvider())
+    Logger.i(TAG, "Forcing BouncyCastle to the top of the list")
+    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+    Security.insertProviderAt(BouncyCastleProvider(), 1)
     val keyMaterial = lazy {
         KeyMaterial.create(serverEnvironment)
     }

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/EnrollmentImpl.kt
@@ -357,12 +357,18 @@ class EnrollmentImpl: Enrollment, RpcAuthInspector by serverAuth {
             identity: ServerIdentity,
             configuration: Configuration
         ): Boolean {
+            if (cert == null) {
+                return false
+            }
+            if (identity == ServerIdentity.KEY_ATTESTATION || identity == ServerIdentity.CLOUD_SECURE_AREA_BINDING) {
+                val basicConstraints = cert.basicConstraints
+                if (basicConstraints == null || !basicConstraints.first || !cert.keyUsage.contains(X509KeyUsage.KEY_CERT_SIGN)) {
+                    Logger.w(TAG, "Certificate for $identity is invalid CA")
+                    return false
+                }
+            }
             if (identity != ServerIdentity.VERIFIER) {
                 return true
-            }
-            if (cert == null) {
-                Logger.w(TAG, "Reader key must have certificate chain")
-                return false
             }
             // check that the certificate satisfies the requirements
             if (!cert.keyUsage.contains(X509KeyUsage.DIGITAL_SIGNATURE)) {

--- a/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/enrollment/ServerIdentity.kt
@@ -235,8 +235,19 @@ private suspend fun getLocalRootIdentity(
         val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
         val rootSigningKeyDataTable = BackendEnvironment.getTable(rootSigningKeyDataTableSpec)
         val rootSigningKeyData = rootSigningKeyDataTable.get(serverIdentity.name)?.let {
-            Logger.i(TAG, "Loaded $serverIdentity root key and certificate")
-            SigningKeyData.fromCbor(it.toByteArray())
+            val keyData = SigningKeyData.fromCbor(it.toByteArray())
+            val cert = keyData.certChain.certificates.firstOrNull()
+            val expectedPathLen = if (serverIdentity == ServerIdentity.KEY_ATTESTATION
+                || serverIdentity == ServerIdentity.CLOUD_SECURE_AREA_BINDING) 1 else 0
+            val actualPathLen = cert?.basicConstraints?.second
+            if (cert?.basicConstraints?.first != true || (actualPathLen != null && actualPathLen < expectedPathLen)) {
+                Logger.w(TAG, "Root certificate for $serverIdentity in database has invalid pathLenConstraint ($actualPathLen < $expectedPathLen), regenerating...")
+                rootSigningKeyDataTable.delete(serverIdentity.name)
+                null
+            } else {
+                Logger.i(TAG, "Loaded $serverIdentity root key and certificate")
+                keyData
+            }
         } ?: run {
             if (!createOnRequest) {
                 throw IllegalStateException("$serverIdentity not available")

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassCreatorComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassCreatorComponent.kt
@@ -111,6 +111,7 @@ val MpzPassCreatorComponent = FC {
     var uniqueId by useState(UUID.randomUUID().toString())
     var versionStr by useState("0")
     var updateUrl by useState("")
+    var userAuthenticationRequired by useState(false)
     var credentialCountStr by useState("1")
 
     // Card Art options: "auto" or "custom"
@@ -405,6 +406,7 @@ val MpzPassCreatorComponent = FC {
                     uniqueId = uniqueId.ifEmpty { UUID.randomUUID().toString() },
                     version = versionStr.toLongOrNull() ?: 0L,
                     updateUrl = updateUrl.trim().ifEmpty { null },
+                    userAuthenticationRequired = userAuthenticationRequired,
                     name = passName.ifEmpty { "Untitled Pass" },
                     typeName = passTypeName.ifEmpty { "ISO mDoc Pass" },
                     cardArt = cardArtBytes?.let { ByteString(*it) },
@@ -588,6 +590,19 @@ val MpzPassCreatorComponent = FC {
                         value = updateUrl
                         placeholder = "https://example.com/pass-update"
                         onChange = { updateUrl = it.target.value }
+                    }
+                }
+
+                div {
+                    label {
+                        css { display = Display.flex; alignItems = AlignItems.center; color = Color("#cbd5e1"); cursor = Cursor.pointer; fontSize = 13.px }
+                        input {
+                            css { marginRight = 8.px }
+                            type = "checkbox".unsafeCast<InputType>()
+                            checked = userAuthenticationRequired
+                            onChange = { userAuthenticationRequired = it.target.checked }
+                        }
+                        +"Require Platform User Authentication (userAuthenticationRequired)"
                     }
                 }
 

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassDecoderComponent.kt
@@ -560,6 +560,10 @@ val MpzPassDecoderComponent = FC {
                                             td { css { padding = Padding(8.px, 12.px); color = Color("#a78bfa") }; +(pass.updateUrl ?: "None") }
                                         }
                                         tr {
+                                            td { css { padding = Padding(8.px, 12.px); color = Color("#64748b"); fontWeight = FontWeight.bold }; +"User Auth Required" }
+                                            td { css { padding = Padding(8.px, 12.px); color = if (pass.userAuthenticationRequired) Color("#ef4444") else Color("#94a3b8") }; +"${pass.userAuthenticationRequired}" }
+                                        }
+                                        tr {
                                             td { css { padding = Padding(8.px, 12.px); color = Color("#64748b"); fontWeight = FontWeight.bold }; +"ISO mDoc Count" }
                                             td { css { padding = Padding(8.px, 12.px); color = Color("#38bdf8") }; +"${pass.isoMdoc.size}" }
                                         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreKeyUnlockData.kt
@@ -19,8 +19,8 @@ import java.security.spec.InvalidKeySpecException
  * @param alias the alias of the key to unlock.
  */
 class AndroidKeystoreKeyUnlockData(
-    val secureArea: AndroidKeystoreSecureArea,
-    val alias: String
+    override val secureArea: AndroidKeystoreSecureArea,
+    override val alias: String
 ): KeyUnlockData {
     internal var signature: Signature? = null
     private var cryptoObjectForSigning: BiometricPrompt.CryptoObject? = null

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -610,19 +610,20 @@ class AndroidKeystoreSecureArea private constructor(
     override suspend fun unlockKey(
         alias: String,
         unlockReason: Reason
-    ): KeyUnlockData? {
+    ): List<KeyUnlockData> {
         val keyInfo = getKeyInfo(alias)
         if (keyInfo.userAuthenticationTypes.isEmpty()) {
-            return null
+            return emptyList()
         }
         val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
             ?: AndroidKeystoreDefaultKeyUnlockDataProvider
-        return unlockDataProvider.getKeyUnlockData(
+        val unlockData = unlockDataProvider.getKeyUnlockData(
             secureArea = this,
             alias = alias,
             algorithm = keyInfo.algorithm,
             unlockReason = unlockReason
         )
+        return listOf(unlockData)
     }
 
     override suspend fun getKeyInfo(alias: String): AndroidKeystoreKeyInfo {

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.android.kt
@@ -1,0 +1,34 @@
+package org.multipaz.securearea.software
+
+import org.multipaz.prompt.AndroidPromptModel
+import org.multipaz.prompt.PromptModelNotAvailableException
+import org.multipaz.prompt.Reason
+import org.multipaz.prompt.showBiometricPrompt
+import org.multipaz.securearea.KeyLockedException
+import org.multipaz.securearea.UserAuthenticationType
+
+internal actual suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean {
+    val promptModel = try {
+        AndroidPromptModel.get()
+    } catch (_: PromptModelNotAvailableException) {
+        throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
+    }
+    val androidAuthTypes = mutableSetOf<UserAuthenticationType>()
+    if (userAuthenticationTypes.contains(SoftwareUserAuthType.PASSCODE)) {
+        androidAuthTypes.add(UserAuthenticationType.LSKF)
+    }
+    if (userAuthenticationTypes.contains(SoftwareUserAuthType.BIOMETRIC)) {
+        androidAuthTypes.add(UserAuthenticationType.BIOMETRIC)
+    }
+    val humanReadable = promptModel.toHumanReadable(unlockReason, null)
+    return promptModel.showBiometricPrompt(
+        cryptoObject = null,
+        reason = unlockReason,
+        userAuthenticationTypes = androidAuthTypes,
+        requireConfirmation = humanReadable.requireConfirmation
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
@@ -39,6 +39,7 @@ import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
 import org.multipaz.securearea.software.SoftwareCreateKeySettings
 import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.securearea.software.SoftwareUserAuthType
 import org.multipaz.storage.NoRecordStorageException
 import org.multipaz.tags.Tags
 import kotlin.coroutines.cancellation.CancellationException
@@ -295,9 +296,9 @@ class DocumentStore private constructor(
     @Throws(IllegalStateException::class, ImportMpzPassException::class, CancellationException::class)
     suspend fun importMpzPass(
         mpzPass: MpzPass,
-        isoMdocDomain: String = "mdoc",
-        sdJwtVcDomain: String = "sdjwtvc",
-        keylessSdJwtVcDomain: String = "sdjwtvc_keyless"
+        isoMdocDomain: String,
+        sdJwtVcDomain: String,
+        keylessSdJwtVcDomain: String
     ): Document {
         val softwareSecureArea = secureAreaRepository.getImplementation(SoftwareSecureArea.IDENTIFIER)
             ?: throw IllegalStateException(
@@ -332,11 +333,17 @@ class DocumentStore private constructor(
 
         try {
             mpzPass.isoMdoc.forEach { isoMdoc ->
+                val createKeySettingsBuilder = SoftwareCreateKeySettings.Builder()
+                    .setPrivateKey(isoMdoc.deviceKeyPrivate)
+                if (mpzPass.userAuthenticationRequired) {
+                    createKeySettingsBuilder.setUserAuthenticationRequired(
+                        true,
+                        setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC)
+                    )
+                }
                 val importedKeyInfo = softwareSecureArea.createKey(
                     alias = null,
-                    createKeySettings = SoftwareCreateKeySettings.Builder()
-                        .setPrivateKey(isoMdoc.deviceKeyPrivate)
-                        .build()
+                    createKeySettings = createKeySettingsBuilder.build()
                 )
                 val credential = MdocCredential.createForExistingAlias(
                     document = document,
@@ -358,11 +365,17 @@ class DocumentStore private constructor(
 
             mpzPass.sdJwtVc.forEach { sdJwtVc ->
                 val credential = if (sdJwtVc.deviceKeyPrivate != null) {
+                    val createKeySettingsBuilder = SoftwareCreateKeySettings.Builder()
+                        .setPrivateKey(sdJwtVc.deviceKeyPrivate)
+                    if (mpzPass.userAuthenticationRequired) {
+                        createKeySettingsBuilder.setUserAuthenticationRequired(
+                            true,
+                            setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC)
+                        )
+                    }
                     val importedKeyInfo = softwareSecureArea.createKey(
                         alias = null,
-                        createKeySettings = SoftwareCreateKeySettings.Builder()
-                            .setPrivateKey(sdJwtVc.deviceKeyPrivate)
-                            .build()
+                        createKeySettings = createKeySettingsBuilder.build()
                     )
                     KeyBoundSdJwtVcCredential.createForExistingAlias(
                         document = document,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -310,13 +310,16 @@ class MdocCredential : SecureAreaBoundCredential {
         check(secureArea is SoftwareSecureArea) {
             "You can only export a credential if it's using a SoftwareSecureArea"
         }
-        val deviceKeyPrivate = (secureArea as SoftwareSecureArea).getPrivateKey(alias, keyUnlockData)
+        val swSecureArea = secureArea as SoftwareSecureArea
+        val keyInfo = swSecureArea.getKeyInfo(alias)
+        val deviceKeyPrivate = swSecureArea.getPrivateKey(alias, keyUnlockData)
         val issuerNamespaces = IssuerNamespaces.fromDataItem(issuerSigned["nameSpaces"])
         val issuerAuth = issuerSigned["issuerAuth"].asCoseSign1
         return MpzPass(
             name = document.displayName,
             typeName = document.typeDisplayName,
             cardArt = document.cardArt,
+            userAuthenticationRequired = keyInfo.isUserAuthenticationRequired,
             isoMdoc = listOf(MpzPassIsoMdoc(
                 docType = docType,
                 deviceKeyPrivate = deviceKeyPrivate,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPass.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mpzpass/MpzPass.kt
@@ -28,6 +28,7 @@ import org.multipaz.util.inflate
  * bits of entropy and should only contain alphanumeric characters, hyphens, and underscores.
  * @property version the version of the pass.
  * @property updateUrl Optional URL which can be used to check for an update.
+ * @property userAuthenticationRequired whether platform user authentication is required to present the pass.
  * @property name The display name of the credential (e.g., "Erika's Driving License").
  * @property typeName The display type of the credential (e.g., "Utopia Driving License").
  * @property cardArt The card art for the pass as a PNG ByteString.
@@ -39,6 +40,7 @@ data class MpzPass(
     val uniqueId: String = UUID.randomUUID().toString(),
     val version: Long = 0L,
     val updateUrl: String? = null,
+    val userAuthenticationRequired: Boolean = false,
     val name: String? = null,
     val typeName: String? = null,
     val cardArt: ByteString? = null,
@@ -68,6 +70,9 @@ data class MpzPass(
             put("uniqueId", uniqueId)
             put("version", version)
             updateUrl?.let { put("updateUrl", it) }
+            if (userAuthenticationRequired) {
+                put("userAuthenticationRequired", true)
+            }
             putCborMap("credential") {
                 if (isoMdoc.isNotEmpty()) {
                     putCborArray("isoMdoc") {
@@ -115,6 +120,7 @@ data class MpzPass(
             val uniqueId = credentialData["uniqueId"].asTstr
             val version = credentialData["version"].asNumber
             val updateUrl = credentialData.getOrNull("updateUrl")?.asTstr
+            val userAuthenticationRequired = credentialData.getOrNull("userAuthenticationRequired")?.asBoolean ?: false
 
             val display = credentialData["display"]
             val name = display.getOrNull("name")?.asTstr
@@ -133,6 +139,7 @@ data class MpzPass(
                 uniqueId = uniqueId,
                 version = version,
                 updateUrl = updateUrl,
+                userAuthenticationRequired = userAuthenticationRequired,
                 name = name,
                 typeName = typeName,
                 cardArt = cardArt,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -131,11 +131,11 @@ suspend fun mdocPresentmentAuthenticateUser(
         for (match in selection.matches) {
             if (match.credential is SecureAreaBoundCredential) {
                 val credential = match.credential
-                val keyUnlockData = credential.secureArea.unlockKey(
+                val keyUnlockDataList = credential.secureArea.unlockKey(
                     alias = credential.alias,
                     unlockReason = PresentmentUnlockReason(credential)
                 )
-                add(credential.secureArea, credential.alias, keyUnlockData)
+                add(keyUnlockDataList)
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
@@ -199,11 +199,14 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
         check(secureArea is SoftwareSecureArea) {
             "You can only export a credential if it's using a SoftwareSecureArea"
         }
-        val deviceKeyPrivate = (secureArea as SoftwareSecureArea).getPrivateKey(alias, keyUnlockData)
+        val swSecureArea = secureArea as SoftwareSecureArea
+        val keyInfo = swSecureArea.getKeyInfo(alias)
+        val deviceKeyPrivate = swSecureArea.getPrivateKey(alias, keyUnlockData)
         return MpzPass(
             name = document.displayName,
             typeName = document.typeDisplayName,
             cardArt = document.cardArt,
+            userAuthenticationRequired = keyInfo.isUserAuthenticationRequired,
             sdJwtVc = listOf(MpzPassSdJwtVc(
                 vct = vct,
                 deviceKeyPrivate = deviceKeyPrivate,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockData.kt
@@ -4,4 +4,14 @@ package org.multipaz.securearea
  * Abstract type with information used when operating on a key that
  * has been unlocked.
  */
-interface KeyUnlockData
+interface KeyUnlockData {
+    /**
+     * The [SecureArea] containing the key for which this unlock data applies.
+     */
+    val secureArea: SecureArea
+
+    /**
+     * The alias of the key for which this unlock data applies.
+     */
+    val alias: String
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/PreloadedKeyUnlockDataProvider.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/PreloadedKeyUnlockDataProvider.kt
@@ -43,9 +43,38 @@ class PreloadedKeyUnlockDataProvider private constructor(
         private val map = mutableMapOf<Pair<String, String>, KeyUnlockData>()
 
         /**
+         * Adds a preloaded [KeyUnlockData].
+         *
+         * If [keyUnlockData] is `null` (e.g. when user authentication is not required),
+         * this method is a no-op.
+         *
+         * @param keyUnlockData the preloaded unlock data, or `null`.
+         * @return this builder.
+         */
+        fun add(keyUnlockData: KeyUnlockData?): Builder {
+            if (keyUnlockData != null) {
+                map[Pair(keyUnlockData.secureArea.identifier, keyUnlockData.alias)] = keyUnlockData
+            }
+            return this
+        }
+
+        /**
+         * Adds a list of preloaded [KeyUnlockData] items.
+         *
+         * @param keyUnlockDataList the list of preloaded unlock data items.
+         * @return this builder.
+         */
+        fun add(keyUnlockDataList: List<KeyUnlockData>): Builder {
+            for (keyUnlockData in keyUnlockDataList) {
+                add(keyUnlockData)
+            }
+            return this
+        }
+
+        /**
          * Adds a preloaded [KeyUnlockData] for a specific key in a [SecureArea].
          *
-         * If [keyUnlockData] is `null` (e.g. returned by [SecureArea.unlockKey] when user authentication is not required),
+         * If [keyUnlockData] is `null` (e.g. when user authentication is not required),
          * this method is a no-op.
          *
          * @param secureArea the Secure Area containing the key.
@@ -56,6 +85,21 @@ class PreloadedKeyUnlockDataProvider private constructor(
         fun add(secureArea: SecureArea, alias: String, keyUnlockData: KeyUnlockData?): Builder {
             if (keyUnlockData != null) {
                 map[Pair(secureArea.identifier, alias)] = keyUnlockData
+            }
+            return this
+        }
+
+        /**
+         * Adds a list of preloaded [KeyUnlockData] items for a specific key in a [SecureArea].
+         *
+         * @param secureArea the Secure Area containing the key.
+         * @param alias the alias of the key.
+         * @param keyUnlockDataList the list of preloaded unlock data items.
+         * @return this builder.
+         */
+        fun add(secureArea: SecureArea, alias: String, keyUnlockDataList: List<KeyUnlockData>): Builder {
+            for (keyUnlockData in keyUnlockDataList) {
+                add(keyUnlockData)
             }
             return this
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
@@ -210,13 +210,13 @@ interface SecureArea {
     /**
      * Unlocks a key requiring user authentication.
      *
-     * Returns `null` if user authentication is not required to unlock the key.
-     * Otherwise it performs user authentication and returns a [KeyUnlockData] object
+     * Returns an empty list if user authentication is not required to unlock the key.
+     * Otherwise, it performs user authentication and returns a list of [KeyUnlockData] objects
      * which can be stored in a [KeyUnlockDataProvider] and returned as appropriate.
      *
      * @param alias the alias of the key to unlock.
      * @param unlockReason the reason for unlocking.
-     * @return a [KeyUnlockData] if user authentication was required and performed, or `null` if not required.
+     * @return a list of [KeyUnlockData] objects if user authentication was required and performed, or empty list if not required.
      * @throws IllegalArgumentException if there is no key with the given alias.
      * @throws KeyLockedException if user authentication was canceled or failed.
      */
@@ -228,5 +228,5 @@ interface SecureArea {
     suspend fun unlockKey(
         alias: String,
         unlockReason: Reason = Reason.Unspecified
-    ): KeyUnlockData?
+    ): List<KeyUnlockData>
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudKeyUnlockData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudKeyUnlockData.kt
@@ -5,11 +5,12 @@ import org.multipaz.securearea.KeyUnlockData
 /**
  * A class to provide information used for unlocking a Cloud Secure Area key.
  *
+ * @param secureArea the [CloudSecureArea] containing the key.
  * @param alias the alias of the key to unlock.
  */
 class CloudKeyUnlockData(
-    private val cloudSecureArea: CloudSecureArea,
-    private val alias: String
+    override val secureArea: CloudSecureArea,
+    override val alias: String
 ) : KeyUnlockData {
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.buildByteString
@@ -86,6 +87,8 @@ import org.multipaz.prompt.PromptDismissedException
 import org.multipaz.prompt.PromptModel
 import org.multipaz.prompt.PromptModelNotAvailableException
 import org.multipaz.securearea.KeyUnlockDataProvider
+import org.multipaz.securearea.PreloadedKeyUnlockDataProvider
+import org.multipaz.securearea.buildPreloadedKeyUnlockDataProvider
 import org.multipaz.prompt.Reason
 import kotlin.random.Random
 import kotlin.time.Duration
@@ -925,19 +928,26 @@ open class CloudSecureArea protected constructor(
     override suspend fun unlockKey(
         alias: String,
         unlockReason: Reason
-    ): KeyUnlockData? {
+    ): List<KeyUnlockData> {
+        val list = mutableListOf<KeyUnlockData>()
         val keyInfo = getKeyInfo(alias)
-        if (!keyInfo.isPassphraseRequired) {
-            return null
+        if (keyInfo.isPassphraseRequired) {
+            val unlockDataProvider = currentCoroutineContext()[KeyUnlockDataProvider.Key]
+                ?: DefaultKeyUnlockDataProvider
+            val cloudUnlockData = unlockDataProvider.getKeyUnlockData(
+                secureArea = this,
+                alias = alias,
+                algorithm = keyInfo.algorithm,
+                unlockReason = unlockReason
+            )
+            list.add(cloudUnlockData)
         }
-        val unlockDataProvider = currentCoroutineContext()[KeyUnlockDataProvider.Key]
-            ?: DefaultKeyUnlockDataProvider
-        return unlockDataProvider.getKeyUnlockData(
-            secureArea = this,
-            alias = alias,
-            algorithm = keyInfo.algorithm,
+        val platformUnlockDataList = platformSecureArea.unlockKey(
+            alias = getLocalKeyAlias(alias),
             unlockReason = unlockReason
         )
+        list.addAll(platformUnlockDataList)
+        return list
     }
 
     private suspend fun saveKeyMetadata(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/config/SecureAreaConfigurationSoftware.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/config/SecureAreaConfigurationSoftware.kt
@@ -10,5 +10,9 @@ import org.multipaz.securearea.software.SoftwareSecureArea
 class SecureAreaConfigurationSoftware(
     algorithm: String = Algorithm.ESP256.name,
     val passphrase: String? = null,
-    val passphraseConstraints: PassphraseConstraints = PassphraseConstraints.NONE
+    val passphraseConstraints: PassphraseConstraints = PassphraseConstraints.NONE,
+    /** Whether user authentication is required. */
+    val userAuthenticationRequired: Boolean = false,
+    /** Bitmask of user authentication types. */
+    val userAuthenticationTypes: Long = 0
 ): SecureAreaConfiguration(algorithm)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareCreateKeySettings.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareCreateKeySettings.kt
@@ -21,10 +21,14 @@ class SoftwareCreateKeySettings internal constructor(
     val subject: String?,
     validFrom: Instant?,
     validUntil: Instant?,
-    val privateKey: EcPrivateKey?
+    val privateKey: EcPrivateKey?,
+    userAuthenticationRequired: Boolean = false,
+    /** The set of user authentication types required to use the key. */
+    val userAuthenticationTypes: Set<SoftwareUserAuthType> = emptySet()
 ) : CreateKeySettings(
     algorithm = algorithm,
     nonce = buildByteString {},
+    userAuthenticationRequired = userAuthenticationRequired,
     validFrom = validFrom,
     validUntil = validUntil
 ) {
@@ -40,6 +44,8 @@ class SoftwareCreateKeySettings internal constructor(
         private var validFrom: Instant? = null
         private var validUntil: Instant? = null
         private var privateKey: EcPrivateKey? = null
+        private var userAuthenticationRequired = false
+        private var userAuthenticationTypes = setOf<SoftwareUserAuthType>()
 
         /**
          * Apply settings from configuration object.
@@ -53,6 +59,10 @@ class SoftwareCreateKeySettings internal constructor(
                 required = configuration.passphrase != null,
                 passphrase = configuration.passphrase,
                 constraints = configuration.passphraseConstraints
+            )
+            setUserAuthenticationRequired(
+                required = configuration.userAuthenticationRequired,
+                types = SoftwareUserAuthType.decodeSet(configuration.userAuthenticationTypes)
             )
         }
 
@@ -87,6 +97,31 @@ class SoftwareCreateKeySettings internal constructor(
             passphraseRequired = required
             this.passphrase = passphrase
             this.passphraseConstraints = constraints
+        }
+
+        /**
+         * Specify if user authentication is required to use the key.
+         *
+         * By default, no user authentication is required.
+         *
+         * @param required True if user authentication is required, false otherwise.
+         * @param types a combination of the flags [SoftwareUserAuthType.PASSCODE]
+         *     and [SoftwareUserAuthType.BIOMETRIC]. Cannot be empty if [required] is `true`.
+         * @return the builder.
+         */
+        fun setUserAuthenticationRequired(
+            required: Boolean,
+            types: Set<SoftwareUserAuthType>
+        ) = apply {
+            userAuthenticationRequired = required
+            if (userAuthenticationRequired) {
+                userAuthenticationTypes = types
+                check(!userAuthenticationTypes.isEmpty()) {
+                    "userAuthenticationTypes cannot be empty if user authentication is required"
+                }
+            } else {
+                userAuthenticationTypes = emptySet()
+            }
         }
 
         /**
@@ -132,7 +167,8 @@ class SoftwareCreateKeySettings internal constructor(
          */
         fun build(): SoftwareCreateKeySettings {
             return SoftwareCreateKeySettings(
-                passphraseRequired, passphrase, passphraseConstraints, algorithm, subject, validFrom, validUntil, privateKey
+                passphraseRequired, passphrase, passphraseConstraints, algorithm, subject, validFrom, validUntil, privateKey,
+                userAuthenticationRequired, userAuthenticationTypes
             )
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareKeyInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareKeyInfo.kt
@@ -11,6 +11,8 @@ import org.multipaz.securearea.PassphraseConstraints
  *
  * @param isPassphraseProtected whether the key is passphrase protected.
  * @param passphraseConstraints constraints on the passphrase, if any.
+ * @param isUserAuthenticationRequired whether user authentication is required.
+ * @param userAuthenticationTypes user authentication types permitted.
  */
 class SoftwareKeyInfo internal constructor(
     alias: String,
@@ -18,7 +20,9 @@ class SoftwareKeyInfo internal constructor(
     attestation: KeyAttestation,
     algorithm: Algorithm,
     val isPassphraseProtected: Boolean,
-    val passphraseConstraints: PassphraseConstraints?
+    val passphraseConstraints: PassphraseConstraints?,
+    val isUserAuthenticationRequired: Boolean = false,
+    val userAuthenticationTypes: Set<SoftwareUserAuthType> = emptySet()
 ): KeyInfo(
     alias,
     algorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareKeyUnlockData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareKeyUnlockData.kt
@@ -1,12 +1,19 @@
 package org.multipaz.securearea.software
 
 import org.multipaz.securearea.KeyUnlockData
+import org.multipaz.securearea.SecureArea
 
 /**
  * A class that can be used to provide information used for unlocking a key.
  *
- * Currently only passphrases are supported.
- *
- * @param passphrase the passphrase.
+ * @param secureArea the [SoftwareSecureArea].
+ * @param alias the alias of the key.
+ * @param passphrase the passphrase or `null` if no passphrase is needed/provided.
+ * @param userAuthenticated whether the user was authenticated.
  */
-class SoftwareKeyUnlockData(val passphrase: String) : KeyUnlockData
+class SoftwareKeyUnlockData(
+    override val secureArea: SoftwareSecureArea,
+    override val alias: String,
+    val passphrase: String? = null,
+    val userAuthenticated: Boolean = false
+) : KeyUnlockData

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -87,6 +87,13 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             // If user passed in a generic SecureArea.CreateKeySettings, honor them.
             val builder = SoftwareCreateKeySettings.Builder()
                 .setAlgorithm(createKeySettings.algorithm)
+                .setUserAuthenticationRequired(
+                    required = createKeySettings.userAuthenticationRequired,
+                    types = setOf(
+                        SoftwareUserAuthType.PASSCODE,
+                        SoftwareUserAuthType.BIOMETRIC,
+                    )
+                )
             if (createKeySettings.validFrom != null && createKeySettings.validUntil != null) {
                 builder.setValidityPeriod(
                     validFrom = createKeySettings.validFrom,
@@ -115,7 +122,9 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
                     encryptedPrivateKey = ByteString(encryptedPrivateKey),
                     encryptedPrivateKeyIv = ByteString(iv),
                     encodedPublicKey = ByteString(encodedPublicKey),
-                    passphraseConstraints = settings.passphraseConstraints
+                    passphraseConstraints = settings.passphraseConstraints,
+                    userAuthenticationRequired = if (settings.userAuthenticationRequired) true else null,
+                    userAuthenticationTypes = if (settings.userAuthenticationRequired) settings.userAuthenticationTypes else null
                 )
             } else {
                 KeyMetadata(
@@ -125,7 +134,9 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
                     encryptedPrivateKey = null,
                     encryptedPrivateKeyIv = null,
                     encodedPublicKey = ByteString(encodedPublicKey),
-                    passphraseConstraints = null
+                    passphraseConstraints = null,
+                    userAuthenticationRequired = if (settings.userAuthenticationRequired) true else null,
+                    userAuthenticationTypes = if (settings.userAuthenticationRequired) settings.userAuthenticationTypes else null
                 )
             }
             val newAlias = storageTable.insert(
@@ -166,14 +177,22 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         alias: String,
         keyUnlockData: KeyUnlockData?
     ): KeyData {
-        var passphrase: String? = null
-        if (keyUnlockData != null) {
-            val unlockData = keyUnlockData as SoftwareKeyUnlockData
-            passphrase = unlockData.passphrase
-        }
         val data = storageTable.get(alias)
             ?: throw IllegalArgumentException("No key with given alias")
         val keyMetadata = KeyMetadata.fromCbor(data.toByteArray())
+
+        var passphrase: String? = null
+        var userAuthenticated = false
+        if (keyUnlockData != null) {
+            val unlockData = keyUnlockData as SoftwareKeyUnlockData
+            passphrase = unlockData.passphrase
+            userAuthenticated = unlockData.userAuthenticated
+        }
+
+        if (keyMetadata.userAuthenticationRequired == true && !userAuthenticated) {
+            throw KeyLockedException("User authentication required")
+        }
+
         val privateKey = if (keyMetadata.passphraseRequired) {
             if (passphrase == null) {
                 throw KeyLockedException("No passphrase provided")
@@ -286,7 +305,9 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
             KeyAttestation(publicKey, null),
             keyMetadata.algorithm,
             keyMetadata.passphraseRequired,
-            keyMetadata.passphraseConstraints
+            keyMetadata.passphraseConstraints,
+            keyMetadata.userAuthenticationRequired ?: false,
+            keyMetadata.userAuthenticationTypes ?: emptySet()
         )
     }
 
@@ -298,19 +319,20 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
     override suspend fun unlockKey(
         alias: String,
         unlockReason: Reason
-    ): KeyUnlockData? {
+    ): List<KeyUnlockData> {
         val keyInfo = getKeyInfo(alias)
-        if (!keyInfo.isPassphraseProtected) {
-            return null
+        if (!keyInfo.isPassphraseProtected && !keyInfo.isUserAuthenticationRequired) {
+            return emptyList()
         }
         val unlockDataProvider = currentCoroutineContext()[KeyUnlockDataProvider.Key]
             ?: DefaultKeyUnlockDataProvider
-        return unlockDataProvider.getKeyUnlockData(
+        val unlockData = unlockDataProvider.getKeyUnlockData(
             secureArea = this,
             alias = alias,
             algorithm = keyInfo.algorithm,
             unlockReason = unlockReason
         )
+        return listOf(unlockData)
     }
 
     object DefaultKeyUnlockDataProvider: KeyUnlockDataProvider {
@@ -322,34 +344,60 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         ): KeyUnlockData {
             secureArea as SoftwareSecureArea
             val keyInfo = secureArea.getKeyInfo(alias)
-            val constraints = keyInfo.passphraseConstraints ?: PassphraseConstraints.NONE
-            val promptModel = try {
-                PromptModel.get()
-            } catch (_: PromptModelNotAvailableException) {
-                throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
-            }
-            val passphrase = try {
-                promptModel.requestPassphrase(
-                    reason = unlockReason,
-                    passphraseConstraints = constraints,
-                    passphraseEvaluator = { enteredPassphrase: String ->
-                        try {
-                            secureArea.loadKey(alias, SoftwareKeyUnlockData(enteredPassphrase))
-                            PassphraseEvaluation.OK
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            PassphraseEvaluation.TryAgain
+
+            var passphrase: String? = null
+            if (keyInfo.isPassphraseProtected) {
+                val constraints = keyInfo.passphraseConstraints ?: PassphraseConstraints.NONE
+                val promptModel = try {
+                    PromptModel.get()
+                } catch (_: PromptModelNotAvailableException) {
+                    throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
+                }
+                passphrase = try {
+                    promptModel.requestPassphrase(
+                        reason = unlockReason,
+                        passphraseConstraints = constraints,
+                        passphraseEvaluator = { enteredPassphrase: String ->
+                            try {
+                                secureArea.loadKey(
+                                    alias,
+                                    SoftwareKeyUnlockData(
+                                        secureArea,
+                                        alias,
+                                        passphrase = enteredPassphrase,
+                                        userAuthenticated = true
+                                    )
+                                )
+                                PassphraseEvaluation.OK
+                            } catch (e: Exception) {
+                                if (e is CancellationException) throw e
+                                PassphraseEvaluation.TryAgain
+                            }
                         }
-                    }
-                )
-            } catch (_: PromptDismissedException) {
-                throw KeyLockedException("User canceled passphrase prompt")
+                    )
+                } catch (_: PromptDismissedException) {
+                    throw KeyLockedException("User canceled passphrase prompt")
+                }
             }
-            return SoftwareKeyUnlockData(passphrase)
+
+            var userAuthenticated = false
+            if (keyInfo.isUserAuthenticationRequired) {
+                if (!softwareSecureAreaPerformUserAuth(alias, keyInfo.userAuthenticationTypes, unlockReason)) {
+                    throw KeyLockedException("User canceled authentication")
+                }
+                userAuthenticated = true
+            }
+
+            return SoftwareKeyUnlockData(
+                secureArea = secureArea,
+                alias = alias,
+                passphrase = passphrase,
+                userAuthenticated = userAuthenticated
+            )
         }
     }
 
-    @CborSerializable(schemaHash = "6ifPnbV5Efd5Yf9NLMh4wXHWIVySzLaTeJqnGxrPuzI")
+    @CborSerializable(schemaHash = "ynX90AswRRwe9nBZrFU1xWMrHvyDlMNcujDfkodkw58")
     internal data class KeyMetadata(
         val algorithm: Algorithm,
         val passphraseRequired: Boolean,
@@ -357,7 +405,9 @@ class SoftwareSecureArea private constructor(private val storageTable: StorageTa
         val encryptedPrivateKey: ByteString?,
         val encryptedPrivateKeyIv: ByteString?,
         val encodedPublicKey: ByteString,  // store as encoded CoseKey
-        val passphraseConstraints: PassphraseConstraints?
+        val passphraseConstraints: PassphraseConstraints?,
+        val userAuthenticationRequired: Boolean? = null,
+        val userAuthenticationTypes: Set<SoftwareUserAuthType>? = null
     ) {
         companion object
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureAreaPerformUserAuth.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureAreaPerformUserAuth.kt
@@ -1,0 +1,9 @@
+package org.multipaz.securearea.software
+
+import org.multipaz.prompt.Reason
+
+internal expect suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareUserAuthType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareUserAuthType.kt
@@ -1,0 +1,52 @@
+package org.multipaz.securearea.software
+
+/**
+ * An enumeration for different user authentication types when using [SoftwareSecureArea].
+ */
+enum class SoftwareUserAuthType(
+    /** The flag bit value for this authentication type. */
+    val flagValue: Long
+) {
+    /**
+     * Flag indicating that authentication is needed using the user's knowledge
+     * factor for Device Lock, e.g. passcode on iOS or LSKF on Android.
+     */
+    PASSCODE(1 shl 0),
+
+    /**
+     * Flag indicating that authentication is needed using the user's biometric.
+     */
+    BIOMETRIC(1 shl 1);
+
+    companion object {
+        /**
+         * Helper to encode a set of [SoftwareUserAuthType] as an integer.
+         */
+        fun encodeSet(types: Set<SoftwareUserAuthType>): Long {
+            var value = 0L
+            for (type in types) {
+                value = value or type.flagValue
+            }
+            return value
+        }
+
+        /**
+         * Helper to decode an integer into a set of [SoftwareUserAuthType].
+         *
+         * Bits not corresponding to an authentication type are ignored.
+         */
+        fun decodeSet(types: Long): Set<SoftwareUserAuthType> {
+            val result = mutableSetOf<SoftwareUserAuthType>()
+            for (type in SoftwareUserAuthType.values()) {
+                if ((types and type.flagValue) != 0L) {
+                    result.add(type)
+                }
+            }
+            return result
+        }
+    }
+}
+
+/** Decodes the number into a set of [SoftwareUserAuthType] */
+val Long.softwareUserAuthTypeSet: Set<SoftwareUserAuthType>
+    get() = SoftwareUserAuthType.decodeSet(this)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mpzpass/MpzPassTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mpzpass/MpzPassTest.kt
@@ -10,12 +10,61 @@ import org.multipaz.utopia.knowntypes.UtopiaMovieTicket
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.presentment.DocumentStoreTestHarness
 import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.software.SoftwareKeyUnlockData
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class MpzPassTest {
+
+    @Test
+    fun testUserAuthenticationRequiredExportImport() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+
+        val doc = harness.documentStore.createDocument(
+            displayName = "Driving license specimen",
+            typeDisplayName = "Utopia driving license",
+            cardArt = ByteString(1, 2, 3),
+        )
+        val credential = DrivingLicense.getDocumentType().createMdocCredentialWithSampleData(
+            document = doc,
+            secureArea = harness.softwareSecureArea,
+            createKeySettings = CreateKeySettings(userAuthenticationRequired = true),
+            dsKey = harness.dsKey,
+            signedAt = harness.signedAt,
+            validFrom = harness.validFrom,
+            validUntil = harness.validUntil,
+            expectedUpdate = null,
+            domain = "mdoc",
+        )
+        doc.edit { provisioned = true }
+
+        val pass = credential.exportToMpzPass(
+            SoftwareKeyUnlockData(
+                secureArea = harness.softwareSecureArea,
+                alias = credential.alias,
+                userAuthenticated = true
+            )
+        )
+        assertTrue(pass.userAuthenticationRequired)
+        assertEquals(
+            pass,
+            MpzPass.fromDataItem(pass.toDataItem())
+        )
+
+        val importedDoc = harness.documentStore.importMpzPass(
+            mpzPass = pass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
+        val importedCredential = importedDoc.getCredentials().first() as MdocCredential
+        val keyInfo = harness.softwareSecureArea.getKeyInfo(importedCredential.alias)
+        assertTrue(keyInfo.isUserAuthenticationRequired)
+    }
 
     @Test
     fun testIsoMdocExportImport() = runTest {
@@ -46,7 +95,12 @@ class MpzPassTest {
             MpzPass.fromDataItem(pass.toDataItem())
         )
 
-        val importedDoc = harness.documentStore.importMpzPass(pass)
+        val importedDoc = harness.documentStore.importMpzPass(
+            mpzPass = pass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
         assertEquals(importedDoc.mpzPassId, pass.uniqueId)
         assertEquals(importedDoc.mpzPassVersion, pass.version)
         assertNotEquals(doc.identifier, importedDoc.identifier)
@@ -95,7 +149,12 @@ class MpzPassTest {
             MpzPass.fromDataItem(pass.toDataItem())
         )
 
-        val importedDoc = harness.documentStore.importMpzPass(pass)
+        val importedDoc = harness.documentStore.importMpzPass(
+            mpzPass = pass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
         assertEquals(importedDoc.mpzPassId, pass.uniqueId)
         assertEquals(importedDoc.mpzPassVersion, pass.version)
         assertNotEquals(doc.identifier, importedDoc.identifier)
@@ -142,7 +201,12 @@ class MpzPassTest {
             MpzPass.fromDataItem(pass.toDataItem())
         )
 
-        val importedDoc = harness.documentStore.importMpzPass(pass)
+        val importedDoc = harness.documentStore.importMpzPass(
+            mpzPass = pass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
         assertEquals(importedDoc.mpzPassId, pass.uniqueId)
         assertEquals(importedDoc.mpzPassVersion, pass.version)
         assertNotEquals(doc.identifier, importedDoc.identifier)
@@ -188,7 +252,12 @@ class MpzPassTest {
             MpzPass.fromDataItem(pass.toDataItem())
         )
 
-        val importedDoc = harness.documentStore.importMpzPass(pass)
+        val importedDoc = harness.documentStore.importMpzPass(
+            mpzPass = pass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
         assertEquals(importedDoc.mpzPassId, pass.uniqueId)
         assertEquals(importedDoc.mpzPassVersion, pass.version)
         assertNotEquals(doc.identifier, importedDoc.identifier)
@@ -210,7 +279,12 @@ class MpzPassTest {
         val updatedPass = pass.copy(
             version = pass.version + 1
         )
-        val updatedDoc = harness.documentStore.importMpzPass(updatedPass)
+        val updatedDoc = harness.documentStore.importMpzPass(
+            mpzPass = updatedPass,
+            isoMdocDomain = "mdoc",
+            sdJwtVcDomain = "sdjwt",
+            keylessSdJwtVcDomain = "sdjwt-keyless"
+        )
         assertEquals(updatedDoc, importedDoc)
         assertEquals(updatedDoc.mpzPassId, updatedPass.uniqueId)
         assertEquals(updatedDoc.mpzPassVersion, updatedPass.version)
@@ -223,14 +297,24 @@ class MpzPassTest {
             exceptionClass = ImportMpzPassException::class,
             message = "Pass already imported at version 1 which is greater or equal to version 1"
         ) {
-            harness.documentStore.importMpzPass(updatedPassSameVersion)
+            harness.documentStore.importMpzPass(
+                mpzPass = updatedPassSameVersion,
+                isoMdocDomain = "mdoc",
+                sdJwtVcDomain = "sdjwt",
+                keylessSdJwtVcDomain = "sdjwt-keyless"
+            )
         }
         // Check older versions are rejected.
         assertFailsWith(
             exceptionClass = ImportMpzPassException::class,
             message = "Pass already imported at version 1 which is greater or equal to version 0"
         ) {
-            harness.documentStore.importMpzPass(pass)
+            harness.documentStore.importMpzPass(
+                mpzPass = pass,
+                isoMdocDomain = "mdoc",
+                sdJwtVcDomain = "sdjwt",
+                keylessSdJwtVcDomain = "sdjwt-keyless"
+            )
         }
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/securearea/PreloadedKeyUnlockDataProviderTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/securearea/PreloadedKeyUnlockDataProviderTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PreloadedKeyUnlockDataProviderTest {
 
@@ -34,15 +35,15 @@ class PreloadedKeyUnlockDataProviderTest {
         )
         sa.createKey("unlockedKey", CreateKeySettings())
 
-        val unlockData1 = SoftwareKeyUnlockData("pass1")
-        val unlockData2 = SoftwareKeyUnlockData("pass2")
-        val nullUnlockData = sa.unlockKey("unlockedKey")
-        assertNull(nullUnlockData)
+        val unlockData1 = SoftwareKeyUnlockData(sa, "key1", "pass1")
+        val unlockData2 = SoftwareKeyUnlockData(sa, "key2", "pass2")
+        val nullUnlockDataList = sa.unlockKey("unlockedKey")
+        assertTrue(nullUnlockDataList.isEmpty())
 
         val preloadedProvider = buildPreloadedKeyUnlockDataProvider {
             add(sa, "key1", unlockData1)
             add(sa, "key2", unlockData2)
-            add(sa, "unlockedKey", nullUnlockData)
+            add(sa, "unlockedKey", nullUnlockDataList)
         }
 
         withContext(preloadedProvider) {
@@ -97,7 +98,7 @@ class PreloadedKeyUnlockDataProviderTest {
                 alias: String,
                 algorithm: Algorithm,
                 unlockReason: Reason
-            ): KeyUnlockData = SoftwareKeyUnlockData("pass1")
+            ): KeyUnlockData = SoftwareKeyUnlockData(secureArea as SoftwareSecureArea, alias, "pass1")
         }
 
         val preloadedProvider = PreloadedKeyUnlockDataProvider.Builder()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
@@ -21,6 +21,7 @@ import org.multipaz.crypto.EcCurve
 import org.multipaz.securearea.software.SoftwareCreateKeySettings
 import org.multipaz.securearea.software.SoftwareKeyUnlockData
 import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.securearea.software.SoftwareUserAuthType
 import org.multipaz.storage.ephemeral.EphemeralStorage
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -113,18 +114,23 @@ class SoftwareSecureAreaTest {
     fun testEcKeyWithGenericCreateKeySettings() = runTest {
         val storage = EphemeralStorage()
         val ks = SoftwareSecureArea.create(storage)
-        val challenge = byteArrayOf(1, 2, 3)
         ks.createKey("testKey", CreateKeySettings())
         val keyInfo = ks.getKeyInfo("testKey")
         assertNotNull(keyInfo)
         assertEquals(Algorithm.ESP256, keyInfo.algorithm)
         assertEquals(EcCurve.P256, keyInfo.publicKey.curve)
         assertFalse(keyInfo.isPassphraseProtected)
+        assertFalse(keyInfo.isUserAuthenticationRequired)
         assertNull(keyInfo.passphraseConstraints)
 
-        // TODO: Check challenge.
-        //val cert = keyInfo.attestation.certificates[0].javaX509Certificate
-        //assertContentEquals(challenge, getChallenge(cert))
+        ks.createKey("userAuthKey", CreateKeySettings(userAuthenticationRequired = true))
+        val userAuthKeyInfo = ks.getKeyInfo("userAuthKey")
+        assertNotNull(userAuthKeyInfo)
+        assertTrue(userAuthKeyInfo.isUserAuthenticationRequired)
+        assertEquals(
+            setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC),
+            userAuthKeyInfo.userAuthenticationTypes
+        )
     }
 
     @Test
@@ -237,7 +243,7 @@ class SoftwareSecureAreaTest {
 
         // Try with the wrong passphrase. This should fail.
         try {
-            withContext(MockKeyUnlockDataProvider(SoftwareKeyUnlockData("wrongPassphrase"))) {
+            withContext(MockKeyUnlockDataProvider("wrongPassphrase")) {
                 ks.sign("testKey", dataToSign)
             }
             fail()
@@ -247,7 +253,7 @@ class SoftwareSecureAreaTest {
 
         // ... and with the right passphrase. This should work.
         val signature = try {
-            withContext(MockKeyUnlockDataProvider(SoftwareKeyUnlockData(passphrase))) {
+            withContext(MockKeyUnlockDataProvider(passphrase)) {
                 ks.sign(
                     "testKey",
                     dataToSign,
@@ -406,11 +412,11 @@ class SoftwareSecureAreaTest {
         val storage = EphemeralStorage()
         val sa = SoftwareSecureArea.create(storage)
 
-        // Key without passphrase requirement -> unlockKey returns null
+        // Key without passphrase requirement -> unlockKey returns empty list
         sa.createKey("unlockedKey", CreateKeySettings())
-        assertNull(sa.unlockKey("unlockedKey"))
+        assertTrue(sa.unlockKey("unlockedKey").isEmpty())
 
-        // Key with passphrase requirement -> unlockKey returns SoftwareKeyUnlockData when provider is present
+        // Key with passphrase requirement -> unlockKey returns list containing SoftwareKeyUnlockData when provider is present
         sa.createKey(
             "lockedKey",
             SoftwareCreateKeySettings.Builder()
@@ -418,23 +424,151 @@ class SoftwareSecureAreaTest {
                 .build()
         )
 
-        val unlockData = SoftwareKeyUnlockData("correctPassword")
-        withContext(MockKeyUnlockDataProvider(unlockData)) {
-            val result = sa.unlockKey("lockedKey")
-            assertNotNull(result)
+        withContext(MockKeyUnlockDataProvider(passphrase = "correctPassword")) {
+            val resultList = sa.unlockKey("lockedKey")
+            assertEquals(1, resultList.size)
+            val result = resultList.first()
             assertTrue(result is SoftwareKeyUnlockData)
             assertEquals("correctPassword", (result as SoftwareKeyUnlockData).passphrase)
         }
     }
 
+    @Test
+    fun testEcKeySigningWithUserAuthenticationRequired() = runTest {
+        val storage = EphemeralStorage()
+        val ks = SoftwareSecureArea.create(storage)
+        ks.createKey(
+            "testKey",
+            SoftwareCreateKeySettings.Builder()
+                .setUserAuthenticationRequired(true, setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC))
+                .build()
+        )
+        val keyInfo = ks.getKeyInfo("testKey")
+        assertNotNull(keyInfo)
+        assertEquals(Algorithm.ESP256, keyInfo.algorithm)
+        assertTrue(keyInfo.isUserAuthenticationRequired)
+        assertEquals(setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC), keyInfo.userAuthenticationTypes)
+        val dataToSign = byteArrayOf(4, 5, 6)
+
+        // Try without unlocking. This should fail.
+        try {
+            ks.sign("testKey", dataToSign)
+            fail("Should fail when user authentication is required and not provided")
+        } catch (e: KeyLockedException) {
+            // Expected path.
+        }
+
+        // Try with userAuthenticated = false. This should fail.
+        try {
+            withContext(MockKeyUnlockDataProvider(userAuthenticated = false)) {
+                ks.sign("testKey", dataToSign)
+            }
+            fail("Should fail when userAuthenticated is false")
+        } catch (e: KeyLockedException) {
+            // Expected path.
+        }
+
+        // Try with userAuthenticated = true. This should succeed.
+        val signature = try {
+            withContext(MockKeyUnlockDataProvider(userAuthenticated = true)) {
+                ks.sign("testKey", dataToSign)
+            }
+        } catch (e: KeyLockedException) {
+            throw AssertionError(e)
+        }
+
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
+        )
+    }
+
+    @Test
+    fun testEcKeySigningWithUserAuthenticationAndPassphrase() = runTest {
+        val storage = EphemeralStorage()
+        val ks = SoftwareSecureArea.create(storage)
+        val passphrase = "pass"
+        ks.createKey(
+            "testKey",
+            SoftwareCreateKeySettings.Builder()
+                .setPassphraseRequired(true, passphrase, null)
+                .setUserAuthenticationRequired(true, setOf(SoftwareUserAuthType.BIOMETRIC))
+                .build()
+        )
+        val keyInfo = ks.getKeyInfo("testKey")
+        assertTrue(keyInfo.isPassphraseProtected)
+        assertTrue(keyInfo.isUserAuthenticationRequired)
+        assertEquals(setOf(SoftwareUserAuthType.BIOMETRIC), keyInfo.userAuthenticationTypes)
+        val dataToSign = byteArrayOf(4, 5, 6)
+
+        // Wrong passphrase, userAuthenticated = true -> fails
+        try {
+            withContext(MockKeyUnlockDataProvider(passphrase = "wrong", userAuthenticated = true)) {
+                ks.sign("testKey", dataToSign)
+            }
+            fail("Should fail with wrong passphrase")
+        } catch (e: KeyLockedException) {
+            // Expected.
+        }
+
+        // Correct passphrase, userAuthenticated = false -> fails
+        try {
+            withContext(MockKeyUnlockDataProvider(passphrase = passphrase, userAuthenticated = false)) {
+                ks.sign("testKey", dataToSign)
+            }
+            fail("Should fail when userAuthenticated is false")
+        } catch (e: KeyLockedException) {
+            // Expected.
+        }
+
+        // Correct passphrase, userAuthenticated = true -> succeeds
+        val signature = withContext(MockKeyUnlockDataProvider(passphrase = passphrase, userAuthenticated = true)) {
+            ks.sign("testKey", dataToSign)
+        }
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
+        )
+    }
+
+    @Test
+    fun testUnlockKeyWithUserAuthentication() = runTest {
+        val storage = EphemeralStorage()
+        val sa = SoftwareSecureArea.create(storage)
+        sa.createKey(
+            "userAuthKey",
+            SoftwareCreateKeySettings.Builder()
+                .setUserAuthenticationRequired(true, setOf(SoftwareUserAuthType.PASSCODE))
+                .build()
+        )
+
+        withContext(MockKeyUnlockDataProvider(userAuthenticated = true)) {
+            val resultList = sa.unlockKey("userAuthKey")
+            assertEquals(1, resultList.size)
+            val result = resultList.first()
+            assertTrue(result is SoftwareKeyUnlockData)
+            assertTrue((result as SoftwareKeyUnlockData).userAuthenticated)
+        }
+    }
+
     private class MockKeyUnlockDataProvider(
-        val keyUnlockData: KeyUnlockData
+        val passphrase: String? = null,
+        val userAuthenticated: Boolean = false
     ): KeyUnlockDataProvider {
         override suspend fun getKeyUnlockData(
             secureArea: SecureArea,
             alias: String,
             algorithm: Algorithm,
             unlockReason: Reason
-        ): KeyUnlockData = keyUnlockData
+        ): KeyUnlockData = SoftwareKeyUnlockData(
+            secureArea = secureArea as SoftwareSecureArea,
+            alias = alias,
+            passphrase = passphrase,
+            userAuthenticated = userAuthenticated
+        )
     }
 }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveKeyUnlockData.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveKeyUnlockData.kt
@@ -8,5 +8,7 @@ import platform.LocalAuthentication.LAContext
  * @param authenticationContext platform native [LAContext](https://developer.apple.com/documentation/LocalAuthentication/LAContext) object.
  */
 class SecureEnclaveKeyUnlockData(
+    override val secureArea: SecureEnclaveSecureArea,
+    override val alias: String,
     val authenticationContext: LAContext = LAContext()
 ): KeyUnlockData

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
@@ -215,9 +215,9 @@ class SecureEnclaveSecureArea private constructor(
     override suspend fun unlockKey(
         alias: String,
         unlockReason: Reason
-    ): KeyUnlockData? {
+    ): List<KeyUnlockData> {
         // Biometric prompts are automatically shown by iOS when using Secure Enclave keys,
         // so explicit pre-unlock authentication is not required.
-        return null
+        return emptyList()
     }
 }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.ios.kt
@@ -1,0 +1,103 @@
+package org.multipaz.securearea.software
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.multipaz.prompt.PromptModel
+import org.multipaz.prompt.PromptModelNotAvailableException
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.KeyLockedException
+import org.multipaz.util.Logger
+import platform.LocalAuthentication.LAContext
+import platform.LocalAuthentication.LAAccessControlOperationUseItem
+import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthentication
+import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthenticationWithBiometrics
+import platform.Security.SecAccessControlCreateWithFlags
+import platform.Security.kSecAccessControlBiometryCurrentSet
+import platform.Security.kSecAccessControlDevicePasscode
+import platform.Security.kSecAccessControlUserPresence
+import platform.Security.kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+import kotlin.coroutines.resume
+
+private const val TAG = "SoftwareSecureArea"
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean {
+    val promptModel = try {
+        PromptModel.get()
+    } catch (_: PromptModelNotAvailableException) {
+        throw KeyLockedException("Key is locked and PromptModel is not available to unlock interactively")
+    }
+
+    val humanReadable = promptModel.toHumanReadable(unlockReason, null)
+    val localizedReason = if (humanReadable.subtitle.isNotBlank()) {
+        "${humanReadable.title} - ${humanReadable.subtitle}"
+    } else {
+        humanReadable.title
+    }
+
+    var flags = 0UL
+    if (userAuthenticationTypes.contains(SoftwareUserAuthType.PASSCODE) &&
+        userAuthenticationTypes.contains(SoftwareUserAuthType.BIOMETRIC)
+    ) {
+        flags = kSecAccessControlUserPresence
+    } else if (userAuthenticationTypes.contains(SoftwareUserAuthType.PASSCODE)) {
+        flags = kSecAccessControlDevicePasscode
+    } else if (userAuthenticationTypes.contains(SoftwareUserAuthType.BIOMETRIC)) {
+        flags = kSecAccessControlBiometryCurrentSet
+    } else {
+        flags = kSecAccessControlUserPresence
+    }
+
+    val accessControl = SecAccessControlCreateWithFlags(
+        allocator = null,
+        protection = kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        flags = flags,
+        error = null
+    )
+
+    return suspendCancellableCoroutine { continuation ->
+        val laContext = LAContext()
+        if (accessControl != null) {
+            laContext.evaluateAccessControl(
+                accessControl = accessControl,
+                operation = LAAccessControlOperationUseItem,
+                localizedReason = localizedReason
+            ) { success, error ->
+                if (continuation.isActive) {
+                    if (error != null) {
+                        Logger.d(TAG, "LAContext evaluateAccessControl error: ${error.localizedDescription}")
+                    }
+                    continuation.resume(success)
+                }
+            }
+        } else {
+            val requireBiometricsOnly = userAuthenticationTypes.contains(SoftwareUserAuthType.BIOMETRIC) &&
+                    !userAuthenticationTypes.contains(SoftwareUserAuthType.PASSCODE)
+            val policy = if (requireBiometricsOnly) {
+                LAPolicyDeviceOwnerAuthenticationWithBiometrics
+            } else {
+                LAPolicyDeviceOwnerAuthentication
+            }
+            if (requireBiometricsOnly) {
+                laContext.localizedFallbackTitle = ""
+            }
+            laContext.evaluatePolicy(
+                policy = policy,
+                localizedReason = localizedReason
+            ) { success, error ->
+                if (continuation.isActive) {
+                    if (error != null) {
+                        Logger.d(TAG, "LAContext evaluatePolicy error: ${error.localizedDescription}")
+                    }
+                    continuation.resume(success)
+                }
+            }
+        }
+    }
+}
+
+

--- a/multipaz/src/jsMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.js.kt
+++ b/multipaz/src/jsMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.js.kt
@@ -1,0 +1,12 @@
+package org.multipaz.securearea.software
+
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.KeyLockedException
+
+internal actual suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean {
+    throw KeyLockedException("User authentication is not supported on JS for SoftwareSecureArea")
+}

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.jvm.kt
@@ -1,0 +1,12 @@
+package org.multipaz.securearea.software
+
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.KeyLockedException
+
+internal actual suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean {
+    throw KeyLockedException("User authentication is not supported on JVM for SoftwareSecureArea")
+}

--- a/multipaz/src/wasmJsMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.wasmJs.kt
+++ b/multipaz/src/wasmJsMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.wasmJs.kt
@@ -1,0 +1,12 @@
+package org.multipaz.securearea.software
+
+import org.multipaz.prompt.Reason
+import org.multipaz.securearea.KeyLockedException
+
+internal actual suspend fun softwareSecureAreaPerformUserAuth(
+    alias: String,
+    userAuthenticationTypes: Set<SoftwareUserAuthType>,
+    unlockReason: Reason
+): Boolean {
+    throw KeyLockedException("User authentication is not supported on WasmJS for SoftwareSecureArea")
+}

--- a/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.entitlements
+++ b/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.sorotokin.multipaz.testapp.sharedgroup</string>
+		<string>group.org.multipaz.testapp.sharedgroup</string>
 	</array>
 </dict>
 </plist>

--- a/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
+++ b/samples/testapp/iosApp/DocumentProviderExtension/DocumentProviderExtension.swift
@@ -100,21 +100,25 @@ func getPresentmentSource() async -> PresentmentSource {
         documentTypeRepository: documentTypeRepository,
         zkSystemRepository: zkSystemRepository,
         resolveTrustFn: { requester in
-            if let certChain = requester.certChain {
+            for requesterIdentity in requester.requesterIdentities {
+                let certChain = requesterIdentity.certChain
                 let result = try! await readerTrustManager.verify(
                     chain: certChain.certificates,
                     atTime: KotlinClockCompanion().getSystem().now()
                 )
-                if result.isTrusted {
-                    return result.trustPoints.first?.metadata
+                if result.isTrusted && result.trustPoints.first != nil {
+                    return TrustedRequesterIdentity(
+                        identity: requesterIdentity,
+                        trustMetadata: result.trustPoints.first!.metadata
+                    )
                 }
             }
             return nil
         },
-        showConsentPromptFn: { requester, trustMetadata, consentData, preselectedDocuments, onDocumentsInFocus in
+        showConsentPromptFn: { requester, trustedRequesterIdentity, consentData, preselectedDocuments, onDocumentsInFocus in
             try! await promptModelSilentConsent(
                 requester: requester,
-                trustMetadata: trustMetadata,
+                trustedRequesterIdentity: trustedRequesterIdentity,
                 consentData: consentData,
                 preselectedDocuments: preselectedDocuments,
                 onDocumentsInFocus: { documents in onDocumentsInFocus(documents) }
@@ -123,8 +127,8 @@ func getPresentmentSource() async -> PresentmentSource {
         preferSignatureToKeyAgreement: false,
         domainsMdocSignature: [TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_USER_AUTH],
         domainsMdocKeyAgreement: [TestAppUtils.shared.CREDENTIAL_DOMAIN_MDOC_MAC_USER_AUTH],
-        domainsKeylessSdJwt: [],
-        domainsKeyBoundSdJwt: []
+        domainsKeylessSdJwt: [TestAppUtils.shared.CREDENTIAL_DOMAIN_SDJWT_KEYLESS],
+        domainsKeyBoundSdJwt: [TestAppUtils.shared.CREDENTIAL_DOMAIN_SDJWT_USER_AUTH]
     )
 }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DocumentStoreScreen.kt
@@ -59,9 +59,13 @@ import kotlinx.serialization.json.Json
 import org.multipaz.compose.cards.CardCarousel
 import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.crypto.Algorithm
-import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.JsonWebSignature
 import org.multipaz.crypto.X509CertChain
+import org.multipaz.cbor.Cbor
+import org.multipaz.compose.pickers.rememberFilePicker
+import org.multipaz.mpzpass.MpzPass
+import org.multipaz.securearea.software.SoftwareUserAuthType
 import org.multipaz.testapp.TestAppConfiguration
 import org.multipaz.util.Logger
 import org.multipaz.util.Platform
@@ -108,6 +112,32 @@ fun DocumentStoreScreen(
     val showProvisioningResult = remember { mutableStateOf<AnnotatedString?>(null) }
     val userAuthenticationTimeout = remember { mutableStateOf<Duration?>(10.seconds) }
     val documentInfos = documentModel.documentInfos.collectAsState().value
+
+    val mpzPassFilePicker = rememberFilePicker(
+        types = listOf("*/*"),
+        allowMultiple = false,
+        onResult = { files ->
+            if (files.isNotEmpty()) {
+                val fileBytes = files.first().toByteArray()
+                coroutineScope.launch {
+                    try {
+                        val mpzPass = MpzPass.fromDataItem(Cbor.decode(fileBytes))
+                        val doc = documentStore.importMpzPass(
+                            mpzPass = mpzPass,
+                            isoMdocDomain = TestAppUtils.CREDENTIAL_DOMAIN_MDOC_SOFTWARE,
+                            sdJwtVcDomain = TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_SOFTWARE,
+                            keylessSdJwtVcDomain = TestAppUtils.CREDENTIAL_DOMAIN_SDJWT_KEYLESS
+                        )
+                        showToast("Imported pass '${doc.displayName ?: doc.identifier}' successfully")
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        e.printStackTrace()
+                        showToast("Error importing pass: ${e.message}")
+                    }
+                }
+            }
+        }
+    )
 
     val showDocumentCreationDialog = remember { mutableStateOf(false) }
     if (showDocumentCreationDialog.value) {
@@ -319,6 +349,13 @@ fun DocumentStoreScreen(
         }
         item {
             TextButton(onClick = {
+                mpzPassFilePicker.launch()
+            }) {
+                Text(text = "Import MpzPass")
+            }
+        }
+        item {
+            TextButton(onClick = {
                 coroutineScope.launch {
                     if (deviceKeyMacAlgorithm.value != Algorithm.UNSET && !TestAppConfiguration.platformSecureAreaHasKeyAgreement) {
                         showToast("Platform Secure Area does not have Key Agreement support. " +
@@ -368,6 +405,7 @@ fun DocumentStoreScreen(
                             SoftwareCreateKeySettings.Builder()
                                 .setAlgorithm(algorithm)
                                 .setPassphraseRequired(true, "1111", PassphraseConstraints.PIN_FOUR_DIGITS)
+                                .setUserAuthenticationRequired(true, setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC))
                                 .build()
                         },
                         dsKey = dsKey,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SoftwareSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SoftwareSecureAreaScreen.kt
@@ -24,6 +24,8 @@ import kotlin.time.Clock
 import org.multipaz.crypto.Algorithm
 import org.multipaz.prompt.Reason
 
+import org.multipaz.securearea.software.SoftwareUserAuthType
+
 private val TAG = "SoftwareSecureAreaScreen"
 
 @Composable
@@ -41,13 +43,33 @@ fun SoftwareSecureAreaScreen(
             Text(text = "Implementation: ${Crypto.provider}")
         }
         for (algorithm in softwareSecureArea.supportedAlgorithms) {
-            for ((passphraseRequired, description) in arrayOf(
-                Pair(true, "- Passphrase"),
-                Pair(false, ""),
+            for ((passphraseRequired, userAuthTypes, description) in arrayOf(
+                Triple(false, emptySet<SoftwareUserAuthType>(), ""),
+                Triple(true, emptySet<SoftwareUserAuthType>(), "- Passphrase"),
+                Triple(
+                    false,
+                    setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC),
+                    "- User Auth (Passcode or Biometric)"
+                ),
+                Triple(
+                    false,
+                    setOf(SoftwareUserAuthType.PASSCODE),
+                    "- User Auth (Passcode only)"
+                ),
+                Triple(
+                    false,
+                    setOf(SoftwareUserAuthType.BIOMETRIC),
+                    "- User Auth (Biometric only)"
+                ),
+                Triple(
+                    true,
+                    setOf(SoftwareUserAuthType.PASSCODE, SoftwareUserAuthType.BIOMETRIC),
+                    "- Passphrase & User Auth"
+                ),
             )) {
-                // For brevity, only do passphrase for P-256 Signature and P-256 Key Agreement)
+                // For brevity, only do passphrase / user auth for P-256 Signature and P-256 Key Agreement
                 if (algorithm.curve!! != EcCurve.P256) {
-                    if (passphraseRequired) {
+                    if (passphraseRequired || userAuthTypes.isNotEmpty()) {
                         continue;
                     }
                 }
@@ -69,6 +91,7 @@ fun SoftwareSecureAreaScreen(
                                 } else {
                                     null
                                 },
+                                userAuthTypes = userAuthTypes,
                                 showToast = showToast
                             )
                         }
@@ -90,13 +113,14 @@ private suspend fun swTest(
     algorithm: Algorithm,
     passphrase: String?,
     passphraseConstraints: PassphraseConstraints?,
+    userAuthTypes: Set<SoftwareUserAuthType>,
     showToast: (message: String) -> Unit) {
     Logger.d(
         TAG,
-        "swTest algorithm:$algorithm passphrase:$passphrase"
+        "swTest algorithm:$algorithm passphrase:$passphrase userAuthTypes:$userAuthTypes"
     )
     try {
-        swTestUnguarded(softwareSecureArea, algorithm, passphrase, passphraseConstraints, showToast)
+        swTestUnguarded(softwareSecureArea, algorithm, passphrase, passphraseConstraints, userAuthTypes, showToast)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         e.printStackTrace();
@@ -109,6 +133,7 @@ private suspend fun swTestUnguarded(
     algorithm: Algorithm,
     passphrase: String?,
     passphraseConstraints: PassphraseConstraints?,
+    userAuthTypes: Set<SoftwareUserAuthType>,
     showToast: (message: String) -> Unit) {
 
     val builder = SoftwareCreateKeySettings.Builder()
@@ -116,14 +141,18 @@ private suspend fun swTestUnguarded(
     if (passphrase != null) {
         builder.setPassphraseRequired(true, passphrase, passphraseConstraints)
     }
+    if (userAuthTypes.isNotEmpty()) {
+        builder.setUserAuthenticationRequired(
+            true,
+            userAuthTypes
+        )
+    }
 
     softwareSecureArea.createKey("testKey", builder.build())
 
     val unlockReason = Reason.HumanReadable(
-        title = "Enter Knowledge Factor",
-        subtitle = "This is used to decrypt the private key material. " +
-                "In this sample the knowledge factor is '1111' but try " +
-                "entering something else to check out error handling",
+        title = "Authentication Required",
+        subtitle = "Authentication is required to use this software-backed key",
         requireConfirmation = false
     )
 

--- a/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/org/multipaz/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
@@ -149,7 +149,11 @@ private suspend fun seTestUnguarded(
     val laContext = platform.LocalAuthentication.LAContext()
     laContext.localizedReason = "Authenticate to use key"
 
-    val keyUnlockData = SecureEnclaveKeyUnlockData(laContext)
+    val keyUnlockData = SecureEnclaveKeyUnlockData(
+        secureArea = secureEnclaveSecureArea,
+        alias = "testKey",
+        authenticationContext = laContext
+    )
 
     if (algorithm.isSigning) {
         val dataToSign = "data".encodeToByteArray()


### PR DESCRIPTION
Add support for requiring platform user authentication (passcode or biometrics) when creating keys in `SoftwareSecureArea`. Introduce `SoftwareUserAuthType` enum to represent passcode and biometric options, and update `SoftwareCreateKeySettings` and `SoftwareKeyInfo` to specify and report user authentication requirements while maintaining backwards compatibility in `SoftwareSecureArea.KeyMetadata`. Implement `softwareSecureAreaPerformUserAuth()` on Android using `AndroidPromptModel` and on iOS using Apple's LocalAuthentication and Security frameworks via `SecAccessControlCreateWithFlags()` and `LAContext.evaluateAccessControl()`. Update the default key unlock provider in `SoftwareSecureArea` to prompt for passphrase first, then perform platform user authentication second.

Refactor `SecureArea.unlockKey()` to return a `List<KeyUnlockData>` so that composite secure areas can return unlock data for both cloud and platform hardware keys. Update `KeyUnlockData` with `secureArea` and `alias` properties, and update `PreloadedKeyUnlockDataProvider.Builder` to map each key unlock data item by its target secure area and alias. Fix Cloud Secure Area attestation by updating root identity generation in `ServerIdentity` to validate that cached root certificates in `RootSigningKeyData` have a basicConstraints path length of at least 1, automatically deleting and regenerating stale root certificates if path length constraints are violated, and verifying intermediate CA certificate validity in `EnrollmentImpl`.

Add `userAuthenticationRequired` optional boolean field support to the `.mpzpass` CDDL specification and update `MpzPass` to encode and decode this field. Update credential export implementations in `MdocCredential` and `KeyBoundSdJwtVcCredential` to propagate `userAuthenticationRequired` from key metadata. Update `importMpzPass()` in `DocumentStore` to create `SoftwareSecureArea` keys with user authentication required when specified in the pass, and update `mpzpass/README.md` to specify HTTP GET with `If-None-Match: "<version>"` header and HTTP 304 Not Modified status code for updates.

Update `MpzPassCreatorComponent` and `MpzPassDecoderComponent` in `multipaz-tools` to support viewing and generating passes with `userAuthenticationRequired`. Add an "Import MpzPass" button to `DocumentStoreScreen` in the sample test app and update the sample app UI combinations to test various user authentication settings. Force `BouncyCastleProvider` to the top of the security provider list during `CloudSecureAreaServer` startup in `ApplicationExt`.

Fixes #1887.

Test: Manually tested on both iOS and Android.
Test: Manually tested with double-tap NFC presentment using Software and Cloud Secure Areas.
Test: ./gradlew check and xcodebuild -project samples/testapp/iosApp/TestApp.xcodeproj -scheme TestApp -sdk iphonesimulator build
