### PR TITLE
Changed transaction handling for mdoc to match lastest draft.

### DIFF
--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransaction.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransaction.kt
@@ -8,7 +8,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.cbor.toDataItem
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.documenttype.CannedTransactionData
@@ -219,12 +221,14 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
     override fun serializeCbor(
         payload: Payload,
         hashAlgorithms: List<Algorithm>?
-    ): ByteString = ByteString(
-        CborData(
-            transactionDataHashesAlg = coseHashAlgorithms(hashAlgorithms),
-            payload = payload
-        ).toCbor()
-    )
+    ): DataItem =
+        Tagged(
+            tagNumber = Tagged.ENCODED_CBOR,
+            taggedItem = CborData(
+                transactionDataHashesAlg = coseHashAlgorithms(hashAlgorithms),
+                payload = payload
+            ).toCbor().toDataItem()
+        )
 
     override fun serializeJson(
         payload: Payload,
@@ -249,11 +253,11 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
         )
     }
 
-    override fun parseCbor(serialized: ByteString): TransactionData<Payload> {
-        val data = CborData.fromCbor(serialized.toByteArray())
+    override fun parseCbor(serialized: DataItem): TransactionData<Payload> {
+        val data = CborData.fromDataItem(serialized.asTaggedEncodedCbor)
         return TransactionData(
             type = this,
-            serialized = serialized,
+            serialized = ByteString(serialized.asTagged.asBstr),
             hashAlgorithms = parseCoseHashAlgorithms(data.transactionDataHashesAlg),
             payload = data.payload,
         )
@@ -265,13 +269,7 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
     ): Boolean {
         return credential is MdocCredential
                 && credential.docType == "org.multipaz.payment.sca.1"
-    }
-
-    override suspend fun applyCbor(
-        transactionData: TransactionData<Payload>,
-        credential: Credential
-    ): Map<String, DataItem> {
-        return buildMap {}
+                && super.isApplicable(transactionData, credential)
     }
 
     /** Sample transaction data for this transaction type */

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredential.kt
@@ -14,6 +14,7 @@ import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.EcPublicKey
+import org.multipaz.documenttype.knowntypes.PaymentTransaction
 import org.multipaz.utopia.knowntypes.DigitalPaymentCredential
 import org.multipaz.mdoc.issuersigned.buildIssuerNamespaces
 import org.multipaz.mdoc.mso.MobileSecurityObject
@@ -24,6 +25,7 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.server.common.getBaseUrl
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.truncateToWholeSeconds
+import org.multipaz.utopia.knowntypes.PingTransaction
 import kotlin.math.max
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -97,7 +99,11 @@ class CredentialFactoryDigitalPaymentCredential : CredentialFactory {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = authenticationKey!!,
-            revocationStatus = revocationStatus
+            revocationStatus = revocationStatus,
+            deviceKeyAuthorizedNamespaces = listOf(
+                PaymentTransaction.mdocResponseNamespace,
+                PingTransaction.mdocResponseNamespace
+            )
         )
         val taggedEncodedMso = Cbor.encode(
             Tagged(

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
@@ -36,6 +36,7 @@ import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.server.common.getBaseUrl
 import org.multipaz.util.Logger
 import org.multipaz.util.truncateToWholeSeconds
+import org.multipaz.utopia.knowntypes.PingTransaction
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -235,7 +236,10 @@ class CredentialFactoryMdl : CredentialFactory {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = authenticationKey!!,
-            revocationStatus = revocationStatus
+            revocationStatus = revocationStatus,
+            deviceKeyAuthorizedNamespaces = listOf(
+                PingTransaction.mdocResponseNamespace
+            )
         )
         val taggedEncodedMso = Cbor.encode(Tagged(
             Tagged.ENCODED_CBOR,

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -34,6 +34,7 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Resources
 import org.multipaz.server.common.getBaseUrl
 import org.multipaz.util.Logger
+import org.multipaz.utopia.knowntypes.PingTransaction
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.iterator
@@ -175,7 +176,10 @@ class CredentialFactoryMdocPid : CredentialFactory {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = authenticationKey!!,
-            revocationStatus = revocationStatus
+            revocationStatus = revocationStatus,
+            deviceKeyAuthorizedNamespaces = listOf(
+                PingTransaction.mdocResponseNamespace
+            )
         )
         val taggedEncodedMso = Cbor.encode(Tagged(
             Tagged.ENCODED_CBOR,

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
@@ -25,6 +25,7 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Resources
 import org.multipaz.server.common.getBaseUrl
 import org.multipaz.util.toBase64Url
+import org.multipaz.utopia.knowntypes.PingTransaction
 import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -138,7 +139,10 @@ class CredentialFactoryUtopiaLoyalty : CredentialFactory {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = authenticationKey!!,
-            revocationStatus = revocationStatus
+            revocationStatus = revocationStatus,
+            deviceKeyAuthorizedNamespaces = listOf(
+                PingTransaction.mdocResponseNamespace
+            )
         )
         val taggedEncodedMso = Cbor.encode(Tagged(
             Tagged.ENCODED_CBOR,

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/PingTransaction.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/PingTransaction.kt
@@ -5,8 +5,12 @@ import kotlinx.io.bytestring.decodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.toDataItem
 import org.multipaz.credential.Credential
@@ -24,7 +28,7 @@ import org.multipaz.util.toBase64Url
 object PingTransaction: TransactionType<PingTransaction.Payload>(
     displayName = "Ping",
     identifier = "org.multipaz.transaction.ping",
-    mdocRequestInfoKeyName = "org.multipaz.transaction.ping.mdoc_request",
+    mdocRequestInfoIdentifier = "org.multipaz.transaction.ping.mdoc_identifier",
     mdocResponseNamespace = "org.multipaz.transaction.ping.mdoc_response",
     kbJwtResponseClaimName = "org.multipaz.transaction.ping.response"
 ) {
@@ -54,12 +58,13 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
     override fun serializeCbor(
         payload: Payload,
         hashAlgorithms: List<Algorithm>?
-    ): ByteString = ByteString(
-        data = CborData(
+    ): DataItem = Tagged(
+        tagNumber = Tagged.ENCODED_CBOR,
+        taggedItem = CborData(
             transactionDataHashesAlg = coseHashAlgorithms(hashAlgorithms),
             string = payload.string,
             blob = payload.blob
-        ).toCbor()
+        ).toCbor().toDataItem()
     )
 
     override fun serializeJson(
@@ -90,11 +95,11 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
         )
     }
 
-    override fun parseCbor(serialized: ByteString): TransactionData<Payload> {
-        val data = CborData.fromCbor(serialized.toByteArray())
+    override fun parseCbor(serialized: DataItem): TransactionData<Payload> {
+        val data = CborData.fromDataItem(serialized.asTaggedEncodedCbor)
         return TransactionData(
             type = this,
-            serialized = serialized,
+            serialized = ByteString(serialized.asTagged.asBstr),
             hashAlgorithms = parseCoseHashAlgorithms(data.transactionDataHashesAlg),
             payload = Payload(
                 string = data.string,
@@ -109,7 +114,20 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
     ): Boolean {
         // For the sake of testing, refuse UtopiaNaturalization
         return !(credential is KeyBoundSdJwtVcCredential
-                && credential.vct == UtopiaNaturalization.VCT)
+                    && credential.vct == UtopiaNaturalization.VCT)
+                && super.isApplicable(transactionData, credential)
+    }
+
+    override suspend fun applyJson(
+        transactionData: TransactionData<Payload>,
+        credential: Credential
+    ): JsonElement = buildJsonObject {
+        transactionData.payload.string?.let {
+            put("string", it)
+        }
+        transactionData.payload.blob?.let {
+            put("blob", it.toByteArray().toBase64Url())
+        }
     }
 
     override suspend fun applyCbor(
@@ -117,6 +135,7 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
         credential: Credential
     ): Map<String, DataItem> {
         return buildMap {
+            putAll(super.applyCbor(transactionData, credential))
             transactionData.payload.string?.let {
                 put("string", it.toDataItem())
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentTypeRepository.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentTypeRepository.kt
@@ -77,7 +77,7 @@ class DocumentTypeRepository {
             check(existingType.identifier != transactionType.identifier)
             check(existingType.kbJwtResponseClaimName != transactionType.kbJwtResponseClaimName)
             check(existingType.mdocResponseNamespace != transactionType.mdocResponseNamespace)
-            check(existingType.mdocRequestInfoKeyName != transactionType.mdocRequestInfoKeyName)
+            check(existingType.mdocRequestInfoIdentifier != transactionType.mdocRequestInfoIdentifier)
         }
         _transactionTypes.add(transactionType)
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
@@ -2,11 +2,15 @@ package org.multipaz.documenttype
 
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.buildJsonObject
+import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.toDataItem
+import org.multipaz.cbor.Tagged
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.document.Document
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.mdoc.mso.MobileSecurityObject
 import org.multipaz.presentment.TransactionData
 import org.multipaz.util.Logger
 
@@ -24,9 +28,9 @@ import org.multipaz.util.Logger
  * @param kbJwtResponseClaimName if transaction processing results in any data, it will be inserted
  *  in key binding JWT using this claim name; all [TransactionType] objects must have distinct
  *  values.
- * @param mdocRequestInfoKeyName key to use in `requestInfo` map in ISO/IEC 18013-5:2021 document
- *  request to represent this transaction data; all [TransactionType] objects must have distinct
- *  values.
+ * @param mdocRequestInfoIdentifier transaction type to use in `transactions` array in
+ *  `requestInfo` map in ISO/IEC 18013-5:2021 document request to represent this transaction
+ *  data; all [TransactionType] objects must have distinct values.
  * @param mdocResponseNamespace namespace to use in `deviceSigned` namespace map in
  *  ISO/IEC 18013-5:2021 response to represent transaction hash and transaction processing
  *  results; all [TransactionType] objects must have distinct values.
@@ -35,7 +39,7 @@ abstract class TransactionType<PayloadT: Any>(
     val displayName: String,
     val identifier: String,
     val kbJwtResponseClaimName: String = identifier,
-    val mdocRequestInfoKeyName: String = identifier,
+    val mdocRequestInfoIdentifier: String = identifier,
     val mdocResponseNamespace: String = identifier,
 ) {
     /**
@@ -62,7 +66,7 @@ abstract class TransactionType<PayloadT: Any>(
     abstract fun serializeCbor(
         payload: PayloadT,
         hashAlgorithms: List<Algorithm>? = null
-    ): ByteString
+    ): DataItem
 
     /**
      * Parses transaction data serialized for use in OpenID4VP protocol.
@@ -75,10 +79,13 @@ abstract class TransactionType<PayloadT: Any>(
     /**
      * Parses transaction data serialized for use in ISO/IEC 18013 protocols.
      *
-     * @param serialized serialized transaction data
+     * @param serialized transaction data as it is represented in the request (specifically,
+     *  value of the `data` field in the transaction object in the `transactions` array inside
+     *  `requestInfo`); in many cases [serialized] is expected to be [Tagged] with
+     *  [Tagged.tagNumber] equal to [Tagged.ENCODED_CBOR]
      * @return [TransactionData] object that holds serialized and parsed transaction data representations
      */
-    abstract fun parseCbor(serialized: ByteString): TransactionData<PayloadT>
+    abstract fun parseCbor(serialized: DataItem): TransactionData<PayloadT>
 
     /**
      * Determines if this transaction is applicable to the given credential.
@@ -87,17 +94,40 @@ abstract class TransactionType<PayloadT: Any>(
      * set option from consideration. If other options are available, presentment still may
      * succeed.
      *
+     * For mdoc credentials this method must check [mdocResponseNamespace] against
+     * [MobileSecurityObject.deviceKeyAuthorizedNamespaces] and possibly
+     * [MobileSecurityObject.deviceKeyAuthorizedDataElements] to determine if the transaction is
+     * applicable for this specific credential.
+     *
      * @param transactionData transaction data being considered
      * @param credential one of the credentials in the [Document] being considered
      * @return true if transaction can be processed false if it cannot
      */
-    abstract suspend fun isApplicable(
+    open suspend fun isApplicable(
         transactionData: TransactionData<PayloadT>,
         credential: Credential
-    ): Boolean
+    ): Boolean {
+        return if (credential is MdocCredential) {
+            // For mdoc there is a per-credential KeyAuthorizations section. We need to check
+            // it to determine if this transaction can be applied to this credential
+            credential.mso.deviceKeyAuthorizedNamespaces.contains(mdocResponseNamespace)
+        } else {
+            true
+        }
+    }
 
     /**
-     * Applies transaction in the context of ISO/IEC 18013-5:2021 presentment.
+     * Applies transaction in the context of ISO mdoc presentment.
+     *
+     * Note: unlike OpenID4VP, ISO/IEC 18013-5:2021 does not impose a particular requirement on
+     * transaction response (e.g. responding at least with transaction data hash). Each transaction
+     * type should define its own **verifiable** response. This response then will be validated
+     * by the verifier the using [verifyCborResponse] method.
+     *
+     * Default implementation computes transaction data hash, similar to how OpenID4VP does it.
+     *
+     * Note: one should not assume that [transactionData] will be in CBOR format. Transaction data
+     * is formatted according to the presentment protocol.
      *
      * @param transactionData transaction data
      * @param credential credential being presented
@@ -107,15 +137,18 @@ abstract class TransactionType<PayloadT: Any>(
     open suspend fun applyCbor(
         transactionData: TransactionData<PayloadT>,
         credential: Credential
-    ): Map<String, DataItem>? {
-        return null
+    ): Map<String, DataItem> = buildMap {
+        val alg = transactionData.hashAlgorithms?.first()?.also {
+            put("transactionDataHashAlg", it.coseAlgorithmIdentifier!!.toDataItem())
+        }
+        put("transactionDataHash",
+            transactionData.computeHash(alg ?: Algorithm.SHA256).toByteArray().toDataItem())
     }
 
     /**
-     * Applies transaction in the context of OpenID4VP presentment.
+     * Applies transaction in the context of IETF SD-JWT presentment.
      *
-     * Default implementation adds the same values as [applyCbor], which is the recommended
-     * behavior.
+     * Default implementation does not add any transaction-specific data.
      *
      * @param transactionData transaction data
      * @param credential credential being presented
@@ -125,12 +158,36 @@ abstract class TransactionType<PayloadT: Any>(
     open suspend fun applyJson(
         transactionData: TransactionData<PayloadT>,
         credential: Credential
-    ): JsonElement? {
-        val extra = applyCbor(transactionData, credential) ?: return null
-        return buildJsonObject {
-            for ((key, value) in extra) {
-                put(key, value.toJson())
-            }
+    ): JsonElement? = null
+
+    /**
+     * Verify transaction response for mdoc presentment.
+     *
+     * Note: unlike OpenID4VP, ISO/IEC 18013-5:2021 does not impose a particular requirement on
+     * transaction response (e.g. responding at least with transaction data hash). Each transaction
+     * type should define its own **verifiable** response and implement verification in this
+     * method.
+     *
+     * Default implementation verifies transaction data hash computed by default implementation
+     * of [applyCbor].
+     *
+     * @param transactionData transaction data
+     * @param transactionResponse key-value-map for values returned in [mdocResponseNamespace]
+     *  namespace in the credential presentation
+     * @throws IllegalStateException if response does not pass verification
+     */
+    open suspend fun verifyCborResponse(
+        transactionData: TransactionData<PayloadT>,
+        transactionResponse: Map<String, DataItem>
+    ) {
+        val hashAlg = transactionResponse["transactionDataHashAlg"]?.let {
+            Algorithm.fromCoseAlgorithmIdentifier(it.asNumber.toInt())
+        }
+        val hash = transactionResponse["transactionDataHash"] as? Bstr
+            ?: throw IllegalStateException("Invalid response for transaction '$identifier'")
+        val expectedHash = transactionData.computeHash(hashAlg ?: Algorithm.SHA256)
+        if (ByteString(hash.asBstr) != expectedHash) {
+            throw IllegalStateException("Transaction hash failed to verify for '$identifier'")
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -1,6 +1,5 @@
 package org.multipaz.mdoc.request
 
-import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArrayBuilder
 import kotlinx.serialization.json.JsonObject
@@ -845,22 +844,15 @@ data class DeviceRequest private constructor(
         requestInfo: DocRequestInfo?,
         documentTypeRepository: DocumentTypeRepository?
     ): List<TransactionData<*>> {
-        if (requestInfo == null || documentTypeRepository == null) {
+        if (requestInfo == null || documentTypeRepository == null || requestInfo.transactions == null) {
             return emptyList()
         }
-        val list = mutableListOf<TransactionData<*>>()
-        for (knownType in documentTypeRepository.transactionTypes) {
-            if (!requestInfo.otherInfo.containsKey(knownType.mdocRequestInfoKeyName)) {
-                continue
-            }
-            val transactionCbor = requestInfo.otherInfo[knownType.mdocRequestInfoKeyName]!!
-            if (transactionCbor !is Tagged || transactionCbor.tagNumber != Tagged.ENCODED_CBOR
-                || transactionCbor.taggedItem !is Bstr) {
-                throw IllegalArgumentException("Incorrectly encoded transaction data '${knownType.identifier}'")
-            }
-            list.add(knownType.parseCbor(ByteString(transactionCbor.taggedItem.asBstr)))
+        return requestInfo.transactions.data.map { (type, data) ->
+            val knownType = documentTypeRepository.transactionTypes.find {
+                it.mdocRequestInfoIdentifier == type
+            } ?: throw IllegalArgumentException("Unknown transaction type: '$type'")
+            knownType.parseCbor(data)
         }
-        return list.toList()
     }
 
     /**
@@ -1120,7 +1112,7 @@ inline fun buildDeviceRequestFromDcql(
     sessionTranscript: DataItem,
     dcql: JsonObject,
     otherInfo: Map<String, DataItem> = emptyMap(),
-    docRequestOtherInfo: Map<String, Map<String, DataItem>> = emptyMap(),
+    transactions: Map<String, TransactionsInfo> = emptyMap(),
     builderAction: DeviceRequest.Builder.() -> Unit = {}
 ): DeviceRequest {
     val dcqlQuery = DcqlQuery.fromJson(dcql)
@@ -1129,7 +1121,7 @@ inline fun buildDeviceRequestFromDcql(
         sessionTranscript = sessionTranscript,
         deviceRequestInfo = deviceRequestInfo,
     )
-    deviceRequestAddQueries(dcqlQuery, docRequestOtherInfo, builder)
+    deviceRequestAddQueries(dcqlQuery, transactions, builder)
     builder.builderAction()
     return builder.build()
 }
@@ -1152,14 +1144,14 @@ inline fun buildDeviceRequestFromDcql(
     sessionTranscript: DataItem,
     dcqlString: String,
     otherInfo: Map<String, DataItem> = emptyMap(),
-    docRequestOtherInfo: Map<String, Map<String, DataItem>> = emptyMap(),
+    transactions: Map<String, TransactionsInfo> = emptyMap(),
     builderAction: DeviceRequest.Builder.() -> Unit = {}
 ): DeviceRequest {
     return buildDeviceRequestFromDcql(
         sessionTranscript = sessionTranscript,
         dcql = Json.decodeFromString<JsonObject>(dcqlString),
         otherInfo = otherInfo,
-        docRequestOtherInfo = docRequestOtherInfo,
+        transactions = transactions,
         builderAction = builderAction
     )
 }
@@ -1214,7 +1206,7 @@ internal fun deviceRequestCalcDeviceRequestInfo(
 @PublishedApi
 internal fun deviceRequestAddQueries(
     dcqlQuery: DcqlQuery,
-    docRequestOtherInfo: Map<String, Map<String, DataItem>>,
+    transactions: Map<String, TransactionsInfo>,
     builder: DeviceRequest.Builder
 ) {
     for (credQuery in dcqlQuery.credentialQueries) {
@@ -1390,17 +1382,16 @@ internal fun deviceRequestAddQueries(
             null
         }
 
-        val otherInfo = docRequestOtherInfo[credQuery.id]
-
+        val docTransactions = transactions[credQuery.id]
         val docRequestInfo = if (alternativeDataElements.isNotEmpty()
-            || zkRequest != null || otherInfo != null || credQuery.format == "dc+sd-jwt"
+            || zkRequest != null || docTransactions != null || credQuery.format == "dc+sd-jwt"
             || dataElementIdentifierMapping.isNotEmpty()) {
             DocRequestInfo(
                 alternativeDataElements = alternativeDataElements,
                 zkRequest = zkRequest,
                 docFormat = if (credQuery.format == "dc+sd-jwt") "sd-jwt+kb" else null,
                 dataElementIdentifierMapping = dataElementIdentifierMapping,
-                otherInfo = otherInfo ?: emptyMap()
+                transactions = docTransactions
             )
         } else {
             null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequest.kt
@@ -1,8 +1,6 @@
 package org.multipaz.mdoc.request
 
-import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.DataItem
-import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cose.Cose
 import org.multipaz.cose.CoseNumberLabel
@@ -102,8 +100,8 @@ data class DocRequest internal constructor(
         documentTypeRepository: DocumentTypeRepository
     ): List<TransactionData<*>> = buildList {
         for (transactionType in documentTypeRepository.transactionTypes) {
-            docRequestInfo?.otherInfo[transactionType.mdocRequestInfoKeyName]?.let { data ->
-                add(transactionType.parseCbor(ByteString((data as Tagged).taggedItem.asBstr)))
+            docRequestInfo?.transactions?.data[transactionType.mdocRequestInfoIdentifier]?.let { data ->
+                add(transactionType.parseCbor(data))
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequestInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequestInfo.kt
@@ -12,6 +12,7 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborArray
 import org.multipaz.cbor.putCborMap
@@ -27,6 +28,7 @@ import org.multipaz.cbor.putCborMap
  * @property docResponseEncryption optional request for encrypting the response.
  * @property docFormat optional document format.
  * @property dataElementIdentifierMapping optional data element identifier mapping.
+ * @property transactions optional information about requested transactions.
  * @property otherInfo other request info.
  */
 data class DocRequestInfo(
@@ -38,6 +40,7 @@ data class DocRequestInfo(
     val docResponseEncryption: EncryptionParameters? = null,
     val docFormat: String? = null,
     val dataElementIdentifierMapping: Map<String, JsonArray> = emptyMap(),
+    val transactions: TransactionsInfo? = null,
     val otherInfo: Map<String, DataItem> = emptyMap(),
 ) {
     internal fun toDataItem() = buildCborMap {
@@ -96,6 +99,16 @@ data class DocRequestInfo(
                 }
             }
         }
+        transactions?.let {
+            putCborArray("transactions") {
+                for ((type, data) in it.data) {
+                    addCborMap {
+                        put("type", type)
+                        put("data", data)
+                    }
+                }
+            }
+        }
         otherInfo.forEach { (key, value) ->
             put(key, value)
         }
@@ -110,7 +123,8 @@ data class DocRequestInfo(
                 zkRequest != null ||
                 docResponseEncryption != null ||
                 docFormat != null ||
-                dataElementIdentifierMapping.isNotEmpty()
+                dataElementIdentifierMapping.isNotEmpty() ||
+                transactions != null
     }
 
     companion object {
@@ -142,10 +156,14 @@ data class DocRequestInfo(
                     }.let { JsonArray(it) }
                 }.toMap()
             } ?: emptyMap()
+            val transactions = dataItem.getOrNull("transactions")?.let {
+                TransactionsInfo(
+                    data = it.asArray.associate { item -> Pair(item["type"].asTstr, item["data"]) }
+                )
+            }
             val otherInfo = mutableMapOf<String, DataItem>()
             for ((otherKeyDataItem, otherValue) in dataItem.asMap) {
-                val otherKey = otherKeyDataItem.asTstr
-                when (otherKey) {
+                when (val otherKey = otherKeyDataItem.asTstr) {
                     "alternativeDataElements",
                     "issuerIdentifiers",
                     "uniqueDocSetRequired",
@@ -153,7 +171,8 @@ data class DocRequestInfo(
                     "zkRequest",
                     "docResponseEncryption",
                     "docFormat",
-                    "dataElementIdentifierMapping" -> continue
+                    "dataElementIdentifierMapping",
+                    "transactions" -> continue
                     else -> otherInfo[otherKey] = otherValue
                 }
             }
@@ -166,6 +185,7 @@ data class DocRequestInfo(
                 docResponseEncryption = docResponseEncryption,
                 docFormat = docFormat,
                 dataElementIdentifierMapping = dataElementIdentifierMapping,
+                transactions = transactions,
                 otherInfo = otherInfo
             )
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/TransactionsInfo.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/TransactionsInfo.kt
@@ -1,0 +1,13 @@
+package org.multipaz.mdoc.request
+
+import org.multipaz.cbor.DataItem
+
+/**
+ * Data structure that describes transactions in a ISO/IEC 18013 request (`transactions` array
+ * in `requestInfo`).
+ *
+ * @property data maps transaction type to its data
+ */
+data class TransactionsInfo(
+    val data: Map<String, DataItem>
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
@@ -231,13 +231,13 @@ data class DeviceResponse internal constructor(
         val data = doc.deviceNamespaces.data
         for (transactionType in documentTypeRepository.transactionTypes) {
             val transactionResponse = data[transactionType.mdocResponseNamespace] ?: continue
-            val transactionDocRequestId = transactionResponse["doc_request_id"] as? Uint
+            val transactionDocRequestId = transactionResponse["docRequestId"] as? Uint
                 ?: throw IllegalStateException(
-                    "'doc_request_id' is missing or invalid for transaction '${transactionType.identifier}'")
+                    "'docRequestId' is missing or invalid for transaction '${transactionType.identifier}'")
             if (docRequestId == null) {
                 docRequestId = transactionDocRequestId.value
             } else if(docRequestId != transactionDocRequestId.value) {
-                throw IllegalStateException("inconsistent 'doc_request_id' values")
+                throw IllegalStateException("inconsistent 'docRequestId' values")
             }
         }
         return docRequestId?.toInt() ?: -1

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/MdocDocument.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/MdocDocument.kt
@@ -243,15 +243,7 @@ class MdocDocument(
             for (transaction in transactionData) {
                 val response = deviceNamespaces.data[transaction.type.mdocResponseNamespace]
                     ?: throw IllegalStateException("No transaction response for '${transaction.type.identifier}'")
-                val hashAlg = response["transaction_data_hash_alg"]?.let {
-                    Algorithm.fromCoseAlgorithmIdentifier(it.asNumber.toInt())
-                }
-                val hash = response["transaction_data_hash"] as? Bstr
-                    ?: throw IllegalStateException("Invalid response for transaction '${transaction.type.identifier}'")
-                val expectedHash = transaction.computeHash(hashAlg ?: Algorithm.SHA256)
-                if (ByteString(hash.asBstr) != expectedHash) {
-                    throw IllegalStateException("Transaction hash failed to verify for '${transaction.type.identifier}'")
-                }
+                transaction.verifyCborResponse(response)
                 put(transaction.type.identifier, response)
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
@@ -1,6 +1,7 @@
 package org.multipaz.presentment
 
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.DataItem
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
@@ -78,6 +79,16 @@ class TransactionData<PayloadT: Any>(
      * @return new [TransactionData] object that holds the same payload and hash algorithm, but
      *  its [TransactionData.serialized] is formatted for use in ISO ISO/IEC 18013 protocols.
      */
-    fun convertToCbor(): TransactionData<PayloadT> =
-        type.parseCbor(type.serializeCbor(payload, hashAlgorithms))
+    fun convertToCbor(): DataItem = type.serializeCbor(payload, hashAlgorithms)
+
+    /**
+     * Verify transaction response for mdoc presentment.
+     *
+     * @see TransactionType.verifyCborResponse
+     *
+     * @param transactionResponse key-value-map for values returned in the presentation
+     * @throws IllegalStateException if response does not pass verification
+     */
+    suspend fun verifyCborResponse(transactionResponse: Map<String, DataItem>) =
+        type.verifyCborResponse(this, transactionResponse)
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -1,6 +1,5 @@
 package org.multipaz.presentment
 
-import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.decodeToString
 import org.multipaz.cbor.Bstr
@@ -458,22 +457,12 @@ internal suspend fun computeTransactionResponse(
 ): DeviceNamespaces {
     val transactionResponseMap = match.transactionData.associate { transaction ->
         Pair(transaction.type.mdocResponseNamespace, buildMap {
-            val alg = transaction.hashAlgorithms?.first()
-            alg?.let {
-                put("transaction_data_hash_alg", it.coseAlgorithmIdentifier!!.toDataItem())
-            }
-            put("transaction_data_hash",
-                transaction.computeHash(alg ?: Algorithm.SHA256).toByteArray().toDataItem())
+            putAll(transaction.applyCbor(match.credential))
             (match.source as? CredentialMatchSourceIso18013)?.let { source ->
                 // This is generally not available anywhere is the ISO 18013 response,
                 // but it is needed to verify the transaction, so we keep it in the
                 // transaction response.
-                put("doc_request_id", source.docRequest.docRequestId.toDataItem())
-            }
-            transaction.applyCbor(match.credential)?.let { extra ->
-                for ((key, value) in extra) {
-                    put(key, value)
-                }
+                put("docRequestId", source.docRequest.docRequestId.toDataItem())
             }
         })
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/VerificationUtil.kt
@@ -41,6 +41,7 @@ import org.multipaz.mdoc.request.DeviceRequest
 import org.multipaz.mdoc.request.DeviceRequestInfo
 import org.multipaz.mdoc.request.DocRequestInfo
 import org.multipaz.mdoc.request.DocumentSet
+import org.multipaz.mdoc.request.TransactionsInfo
 import org.multipaz.mdoc.request.UseCase
 import org.multipaz.mdoc.request.ZkRequest
 import org.multipaz.mdoc.request.buildDeviceRequest
@@ -101,7 +102,8 @@ object VerificationUtil {
      * @param zkSystemSpecs if non-empty, request a ZK proof using these systems.
      * @param jsonTransactionData JSON-formatted transaction data, *before* base64url encoding,
      *   see OpenID4VP 1.0 section 8.4.
-     * @param docRequestOtherInfo transaction data encoded for use in requestInfo` map in ISO 18013-7.
+     * @param cborTransactionData CBOR-formatted transaction data
+     * @param docRequestOtherInfo additional data to add to `requestInfo` map in ISO 18013-7.
      * @return a [JsonObject] with the request.
      */
     @Throws(CancellationException::class)
@@ -115,6 +117,7 @@ object VerificationUtil {
         verifierIdentities: List<VerifierIdentity>,
         zkSystemSpecs: List<ZkSystemSpec>,
         jsonTransactionData: List<String> = emptyList(),
+        cborTransactionData: TransactionsInfo? = null,
         docRequestOtherInfo: Map<String, DataItem> = emptyMap()
     ): JsonObject {
         val requests = exchangeProtocols.map { exchangeProtocol ->
@@ -130,6 +133,7 @@ object VerificationUtil {
                 verifierIdentities = verifierIdentities,
                 zkSystemSpecs = zkSystemSpecs,
                 jsonTransactionData = jsonTransactionData,
+                cborTransactionData = cborTransactionData,
                 docRequestOtherInfo = docRequestOtherInfo
             )
         }
@@ -168,7 +172,7 @@ object VerificationUtil {
      *  for unsigned request
      * @param jsonTransactionData JSON-formatted transaction data, *before* base64url encoding,
      *   see OpenID4VP 1.0 section 8.4.
-     * @param docRequestOtherInfo transaction data encoded for use in requestInfo map in ISO 18013-7.
+     * @param cborTransactionData transaction data encoded for use in requestInfo map in ISO 18013-5.
      * @param state optional state parameter defined in OpenID4VP and ISO 18013-7 that is then
      *   included in the presentation
      * @throws IllegalArgumentException if [dcql] contains features not supported by [DeviceRequest], for
@@ -184,7 +188,7 @@ object VerificationUtil {
         responseEncryptionKey: EcPublicKey?,
         verifierIdentities: List<VerifierIdentity>,
         jsonTransactionData: List<String> = emptyList(),
-        docRequestOtherInfo: Map<String, Map<String, DataItem>> = emptyMap(),
+        cborTransactionData: Map<String, TransactionsInfo> = emptyMap(),
         state: String? = null
     ): JsonObject {
         val requests = exchangeProtocols.map { exchangeProtocol ->
@@ -196,7 +200,7 @@ object VerificationUtil {
                 responseEncryptionKey = responseEncryptionKey,
                 verifierIdentities = verifierIdentities,
                 jsonTransactionData = jsonTransactionData,
-                docRequestOtherInfo = docRequestOtherInfo,
+                cborTransactionData = cborTransactionData,
                 state = state
             )
         }
@@ -213,7 +217,7 @@ object VerificationUtil {
         responseEncryptionKey: EcPublicKey?,
         verifierIdentities: List<VerifierIdentity>,
         jsonTransactionData: List<String>,
-        docRequestOtherInfo: Map<String, Map<String, DataItem>>,
+        cborTransactionData: Map<String, TransactionsInfo>,
         state: String?
     ): JsonObject = buildJsonObject {
         put("protocol", exchangeProtocol)
@@ -271,7 +275,7 @@ object VerificationUtil {
                     buildDeviceRequestFromDcql(
                         sessionTranscript = sessionTranscript,
                         dcql = dcql,
-                        docRequestOtherInfo = docRequestOtherInfo,
+                        transactions = cborTransactionData,
                         // TODO: sign individual requests with readerAuthenticationKey
                     ) {
                         verifierIdentities.forEach { readerIdentity ->
@@ -305,6 +309,7 @@ object VerificationUtil {
         verifierIdentities: List<VerifierIdentity>,
         zkSystemSpecs: List<ZkSystemSpec>,
         jsonTransactionData: List<String>,
+        cborTransactionData: TransactionsInfo?,
         docRequestOtherInfo: Map<String, DataItem>
     ): JsonObject = buildJsonObject {
         put("protocol", exchangeProtocol)
@@ -395,6 +400,7 @@ object VerificationUtil {
                             zkRequest = zkRequest,
                             docFormat = docFormat,
                             dataElementIdentifierMapping = dataElementIdentifierMapping,
+                            transactions = cborTransactionData,
                             otherInfo = docRequestOtherInfo
                         )
                     )
@@ -441,6 +447,9 @@ object VerificationUtil {
      *   if this is `null` for such protocols
      * @param verifierIdentities a list of verifier identities used to sign the request; empty list
      *  for unsigned request
+     * @param jsonTransactionData JSON-formatted transaction data, *before* base64url encoding,
+     *   see OpenID4VP 1.0 section 8.4.
+     * @param cborTransactionData transaction data encoded for use in requestInfo map in ISO 18013-5.
      * @return a [JsonObject] with the request.
      */
     @Throws(CancellationException::class)
@@ -452,7 +461,8 @@ object VerificationUtil {
         origin: String,
         responseEncryptionKey: EcPublicKey?,
         verifierIdentities: List<VerifierIdentity>,
-        jsonTransactionData: List<String> = emptyList()
+        jsonTransactionData: List<String> = emptyList(),
+        cborTransactionData: TransactionsInfo? = null
     ): JsonObject {
         val requests = exchangeProtocols.map { exchangeProtocol ->
             buildJsonObject {
@@ -488,8 +498,9 @@ object VerificationUtil {
                                 responseEncryptionKey = responseEncryptionKey,
                                 verifierIdentities = verifierIdentities,
                                 zkSystemSpecs = emptyList(),
-                                docRequestOtherInfo = emptyMap(), // TODO: implement transactions
-                                jsonTransactionData = emptyList()
+                                cborTransactionData = cborTransactionData,
+                                jsonTransactionData = jsonTransactionData,
+                                docRequestOtherInfo = emptyMap()
                             )["data"] as JsonObject
                         )
                     }
@@ -1176,20 +1187,18 @@ object VerificationUtil {
         val dcqlJson = Json.parseToJsonElement(dcql).jsonObject
         val nonceStr = nonce.toByteArray().toBase64Url()
 
-        val docRequestOtherInfo = if (transactionData.isNullOrEmpty()) {
+        val docRequestTransactions = if (transactionData.isNullOrEmpty()) {
             null
         } else {
             lazy {
                 documentTypeRepository!!.parseJsonTransactions(transactionData.map {
                     it.encodeToByteArray().toBase64Url()
                 }).mapValues { (_, transactionData) ->
-                    transactionData.associate { data ->
-                        val converted = data.convertToCbor()
-                        converted.type.mdocRequestInfoKeyName to Tagged(
-                            tagNumber = Tagged.ENCODED_CBOR,
-                            taggedItem = Bstr(converted.serialized.toByteArray())
-                        )
-                    }
+                    TransactionsInfo(
+                        data = transactionData.associate { data ->
+                            data.type.mdocRequestInfoIdentifier to data.convertToCbor()
+                        }
+                    )
                 }
             }
         }
@@ -1202,7 +1211,7 @@ object VerificationUtil {
         ): String = OpenID4VP.generateRequest(
             version = version,
             dcqlQuery = dcqlJson,
-            jsonTransactionData =transactionData ?: emptyList(),
+            jsonTransactionData = transactionData ?: emptyList(),
             nonce = nonceStr,
             state = state,
             origin = origin
@@ -1218,7 +1227,7 @@ object VerificationUtil {
         ): DataItem = buildDeviceRequestFromDcql(
             sessionTranscript = sessionTranscript,
             dcql = dcqlJson,
-            docRequestOtherInfo = docRequestOtherInfo?.value ?: emptyMap(),
+            transactions = docRequestTransactions?.value ?: emptyMap()
         ) {
             verifierIdentities.forEach { addReaderAuthAll(it.key) }
         }.toDataItem()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
@@ -8,6 +8,7 @@ import kotlinx.io.bytestring.decodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
@@ -22,11 +23,13 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.Uint
 import org.multipaz.cbor.addCborArray
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborArray
+import org.multipaz.cbor.toDataItem
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.AsymmetricKey
@@ -78,17 +81,20 @@ class DigitalCredentialsPresentmentTest {
         override fun serializeCbor(
             payload: Boolean,
             hashAlgorithms: List<Algorithm>?
-        ): ByteString = ByteString(
-            Cbor.encode(buildCborMap {
-                put("succeed", payload)
-                coseHashAlgorithms(hashAlgorithms)?.let { algs ->
-                    putCborArray("transactionDataHashesAlg") {
-                        for (alg in algs) {
-                            add(alg)
+        ): DataItem = Tagged(
+            tagNumber = Tagged.ENCODED_CBOR,
+            taggedItem = Cbor.encode(
+                item = buildCborMap {
+                    put("succeed", payload)
+                    coseHashAlgorithms(hashAlgorithms)?.let { algs ->
+                        putCborArray("transactionDataHashesAlg") {
+                            for (alg in algs) {
+                                add(alg)
+                            }
                         }
                     }
                 }
-            })
+            ).toDataItem()
         )
 
         override fun serializeJson(
@@ -115,11 +121,11 @@ class DigitalCredentialsPresentmentTest {
             )
         }
 
-        override fun parseCbor(serialized: ByteString): TransactionData<Boolean> {
-            val data = Cbor.decode(serialized.toByteArray())
+        override fun parseCbor(serialized: DataItem): TransactionData<Boolean> {
+            val data = serialized.asTaggedEncodedCbor
             return TransactionData(
                 type = this,
-                serialized = serialized,
+                serialized = ByteString(serialized.asTagged.asBstr),
                 hashAlgorithms = if (data.hasKey("transactionDataHashesAlg")) {
                     parseCoseHashAlgorithms(
                         data["transactionDataHashesAlg"].asArray.map {
@@ -136,7 +142,7 @@ class DigitalCredentialsPresentmentTest {
             transactionData: TransactionData<Boolean>,
             credential: Credential
         ): Boolean {
-            return transactionData.payload
+            return transactionData.payload && super.isApplicable(transactionData, credential)
         }
 
         companion object {
@@ -154,18 +160,25 @@ class DigitalCredentialsPresentmentTest {
         kbJwtResponseClaimName = "kb_foo",
         mdocResponseNamespace = "FooNS"
     ) {
-
         override suspend fun isApplicable(
             transactionData: TransactionData<Boolean>,
             credential: Credential
         ): Boolean {
-            return transactionData.payload
+            return transactionData.payload && super.isApplicable(transactionData, credential)
+        }
+
+        override suspend fun applyJson(
+            transactionData: TransactionData<Boolean>,
+            credential: Credential
+        ): JsonElement = buildJsonObject {
+            put("result", 42)
         }
 
         override suspend fun applyCbor(
             transactionData: TransactionData<Boolean>,
             credential: Credential
         ): Map<String, DataItem> = buildMap {
+            putAll(super.applyCbor(transactionData, credential))
             put("result", Uint(42UL))
         }
     }
@@ -174,10 +187,18 @@ class DigitalCredentialsPresentmentTest {
         displayName = "Bar",
         identifier = "bar"
     ) {
+        override suspend fun applyJson(
+            transactionData: TransactionData<Boolean>,
+            credential: Credential
+        ): JsonElement = buildJsonObject {
+            put("result", 57)
+        }
+
         override suspend fun applyCbor(
             transactionData: TransactionData<Boolean>,
             credential: Credential
         ): Map<String, DataItem> = buildMap {
+            putAll(super.applyCbor(transactionData, credential))
             put("result", Uint(57UL))
         }
     }
@@ -186,12 +207,7 @@ class DigitalCredentialsPresentmentTest {
     private object BuzTransactionType: BooleanTransaction(
         displayName = "Buz",
         identifier = "buz",
-    ) {
-        override suspend fun isApplicable(
-            transactionData: TransactionData<Boolean>,
-            credential: Credential
-        ): Boolean = true
-    }
+    )
 
     companion object {
         private const val TAG = "DigitalCredentialsPresentmentTest"
@@ -209,7 +225,13 @@ class DigitalCredentialsPresentmentTest {
 
     private suspend fun setup() {
         documentStoreTestHarness.initialize()
-        documentStoreTestHarness.provisionStandardDocuments()
+        documentStoreTestHarness.provisionStandardDocuments(
+            keyAuthorizedNamespaces = listOf(
+                FooTransactionType.mdocResponseNamespace,
+                BarTransactionType.mdocResponseNamespace,
+                BuzTransactionType.mdocResponseNamespace
+            )
+        )
         documentStoreTestHarness.documentTypeRepository.addTransactionType(FooTransactionType)
         documentStoreTestHarness.documentTypeRepository.addTransactionType(BarTransactionType)
     }
@@ -600,11 +622,11 @@ class DigitalCredentialsPresentmentTest {
                           portrait: 5318 bytes
                       DeviceNamespaces:
                         FooNS:
-                          transaction_data_hash: 32 bytes
+                          transactionDataHash: 32 bytes
                           result: 42
                         bar:
-                          transaction_data_hash_alg: -43
-                          transaction_data_hash: 48 bytes
+                          transactionDataHashAlg: -43
+                          transactionDataHash: 48 bytes
                           result: 57
                 """.trimIndent().trim(),
         )

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
@@ -237,7 +237,9 @@ class DocumentStoreTestHarness {
         isInitialized = true
     }
 
-    suspend fun provisionStandardDocuments() {
+    suspend fun provisionStandardDocuments(
+        keyAuthorizedNamespaces: List<String> = listOf()
+    ) {
         initialize()
         provisionTestDocuments(
             documentStore = documentStore,
@@ -245,13 +247,15 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
     }
 
     suspend fun provisionMdoc(
         displayName: String,
         docType: String,
-        data: Map<String, List<Pair<String, DataItem>>>
+        data: Map<String, List<Pair<String, DataItem>>>,
+        keyAuthorizedNamespaces: List<String> = listOf()
     ): Document {
         initialize()
         val document = documentStore.createDocument(
@@ -274,6 +278,7 @@ class DocumentStoreTestHarness {
             validFrom = validFrom,
             validUntil = validUntil,
             dsKey = dsKey,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         return document
     }
@@ -310,6 +315,7 @@ class DocumentStoreTestHarness {
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
+        keyAuthorizedNamespaces: List<String>
     ) {
         docMdl = provisionDocument(
             documentStore = documentStore,
@@ -321,6 +327,7 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         docEuPid = provisionDocument(
             documentStore = documentStore,
@@ -338,6 +345,7 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         docEuPid2 = provisionDocument(
             documentStore = documentStore,
@@ -355,6 +363,7 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         docPhotoId = provisionDocument(
             documentStore = documentStore,
@@ -370,6 +379,7 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         docPhotoId2 = provisionDocument(
             documentStore = documentStore,
@@ -385,6 +395,7 @@ class DocumentStoreTestHarness {
             signedAt = signedAt,
             validFrom = validFrom,
             validUntil = validUntil,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
     }
 
@@ -398,6 +409,7 @@ class DocumentStoreTestHarness {
         signedAt: Instant,
         validFrom: Instant,
         validUntil: Instant,
+        keyAuthorizedNamespaces: List<String>
     ): Document {
         val document = documentStore.createDocument(
             displayName = displayName
@@ -412,6 +424,7 @@ class DocumentStoreTestHarness {
                 validFrom = validFrom,
                 validUntil = validUntil,
                 dsKey = dsKey,
+                keyAuthorizedNamespaces = keyAuthorizedNamespaces
             )
         }
 
@@ -438,6 +451,7 @@ class DocumentStoreTestHarness {
         validFrom: Instant,
         validUntil: Instant,
         dsKey: AsymmetricKey.X509Certified,
+        keyAuthorizedNamespaces: List<String> 
     ) {
         val issuerNamespaces = buildIssuerNamespaces {
             for ((nsName, ns) in documentType.mdocDocumentType?.namespaces!!) {
@@ -466,6 +480,7 @@ class DocumentStoreTestHarness {
             validFrom = validFrom,
             validUntil = validUntil,
             dsKey = dsKey,
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
     }
 
@@ -477,6 +492,7 @@ class DocumentStoreTestHarness {
         validFrom: Instant,
         validUntil: Instant,
         dsKey: AsymmetricKey.X509Certified,
+        keyAuthorizedNamespaces: List<String>
     ) {
         // Create authentication keys...
         val mdocCredential = MdocCredential.create(
@@ -499,6 +515,7 @@ class DocumentStoreTestHarness {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = mdocCredential.getAttestation().publicKey,
+            deviceKeyAuthorizedNamespaces = keyAuthorizedNamespaces
         )
         val taggedEncodedMso = Cbor.encode(Tagged(
             Tagged.ENCODED_CBOR,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/verification/VerificationSessionTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/verification/VerificationSessionTest.kt
@@ -66,7 +66,11 @@ class VerificationSessionTest {
 
     private suspend fun setup() {
         harness.initialize()
-        harness.provisionStandardDocuments()
+        harness.provisionStandardDocuments(
+            keyAuthorizedNamespaces = listOf(
+                PingTransaction.mdocResponseNamespace
+            )
+        )
 
         val readerPrivateKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val readerCert = MdocUtil.generateReaderCertificate(
@@ -151,7 +155,7 @@ class VerificationSessionTest {
                 "expected a Ping transaction response"
             )
             assertEquals("string data", pingResponse["string"]!!.asTstr)
-            assertEquals(32, pingResponse["transaction_data_hash"]!!.asBstr.size)
+            assertEquals(32, pingResponse["transactionDataHash"]!!.asBstr.size)
         }
     }
 
@@ -218,8 +222,8 @@ class VerificationSessionTest {
             "expected a Ping transaction response"
         )
         assertEquals(expectedPingString, pingResponse["string"]!!.asTstr)
-        assertEquals(32, pingResponse["transaction_data_hash"]!!.asBstr.size)
-        assertEquals(expectedDocRequestId, pingResponse["doc_request_id"]?.asNumber)
+        assertEquals(32, pingResponse["transactionDataHash"]!!.asBstr.size)
+        assertEquals(expectedDocRequestId, pingResponse["docRequestId"]?.asNumber)
     }
 
     @Test


### PR DESCRIPTION
This changes how transactions are encoded and verified with minor tweaks to the functionality.

Importantly, we now check that mdoc credential explicitly allows the transaction type by checking KeyAuthorizedNamespaces. (But we do not process KeyAuthorizedDataElements yet).

Fixes #1891

Test: unit tests + manual testing with issuer and verifier
