### PR TITLE
skip nonce verification during payment processing for ISO 18013-5 proximity presentations

### DIFF
--- a/multipaz-records/src/main/java/org/multipaz/records/payment/PaymentProcessorImpl.kt
+++ b/multipaz-records/src/main/java/org/multipaz/records/payment/PaymentProcessorImpl.kt
@@ -24,7 +24,9 @@ import org.multipaz.trustmanagement.TrustManagerInterface
 import org.multipaz.util.Logger
 import org.multipaz.util.truncateToWholeSeconds
 import org.multipaz.utopia.knowntypes.DigitalPaymentCredential
+import org.multipaz.verification.Iso18013PresentmentRecord
 import org.multipaz.verification.MdocVerifiedPresentation
+import org.multipaz.verification.OpenID4VPPresentmentRecord
 import kotlin.math.roundToLong
 import kotlin.random.Random
 import kotlin.time.Clock
@@ -101,7 +103,10 @@ class PaymentProcessorImpl: PaymentProcessor, RpcAuthInspector by rpcAuth {
             ?: throw InvalidRequestException("Transaction '$transactionId' is invalid or expired")
         val draft = PaymentData.fromCbor(data.toByteArray())
 
-        presentmentRecord.verifyNonce(draft.nonce)
+        if (requiresNonceVerification(presentmentRecord)) {
+            presentmentRecord.verifyNonce(draft.nonce)
+        }
+
         if ((amount * 100).roundToLong() != (draft.amount * 100).roundToLong() || currency != draft.currency) {
             throw InvalidRequestException("Inconsistent transaction amount or currency")
         }
@@ -167,4 +172,27 @@ class PaymentProcessorImpl: PaymentProcessor, RpcAuthInspector by rpcAuth {
 
         private val transactionLock = Mutex()
     }
+}
+
+/**
+ * Whether [record]'s verifier nonce must be checked before committing a payment.
+ *
+ * Nonce verification binds a presentment to a specific verifier challenge. It applies to DC-API /
+ * OpenID4VP flows, which carry the nonce out of band — in `encryptionInfo` + `origin` for ISO
+ * 18013-5 over the Digital Credentials API, or in the VP request for OpenID4VP. ISO 18013-5
+ * *proximity* presentations (NFC/BLE/QR) carry neither, so there is no verifier nonce to fold into
+ * the session transcript; the equivalent anti-replay guarantee comes from the transport instead: a
+ * fresh ephemeral reader key per session yields a unique `SessionTranscript`, so a captured
+ * `DeviceResponse` fails device-signature verification if replayed, and the single-use,
+ * server-minted `transactionId` in the device-signed `transaction_data` binds the presentment to
+ * exactly one pending transaction.
+ *
+ * Fails closed: only a proximity [Iso18013PresentmentRecord] (both `encryptionInfo` and `origin`
+ * absent) skips the check; [OpenID4VPPresentmentRecord] and DC-API ISO always verify. Because
+ * [PresentmentRecord] is sealed and this `when` is exhaustive, adding a new subtype is a compile
+ * error here — forcing an explicit nonce-handling decision rather than silently defaulting.
+ */
+internal fun requiresNonceVerification(record: PresentmentRecord): Boolean = when (record) {
+    is Iso18013PresentmentRecord -> record.encryptionInfo != null || record.origin != null
+    is OpenID4VPPresentmentRecord -> true
 }

--- a/multipaz-records/src/test/java/org/multipaz/records/payment/RequiresNonceVerificationTest.kt
+++ b/multipaz-records/src/test/java/org/multipaz/records/payment/RequiresNonceVerificationTest.kt
@@ -1,0 +1,78 @@
+package org.multipaz.records.payment
+
+import kotlinx.io.bytestring.ByteString
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.verification.Iso18013PresentmentRecord
+import org.multipaz.verification.OpenID4VPPresentmentRecord
+import org.junit.Test
+
+/**
+ * Unit tests for [requiresNonceVerification], the gate that decides whether a presentment's verifier
+ * nonce is checked before a payment is committed. The security contract is fail-closed: only an ISO
+ * 18013-5 *proximity* record (no `encryptionInfo`, no `origin`) may skip the check; everything else
+ * must verify.
+ */
+class RequiresNonceVerificationTest {
+
+    // requiresNonceVerification never inspects these, so an empty CBOR array is a fine placeholder.
+    private fun isoRecord(encryptionInfo: ByteString?, origin: String?) =
+        Iso18013PresentmentRecord(
+            response = buildCborArray {},
+            sessionTranscript = buildCborArray {},
+            request = buildCborArray {},
+            eDeviceKey = null,
+            encryptionInfo = encryptionInfo,
+            origin = origin,
+        )
+
+    @Test
+    fun proximityIsoRecordSkipsNonceVerification() {
+        // NFC/BLE/QR proximity: neither encryptionInfo nor origin — anti-replay is transport-level.
+        assertFalse(requiresNonceVerification(isoRecord(encryptionInfo = null, origin = null)))
+    }
+
+    @Test
+    fun dcApiIsoRecordWithEncryptionInfoRequiresNonceVerification() {
+        assertTrue(
+            requiresNonceVerification(
+                isoRecord(encryptionInfo = ByteString(byteArrayOf(1, 2, 3)), origin = null)
+            )
+        )
+    }
+
+    @Test
+    fun dcApiIsoRecordWithOriginRequiresNonceVerification() {
+        assertTrue(
+            requiresNonceVerification(
+                isoRecord(encryptionInfo = null, origin = "https://verifier.example")
+            )
+        )
+    }
+
+    @Test
+    fun dcApiIsoRecordWithBothRequiresNonceVerification() {
+        assertTrue(
+            requiresNonceVerification(
+                isoRecord(
+                    encryptionInfo = ByteString(byteArrayOf(1, 2, 3)),
+                    origin = "https://verifier.example",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun openId4VpRecordRequiresNonceVerification() {
+        assertTrue(
+            requiresNonceVerification(
+                OpenID4VPPresentmentRecord(
+                    vpToken = "{}",
+                    vpRequest = "{}",
+                    mdocSessionTranscript = null,
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
`Iso18013PresentmentRecord#verifyNonce` was being called unconditionally and it required encryptionInfo and origin, throwing for any record lacking it. That assumption only holds for Digital Credentials API / OpenID4VP presentations, which carry both an encryptionInfo blob and a web origin so the verifier nonce can be folded into the session transcript.

ISO 18013-5 proximity presentations (NFC/BLE/QR) carry neither, so every proximity commit failed at the nonce check even though the presentation was otherwise valid. This PR modifies the code to skip nonce verification for a pure proximity record (both encryptionInfo and origin absent). the equivalent anti-replay guarantee comes from the transport layer — a fresh ephemeral reader key per session yields a unique SessionTranscript, so a captured DeviceResponse fails device-signature verification if replayed, and the single-use, server-minted transaction_id in the device-signed transaction_data binds the presentment to exactly one pending transaction.

Fixes #1897

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR