### PR TITLE
Add support for presenting multiple documents in presentment UI.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNdefService.kt
@@ -383,6 +383,7 @@ abstract class MdocNdefService(
         }
 
         try {
+            val preselectedDocuments = settings.presentmentModel?.documentsSelected?.value ?: emptyList()
             settings.presentmentModel?.setConnecting()
             Iso18013Presentment(
                 transport = transport,
@@ -391,6 +392,7 @@ abstract class MdocNdefService(
                 handover = handover,
                 source = settings.source,
                 keyAgreementPossible = listOf(eDeviceKey.curve),
+                preselectedDocuments = preselectedDocuments,
                 onWaitingForRequest = { settings.presentmentModel?.setWaitingForReader() },
                 onWaitingForUserInput = { settings.presentmentModel?.setWaitingForUserInput() },
                 onDocumentsInFocus = { documents ->

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/mdoc/MdocNfcV2Service.kt
@@ -445,12 +445,14 @@ abstract class MdocNfcV2Service(
         }
 
         try {
+            val preselectedDocuments = settings.presentmentModel?.documentsSelected?.value ?: emptyList()
             settings.presentmentModel?.setConnecting()
             Iso18013Presentment(
                 transport = transport,
                 engagementParams = engagementParamsFlow,
                 source = settings.source,
                 keyAgreementPossible = listOf(eDeviceKey.curve),
+                preselectedDocuments = preselectedDocuments,
                 insertSequenceNumbers = true,
                 onWaitingForRequest = { settings.presentmentModel?.setWaitingForReader() },
                 onWaitingForUserInput = { settings.presentmentModel?.setWaitingForUserInput() },

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -27,9 +28,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -54,11 +58,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.fragment.app.FragmentActivity
 import coil3.ImageLoader
 import coil3.network.ktor3.KtorNetworkFetcherFactory
@@ -78,6 +86,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.branding.Branding
+import org.multipaz.compose.cards.CardBadges
+import org.multipaz.compose.cards.CardView
 import org.multipaz.compose.cards.VerticalCardList
 import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.compose.document.DocumentModel
@@ -489,11 +499,14 @@ internal fun PresentmentActivityContent(
                         )
                     } else {
                         val docsToShow = presentmentModel!!.documentsSelected.collectAsState().value
-                        val docIdToShow =
-                            docsToShow.firstOrNull()?.identifier ?: selectedDocIdFromCardChooser.value
+                        val docIdsToShow = if (docsToShow.isNotEmpty()) {
+                            docsToShow.map { it.identifier }.distinct()
+                        } else {
+                            listOfNotNull(selectedDocIdFromCardChooser.value)
+                        }
                         ShowCard(
                             documentModel = documentModel!!,
-                            documentId = docIdToShow,
+                            documentIds = docIdsToShow,
                             contentBelow = {
                                 val isNfcConnected by presentmentModel!!.isNfcConnected.collectAsState()
                                 val isNfcOnly by presentmentModel!!.isNfcOnly.collectAsState()
@@ -561,29 +574,83 @@ internal fun PresentmentActivityContent(
     }
 }
 
+private const val STACKED_CARD_SCALE_PERCENT = 85
+
 @Composable
 private fun ShowCard(
     documentModel: DocumentModel,
-    documentId: String?,
+    documentIds: List<String>,
     contentBelow: @Composable () -> Unit
 ) {
     val configuration = LocalConfiguration.current
     val maxCardHeight = configuration.screenHeightDp.dp / 3
 
     val docInfos by documentModel.documentInfos.collectAsState()
-    val documentInfo = docInfos.find { it.document.identifier == documentId }
-    if (documentInfo != null) {
-        VerticalCardList(
-            cardInfos = docInfos,
-            focusedCard = documentInfo,
-            unfocusedVisiblePercent = 25,
-            allowCardReordering = false,
-            showStackWhileFocused = false,
-            cardMaxHeight = maxCardHeight,
-            showCardInfo = { cardInfo ->
+    val matchingDocInfos = remember(docInfos, documentIds) {
+        documentIds.mapNotNull { id -> docInfos.find { it.document.identifier == id } }.distinctBy { it.document.identifier }
+    }
+
+    if (matchingDocInfos.isNotEmpty()) {
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            val density = LocalDensity.current
+            val maxWidthDp = maxWidth
+            var cardWidthDp = maxWidthDp - 32.dp
+            var cardHeightDp = cardWidthDp / 1.586f
+            if (cardHeightDp > maxCardHeight) {
+                cardHeightDp = maxCardHeight
+                cardWidthDp = cardHeightDp * 1.586f
+            }
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Box(
+                    modifier = Modifier
+                        .width(cardWidthDp)
+                        .height(cardHeightDp),
+                    contentAlignment = Alignment.TopStart
+                ) {
+                    if (matchingDocInfos.size == 1) {
+                        val documentInfo = matchingDocInfos.first()
+                        CardView(
+                            cardInfo = documentInfo,
+                            modifier = Modifier.fillMaxSize(),
+                            shape = RoundedCornerShape(24.dp),
+                            elevation = 12.dp
+                        )
+                    } else {
+                        val cardCount = matchingDocInfos.size
+                        val scale = STACKED_CARD_SCALE_PERCENT / 100f
+                        val cardW = cardWidthDp * scale
+                        val cardH = cardHeightDp * scale
+                        val maxXOffset = cardWidthDp * (1.0f - scale)
+                        val maxYOffset = cardHeightDp * (1.0f - scale)
+
+                        matchingDocInfos.forEachIndexed { index, documentInfo ->
+                            val offsetX = maxXOffset * (index.toFloat() / (cardCount - 1))
+                            val offsetY = maxYOffset * (index.toFloat() / (cardCount - 1))
+                            CardView(
+                                cardInfo = documentInfo,
+                                modifier = Modifier
+                                    .offset(x = offsetX, y = offsetY)
+                                    .width(cardW)
+                                    .height(cardH)
+                                    .zIndex(index.toFloat()),
+                                shape = RoundedCornerShape((24 * scale).dp),
+                                elevation = 12.dp
+                            )
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(24.dp))
                 contentBelow()
             }
-        )
+        }
     } else {
         Column(
             modifier = Modifier.fillMaxSize()

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardView.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/CardView.kt
@@ -1,0 +1,61 @@
+package org.multipaz.compose.cards
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+
+/**
+ * A composable that displays a card's artwork with rounded corners, shadow elevation, and badges.
+ *
+ * @param cardInfo The [CardInfo] containing the artwork and badges to display.
+ * @param modifier The modifier to be applied to the card container.
+ * @param shape The shape for the rounded corners. Defaults to `RoundedCornerShape(24.dp)`.
+ * @param elevation The shadow elevation for the card. Defaults to `12.dp`.
+ * @param contentScale The content scale for the card art image. Defaults to `ContentScale.FillWidth`.
+ */
+@Composable
+fun CardView(
+    cardInfo: CardInfo,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(24.dp),
+    elevation: Dp = 12.dp,
+    contentScale: ContentScale = ContentScale.FillWidth
+) {
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                shadowElevation = elevation.toPx()
+                this.shape = shape
+                clip = false
+            }
+    ) {
+        Image(
+            bitmap = cardInfo.cardArt,
+            contentDescription = "Card Image",
+            contentScale = contentScale,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    this.shape = shape
+                    clip = true
+                }
+        )
+        CardBadges(
+            badges = cardInfo.badges,
+            elevation = 8.dp,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .zIndex(100f)
+        )
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/Iso18013Presentment.kt
@@ -40,6 +40,8 @@ private const val TAG = "Iso180135Presentment"
  * @param engagementParams a [StateFlow] providing the current engagement parameters.
  * @param source the source of truth for documents to present.
  * @param keyAgreementPossible curves available for key agreement.
+ * @param preselectedDocuments the list of documents the user may have preselected earlier or the
+ *   empty list if the user didn't preselect.
  * @param insertSequenceNumbers whether sequence numbers should be inserted in session messages.
  * @param timeout timeout for initial message.
  * @param timeoutSubsequentRequests timeout for subsequent messages.
@@ -61,6 +63,7 @@ suspend fun Iso18013Presentment(
     engagementParams: StateFlow<EngagementParams>,
     source: PresentmentSource,
     keyAgreementPossible: List<EcCurve>,
+    preselectedDocuments: List<Document> = emptyList(),
     insertSequenceNumbers: Boolean = false,
     timeout: Duration? = 15.seconds,
     timeoutSubsequentRequests: Duration? = 30.seconds,
@@ -208,6 +211,7 @@ suspend fun Iso18013Presentment(
                     keyAgreementPossible = keyAgreementPossible,
                     requesterAppId = null,
                     requesterOrigin = null,
+                    preselectedDocuments = preselectedDocuments,
                     onWaitingForUserInput = onWaitingForUserInput,
                     onDocumentsInFocus = onDocumentsInFocus
                 )
@@ -309,6 +313,22 @@ suspend fun Iso18013Presentment(
 
 /**
  * Performs proximity presentment according to ISO/IEC 18013-5:2021 using individual engagement parameters.
+ *
+ * @param transport the transport to use for communicating with the reader.
+ * @param eDeviceKey the ephemeral device key generated for engagement.
+ * @param deviceEngagement the encoded DeviceEngagement structure.
+ * @param handover the handover structure.
+ * @param source the source of truth for documents to present.
+ * @param keyAgreementPossible curves available for key agreement.
+ * @param preselectedDocuments the list of documents the user may have preselected earlier or the
+ *   empty list if the user didn't preselect.
+ * @param insertSequenceNumbers whether sequence numbers should be inserted in session messages.
+ * @param timeout timeout for initial message.
+ * @param timeoutSubsequentRequests timeout for subsequent messages.
+ * @param onWaitingForRequest callback when waiting for request.
+ * @param onWaitingForUserInput callback when waiting for user input.
+ * @param onDocumentsInFocus callback with selected documents.
+ * @param onSendingResponse callback when sending response.
  */
 @Throws(
     CancellationException::class,
@@ -325,6 +345,7 @@ suspend fun Iso18013Presentment(
     handover: DataItem,
     source: PresentmentSource,
     keyAgreementPossible: List<EcCurve>,
+    preselectedDocuments: List<Document> = emptyList(),
     insertSequenceNumbers: Boolean = false,
     timeout: Duration? = 15.seconds,
     timeoutSubsequentRequests: Duration? = 30.seconds,
@@ -343,6 +364,7 @@ suspend fun Iso18013Presentment(
     ),
     source = source,
     keyAgreementPossible = keyAgreementPossible,
+    preselectedDocuments = preselectedDocuments,
     insertSequenceNumbers = insertSequenceNumbers,
     timeout = timeout,
     timeoutSubsequentRequests = timeoutSubsequentRequests,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/PresentmentModel.kt
@@ -4,13 +4,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.multipaz.document.Document
-import org.multipaz.document.DocumentBadge
+import org.multipaz.presentment.PresentmentModel.State.CanceledByUser
+import org.multipaz.presentment.PresentmentModel.State.Completed
+import org.multipaz.presentment.PresentmentModel.State.Reset
 
 /**
  * A model which can be used to drive UI for presentment.
  *
  * This model is designed to be shared by a _mechanism_ (the code communicating with a credential
- * reader) and the _UI layer_ (which displays UI to the user). Typically the mechanism will also
+ * reader) and the _UI layer_ (which displays UI to the user). Typically, the mechanism will also
  * include a [PromptModel] bound to the UI so things like consent prompts and authentication dialogs
  * are displayed in the UI.
  */
@@ -22,6 +24,18 @@ class PresentmentModel {
      * The current state of the model.
      */
     val state: StateFlow<State> = mutableState.asStateFlow()
+
+    /**
+     * Whether the presentment model is currently active.
+     *
+     * A presentment model is considered active when it's not in [State.Reset], [State.Completed],
+     * or [State.CanceledByUser].
+     */
+    val isActive: Boolean
+        get() = when(state.value) {
+            is Reset, is Completed, CanceledByUser -> false
+            else -> true
+        }
 
     private var mutableSource: PresentmentSource? = null
     private var mutableDocumentsSelected = MutableStateFlow<List<Document>>(emptyList())

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -54,9 +54,8 @@ private const val TAG = "mdocPresentment"
  * @param keyAgreementPossible the list of curves for which key agreement is possible.
  * @param requesterAppId the appId if an app is making the request or `null`.
  * @param requesterOrigin the origin or `null`.
- * @param preselectedDocuments the list of documents the user may have preselected earlier (for
- *   example an OS-provided credential picker like Android's Credential Manager) or the empty list
- *   if the user didn't preselect.
+ * @param preselectedDocuments the list of documents the user may have preselected earlier or the
+ *   empty list if the user didn't preselect.
  * @param onWaitingForUserInput called when waiting for input from the user (consent or authentication)
  * @param onDocumentsInFocus called with the documents currently selected for the user, including when
  *   first shown. If the user selects a different set of documents in the prompt, this will be called again.

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
@@ -30,7 +30,7 @@ class TestAppMdocNdefService(
         TestAppConfiguration.cryptoInit(app.settingsModel)
 
         val source = app.getPresentmentSource()
-        if (PresentmentActivity.presentmentModel.state.value is PresentmentModel.State.Reset) {
+        if (!PresentmentActivity.presentmentModel.isActive) {
             PresentmentActivity.presentmentModel.reset(
                 source = source,
                 // TODO: if user is currently selecting a document, pass it here

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcV2Service.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNfcV2Service.kt
@@ -26,7 +26,7 @@ class TestAppMdocNfcV2Service(
         TestAppConfiguration.cryptoInit(app.settingsModel)
 
         val source = app.getPresentmentSource()
-        if (PresentmentActivity.presentmentModel.state.value is PresentmentModel.State.Reset) {
+        if (!PresentmentActivity.presentmentModel.isActive) {
             PresentmentActivity.presentmentModel.reset(
                 source = source,
                 // TODO: if user is currently selecting a document, pass it here


### PR DESCRIPTION
Update `PresentmentActivity` to support displaying multiple selected documents when presentment is requested. Reimplement `ShowCard()` without `VerticalCardList` to support displaying stacked document cards scaled down (85% size) and overlaid from top-left to bottom-right with shadows, taking up the exact same bounding space as a single card. Deduplicate documents so multiple credentials from the same document flatten into a single card.

Extract card image, rounded corners, shadow elevation, and `CardBadges` into a reusable `CardView` composable.

Add `isActive` property to `PresentmentModel` and update presentment services `MdocNdefService` and `MdocNfcV2Service` to check model state before resetting. Add support for passing preselected documents in `Iso18013Presentment()`.

Fixes #1900.

Test: Manually tested multi-document presentment UI.
Test: ./gradlew :multipaz-compose:compileDebugKotlinAndroid
Test: ./gradlew check
