### PR TITLE
Add card selection callback and custom UI slot to quick wallet chooser.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ The following rules apply when being asked to generate a commit.
 * The commit message should detail the changes being committed, not all the prompts that led to here. This includes changes to the source that was done by others, for example the human driving the AI.
 * Commit messages must be detailed and to the point. If referring to classes or types in the project enclose it in backticks, if referring to function or method names use trailing open and close parenthesis. 
 * First line of the commit message must end in a period and be no longer than 72 characters and should avoid using type or function names. 
+* Commit messages should use line breaks and lines should not be larger than 80 characters, with exceptions to avoid breaking hyperlinks.
 * Commit messages must have a "Test:" stanza detailing how the change was tested. 
 * Commit messages have a Signed-off-by line.
 

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ComposeDocumentChooserData.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/ComposeDocumentChooserData.kt
@@ -1,0 +1,34 @@
+package org.multipaz.compose.prompt
+
+import android.app.PendingIntent
+import android.content.ComponentName
+import androidx.compose.runtime.Composable
+import org.multipaz.document.Document
+import org.multipaz.presentment.DocumentChooserData
+
+/**
+ * Data for configuring a document chooser with Compose Multiplatform UI slots.
+ *
+ * Extends [DocumentChooserData] to add composable UI slots when driving presentment with Compose.
+ *
+ * @property initiallySelectedDocumentId the document identifier to initially focus or `null`.
+ * @property openAppPendingIntentFn a function to create a [PendingIntent] to open the given document when the button is pressed.
+ * @property preferredService the services which should be preferred while an activity providing the UI for
+ *  [PresentmentModel] is in the foreground. See [PresentmentActivity] for an example.
+ * @property onDocumentSelected a callback invoked whenever a document is shown as selected or when no document is selected.
+ * @property documentSelectedContent optional composable content (e.g. `@Composable (documentId: String) -> Unit`) to
+ *   render for a document is selected in the document chooser. The content will appear below the instructions to the
+ *   user for holding closer to a reader to share.
+ */
+class ComposeDocumentChooserData(
+    initiallySelectedDocumentId: String?,
+    openAppPendingIntentFn: (document: Document) -> PendingIntent,
+    preferredService: ComponentName,
+    onDocumentSelected: ((documentId: String?) -> Unit)? = null,
+    val documentSelectedContent: (@Composable (documentId: String) -> Unit)? = null
+) : DocumentChooserData(
+    initiallySelectedDocumentId = initiallySelectedDocumentId,
+    openAppPendingIntentFn = openAppPendingIntentFn,
+    preferredService = preferredService,
+    onDocumentSelected = onDocumentSelected
+)

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -30,6 +30,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -170,20 +172,27 @@ class PresentmentActivity: FragmentActivity() {
          * for when the user presses the "Open Wallet" button.
          * @param preferredService the [ComponentName]s which will be preferred over other
          * services. This is used in [onResume] to pass to [CardEmulation.setPreferredService].
+         * @param onDocumentSelected a callback invoked whenever a document is shown as selected
+         * (with non-null document ID) or when no document is selected (with null).
+         * @param documentSelectedContent optional composable content rendered below the buttons when a document is selected.
          */
         fun getPendingIntent(
             source: PresentmentSource,
             initiallySelectedDocumentId: String?,
             openWalletAppPendingIntentFn: (document: Document) -> PendingIntent,
-            preferredService: ComponentName
+            preferredService: ComponentName,
+            onDocumentSelected: ((documentId: String?) -> Unit)? = null,
+            documentSelectedContent: (@Composable (documentId: String) -> Unit)? = null
         ): PendingIntent {
             presentmentModel.reset(
                 source = source,
                 preselectedDocuments = emptyList(),
-                showDocumentChooser = DocumentChooserData(
+                showDocumentChooser = ComposeDocumentChooserData(
                     initiallySelectedDocumentId = initiallySelectedDocumentId,
                     openAppPendingIntentFn = openWalletAppPendingIntentFn,
-                    preferredService = preferredService
+                    preferredService = preferredService,
+                    onDocumentSelected = onDocumentSelected,
+                    documentSelectedContent = documentSelectedContent
                 )
             )
 
@@ -419,14 +428,21 @@ internal fun PresentmentActivityContent(
                             documentModel = documentModel!!,
                             initiallySelectedDocumentId = presentmentModel!!.showDocumentChooser!!.initiallySelectedDocumentId,
                             selectedDocIdFromCardChooser = selectedDocIdFromCardChooser,
-                            contentBelow = {
+                            onDocumentSelected = presentmentModel!!.showDocumentChooser!!.onDocumentSelected,
+                            contentBelow = { documentId ->
                                 Column(
-                                    modifier = Modifier.fillMaxHeight(),
-                                    horizontalAlignment = Alignment.CenterHorizontally
+                                    modifier = Modifier
+                                        .fillMaxHeight()
+                                        .verticalScroll(rememberScrollState()),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.SpaceBetween
                                 ) {
                                     val isNfcOnly by presentmentModel!!.isNfcOnly.collectAsState()
                                     ShowHoldToReader(isNfcOnly = isNfcOnly)
-                                    Spacer(modifier = Modifier.weight(1.0f))
+                                    val customContent = (presentmentModel!!.showDocumentChooser as? ComposeDocumentChooserData)?.documentSelectedContent
+                                    if (customContent != null) {
+                                        customContent(documentId)
+                                    }
                                     Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -444,7 +460,7 @@ internal fun PresentmentActivityContent(
                                                     switchToAppOnFinishPendingIntent =
                                                         presentmentModel!!.showDocumentChooser!!.openAppPendingIntentFn(
                                                             presentmentModel!!.source.documentStore.lookupDocument(
-                                                                selectedDocIdFromCardChooser.value!!
+                                                                documentId
                                                             )!!
                                                         )
                                                     startFadeOut = true
@@ -465,6 +481,7 @@ internal fun PresentmentActivityContent(
                             }
                         )
                     } else {
+                        val docsToShow = presentmentModel!!.documentsSelected.collectAsState().value
                         val docIdToShow =
                             docsToShow.firstOrNull()?.identifier ?: selectedDocIdFromCardChooser.value
                         ShowCard(
@@ -574,7 +591,8 @@ private fun ShowCardChooser(
     documentModel: DocumentModel,
     initiallySelectedDocumentId: String?,
     selectedDocIdFromCardChooser: MutableState<String?>,
-    contentBelow: @Composable () -> Unit
+    onDocumentSelected: ((documentId: String?) -> Unit)?,
+    contentBelow: @Composable (documentId: String) -> Unit
 ) {
     val configuration = LocalConfiguration.current
     val maxCardHeight = configuration.screenHeightDp.dp / 3
@@ -586,9 +604,11 @@ private fun ShowCardChooser(
     val focusedDocument = docInfos.find { documentInfo ->
         documentInfo.document.identifier == focusedDocumentId
     }
+    val currentSelectedDocId = focusedDocument?.document?.identifier
 
-    LaunchedEffect(Unit) {
-        selectedDocIdFromCardChooser.value = focusedDocumentId
+    LaunchedEffect(currentSelectedDocId) {
+        selectedDocIdFromCardChooser.value = currentSelectedDocId
+        onDocumentSelected?.invoke(currentSelectedDocId)
     }
 
     VerticalCardList(
@@ -598,7 +618,7 @@ private fun ShowCardChooser(
         allowCardReordering = false,
         showStackWhileFocused = true,
         cardMaxHeight = maxCardHeight,
-        showCardInfo = { cardInfo -> contentBelow() },
+        showCardInfo = { cardInfo -> contentBelow(cardInfo.identifier) },
         emptyContent = {
             Text(stringResource(
                 Res.string.presentment_activity_no_documents_available
@@ -607,15 +627,12 @@ private fun ShowCardChooser(
         onCardFocused = { cardInfo ->
             val documentInfo = cardInfo as DocumentInfo
             focusedDocumentId = documentInfo.document.identifier
-            selectedDocIdFromCardChooser.value = documentInfo.document.identifier
         },
         onCardFocusedTapped = { _ ->
             focusedDocumentId = null
-            selectedDocIdFromCardChooser.value = null
         },
         onCardFocusedStackTapped = {
             focusedDocumentId = null
-            selectedDocIdFromCardChooser.value = null
         }
     )
 }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/presentment/DocumentChooserData.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/presentment/DocumentChooserData.android.kt
@@ -14,9 +14,13 @@ import org.multipaz.document.DocumentBadge
  * @property openAppPendingIntentFn a function to create a [PendingIntent] to open the given document when the button is pressed.
  * @property preferredService the services which should be preferred while an activity providing the UI for
  *  [PresentmentModel] is in the foreground. See [PresenmentActivity] in the multipaz-compose library for an example.
+ * @property onDocumentSelected a callback invoked whenever a document is shown as selected or when no document is selected.
  */
-actual data class DocumentChooserData(
+actual open class DocumentChooserData(
     val initiallySelectedDocumentId: String?,
     val openAppPendingIntentFn: (document: Document) -> PendingIntent,
-    val preferredService: ComponentName
+    val preferredService: ComponentName,
+    val onDocumentSelected: ((documentId: String?) -> Unit)? = null
 )
+
+

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/DocumentChooserData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/DocumentChooserData.kt
@@ -3,4 +3,4 @@ package org.multipaz.presentment
 /**
  * Data used to configure the document chooser used in [PresentmentModel].
  */
-expect class DocumentChooserData
+expect open class DocumentChooserData

--- a/multipaz/src/iosMain/kotlin/org/multipaz/presentment/DocumentChooserData.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/presentment/DocumentChooserData.ios.kt
@@ -3,4 +3,4 @@ package org.multipaz.presentment
 /**
  * Not implemented for iOS at this point.
  */
-actual class DocumentChooserData
+actual open class DocumentChooserData

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/presentment/DocumentChooserData.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/presentment/DocumentChooserData.jvm.kt
@@ -3,4 +3,4 @@ package org.multipaz.presentment
 /**
  * Not implemented for JVM platform at this point.
  */
-actual class DocumentChooserData
+actual open class DocumentChooserData

--- a/multipaz/src/webMain/kotlin/org/multipaz/presentment/DocumentChooserData.web.kt
+++ b/multipaz/src/webMain/kotlin/org/multipaz/presentment/DocumentChooserData.web.kt
@@ -3,4 +3,4 @@ package org.multipaz.presentment
 /**
  * Not implemented for web-based platforms at this point.
  */
-actual class DocumentChooserData
+actual open class DocumentChooserData

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppConfiguration.android.kt
@@ -12,6 +12,20 @@ import org.multipaz.securearea.AndroidKeystoreSecureArea
 import multipazproject.samples.testapp.generated.resources.Res
 import multipazproject.samples.testapp.generated.resources.app_icon
 import multipazproject.samples.testapp.generated.resources.app_icon_red
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.multipaz.compose.notifications.NotificationManagerAndroid
 import org.multipaz.compose.prompt.PresentmentActivity
@@ -93,6 +107,28 @@ actual object TestAppConfiguration {
     fun getPendingIntentForLaunchingQuickAccessWallet(
         source: PresentmentSource,
         initiallySelectedDocumentId: String?,
+        onDocumentSelected: ((documentId: String?) -> Unit)? = { documentId ->
+            Logger.i(TAG, "Quick Access Wallet card selected: $documentId")
+        },
+        documentSelectedContent: (@Composable (documentId: String) -> Unit)? = @Composable { documentId ->
+            var dummyState by remember { mutableStateOf(true) }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Example option for document",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1.0f)
+                )
+                Switch(
+                    checked = dummyState,
+                    onCheckedChange = { dummyState = it }
+                )
+            }
+        }
     ): PendingIntent {
         return PresentmentActivity.getPendingIntent(
             source = source,
@@ -113,7 +149,9 @@ actual object TestAppConfiguration {
                     /* flags = */ PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
             },
-            preferredService = ComponentName(applicationContext, TestAppCombinedNfcService::class.java)
+            preferredService = ComponentName(applicationContext, TestAppCombinedNfcService::class.java),
+            onDocumentSelected = onDocumentSelected,
+            documentSelectedContent = documentSelectedContent
         )
     }
 


### PR DESCRIPTION
Extend `DocumentChooserData` and `PresentmentActivity.getPendingIntent()` to accept an `onDocumentSelected` callback invoked whenever a card is focused or deselected, and a `documentSelectedContent` slot for rendering custom Compose UI for the selected document.

In `ShowCardChooser()`, trigger `onDocumentSelected` when the selected document ID changes. Update `PresentmentActivity` content layout to position the custom UI slot between the "Hold reader to share" prompt and the "Open Wallet" button. In `TestAppConfiguration.getPendingIntentForLaunchingQuickAccessWallet()`, provide an example `Switch` composable to demonstrate custom slot usage.

Fixes #1892.

Test: Manually tested.
Test: Ran `./gradlew :samples:testapp:assembleBlueDebug :multipaz:jvmTest`.
