### PR TITLE
Fix USB connection leaks in external CCID reader driver.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/CcidDriver.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/CcidDriver.kt
@@ -6,6 +6,7 @@ import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
+import kotlinx.coroutines.CancellationException
 import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 import kotlin.math.min
@@ -48,7 +49,7 @@ internal class CcidDriver(
      * operations can be performed. It requests permission to access the USB device,
      * opens a connection, and starts listening for card events.
      *
-     * @throws IOException if the connection to the device fails.
+     * @throws IOException if the connection to the device fails or interface cannot be claimed.
      * @throws SecurityException if permission to access the device is denied.
      */
     fun connect() {
@@ -60,15 +61,25 @@ internal class CcidDriver(
         connection = conn
 
         val iface = findCcidInterface(device, conn)
-            ?: throw IOException("CCID interface not found")
+            ?: run {
+                conn.close()
+                connection = null
+                throw IOException("CCID interface not found")
+            }
         usbInterface = iface
 
         findEndpoints(iface)
-        conn.claimInterface(iface, true)
+        if (!conn.claimInterface(iface, true)) {
+            conn.close()
+            connection = null
+            usbInterface = null
+            throw IOException("Could not claim CCID interface id=${iface.id}")
+        }
         isConnected = true
         Logger.i(TAG, "Connected to CCID device ${device.deviceName} (interface id=${iface.id}), maxCommandLength=$maxCommandLength")
         startInterruptListener()
     }
+
     /**
      * Disconnects from the CCID reader. This method should be called when the
      * application is finished with the device. It releases all resources and closes
@@ -77,9 +88,26 @@ internal class CcidDriver(
     fun disconnect() {
         isConnected = false
         isCardPoweredOn = false
-        connection?.releaseInterface(usbInterface)
-        connection?.close()
+        val iface = usbInterface
+        val conn = connection
+        usbInterface = null
         connection = null
+        if (conn != null && iface != null) {
+            try {
+                conn.releaseInterface(iface)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Error releasing USB interface", e)
+            }
+        }
+        if (conn != null) {
+            try {
+                conn.close()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Error closing USB connection", e)
+            }
+        }
     }
 
     /**
@@ -242,7 +270,12 @@ internal class CcidDriver(
 
     val supportsCcidChaining: Boolean
         get() {
-            val raw = try { connection?.rawDescriptors } catch (_: Throwable) { null }
+            val raw = try {
+                connection?.rawDescriptors
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
             val ifaceId = usbInterface?.id ?: 0
             if (raw != null) {
                 val ccidDesc = getCcidDescriptorForInterface(raw, ifaceId)
@@ -261,7 +294,12 @@ internal class CcidDriver(
 
     val maxCcidDataLength: Int
         get() {
-            val raw = try { connection?.rawDescriptors } catch (_: Throwable) { null }
+            val raw = try {
+                connection?.rawDescriptors
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
             val ifaceId = usbInterface?.id ?: 0
             if (raw != null) {
                 val ccidDesc = getCcidDescriptorForInterface(raw, ifaceId)
@@ -348,9 +386,17 @@ internal class CcidDriver(
         Thread {
             val buffer = ByteArray(endpoint.maxPacketSize)
             while (isConnected) {
-                val bytesRead = connection?.bulkTransfer(endpoint, buffer, buffer.size, 0)
-                if (bytesRead != null && bytesRead > 0) {
+                val conn = connection ?: break
+                val bytesRead = try {
+                    conn.bulkTransfer(endpoint, buffer, buffer.size, 500)
+                } catch (e: Exception) {
+                    -1
+                }
+                if (bytesRead > 0) {
                     handleInterrupt(buffer)
+                } else if (bytesRead < 0) {
+                    if (!isConnected) break
+                    try { Thread.sleep(50) } catch (_: InterruptedException) {}
                 }
             }
         }.start()
@@ -373,7 +419,12 @@ internal class CcidDriver(
     }
 
     private fun findCcidInterface(device: UsbDevice, connection: UsbDeviceConnection?): UsbInterface? {
-        val iface = try { device.getInterface(interfaceIndex) } catch (_: Throwable) { null }
+        val iface = try {
+            device.getInterface(interfaceIndex)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
         if (iface != null) {
             Logger.i(TAG, "Using specified USB interface id=${iface.id} for device ${device.deviceName}")
             return iface

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/ExternalNfcReaderStore.android.kt
@@ -6,6 +6,7 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
+import kotlinx.coroutines.CancellationException
 import org.multipaz.context.applicationContext
 import org.multipaz.util.Logger
 
@@ -69,9 +70,21 @@ suspend fun ExternalNfcReaderStore.handleUsbDeviceAttached(device: UsbDevice): E
     val usbManager = applicationContext.getSystemService(Context.USB_SERVICE) as UsbManager
     val connection: UsbDeviceConnection? = try {
         if (usbManager.hasPermission(device)) usbManager.openDevice(device) else null
-    } catch (_: Throwable) { null }
-    val rawDescriptors = try { connection?.rawDescriptors } catch (_: Throwable) { null }
-    try { connection?.close() } catch (_: Throwable) {}
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+    val rawDescriptors = try {
+        connection?.rawDescriptors
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+    try {
+        connection?.close()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+    }
 
     val candidateNfcInterfaces = ccidInterfaces.filter { !isDefinitelyNotNfc(it, rawDescriptors) }
     val targetInterfaces = when {
@@ -90,7 +103,12 @@ suspend fun ExternalNfcReaderStore.handleUsbDeviceAttached(device: UsbDevice): E
         val ifaceIndex = iface.id
 
         val nameSuffix = if (targetInterfaces.size > 1) {
-            val ifaceName = try { iface.name?.trim() ?: "" } catch (_: Throwable) { "" }
+            val ifaceName = try {
+                iface.name?.trim() ?: ""
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                ""
+            }
             if (ifaceName.isNotEmpty()) " ($ifaceName)" else " (Interface ${iface.id})"
         } else ""
         val displayName = "$deviceDisplayName$nameSuffix"
@@ -113,7 +131,12 @@ suspend fun ExternalNfcReaderStore.handleUsbDeviceAttached(device: UsbDevice): E
 }
 
 private fun isDefinitelyNotNfc(iface: UsbInterface, rawDescriptors: ByteArray?): Boolean {
-    val ifaceName = try { iface.name?.lowercase()?.trim() ?: "" } catch (_: Throwable) { "" }
+    val ifaceName = try {
+        iface.name?.lowercase()?.trim() ?: ""
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        ""
+    }
     if (ifaceName.contains("sam") || ifaceName.contains("sim")) {
         return true
     }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/NfcTagReaderUsb.kt
@@ -54,6 +54,18 @@ internal class NfcTagReaderUsb(
     override val dialogNeverShown: Boolean
         get() = true
 
+    /**
+     * Scans for an NFC tag using the USB CCID reader and executes [tagInteractionFunc].
+     *
+     * @param message Optional message to show during scanning.
+     * @param tagInteractionFunc The interaction function to execute when a tag is detected.
+     * @param options Options for NFC scanning.
+     * @param context The coroutine context for execution.
+     * @return The result of [tagInteractionFunc].
+     * @throws NfcTagLostException if the tag is lost during transaction.
+     * @throws IOException if a USB or CCID communication error occurs.
+     * @throws SecurityException if USB permission is denied.
+     */
     override suspend fun <T : Any> scan(
         message: String?,
         tagInteractionFunc: suspend (NfcIsoTag) -> T?,
@@ -111,6 +123,7 @@ internal class NfcTagReaderUsb(
                         listener.onCardInserted()
                     }
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     Logger.w(TAG, "Failed to query initial card status", e)
                 }
 
@@ -122,10 +135,10 @@ internal class NfcTagReaderUsb(
             return result
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            driver.disconnect()
             throw e
         } finally {
             driver.setListener(null)
+            driver.disconnect()
         }
     }
 }


### PR DESCRIPTION
Ensure `NfcTagReaderUsb.scan()` disconnects `CcidDriver` in its `finally` block so USB device connections, claimed interfaces, and interrupt threads are always released when scanning finishes.

Improve USB resource management in `CcidDriver.connect()`, `CcidDriver.disconnect()`, and `CcidDriver.startInterruptListener()`.

Ensure all broad `Exception` catch blocks rethrow `CancellationException` and avoid catching `Throwable` per coding style guidelines.

Fixes #1902.

Test: Manually tested with ACS WalletMate II reader.
Test: Ran ./gradlew :shared:allTests in multipaz-wallet.
Test: Ran ./gradlew :androidApp:assembleDebug in multipaz-wallet.
