### PR TITLE
Add debug log statements for OpenID4VCI provisioning.

### DIFF
--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/challenge.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/challenge.kt
@@ -13,6 +13,10 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Configuration
 import org.multipaz.rpc.handler.InvalidRequestException
 
+import org.multipaz.util.Logger
+
+private const val TAG = "challenge"
+
 /**
  * Issues a fresh wallet attestation challenge
  */
@@ -21,10 +25,12 @@ suspend fun challenge(call: ApplicationCall) {
     call.response.header("Cache-Control", "no-store")
     nonces.dpopNonce?.let { call.response.header("DPoP-Nonce", it) }
     check(nonces.credentialNonce == null)
+    val responseJson = buildJsonObject {
+        put("attestation_challenge", nonces.clientAttestationNonce!!)
+    }
+    Logger.dJson(TAG, "Sending challenge response", responseJson)
     call.respondText(
-        text = buildJsonObject {
-            put("attestation_challenge", nonces.clientAttestationNonce!!)
-        }.toString(),
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json
     )
 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/credential.kt
@@ -93,6 +93,7 @@ suspend fun credential(call: ApplicationCall) {
 
     val requestString = call.receiveText()
     val json = Json.parseToJsonElement(requestString) as JsonObject
+    Logger.dJson(TAG, "Received credential request", json)
 
     val credentialConfigurationId = (json["credential_configuration_id"] as? JsonPrimitive)?.content
     val credentialIdentifier = (json["credential_identifier"] as? JsonPrimitive)?.content
@@ -159,15 +160,17 @@ suspend fun credential(call: ApplicationCall) {
         ))
         // Do not extend session expiration
         IssuanceState.updateIssuanceState(id, state, expiration = null)
-        call.respondText(
-            text = buildJsonObject {
-                addDisplay(locale, display)
-                putJsonArray("credentials") {
-                    addJsonObject {
-                        put("credential", minted.credential)
-                    }
+        val response = buildJsonObject {
+            addDisplay(locale, display)
+            putJsonArray("credentials") {
+                addJsonObject {
+                    put("credential", minted.credential)
                 }
-            }.toString(),
+            }
+        }
+        Logger.dJson(TAG, "Sending credential response", response)
+        call.respondText(
+            text = response.toString(),
             contentType = ContentType.Application.Json
         )
         return
@@ -202,6 +205,8 @@ suspend fun credential(call: ApplicationCall) {
     val authenticationKeysAndIds = when (proofType) {
         "attestation" -> {
             proofs.flatMap { proof ->
+                val jwtStr = proof.jsonPrimitive.content
+                Logger.dJwt(TAG, "Received Key Attestation JWT", jwtStr)
                 val body = try {
                     validateJwt(
                         jwt = proof.jsonPrimitive.content,
@@ -277,6 +282,7 @@ suspend fun credential(call: ApplicationCall) {
             var expectedNonce: String? = null
             proofs.map { proof ->
                 val jwt = proof.jsonPrimitive.content
+                Logger.dJwt(TAG, "Received Proof of Possession JWT", jwt)
                 val parts = jwt.split(".")
                 if (parts.size != 3) {
                     throw InvalidRequestException("invalid value for 'proof.jwt' parameter")
@@ -357,6 +363,7 @@ suspend fun credential(call: ApplicationCall) {
                 }
             }
         }
+    Logger.dJson(TAG, "Sending credential response", result)
     call.respondText(
         text = Json.encodeToString(result),
         contentType = ContentType.Application.Json

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/nonce.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/nonce.kt
@@ -12,6 +12,10 @@ import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.storage.StorageTableSpec
 
+import org.multipaz.util.Logger
+
+private const val TAG = "nonce"
+
 /**
  * Endpoint to obtain fresh `c_nonce` (challenge for device binding key attestation).
  */
@@ -22,10 +26,12 @@ suspend fun nonce(call: ApplicationCall) {
     nonces.clientAttestationNonce?.let {
         call.response.header("OAuth-Client-Attestation-Challenge", it)
     }
+    val responseJson = buildJsonObject {
+        put("c_nonce", nonces.credentialNonce!!)
+    }
+    Logger.dJson(TAG, "Sending nonce response", responseJson)
     call.respondText(
-        text = buildJsonObject {
-            put("c_nonce", nonces.credentialNonce!!)
-        }.toString(),
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json
     )
 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/pushedAuthorizationRequest.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/pushedAuthorizationRequest.kt
@@ -18,6 +18,10 @@ import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
+import org.multipaz.util.Logger
+
+private const val TAG = "pushedAuthorizationRequest"
+
 /**
  * Pushed Authorization Request, which is the first request to be sent to our OpenID4VCI server
  * if authorize challenge path is not used. In theory, other, simpler (and less secure) forms of
@@ -37,6 +41,7 @@ import kotlin.time.Duration.Companion.minutes
  */
 suspend fun pushedAuthorizationRequest(call: ApplicationCall) {
     val parameters = call.receiveParameters()
+    Logger.d(TAG, "Received PAR request with parameters: $parameters")
     val timeout: Duration = 5.minutes
     val nonces = NonceManager.get().pushedAuthorizationRequest()
 
@@ -55,11 +60,13 @@ suspend fun pushedAuthorizationRequest(call: ApplicationCall) {
     nonces.clientAttestationNonce?.let {
         call.response.header("OAuth-Client-Attestation-Challenge", it)
     }
+    val responseJson = buildJsonObject {
+        put("request_uri", "urn:ietf:params:oauth:request_uri:$code")
+        put("expires_in", timeout.inWholeSeconds)
+    }
+    Logger.dJson(TAG, "Sending PAR response", responseJson)
     call.respondText(
-        text = buildJsonObject {
-                put("request_uri", "urn:ietf:params:oauth:request_uri:$code")
-                put("expires_in", timeout.inWholeSeconds)
-            }.toString(),
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json,
         status = HttpStatusCode.Created
     )

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/token.kt
@@ -62,6 +62,7 @@ suspend fun token(call: ApplicationCall) {
     val digest: ByteString?
     val parameters = call.receiveParameters()
     val grantType = parameters["grant_type"]
+    Logger.d(TAG, "Received token request for grant_type '$grantType' with parameters: $parameters")
     val id = when (grantType) {
         "authorization_code" -> {
             val code = parameters["code"]
@@ -176,13 +177,15 @@ suspend fun token(call: ApplicationCall) {
     nonces.clientAttestationNonce?.let {
         call.response.header("OAuth-Client-Attestation-Challenge", it)
     }
+    val responseJson = buildJsonObject {
+        put("access_token", accessToken)
+        put("refresh_token", refreshToken)
+        put("expires_in", expiresIn.inWholeSeconds.toInt())
+        put("token_type", "DPoP")
+    }
+    Logger.dJson(TAG, "Sending token response", responseJson)
     call.respondText(
-        text = buildJsonObject {
-                put("access_token", accessToken)
-                put("refresh_token", refreshToken)
-                put("expires_in", expiresIn.inWholeSeconds.toInt())
-                put("token_type", "DPoP")
-            }.toString(),
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json
     )
 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOauthAuthorization.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOauthAuthorization.kt
@@ -11,6 +11,10 @@ import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Configuration
 import org.multipaz.server.common.baseUrl
 
+import org.multipaz.util.Logger
+
+private const val TAG = "wellKnownOauthAuthorization"
+
 /**
  * Generates `.well-known/oauth-authorization-server` metadata file.
  */
@@ -21,42 +25,44 @@ suspend fun wellKnownOauthAuthorization(call: ApplicationCall) {
     val supportClientAttestation = configuration.getValue("support_client_attestation") != "false"
     val useClientAttestationChallenge =
         configuration.getValue("use_client_attestation_challenge") != "false"
+    val responseJson = buildJsonObject {
+        put("issuer", baseUrl)
+        if (useClientAttestationChallenge) {
+            put("challenge_endpoint", "$baseUrl/challenge")
+        }
+        put("authorization_endpoint", "$baseUrl/authorize")
+        // OAuth for First-Party Apps (FiPA), this got reworked substantially, disable for now
+        //put("authorization_challenge_endpoint", "$baseUrl/authorize_challenge")
+        put("token_endpoint", "$baseUrl/token")
+        put("pushed_authorization_request_endpoint", "$baseUrl/par")
+        put("require_pushed_authorization_requests", true)
+        putJsonArray("token_endpoint_auth_methods_supported") {
+            if (supportClientAssertion) {
+                add("private_key_jwt")
+            }
+            if (supportClientAttestation) {
+                add("attest_jwt_client_auth")
+            }
+        }
+        putJsonArray("response_types_supported") {
+            add("code")
+        }
+        putJsonArray("code_challenge_methods_supported") {
+            add("S256")
+        }
+        putJsonArray("dpop_signing_alg_values_supported") {
+            add("ES256")
+        }
+        putJsonArray("client_attestation_signing_alg_values_supported") {
+            add("ES256")
+        }
+        putJsonArray("client_attestation_pop_signing_alg_values_supported") {
+            add("ES256")
+        }
+    }
+    Logger.dJson(TAG, "Sending well-known oauth-authorization-server response", responseJson)
     call.respondText(
-        text = buildJsonObject {
-            put("issuer", baseUrl)
-            if (useClientAttestationChallenge) {
-                put("challenge_endpoint", "$baseUrl/challenge")
-            }
-            put("authorization_endpoint", "$baseUrl/authorize")
-            // OAuth for First-Party Apps (FiPA), this got reworked substantially, disable for now
-            //put("authorization_challenge_endpoint", "$baseUrl/authorize_challenge")
-            put("token_endpoint", "$baseUrl/token")
-            put("pushed_authorization_request_endpoint", "$baseUrl/par")
-            put("require_pushed_authorization_requests", true)
-            putJsonArray("token_endpoint_auth_methods_supported") {
-                if (supportClientAssertion) {
-                    add("private_key_jwt")
-                }
-                if (supportClientAttestation) {
-                    add("attest_jwt_client_auth")
-                }
-            }
-            putJsonArray("response_types_supported") {
-                add("code")
-            }
-            putJsonArray("code_challenge_methods_supported") {
-                add("S256")
-            }
-            putJsonArray("dpop_signing_alg_values_supported") {
-                add("ES256")
-            }
-            putJsonArray("client_attestation_signing_alg_values_supported") {
-                add("ES256")
-            }
-            putJsonArray("client_attestation_pop_signing_alg_values_supported") {
-                add("ES256")
-            }
-        }.toString(),
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json
     )
 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/request/wellKnownOpenidCredentialIssuer.kt
@@ -17,7 +17,10 @@ import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.server.common.baseUrl
 
+import org.multipaz.util.Logger
+
 const val PREFIX = "openid4vci.issuer"
+private const val TAG = "wellKnownOpenidCredentialIssuer"
 
 /**
  * Generates `.well-known/openid-credential-issuer` metadata file.
@@ -30,104 +33,102 @@ suspend fun wellKnownOpenidCredentialIssuer(call: ApplicationCall) {
     val locale = configuration.getValue("issuer_locale") ?: "en-US"
     val registry = BackendEnvironment.getInterface(CredentialFactoryRegistry::class)!!
     val signingKeys = registry.byId.mapValues { (_, factory) -> factory.getSigningKey() }
-    call.respondText(
-        text = buildJsonObject {
-            put("credential_issuer", baseUrl)
-            put("credential_endpoint", "$baseUrl/credential")
-            put("nonce_endpoint", "$baseUrl/nonce")
-            putJsonArray("authorization_servers") {
-                add(JsonPrimitive(baseUrl))
+    val responseJson = buildJsonObject {
+        put("credential_issuer", baseUrl)
+        put("credential_endpoint", "$baseUrl/credential")
+        put("nonce_endpoint", "$baseUrl/nonce")
+        putJsonArray("authorization_servers") {
+            add(JsonPrimitive(baseUrl))
+        }
+        putJsonArray("display") {
+            addJsonObject {
+                put("name", name)
+                put("locale", locale)
+                put("logo", buildJsonObject {
+                    put("uri", JsonPrimitive("$baseUrl/logo.png"))
+                })
             }
-            putJsonArray("display") {
-                addJsonObject {
-                    put("name", name)
-                    put("locale", locale)
-                    put("logo", buildJsonObject {
-                        put("uri", JsonPrimitive("$baseUrl/logo.png"))
-                    })
-                }
-            }
-            putJsonObject("batch_credential_issuance") {
-                val batchSize =
-                    configuration.getValue("$PREFIX.batch_size")?.toIntOrNull() ?: 12
-                put("batch_size", JsonPrimitive(batchSize))
-            }
-            putJsonObject("credential_configurations_supported") {
-                for (credentialFactory in registry.byId.values) {
-                    val signingKey = signingKeys[credentialFactory.configurationId]!!
-                    putJsonObject(credentialFactory.configurationId) {
-                        if (useScopes) {
-                            put("scope", credentialFactory.scope)
-                        }
-                        val format = credentialFactory.format
-                        put("format", format.formatId)
-                        when (format) {
-                            is CredentialFormat.Mdoc -> put("doctype", format.docType)
-                            is CredentialFormat.SdJwt -> put("vct", format.vct)
-                        }
-                        if (credentialFactory.proofSigningAlgorithms.isNotEmpty()) {
-                            putJsonObject("proof_types_supported") {
-                                if (!credentialFactory.requireKeyAttestation) {
-                                    putJsonObject("jwt") {
-                                        putJsonArray("proof_signing_alg_values_supported") {
-                                            credentialFactory.proofSigningAlgorithms.forEach {
-                                                add(it)
-                                            }
-                                        }
-                                    }
-                                }
-                                putJsonObject("attestation") {
+        }
+        putJsonObject("batch_credential_issuance") {
+            val batchSize =
+                configuration.getValue("$PREFIX.batch_size")?.toIntOrNull() ?: 12
+            put("batch_size", JsonPrimitive(batchSize))
+        }
+        putJsonObject("credential_configurations_supported") {
+            for (credentialFactory in registry.byId.values) {
+                val signingKey = signingKeys[credentialFactory.configurationId]!!
+                putJsonObject(credentialFactory.configurationId) {
+                    if (useScopes) {
+                        put("scope", credentialFactory.scope)
+                    }
+                    val format = credentialFactory.format
+                    put("format", format.formatId)
+                    when (format) {
+                        is CredentialFormat.Mdoc -> put("doctype", format.docType)
+                        is CredentialFormat.SdJwt -> put("vct", format.vct)
+                    }
+                    if (credentialFactory.proofSigningAlgorithms.isNotEmpty()) {
+                        putJsonObject("proof_types_supported") {
+                            if (!credentialFactory.requireKeyAttestation) {
+                                putJsonObject("jwt") {
                                     putJsonArray("proof_signing_alg_values_supported") {
                                         credentialFactory.proofSigningAlgorithms.forEach {
                                             add(it)
                                         }
                                     }
                                 }
-                                if (credentialFactory.acceptAndroidKeyAttestation) {
-                                    val level = when (credentialFactory.keyMintSecurityLevel) {
-                                        AndroidKeystoreSecurityLevel.SOFTWARE ->
-                                            "Software"
-                                        AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT ->
-                                            "TrustedEnvironment"
-                                        AndroidKeystoreSecurityLevel.STRONG_BOX ->
-                                            "StrongBox"
+                            }
+                            putJsonObject("attestation") {
+                                putJsonArray("proof_signing_alg_values_supported") {
+                                    credentialFactory.proofSigningAlgorithms.forEach {
+                                        add(it)
                                     }
-                                    putJsonObject("android_keystore_attestation") {
-                                        putJsonObject("key_attestations_required") {
-                                            put("key_mint_security_level", level)
-                                        }
-                                        putJsonArray("proof_signing_alg_values_supported") {
-                                            credentialFactory.proofSigningAlgorithms.forEach {
-                                                add(it)
-                                            }
+                                }
+                            }
+                            if (credentialFactory.acceptAndroidKeyAttestation) {
+                                val level = when (credentialFactory.keyMintSecurityLevel) {
+                                    AndroidKeystoreSecurityLevel.SOFTWARE ->
+                                        "Software"
+                                    AndroidKeystoreSecurityLevel.TRUSTED_ENVIRONMENT ->
+                                        "TrustedEnvironment"
+                                    AndroidKeystoreSecurityLevel.STRONG_BOX ->
+                                        "StrongBox"
+                                }
+                                putJsonObject("android_keystore_attestation") {
+                                    putJsonObject("key_attestations_required") {
+                                        put("key_mint_security_level", level)
+                                    }
+                                    putJsonArray("proof_signing_alg_values_supported") {
+                                        credentialFactory.proofSigningAlgorithms.forEach {
+                                            add(it)
                                         }
                                     }
                                 }
                             }
                         }
-                        if (credentialFactory.cryptographicBindingMethods.isNotEmpty()) {
-                            putJsonArray("cryptographic_binding_methods_supported") {
-                                credentialFactory.cryptographicBindingMethods.forEach {
-                                    add(it)
-                                }
+                    }
+                    if (credentialFactory.cryptographicBindingMethods.isNotEmpty()) {
+                        putJsonArray("cryptographic_binding_methods_supported") {
+                            credentialFactory.cryptographicBindingMethods.forEach {
+                                add(it)
                             }
                         }
-                        putJsonArray("credential_signing_alg_values_supported") {
-                            if (credentialFactory.format is CredentialFormat.Mdoc) {
-                                add(signingKey.algorithm.coseAlgorithmIdentifier)
-                            } else {
-                                add(signingKey.algorithm.joseAlgorithmIdentifier)
-                            }
+                    }
+                    putJsonArray("credential_signing_alg_values_supported") {
+                        if (credentialFactory.format is CredentialFormat.Mdoc) {
+                            add(signingKey.algorithm.coseAlgorithmIdentifier)
+                        } else {
+                            add(signingKey.algorithm.joseAlgorithmIdentifier)
                         }
-                        putJsonObject("credential_metadata") {
-                            putJsonArray("display") {
-                                addJsonObject {
-                                    put("name", credentialFactory.name)
-                                    put("locale", locale)
-                                    if (credentialFactory.logo != null) {
-                                        putJsonObject("logo") {
-                                            put("uri", "$baseUrl/${credentialFactory.logo}")
-                                        }
+                    }
+                    putJsonObject("credential_metadata") {
+                        putJsonArray("display") {
+                            addJsonObject {
+                                put("name", credentialFactory.name)
+                                put("locale", locale)
+                                if (credentialFactory.logo != null) {
+                                    putJsonObject("logo") {
+                                        put("uri", "$baseUrl/${credentialFactory.logo}")
                                     }
                                 }
                             }
@@ -135,7 +136,11 @@ suspend fun wellKnownOpenidCredentialIssuer(call: ApplicationCall) {
                     }
                 }
             }
-        }.toString(),
+        }
+    }
+    Logger.dJson(TAG, "Sending well-known openid-credential-issuer response", responseJson)
+    call.respondText(
+        text = responseJson.toString(),
         contentType = ContentType.Application.Json
     )
 }

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/auth.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/util/auth.kt
@@ -28,6 +28,7 @@ import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.openid4vci.credential.CredentialFactoryRegistry
 import org.multipaz.openid4vci.customization.NonceManager
 import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.util.Logger
 import org.multipaz.rpc.handler.InvalidRequestException
 import org.multipaz.rpc.handler.SimpleCipher
 import org.multipaz.server.common.getBaseUrl
@@ -36,12 +37,15 @@ import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 import org.multipaz.webtoken.validateJwt
 import org.multipaz.rpc.backend.Configuration
+
 import org.multipaz.server.common.ServerException
 import org.multipaz.server.common.baseUrl
 import org.multipaz.server.enrollment.ServerIdentity
 import org.multipaz.server.enrollment.validateServerIdentityCertificateChain
 import kotlin.time.Duration
 import kotlin.time.Instant
+
+private const val TAG = "auth"
 
 const val OAUTH_REQUEST_URI_PREFIX = "urn:ietf:params:oauth:request_uri:"
 const val MULTIPAZ_PRE_AUTHORIZE_URI = "https://pre-authorize.multipaz.org/"
@@ -174,6 +178,7 @@ suspend fun validateClientAttestation(
 ): EcPublicKey? {
     val clientAttestationJwt = request.headers["OAuth-Client-Attestation"]
         ?: return null
+    Logger.dJwt(TAG, "Received OAuth-Client-Attestation JWT", clientAttestationJwt)
 
     val configuration = BackendEnvironment.getInterface(Configuration::class)!!
     val requireIssuerMatch =
@@ -218,6 +223,7 @@ suspend fun validateClientAttestationPoP(
 ) {
     val popJwt = request.headers["OAuth-Client-Attestation-PoP"]
         ?: throw InvalidRequestException("OAuth-Client-Attestation-PoP header required")
+    Logger.dJwt(TAG, "Received OAuth-Client-Attestation-PoP JWT", popJwt)
 
     val configuration = BackendEnvironment.getInterface(Configuration::class)!!
     val baseUrl = configuration.baseUrl
@@ -385,6 +391,7 @@ suspend fun validateClientAssertion(parameters: Parameters, clientId: String): B
         return false
     }
     val clientAssertionJwt = parameters["client_assertion"] ?: return false
+    Logger.dJwt(TAG, "Received Client Assertion JWT", clientAssertionJwt)
     validateClientAssertionJwt(clientAssertionJwt, clientId)
     return true
 }
@@ -398,6 +405,7 @@ private suspend fun validateDPoPJwt(
     initial: Boolean,
 ) {
     val dpop = request.headers["DPoP"] ?: throw InvalidRequestException("DPoP header required")
+    Logger.dJwt(TAG, "Received DPoP JWT", dpop)
     val baseUrl = BackendEnvironment.getBaseUrl()
     val nonceManager = NonceManager.get()
     val nonceValidator: suspend (String) -> Unit = if (isResourceServer) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/AuthorizationConfiguration.kt
@@ -28,12 +28,14 @@ internal data class AuthorizationConfiguration(
 
             // Fetch issuer metadata
             val metadataUrl = wellKnown(url, "oauth-authorization-server", dropTrailingSlash = true)
+            Logger.d(TAG, "Fetching authorization server metadata from $metadataUrl")
             val metadataRequest = httpClient.get(metadataUrl) {}
             if (metadataRequest.status != HttpStatusCode.OK) {
                 throw IllegalStateException("Invalid issuer, no $metadataUrl")
             }
             val metadataText = metadataRequest.readRawBytes().decodeToString()
             val metadata = Json.parseToJsonElement(metadataText).jsonObject
+            Logger.dJson(TAG, "Received authorization server metadata", metadata)
             val identifier = metadata.stringOrNull("issuer") ?: url
             val challengeEndpoint = metadata.stringOrNull("challenge_endpoint")
             val authorizationEndpoint = metadata.string("authorization_endpoint")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/CredentialOffer.kt
@@ -56,6 +56,7 @@ internal sealed class CredentialOffer {
 
 
     internal companion object: JsonParsing("Credential offer") {
+        private const val TAG = "CredentialOffer"
 
         /**
          * Parse openid4vci credential offer Url (from a deep link or Qr scan) and return
@@ -65,11 +66,13 @@ internal sealed class CredentialOffer {
             offerUri: String
         ): CredentialOffer {
             try {
+                Logger.d(TAG, "Parsing credential offer from URI: $offerUri")
                 val params = Url(offerUri).parameters
                 var credentialOfferString = params["credential_offer"]
                 if (credentialOfferString == null) {
                     val url = params["credential_offer_uri"]
                         ?: throw IllegalStateException("Neither 'credential_offer' nor 'credential_offer_uri' are given")
+                    Logger.d(TAG, "Fetching credential offer from URI: $url")
                     val response = HttpClient().get(url) {}
                     if (response.status != HttpStatusCode.OK) {
                         throw IllegalStateException("Error retrieving '$url'")
@@ -77,11 +80,12 @@ internal sealed class CredentialOffer {
                     credentialOfferString = response.readRawBytes().decodeToString()
                 }
                 val json = Json.parseToJsonElement(credentialOfferString).jsonObject
+                Logger.dJson(TAG, "Parsed credential offer", json)
                 return parseJson(json)
             } catch (err: CancellationException) {
                 throw err
             } catch (err: Exception) {
-                Logger.e("CredentialOffer", "Parsing error", err)
+                Logger.e(TAG, "Parsing error", err)
                 throw err
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/IssuerConfiguration.kt
@@ -47,12 +47,14 @@ internal data class IssuerConfiguration(
 
             // Fetch issuer metadata
             val issuerMetadataUrl = wellKnown(url, "openid-credential-issuer")
+            Logger.d(TAG, "Fetching issuer metadata from $issuerMetadataUrl")
             val issuerMetadataRequest = httpClient.get(issuerMetadataUrl) {}
             if (issuerMetadataRequest.status != HttpStatusCode.OK) {
                 throw IllegalStateException("Invalid issuer, no $issuerMetadataUrl")
             }
             val credentialMetadataText = issuerMetadataRequest.readRawBytes().decodeToString()
             val credentialMetadata = Json.parseToJsonElement(credentialMetadataText).jsonObject
+            Logger.dJson(TAG, "Received issuer metadata", credentialMetadata)
 
             val authorizationServers = credentialMetadata.arrayOrNull("authorization_servers")
             val authorizationServerUrls =

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/openid4vci/OpenID4VCIProvisioningClient.kt
@@ -139,6 +139,7 @@ internal class OpenID4VCIProvisioningClient(
         }
         // obtain c_nonce (serves as challenge for the device-bound key)
         val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+        Logger.d(TAG, "Requesting nonce from ${issuerConfiguration.nonceEndpoint}")
         val nonceResponse = httpClient.post(issuerConfiguration.nonceEndpoint!!) {}
         if (nonceResponse.status != HttpStatusCode.OK) {
             throw IllegalStateException("Error getting a nonce")
@@ -147,7 +148,9 @@ internal class OpenID4VCIProvisioningClient(
         // A fresh DPoP nonce might or might not be given
         nonceResponse.headers["DPoP-Nonce"]?.let { issuerDPoPNonce = it }
         val responseText = nonceResponse.readRawBytes().decodeToString()
-        val cNonce = Json.parseToJsonElement(responseText).jsonObject.string("c_nonce")
+        val json = Json.parseToJsonElement(responseText).jsonObject
+        Logger.dJson(TAG, "Received nonce response", json)
+        val cNonce = json.string("c_nonce")
         keyChallenge = cNonce
         return cNonce
     }
@@ -165,6 +168,23 @@ internal class OpenID4VCIProvisioningClient(
             issuerConfiguration.credentialConfigurations[credentialOffer.configurationId]!!
         val keyProofs = buildKeyProofs(keyInfo, credentialConfiguration)
         val dpopKey = getDPopKey()
+        val requestBody = buildJsonObject {
+            put("credential_configuration_id", credentialOffer.configurationId)
+            if (keyProofs != null) {
+                put("proofs", keyProofs)
+            }
+            when (credentialMetadata.format) {
+                is CredentialFormat.Mdoc -> {
+                    put("format", "mso_mdoc")
+                    put("doctype", credentialMetadata.format.docType)
+                }
+                is CredentialFormat.SdJwt -> {
+                    put("format", "dc+sd-jwt")
+                    put("vct", credentialMetadata.format.vct)
+                }
+            }
+        }
+        Logger.dJson(TAG, "Sending credential request to ${issuerConfiguration.credentialEndpoint}", requestBody)
         while (true) {
             val dpop = OpenID4VCIUtil.generateDPoP(
                 dpopKey = dpopKey,
@@ -173,28 +193,14 @@ internal class OpenID4VCIProvisioningClient(
                 dpopNonce = issuerDPoPNonce,
                 accessToken = token
             )
+            Logger.dJwt(TAG, "Credential DPoP JWT", dpop)
             credentialResponse = httpClient.post(issuerConfiguration.credentialEndpoint) {
                 headers {
                     append("Authorization", "DPoP $token")
                     append("DPoP", dpop)
                     contentType(ContentType.Application.Json)
                 }
-                setBody(buildJsonObject {
-                    put("credential_configuration_id", credentialOffer.configurationId)
-                    if (keyProofs != null) {
-                        put("proofs", keyProofs)
-                    }
-                    when (credentialMetadata.format) {
-                        is CredentialFormat.Mdoc -> {
-                            put("format", "mso_mdoc")
-                            put("doctype", credentialMetadata.format.docType)
-                        }
-                        is CredentialFormat.SdJwt -> {
-                            put("format", "dc+sd-jwt")
-                            put("vct", credentialMetadata.format.vct)
-                        }
-                    }
-                }.toString())
+                setBody(requestBody.toString())
             }
             if (credentialResponse.headers.contains("DPoP-Nonce")) {
                 issuerDPoPNonce = credentialResponse.headers["DPoP-Nonce"]!!
@@ -218,6 +224,7 @@ internal class OpenID4VCIProvisioningClient(
         Logger.i(TAG, "Got successful response for credential request")
 
         val response = Json.parseToJsonElement(responseText) as JsonObject
+        Logger.dJson(TAG, "Received credential response", response)
         val serializedCredentials = response["credentials"]!!.jsonArray.map {
             if (it !is JsonObject) {
                 throw IllegalStateException("Credential must be represented as json string")
@@ -249,6 +256,7 @@ internal class OpenID4VCIProvisioningClient(
             is KeyBindingInfo.OpenidProofOfPossession -> buildJsonObject {
                 putJsonArray("jwt") {
                     for (jwt in keyInfo.jwtList) {
+                        Logger.dJwt(TAG, "Proof of Possession JWT", jwt)
                         add(jwt)
                     }
                 }
@@ -270,6 +278,7 @@ internal class OpenID4VCIProvisioningClient(
                         credentialKeyAttestations = keyInfo.attestations,
                         challenge = keyChallenge!!
                     )
+                    Logger.dJwt(TAG, "Key Attestation JWT", jwtKeyAttestation)
                     putJsonArray("attestation") {
                         add(jwtKeyAttestation)
                     }
@@ -352,6 +361,48 @@ internal class OpenID4VCIProvisioningClient(
             val redirectState = createUniqueStateValue()
             this.redirectState = redirectState
 
+            val parParams = buildJsonObject {
+                if (scope != null) {
+                    put("scope", scope)
+                } else {
+                    put("authorization_details", buildJsonArray {
+                        addJsonObject {
+                            put("type", "openid_credential")
+                            put("credential_configuration_id", configurationId)
+                        }
+                    })
+                }
+                if (credentialOffer is CredentialOffer.AuthorizationCode) {
+                    val issuerState = credentialOffer.issuerState
+                    if (issuerState != null) {
+                        put("issuer_state", issuerState)
+                    }
+                }
+                if (clientAssertion != null) {
+                    put("client_assertion", clientAssertion)
+                    put(
+                        "client_assertion_type",
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                    )
+                }
+                put("response_type", "code")
+                put("code_challenge_method", "S256")
+                put("redirect_uri", clientPreferences.redirectUrl)
+                put("code_challenge", codeChallenge)
+                put("client_id", clientPreferences.clientId)
+                put("state", redirectState)
+            }
+            Logger.dJson(
+                TAG,
+                "Sending PAR request to ${authorizationConfiguration.pushedAuthorizationRequestEndpoint}",
+                parParams
+            )
+
+            Logger.dJwt(TAG, "PAR DPoP JWT", dpop)
+            clientAssertion?.let { Logger.dJwt(TAG, "PAR Client Assertion JWT", it) }
+            authorizationData.walletAttestation?.let { Logger.dJwt(TAG, "PAR OAuth-Client-Attestation JWT", it) }
+            walletAttestationPoP?.let { Logger.dJwt(TAG, "PAR OAuth-Client-Attestation-PoP JWT", it) }
+
             response = httpClient.submitForm(
                 url = authorizationConfiguration.pushedAuthorizationRequestEndpoint,
                 formParameters = parameters {
@@ -411,6 +462,7 @@ internal class OpenID4VCIProvisioningClient(
         }
         val responseText = response.readRawBytes().decodeToString()
         val parsedResponse = Json.parseToJsonElement(responseText).jsonObject
+        Logger.dJson(TAG, "Received PAR response", parsedResponse)
         return parsedResponse.string("request_uri")
     }
 
@@ -437,6 +489,7 @@ internal class OpenID4VCIProvisioningClient(
     }
 
     private suspend fun processOauthResponse(parameterizedRedirectUrl: String) {
+        Logger.d(TAG, "Processing OAuth redirect URL: $parameterizedRedirectUrl")
         val navigatedUrl = Url(parameterizedRedirectUrl)
         if (navigatedUrl.parameters["state"] != redirectState) {
             throw IllegalStateException("Openid4Vci: state parameter value mismatch")
@@ -455,6 +508,7 @@ internal class OpenID4VCIProvisioningClient(
     }
 
     private suspend fun processSecretTextResponse(secret: String) {
+        Logger.d(TAG, "Processing secret text response")
         val credentialOffer = this.credentialOffer as CredentialOffer.PreauthorizedCode
         obtainToken(preauthorizedCode = credentialOffer.preauthorizedCode, txCode = secret)
     }
@@ -510,6 +564,50 @@ internal class OpenID4VCIProvisioningClient(
             } else {
                 null
             }
+
+            val tokenParams = buildJsonObject {
+                if (refreshToken != null) {
+                    put("grant_type", "refresh_token")
+                    put("refresh_token", refreshToken)
+                } else if (authorizationCode != null) {
+                    put("grant_type", "authorization_code")
+                    put("code", authorizationCode)
+                } else if (preauthorizedCode != null) {
+                    put("grant_type", "urn:ietf:params:oauth:grant-type:pre-authorized_code")
+                    put("pre-authorized_code", preauthorizedCode)
+                    if (txCode != null) {
+                        put("tx_code", txCode)
+                    }
+                    put("authorization_details", buildJsonArray {
+                        addJsonObject {
+                            put("type", "openid_credential")
+                            put("credential_configuration_id", credentialOffer.configurationId)
+                        }
+                    })
+                }
+                if (codeVerifier != null) {
+                    put("code_verifier", codeVerifier)
+                }
+                if (clientAssertion != null) {
+                    put("client_assertion", clientAssertion)
+                    put(
+                        "client_assertion_type",
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                    )
+                }
+                put("client_id", clientPreferences.clientId)
+                put("redirect_uri", clientPreferences.redirectUrl)
+            }
+            Logger.dJson(
+                TAG,
+                "Sending token request to ${authorizationConfiguration.tokenEndpoint}",
+                tokenParams
+            )
+
+            Logger.dJwt(TAG, "Token DPoP JWT", dpop)
+            clientAssertion?.let { Logger.dJwt(TAG, "Token Client Assertion JWT", it) }
+            authorizationData.walletAttestation?.let { Logger.dJwt(TAG, "Token OAuth-Client-Attestation JWT", it) }
+            walletAttestationPoP?.let { Logger.dJwt(TAG, "Token OAuth-Client-Attestation-PoP JWT", it) }
 
             val response = httpClient.submitForm(
                 url = authorizationConfiguration.tokenEndpoint,
@@ -588,6 +686,7 @@ internal class OpenID4VCIProvisioningClient(
             }
             val tokenResponseString = response.readRawBytes().decodeToString()
             val tokenResponse = Json.parseToJsonElement(tokenResponseString) as JsonObject
+            Logger.dJson(TAG, "Received token response", tokenResponse)
             token = tokenResponse.string("access_token")
             val duration = tokenResponse.integer("expires_in")
             tokenExpiration = Clock.System.now() + duration.seconds
@@ -603,6 +702,7 @@ internal class OpenID4VCIProvisioningClient(
         if (authorizationConfiguration.clientAuthentication == ClientAuthenticationType.CLIENT_ATTESTATION) {
             // Using client attestation. Check if we need to get a fresh challenge
             if (authorizationConfiguration.challengeEndpoint != null) {
+                Logger.d(TAG, "Requesting client attestation challenge from ${authorizationConfiguration.challengeEndpoint}")
                 val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
                 val response = httpClient.post(authorizationConfiguration.challengeEndpoint) {}
                 if (response.status != HttpStatusCode.OK) {
@@ -612,8 +712,9 @@ internal class OpenID4VCIProvisioningClient(
                 // DPoP nonce might or might not be given
                 authorizationDPoPNonce = response.headers["DPoP-Nonce"]
                 val responseText = response.readRawBytes().decodeToString()
-                clientAttestationChallenge = Json.parseToJsonElement(responseText)
-                    .jsonObject.string("attestation_challenge")
+                val json = Json.parseToJsonElement(responseText).jsonObject
+                Logger.dJson(TAG, "Received client attestation challenge response", json)
+                clientAttestationChallenge = json.string("attestation_challenge")
             }
         }
     }
@@ -780,6 +881,10 @@ internal class OpenID4VCIProvisioningClient(
             authorizationData: OpenID4VCIAuthorizationData
         ): OpenID4VCIProvisioningClient {
             require(authorizationData.secureAreaId == secureArea.identifier)
+            Logger.d(
+                TAG,
+                "Creating OpenID4VCIProvisioningClient: issuerUri='${credentialOffer.issuerUri}', configurationId='${credentialOffer.configurationId}'"
+            )
             val issuerConfig = IssuerConfiguration.get(
                 url = credentialOffer.issuerUri,
                 httpClient = BackendEnvironment.getInterface(HttpClient::class)!!,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Logger.kt
@@ -343,6 +343,65 @@ object Logger {
     fun eJson(tag: String, message: String, json: JsonElement) {
         json(Level.ERROR, tag, message, json)
     }
+
+    private fun jwt(level: Level, tag: String, message: String, jwtString: String) {
+        if (jwtString.contains('~')) {
+            val sdParts = jwtString.split('~')
+            val mainJwt = sdParts.first()
+            jwt(level, tag, "$message (SD-JWT issuer JWT)", mainJwt)
+            if (sdParts.size > 1 && sdParts.last().count { it == '.' } == 2) {
+                val kbJwt = sdParts.last()
+                jwt(level, tag, "$message (SD-JWT key binding JWT)", kbJwt)
+            }
+            return
+        }
+
+        try {
+            val parts = jwtString.split('.')
+            if (parts.size == 3 || parts.size == 5) {
+                val header = Json.parseToJsonElement(parts[0].fromBase64Url().decodeToString())
+                json(level, tag, "$message (header)", header)
+                if (parts.size == 3) {
+                    val payload = Json.parseToJsonElement(parts[1].fromBase64Url().decodeToString())
+                    json(level, tag, "$message (payload)", payload)
+                }
+                return
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+        }
+        printLine(level, tag, "$message: $jwtString", null)
+    }
+
+    /**
+     * Prints a debug log message pretty-printing the decoded header and payload of a JWT string.
+     */
+    fun dJwt(tag: String, message: String, jwtString: String) {
+        if (isDebugEnabled) {
+            jwt(Level.DEBUG, tag, message, jwtString)
+        }
+    }
+
+    /**
+     * Prints an info log message pretty-printing the decoded header and payload of a JWT string.
+     */
+    fun iJwt(tag: String, message: String, jwtString: String) {
+        jwt(Level.INFO, tag, message, jwtString)
+    }
+
+    /**
+     * Prints a warning log message pretty-printing the decoded header and payload of a JWT string.
+     */
+    fun wJwt(tag: String, message: String, jwtString: String) {
+        jwt(Level.WARNING, tag, message, jwtString)
+    }
+
+    /**
+     * Prints an error log message pretty-printing the decoded header and payload of a JWT string.
+     */
+    fun eJwt(tag: String, message: String, jwtString: String) {
+        jwt(Level.ERROR, tag, message, jwtString)
+    }
 }
 
 // Low-level platform-specific printer


### PR DESCRIPTION
Insert `Logger.d()`, `Logger.dJson()`, and `Logger.dJwt()` statements to log structures being sent and received during OpenID4VCI provisioning flow:
- Add `Logger.dJwt()`, `iJwt()`, `wJwt()`, and `eJwt()` to `Logger` to pretty print JWT headers and payloads.
- Log JWT headers and payloads automatically in `buildJwt()` and `validateJwt()`.
- Log parsed credential offer URI and JSON in `CredentialOffer`.
- Log issuer and authorization server metadata in `IssuerConfiguration` and `AuthorizationConfiguration`.
- Log client attestation challenge requests, key binding challenge requests, pushed authorization requests (PAR), token requests, credential requests, and associated DPoP and attestation JWTs in `OpenID4VCIProvisioningClient`.
- Log server-side endpoint request parameters and response JSON in `pushedAuthorizationRequest()`, `token()`, `credential()`, `challenge()`, `nonce()`, `wellKnownOpenidCredentialIssuer()`, and `wellKnownOauthAuthorization()`.

Fixes #1907.

Test: Ran ./gradlew :multipaz:jvmTest :multipaz-openid4vci:assemble
Test: Ran ./gradlew :multipaz-openid4vci-server:assemble detekt
Signed-off-by: David Zeuthen <zeuthen@gmail.com>