### PR TITLE
Support application data and secure area selection in provisioning.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/provisioning/ProvisioningBottomSheet.kt
@@ -120,6 +120,7 @@ fun ProvisioningBottomSheet(
     backend: Deferred<OpenID4VCIBackend>,
     onFinishedProvisioning: (document: Document?, isNewlyIssued: Boolean) -> Unit = { _, _ -> },
     issuerUrl: String? = null,
+    appData: ByteString? = null,
 ) {
     val provisioningState = provisioningModel.state.collectAsState().value
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -155,6 +156,7 @@ fun ProvisioningBottomSheet(
                 issuerMetadata = issuerMetadata,
                 clientPreferences = clientPreferences,
                 backend = backend,
+                appData = appData,
             )
         }
     }
@@ -218,6 +220,7 @@ private fun ProvisioningBottomSheetBody(
     issuerMetadata: MutableState<ProvisioningMetadata?>,
     clientPreferences: Deferred<OpenID4VCIClientPreferences>,
     backend: Deferred<OpenID4VCIBackend>,
+    appData: ByteString?,
 ) {
     val clientPreferencesHolder = remember { mutableStateOf<OpenID4VCIClientPreferences?>(null) }
     val backendHolder = remember { mutableStateOf<OpenID4VCIBackend?>(null) }
@@ -304,6 +307,7 @@ private fun ProvisioningBottomSheetBody(
             issuerMetadata = issuerMetadata.value,
             clientPreferences = preferences,
             backend = be,
+            appData = appData,
        )
     }
 }
@@ -319,6 +323,7 @@ private fun ProvisioningBottomSheetContent(
     issuerMetadata: ProvisioningMetadata?,
     clientPreferences: OpenID4VCIClientPreferences?,
     backend: OpenID4VCIBackend?,
+    appData: ByteString?,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val credentialIdState = remember { mutableStateOf<String?>(null) }
@@ -366,7 +371,8 @@ private fun ProvisioningBottomSheetContent(
                             issuerUrl = issuerUrl!!,
                             credentialId = credentialId,
                             clientPreferences = clientPreferences!!,
-                            backend = backend!!
+                            backend = backend!!,
+                            appData = appData,
                         )
                     }
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/Document.kt
@@ -150,6 +150,11 @@ class Document internal constructor(
     val authorizationData: ByteString? get() = data.authorizationData
 
     /**
+     * Application-specific data.
+     */
+    val appData: ByteString? get() = data.appData
+
+    /**
      * The unique identifier if this document is imported from a [org.multipaz.mpzpass.MpzPass].
      */
     val mpzPassId: String? get() = data.mpzPassId
@@ -177,6 +182,7 @@ class Document internal constructor(
                     cardArt = data.cardArt,
                     issuerLogo = data.issuerLogo,
                     authorizationData = data.authorizationData,
+                    appData = data.appData,
                     mpzPassId = data.mpzPassId,
                     mpzPassVersion = data.mpzPassVersion,
                     metadata = data.metadata,
@@ -440,6 +446,7 @@ class Document internal constructor(
                 cardArt = data.cardArt,
                 issuerLogo = data.issuerLogo,
                 authorizationData = data.authorizationData,
+                appData = data.appData,
                 mpzPassId = data.mpzPassId,
                 mpzPassVersion = data.mpzPassVersion,
                 metadata = metadata,
@@ -461,6 +468,7 @@ class Document internal constructor(
                 cardArt = editor.cardArt,
                 issuerLogo = editor.issuerLogo,
                 authorizationData = editor.authorizationData,
+                appData = editor.appData,
                 mpzPassId = editor.mpzPassId,
                 mpzPassVersion = editor.mpzPassVersion,
                 metadata = editor.metadata?.serialize(),
@@ -491,6 +499,7 @@ class Document internal constructor(
      * @property cardArt An image that represents this document to the user in the UI.
      * @property issuerLogo An image that represents the issuer of the document in the UI.
      * @property authorizationData Saved authorization data to refresh credentials, possibly without requiring user to re-authorize.
+     * @property appData Application-specific data.
      * @property mpzPassId The unique identifier if this document is imported from a [org.multipaz.mpzpass.MpzPass].
      * @property mpzPassVersion The version if this document is imported from a [org.multipaz.mpzpass.MpzPass].
      * @property metadata A [AbstractDocumentMetadata] for storing application-specific data.
@@ -504,6 +513,7 @@ class Document internal constructor(
         var cardArt: ByteString?,
         var issuerLogo: ByteString?,
         var authorizationData: ByteString?,
+        var appData: ByteString?,
         var mpzPassId: String?,
         var mpzPassVersion: Long?,
         var metadata: AbstractDocumentMetadata?,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentData.kt
@@ -20,6 +20,7 @@ internal data class DocumentData(
     val cardArt: ByteString? = null,
     val issuerLogo: ByteString? = null,
     val authorizationData: ByteString? = null,
+    val appData: ByteString? = null,
     val mpzPassId: String? = null,
     val mpzPassVersion: Long? = null,
     val metadata: ByteString? = null,  // serialized AbstractDocumentMetadata

--- a/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/document/DocumentStore.kt
@@ -135,6 +135,10 @@ class DocumentStore private constructor(
      * @param issuerLogo An image that represents the issuer of the document in the UI,
      *  e.g. passport office logo. PNG format is expected, transparency is supported and square
      *  aspect ratio is preferred.
+     * @param authorizationData Saved authorization data to refresh credentials, possibly without requiring
+     *  user to re-authorize.
+     * @param appData Application-specific data.
+     * @param created The time the document was created.
      * @param metadata initial value for [Document.metadata]
      * @return A newly created document.
      */
@@ -144,6 +148,7 @@ class DocumentStore private constructor(
         cardArt: ByteString? = null,
         issuerLogo: ByteString? = null,
         authorizationData: ByteString? = null,
+        appData: ByteString? = null,
         created: Instant = Clock.System.now(),
         metadata: AbstractDocumentMetadata? = null
     ): Document {
@@ -156,6 +161,7 @@ class DocumentStore private constructor(
             cardArt = cardArt,
             issuerLogo = issuerLogo,
             authorizationData = authorizationData,
+            appData = appData,
             metadata = metadata?.serialize()
         )
         // NB: insertion in the storage is when the document is actually added, it may be

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/AbstractDocumentProvisioningHandler.kt
@@ -21,12 +21,14 @@ interface AbstractDocumentProvisioningHandler {
      * @param issuerMetadata information about the credential issuer
      * @param documentAuthorizationData data that can be used to provision additional credentials
      *  (e.g. for credential refresh)
+     * @param appData optional application-specific data to store with the document
      * @return new [Document] to hold the provisioned credentials.
      */
     suspend fun createDocument(
         credentialMetadata: CredentialMetadata,
         issuerMetadata: ProvisioningMetadata,
-        documentAuthorizationData: ByteString?
+        documentAuthorizationData: ByteString?,
+        appData: ByteString? = null
     ): Document
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/DocumentProvisioningHandler.kt
@@ -45,13 +45,39 @@ private const val TAG = "DocumentProvisioningHandler"
  *  provided if [DocumentStore] uses an [AbstractDocumentMetadata] factory (see
  *  [DocumentStore.Builder.setDocumentMetadataFactory]).
  * @param defaultDocumentProvisioningSettings the default [DocumentProvisioningSettings] to use.
+ * @param selectSecureArea optional lambda to select [SecureArea] and customize [CreateKeySettings]
+ *  based on `appData` and suggested key settings.
  */
 open class DocumentProvisioningHandler(
     val secureArea: SecureArea,
     val documentStore: DocumentStore,
     val metadataHandler: AbstractDocumentMetadataHandler? = null,
-    val defaultDocumentProvisioningSettings: DocumentProvisioningSettings = DocumentProvisioningSettings()
+    val defaultDocumentProvisioningSettings: DocumentProvisioningSettings = DocumentProvisioningSettings(),
+    val selectSecureArea: (suspend (
+        appData: ByteString?,
+        suggestedCreateKeySettings: CreateKeySettings
+    ) -> Pair<SecureArea, CreateKeySettings>)? = null
 ): AbstractDocumentProvisioningHandler {
+
+    /**
+     * Function to select [SecureArea] and customize [CreateKeySettings] for a document.
+     *
+     * The default implementation invokes [selectSecureArea] lambda if provided, or returns
+     * `Pair(this.secureArea, suggestedCreateKeySettings)`.
+     *
+     * Applications can override this method or pass a [selectSecureArea] lambda to the constructor.
+     *
+     * @param document the [Document] that credentials are being created for.
+     * @param suggestedCreateKeySettings suggested settings for creating the key.
+     * @return the [SecureArea] to use and the [CreateKeySettings] to use for key creation.
+     */
+    open suspend fun selectSecureArea(
+        document: Document,
+        suggestedCreateKeySettings: CreateKeySettings
+    ): Pair<SecureArea, CreateKeySettings> {
+        return selectSecureArea?.invoke(document.appData, suggestedCreateKeySettings)
+            ?: Pair(secureArea, suggestedCreateKeySettings)
+    }
 
     /**
      * Function to select which [DocumentProvisioningSettings] to use when provisioning.
@@ -73,7 +99,8 @@ open class DocumentProvisioningHandler(
     override suspend fun createDocument(
         credentialMetadata: CredentialMetadata,
         issuerMetadata: ProvisioningMetadata,
-        documentAuthorizationData: ByteString?
+        documentAuthorizationData: ByteString?,
+        appData: ByteString?
     ): Document =
         documentStore.createDocument(
             displayName = credentialMetadata.display.text,
@@ -81,6 +108,7 @@ open class DocumentProvisioningHandler(
             cardArt = credentialMetadata.display.logo,
             issuerLogo = issuerMetadata.display.logo,
             authorizationData = documentAuthorizationData,
+            appData = appData,
             metadata = metadataHandler?.initializeDocumentMetadata(
                 credentialDisplay = credentialMetadata.display,
                 issuerDisplay = issuerMetadata.display,
@@ -178,6 +206,10 @@ open class DocumentProvisioningHandler(
             validFrom = null,
             validUntil = null
         )
+        val (selectedSecureArea, finalCreateKeySettings) = selectSecureArea(
+            document = document,
+            suggestedCreateKeySettings = cks
+        )
         val domain = when (format) {
             is CredentialFormat.Mdoc -> if (userAuth) settings.mdocUserAuthDomain else settings.mdocNoUserAuthDomain
             is CredentialFormat.SdJwt -> if (userAuth) settings.sdJwtUserAuthDomain else settings.sdJwtNoUserAuthDomain
@@ -192,9 +224,9 @@ open class DocumentProvisioningHandler(
                             document = document,
                             asReplacementForIdentifier = credentialIdentifierToReplace,
                             domain = domain,
-                            secureArea = secureArea,
+                            secureArea = selectedSecureArea,
                             docType = format.docType,
-                            createKeySettings = cks
+                            createKeySettings = finalCreateKeySettings
                         )
                     }
 
@@ -203,9 +235,9 @@ open class DocumentProvisioningHandler(
                             document = document,
                             asReplacementForIdentifier = credentialIdentifierToReplace,
                             domain = domain,
-                            secureArea = secureArea,
+                            secureArea = selectedSecureArea,
                             vct = format.vct,
-                            createKeySettings = cks
+                            createKeySettings = finalCreateKeySettings
                         )
                     }
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningModel.kt
@@ -90,14 +90,19 @@ class ProvisioningModel(
      * @param offerUri credential offer (formatted as URI with custom protocol name)
      * @param clientPreferences configuration parameters for OpenID4VCI client
      * @param backend interface to the wallet back-end service
+     * @param appData optional application-specific data to store with the document
      * @return deferred [Document] value
      */
     fun launchOpenID4VCIProvisioning(
         offerUri: String,
         clientPreferences: OpenID4VCIClientPreferences,
         backend: OpenID4VCIBackend,
+        appData: ByteString? = null,
     ): Deferred<Document> =
-        launch(createCoroutineContext(clientPreferences, backend)) {
+        launch(
+            coroutineContext = createCoroutineContext(clientPreferences, backend),
+            appData = appData
+        ) {
             targetDocument = null
             OpenID4VCI.createClientFromOffer(offerUri, clientPreferences)
         }
@@ -110,6 +115,7 @@ class ProvisioningModel(
      * @param credentialId credential configuration id
      * @param clientPreferences configuration parameters for OpenID4VCI client
      * @param backend interface to the wallet back-end service
+     * @param appData optional application-specific data to store with the document
      * @return deferred [Document] value
      */
     fun launchOpenID4VCIProvisioning(
@@ -117,8 +123,12 @@ class ProvisioningModel(
         credentialId: String,
         clientPreferences: OpenID4VCIClientPreferences,
         backend: OpenID4VCIBackend,
+        appData: ByteString? = null,
     ): Deferred<Document> =
-        launch(createCoroutineContext(clientPreferences, backend)) {
+        launch(
+            coroutineContext = createCoroutineContext(clientPreferences, backend),
+            appData = appData
+        ) {
             targetDocument = null
             OpenID4VCI.createClientCredentialId(issuerUrl, credentialId, clientPreferences)
         }
@@ -195,12 +205,14 @@ class ProvisioningModel(
      * @param coroutineContext coroutine context to run [ProvisioningClient] in
      * @param document if null, this is an initial provisioning, if not null, provision more
      *  credentials into the given document
+     * @param appData optional application-specific data to store with the document (used if [document] is null)
      * @param provisioningClientFactory function that creates [ProvisioningClient]
      * @return deferred [Document] value
      */
     fun launch(
         coroutineContext: CoroutineContext,
         document: Document? = null,
+        appData: ByteString? = null,
         provisioningClientFactory: suspend () -> ProvisioningClient
     ): Deferred<Document> {
         if (isActive) {
@@ -229,6 +241,7 @@ class ProvisioningModel(
                     provisioningClient = provisioningClient,
                     targetDocument = targetDocument,
                     documentProvisioningHandler = documentProvisioningHandler,
+                    appData = appData,
                     eventLogger = eventLogger,
                     onRequestingCredentials = {
                         mutableState.emit(RequestingCredentials)
@@ -400,6 +413,7 @@ class ProvisioningModel(
  * @param provisioningClient a [ProvisioningClient]
  * @param targetDocument the document to request credentials for or `null`.
  * @param documentProvisioningHandler a [AbstractDocumentProvisioningHandler].
+ * @param appData optional application-specific data to store with the document (used if [targetDocument] is null).
  * @param onRequestingCredentials called when requesting credentials.
  * @return the [Document] (either newly created or [targetDocument] if not null) and how many credentials were fetched.
  */
@@ -407,6 +421,7 @@ private suspend fun requestCredentials(
     provisioningClient: ProvisioningClient,
     targetDocument: Document?,
     documentProvisioningHandler: AbstractDocumentProvisioningHandler,
+    appData: ByteString? = null,
     eventLogger: EventLogger?,
     onRequestingCredentials: suspend () -> Unit = {},
 ): Pair<Document, Int> {
@@ -418,7 +433,8 @@ private suspend fun requestCredentials(
         documentProvisioningHandler.createDocument(
             credentialConfig,
             issuerMetadata,
-            documentAuthorizationData
+            documentAuthorizationData,
+            appData
         )
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/document/DocumentStoreTest.kt
@@ -198,6 +198,62 @@ class DocumentStoreTest {
         )
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testAppData() = runTest {
+        val documentStore = buildDocumentStore(
+            storage = storage,
+            secureAreaRepository = secureAreaRepository
+        ) {
+            addCredentialImplementation(TestCredential.CREDENTIAL_TYPE) { document ->
+                TestCredential(document)
+            }
+        }
+
+        val testData1 = ByteString(1, 2, 3)
+        val testData2 = ByteString(4, 5, 6, 7)
+
+        val doc1 = documentStore.createDocument()
+        assertNull(doc1.appData)
+
+        val doc2 = documentStore.createDocument(appData = testData1)
+        assertEquals(testData1, doc2.appData)
+
+        doc2.edit {
+            appData = testData2
+        }
+        assertEquals(testData2, doc2.appData)
+
+        // Check persistence
+        runCurrent()
+        val documentStore2 = buildDocumentStore(
+            storage = storage,
+            secureAreaRepository = secureAreaRepository
+        ) {
+            addCredentialImplementation(TestCredential.CREDENTIAL_TYPE) { document ->
+                TestCredential(document)
+            }
+        }
+        assertNull(documentStore2.lookupDocument(doc1.identifier)!!.appData)
+        assertEquals(testData2, documentStore2.lookupDocument(doc2.identifier)!!.appData)
+
+        val doc2Reloaded = documentStore2.lookupDocument(doc2.identifier)!!
+        doc2Reloaded.edit {
+            appData = null
+        }
+        assertNull(doc2Reloaded.appData)
+
+        val documentStore3 = buildDocumentStore(
+            storage = storage,
+            secureAreaRepository = secureAreaRepository
+        ) {
+            addCredentialImplementation(TestCredential.CREDENTIAL_TYPE) { document ->
+                TestCredential(document)
+            }
+        }
+        assertNull(documentStore3.lookupDocument(doc2.identifier)!!.appData)
+    }
+
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/provisioning/ProvisioningModelTest.kt
@@ -51,6 +51,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -100,6 +101,7 @@ class ProvisioningModelTest {
             TestProvisioningClient()
         }.await()
         assertTrue(doc.provisioned)
+        assertNull(doc.appData)
         assertEquals("Document Title", doc.displayName)
         assertEquals("Test Document", doc.typeDisplayName)
         val credentials = doc.getCredentials()
@@ -107,6 +109,82 @@ class ProvisioningModelTest {
         val credential = credentials.first() as MdocCredential
         assertTrue(credential.isCertified)
         assertEquals(TestProvisioningClient.DOCTYPE, credential.docType)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun basicWithAppData() = runTest {
+        val expectedAppData = ByteString(10, 20, 30, 40)
+        val doc = model.launch(
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+            appData = expectedAppData
+        ) {
+            TestProvisioningClient()
+        }.await()
+        assertTrue(doc.provisioned)
+        assertEquals(expectedAppData, doc.appData)
+        assertEquals("Document Title", doc.displayName)
+        assertEquals("Test Document", doc.typeDisplayName)
+
+        // Verify it was persisted in DocumentStore
+        val docFromStore = documentStore.lookupDocument(doc.identifier)!!
+        assertEquals(expectedAppData, docFromStore.appData)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun basicWithCustomSecureAreaSelection() = runTest {
+        val alternateSecureArea = object : SecureArea by secureArea {
+            override val identifier: String get() = "AlternateSecureArea"
+            override val displayName: String get() = "Alternate Secure Area"
+        }
+        val customRepo = SecureAreaRepository.Builder()
+            .add(secureArea)
+            .add(alternateSecureArea)
+            .build()
+        val customDocStore = buildDocumentStore(
+            storage = storage,
+            secureAreaRepository = customRepo
+        ) {}
+        val customHandler = DocumentProvisioningHandler(
+            documentStore = customDocStore,
+            secureArea = secureArea,
+            selectSecureArea = { appData, suggestedSettings ->
+                if (appData == ByteString(0x01)) {
+                    Pair(alternateSecureArea, suggestedSettings)
+                } else {
+                    Pair(secureArea, suggestedSettings)
+                }
+            }
+        )
+        val customModel = ProvisioningModel(
+            documentProvisioningHandler = customHandler,
+            httpClient = HttpClient(mockHttpEngine),
+            promptModel = TestPromptModel.Builder().apply { addCommonDialogs() }.build(),
+            authorizationSecureArea = secureArea
+        )
+
+        // Provision with appData = 0x01 -> should use alternateSecureArea
+        val docWithAlternate = customModel.launch(
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+            appData = ByteString(0x01)
+        ) {
+            TestProvisioningClient()
+        }.await()
+        assertEquals(ByteString(0x01), docWithAlternate.appData)
+        val cred1 = docWithAlternate.getCredentials().first() as MdocCredential
+        assertEquals(alternateSecureArea.identifier, cred1.secureArea.identifier)
+
+        // Provision with appData = null -> should use default secureArea
+        val docWithDefault = customModel.launch(
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+            appData = null
+        ) {
+            TestProvisioningClient()
+        }.await()
+        assertNull(docWithDefault.appData)
+        val cred2 = docWithDefault.getCredentials().first() as MdocCredential
+        assertEquals(secureArea.identifier, cred2.secureArea.identifier)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Allow applications to pass optional application data `ByteString` through the provisioning API and persist it alongside documents in `DocumentStore`:
- Add `appData` property to `DocumentData` and expose it via `Document.appData` and `Document.Editor.appData`.
- Update `DocumentStore.createDocument()` to accept optional `appData`.
- Update `AbstractDocumentProvisioningHandler.createDocument()` and `DocumentProvisioningHandler.createDocument()` to accept and forward `appData`.
- Update `ProvisioningModel.launch()`, `launchOpenID4VCIProvisioning()`, and `ProvisioningBottomSheet` to accept optional `appData`.
- Add `selectSecureArea` lambda parameter and `selectSecureArea()` method to `DocumentProvisioningHandler` to allow customizing `SecureArea` and `CreateKeySettings` on a per-document basis using `appData`.
- Add unit tests in `DocumentStoreTest` and `ProvisioningModelTest`.

Specifically this allows wallet applications to easily control what SecureArea to use for a particular document type.

Fixes #1909.

Test: Ran ./gradlew :multipaz:jvmTest :multipaz-compose:assemble detekt
Test: Ran ./gradlew :samples:testapp:testBlueDebugUnitTest :multipaz:assemble
