### PR TITLE
Implemented transaction section in the consent prompt

### DIFF
--- a/multipaz-compose/build.gradle.kts
+++ b/multipaz-compose/build.gradle.kts
@@ -106,6 +106,8 @@ kotlin {
 
                 implementation(project(":multipaz"))
                 implementation(project(":multipaz-dcapi"))
+                implementation(project(":multipaz-doctypes"))
+                implementation(project(":multipaz-utopia"))
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.kotlinx.io.core)

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -35,12 +37,17 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -88,6 +95,8 @@ import org.multipaz.compose.text.fromMarkdown
 import org.multipaz.credential.Credential
 import org.multipaz.document.Document
 import org.multipaz.documenttype.Icon
+import org.multipaz.documenttype.TransactionUserInput
+import org.multipaz.documenttype.knowntypes.PaymentTransaction
 import org.multipaz.multipaz_compose.generated.resources.Res
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_cancel
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_button_more
@@ -113,7 +122,6 @@ import org.multipaz.multipaz_compose.generated.resources.credential_presentment_
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_share_with_known_requester_and_unknown_enc_target
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_share_with_unknown_requester
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_share_with_unknown_requester_and_unknown_enc_target
-import org.multipaz.multipaz_compose.generated.resources.credential_presentment_transaction_data
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_verifier_icon_description
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list_anonymous
@@ -124,11 +132,14 @@ import org.multipaz.presentment.CredentialMatchSourceOpenID4VP
 import org.multipaz.presentment.CredentialSelection
 import org.multipaz.presentment.ConsentData
 import org.multipaz.presentment.ConsentUseCase
+import org.multipaz.presentment.TransactionData
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.Requester
 import org.multipaz.request.TrustedRequesterIdentity
 import org.multipaz.trustmanagement.TrustMetadata
 import org.multipaz.util.Logger
+import org.multipaz.util.toBase64Url
+import org.multipaz.utopia.knowntypes.PingTransaction
 import kotlin.math.min
 
 private val PAGER_INDICATOR_HEIGHT = 30.dp
@@ -202,11 +213,16 @@ fun Consent(
     }
 
     var selections by remember(initialSelections) { mutableStateOf(initialSelections) }
+    var transactionUserInput by remember {
+        mutableStateOf(emptyMap<String, TransactionUserInput>())
+    }
     var activeUseCaseIndex by remember { mutableStateOf(0) }
     var isFlipped by remember { mutableStateOf(false) }
 
+    // TODO: it seems that we do not need to worry about transactionUserInput here; if we actually
+    //  do, we should add it BOTH as key to remember and as a parameter to toCredentialSelection
     val currentSelection = remember(selections, consentData) {
-        consentData.toCredentialSelection(selections)
+        consentData.toCredentialSelection(selections, emptyMap())
     }
     val currentDocumentsInFocus = remember(currentSelection) {
         currentSelection.matches.map { it.credential.document }
@@ -269,10 +285,14 @@ fun Consent(
                             imageLoader = imageLoader,
                             consentData = consentData,
                             selections = selections,
+                            transactionUserInput = transactionUserInput,
                             onSelectionChanged = { index, value ->
                                 val newList = selections.toMutableList()
                                 newList[index] = value
                                 selections = newList
+                            },
+                            onTransactionUserInputChanged = { type, userInput ->
+                                transactionUserInput = transactionUserInput.plus(type to userInput)
                             },
                             onShowRequesterInfo = {
                                 navController.navigate("showRequesterInfo")
@@ -429,7 +449,9 @@ private fun ConsentPage(
     imageLoader: ImageLoader?,
     consentData: ConsentData,
     selections: List<Int>,
+    transactionUserInput: Map<String, TransactionUserInput>,
     onSelectionChanged: (Int, Int) -> Unit,
+    onTransactionUserInputChanged: (String, TransactionUserInput) -> Unit,
     onShowRequesterInfo: () -> Unit,
     onNavigateToPickSolution: (Int) -> Unit,
     onConfirm: (selection: CredentialSelection) -> Unit,
@@ -489,11 +511,13 @@ private fun ConsentPage(
                             selectionIndex = selections[index],
                             requester = requester,
                             requesterDisplayData = requesterDisplayData,
+                            transactionUserInput = transactionUserInput,
                             trustMetadata = trustMetadata,
                             appInfo = appInfo,
                             onSelectionChanged = { value ->
                                 onSelectionChanged(index, value)
                             },
+                            onTransactionUserInputChanged = onTransactionUserInputChanged,
                             onNavigateToPickSolution = {
                                 onNavigateToPickSolution(index)
                             }
@@ -532,7 +556,7 @@ private fun ConsentPage(
 
         ButtonSection(
             onConfirm = {
-                onConfirm(consentData.toCredentialSelection(selections))
+                onConfirm(consentData.toCredentialSelection(selections, transactionUserInput))
             },
             onCancel = onCancel,
             scrollState = scrollState
@@ -547,9 +571,11 @@ private fun UseCaseViewer(
     selectionIndex: Int,
     requester: Requester,
     requesterDisplayData: RequesterDisplayData,
+    transactionUserInput: Map<String, TransactionUserInput>,
     trustMetadata: TrustMetadata?,
     appInfo: ApplicationInfo?,
     onSelectionChanged: (Int) -> Unit,
+    onTransactionUserInputChanged: (String, TransactionUserInput) -> Unit,
     onNavigateToPickSolution: () -> Unit
 ) {
     val isSelected = selectionIndex >= 0
@@ -621,24 +647,25 @@ private fun UseCaseViewer(
                             if (credential.match.transactionData.isNotEmpty()) {
                                 Column(
                                     modifier = Modifier
-                                        .background(MaterialTheme.colorScheme.error)
+                                        .padding(8.dp)
+                                        .border(
+                                            width = 2.dp,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            shape = RoundedCornerShape(8.dp)
+                                        )
                                         .padding(8.dp)
                                         .fillMaxWidth()
                                 ) {
-                                    Text(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        text = stringResource(Res.string.credential_presentment_transaction_data),
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = MaterialTheme.colorScheme.onError,
-                                        fontWeight = FontWeight.Bold
-                                    )
                                     for (data in credential.match.transactionData) {
-                                        Text(
-                                            modifier = Modifier.fillMaxWidth().padding(12.dp, 0.dp, 0.dp, 0.dp),
-                                            text = "\u2022 ${data.type.displayName}",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onError,
-                                            fontWeight = FontWeight.Bold
+                                        DisplayTransactionData(
+                                            transactionData = data,
+                                            userInput = transactionUserInput[data.type.identifier],
+                                            onUserInputChanged = { userInput ->
+                                                onTransactionUserInputChanged.invoke(
+                                                    data.type.identifier,
+                                                    userInput
+                                                )
+                                            }
                                         )
                                     }
                                 }
@@ -667,6 +694,88 @@ private fun UseCaseViewer(
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DisplayTransactionData(
+    transactionData: TransactionData<*>,
+    userInput: TransactionUserInput?,
+    onUserInputChanged: (userInput: TransactionUserInput) -> Unit
+) {
+    when (val type = transactionData.type) {
+        PingTransaction -> {
+            val payload = transactionData.payload as PingTransaction.Payload
+            Text("Test \"ping\" transaction")
+            payload.string?.let { Text("String value: '$it'") }
+            payload.blob?.let { Text("Blob value: '${it.toByteArray().toBase64Url()}") }
+        }
+
+        PaymentTransaction -> {
+            val payload = transactionData.payload as PaymentTransaction.Payload
+            val tipPercent = (userInput as? PaymentTransaction.UserInput)?.tipPercent ?: 0.0
+            Text("Payment transaction")
+            Text("Amount: ${payload.amount} ${payload.currency}")
+            if (payload.tipRequested == true) {
+                Row {
+                    // 2. Track the expanded state and the currently selected item
+                    var isExpanded by remember { mutableStateOf(false) }
+                    var selectedOption by remember { mutableStateOf(
+                        if (tipPercent == 0.0) {
+                            tipOptions.first()
+                        } else {
+                            "$tipPercent%"
+                        }
+                    ) }
+
+                    ExposedDropdownMenuBox(
+                        expanded = isExpanded,
+                        onExpandedChange = { isExpanded = !isExpanded },
+                    ) {
+                        OutlinedTextField(
+                            value = selectedOption,
+                            onValueChange = {},
+                            readOnly = true, // Prevents keyboard from appearing
+                            label = { Text("Add tip") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded) },
+                            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                            modifier = Modifier
+                                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                                .fillMaxWidth()
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = isExpanded,
+                            onDismissRequest = { isExpanded = false }
+                        ) {
+                            tipOptions.forEach { option ->
+                                DropdownMenuItem(
+                                    text = { Text(text = option) },
+                                    onClick = {
+                                        selectedOption = option // Update selection truth
+                                        val percent = if (option.endsWith("%")) {
+                                            option.take(option.lastIndex).toDouble()
+                                        } else {
+                                            0.0
+                                        }
+                                        onUserInputChanged(PaymentTransaction.UserInput(percent))
+                                        isExpanded = false      // Close menu
+                                    },
+                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        else -> {
+            Text("Unknown transaction type '${type.displayName}'")
+        }
+    }
+}
+
+private val tipOptions = listOf("No tip", "10%", "15%", "20%", "25%")
 
 @Composable
 private fun calcSharedWithText(

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransaction.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PaymentTransaction.kt
@@ -6,7 +6,9 @@ import kotlinx.io.bytestring.decodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.JsonPrimitive
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.annotation.CborSerializable
@@ -15,9 +17,11 @@ import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.documenttype.CannedTransactionData
 import org.multipaz.documenttype.TransactionType
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.presentment.TransactionData
 import org.multipaz.util.fromBase64Url
+import kotlin.math.ceil
 import kotlin.time.Instant
 
 /**
@@ -86,6 +90,7 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
      * @property amountEstimated Flag indicating if the amount is an estimate rather than the final total (mapped to `amount_estimated`).
      * @property amountEarmarked Flag indicating if the funds are reserved/earmarked for this transaction (mapped to `amount_earmarked`).
      * @property sctInst Flag indicating if the transaction uses SEPA Instant Credit Transfer (mapped to `sct_inst`).
+     * @property tipRequested (extension, not defined in the spec) Flag indicating that a tip can additionally be added by the payee.
      * @property recurrence Optional [Recurrence] configuration specifying payment intervals for standing/recurring orders.
      * @property mitOptions Optional Merchant Initiated Transaction options ([MitOptions]).
      */
@@ -102,6 +107,7 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
         val amountEstimated: Boolean? = null,
         val amountEarmarked: Boolean? = null,
         val sctInst: Boolean? = null,
+        val tipRequested: Boolean? = null,
         val recurrence: Recurrence? = null,
         val mitOptions: MitOptions? = null
     ) {
@@ -186,6 +192,33 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
         val apr: Double?
     ) {
         companion object
+    }
+
+    /**
+     * Optional user input for payment transaction processing.
+     *
+     * @property tipPercent amount of tip in the currency specified in [Payload.currency]
+     */
+    data class UserInput(
+        val tipPercent: Double
+    ): TransactionUserInput() {
+        override fun applyCbor(
+            transactionData: TransactionData<*>,
+            credential: Credential
+        ): Map<String, DataItem> = buildMap {
+            val payload = transactionData.payload as Payload
+            val amount = ceil(payload.amount * tipPercent) / 100.0
+            put("tipAmount", amount.toDataItem())
+        }
+
+        override fun applyJson(
+            transactionData: TransactionData<*>,
+            credential: Credential
+        ): Map<String, JsonElement> = buildMap {
+            val payload = transactionData.payload as Payload
+            val amount = ceil(payload.amount * tipPercent) / 100.0
+            put("tip_amount", JsonPrimitive(amount))
+        }
     }
 
     /**
@@ -279,6 +312,7 @@ object PaymentTransaction: TransactionType<PaymentTransaction.Payload>(
             transactionId = "3AD99006-6E0D-4D07-AE75-5DAEF0FE21D9",
             amount = 123.25,
             currency = "USD",
+            tipRequested = true,
             payee = Payee(
                 id = "01234",
                 name = "Linux Foundation"

--- a/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/PingTransaction.kt
+++ b/multipaz-utopia/src/commonMain/kotlin/org/multipaz/utopia/knowntypes/PingTransaction.kt
@@ -17,10 +17,14 @@ import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.documenttype.CannedTransactionData
 import org.multipaz.documenttype.TransactionType
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.presentment.TransactionData
 import org.multipaz.sdjwt.credential.KeyBoundSdJwtVcCredential
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
 
 /**
  * Transaction type that round-trips some data through the presentment process for testing.
@@ -120,8 +124,16 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
 
     override suspend fun applyJson(
         transactionData: TransactionData<Payload>,
-        credential: Credential
+        credential: Credential,
+        userInput: TransactionUserInput?
     ): JsonElement = buildJsonObject {
+        userInput?.applyJson(transactionData, credential)?.let { claims ->
+            buildJsonObject {
+                for ((name, value) in claims) {
+                    put(name, value)
+                }
+            }
+        }
         transactionData.payload.string?.let {
             put("string", it)
         }
@@ -132,10 +144,11 @@ object PingTransaction: TransactionType<PingTransaction.Payload>(
 
     override suspend fun applyCbor(
         transactionData: TransactionData<Payload>,
-        credential: Credential
+        credential: Credential,
+        userInput: TransactionUserInput?
     ): Map<String, DataItem> {
         return buildMap {
-            putAll(super.applyCbor(transactionData, credential))
+            putAll(super.applyCbor(transactionData, credential, userInput))
             transactionData.payload.string?.let {
                 put("string", it.toDataItem())
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
@@ -2,6 +2,7 @@ package org.multipaz.documenttype
 
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.toDataItem
@@ -131,13 +132,16 @@ abstract class TransactionType<PayloadT: Any>(
      *
      * @param transactionData transaction data
      * @param credential credential being presented
+     * @param userInput additional data specified by the user
      * @return transaction-specific data that should be added to the presentment (in `deviceSigned`
      *  namespace map using [mdocResponseNamespace]), `null` if no extra data should be added.
      */
     open suspend fun applyCbor(
         transactionData: TransactionData<PayloadT>,
-        credential: Credential
+        credential: Credential,
+        userInput: TransactionUserInput?
     ): Map<String, DataItem> = buildMap {
+        userInput?.applyCbor(transactionData, credential)?.let { putAll(it) }
         val alg = transactionData.hashAlgorithms?.first()?.also {
             put("transactionDataHashAlg", it.coseAlgorithmIdentifier!!.toDataItem())
         }
@@ -152,13 +156,21 @@ abstract class TransactionType<PayloadT: Any>(
      *
      * @param transactionData transaction data
      * @param credential credential being presented
+     * @param userInput additional data specified by the user
      * @return transaction-specific data that should be added to the presentment (in key-binding
      *  JWT body using [kbJwtResponseClaimName]), `null` if no extra data should be added.
      */
     open suspend fun applyJson(
         transactionData: TransactionData<PayloadT>,
-        credential: Credential
-    ): JsonElement? = null
+        credential: Credential,
+        userInput: TransactionUserInput?
+    ): JsonElement? = userInput?.applyJson(transactionData, credential)?.let { claims ->
+        buildJsonObject {
+            for ((name, value) in claims) {
+                put(name, value)
+            }
+        }
+    }
 
     /**
      * Verify transaction response for mdoc presentment.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionUserInput.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionUserInput.kt
@@ -1,0 +1,43 @@
+package org.multipaz.documenttype
+
+import kotlinx.serialization.json.JsonElement
+import org.multipaz.cbor.DataItem
+import org.multipaz.credential.Credential
+import org.multipaz.presentment.TransactionData
+
+/**
+ * Object that encapsulates additional explicit user input for transaction processing for certain
+ * transaction type.
+ *
+ * For instance, this can hold user-selected tip amount for a payment transaction.
+ */
+abstract class TransactionUserInput {
+
+    /**
+     * Returns the list of claims to add to the transaction response in ISO mdoc presentment.
+     *
+     * Note: [TransactionType.applyCbor] may or may not call this method or override its result
+     *
+     * @param transactionData transaction data
+     * @param credential credential being presented
+     * @return transaction-specific data that should be added to the presentment
+     */
+    abstract fun applyCbor(
+        transactionData: TransactionData<*>,
+        credential: Credential
+    ): Map<String, DataItem>
+
+    /**
+     * Returns the list of claims to add to the transaction response in SD-JWT presentment.
+     *
+     * Note: [TransactionType.applyJson] may or may not call this method or override its result
+     *
+     * @param transactionData transaction data
+     * @param credential credential being presented
+     * @return transaction-specific data that should be added to the presentment
+     */
+    abstract fun applyJson(
+        transactionData: TransactionData<*>,
+        credential: Credential
+    ): Map<String, JsonElement>
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -33,6 +33,7 @@ import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
 import org.multipaz.crypto.JsonWebEncryption
 import org.multipaz.crypto.AsymmetricKey
 import org.multipaz.document.Document
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.webtoken.buildJwt
 import org.multipaz.mdoc.credential.MdocCredential
@@ -517,6 +518,7 @@ object OpenID4VP {
                     reReaderPublicKey = reReaderPublicKey,
                     responseUri = responseUri,
                     requestIsForZk = requestIsForZk,
+                    transactionUserInput = selection.transactionUserInput
                 )
             } else if (match.source.credentialQuery.vctValues != null) {
                 openID4VPSdJwt(
@@ -526,6 +528,7 @@ object OpenID4VP {
                     clientId = clientId,
                     nonce = nonce,
                     responseMode = responseMode,
+                    transactionUserInput = selection.transactionUserInput
                 )
             } else {
                 throw IllegalArgumentException("Expected ISO mdoc or IETF SD-JWT, got neither")
@@ -610,6 +613,7 @@ object OpenID4VP {
         reReaderPublicKey: EcPublicKey?,
         responseUri: String?,
         requestIsForZk: Boolean,
+        transactionUserInput: Map<String, TransactionUserInput>,
         onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
@@ -715,7 +719,7 @@ object OpenID4VP {
             sessionTranscript = Cbor.decode(encodedSessionTranscript),
             credential = mdocCredential,
             requestedClaims = match.source.credentialQuery.claims as List<MdocRequestedClaim>,
-            deviceNamespaces = computeTransactionResponse(match)
+            deviceNamespaces = computeTransactionResponse(match, transactionUserInput)
         )
         val deviceResponse = buildDeviceResponse(
             sessionTranscript = Cbor.decode(encodedSessionTranscript),
@@ -750,11 +754,12 @@ object OpenID4VP {
     suspend fun processTransactions(
         credential: SdJwtVcCredential,
         transactionData: List<TransactionData<*>>,
+        transactionUserInput: Map<String, TransactionUserInput>,
         docRequestId: Int? = null
     ): Map<String, JsonElement> {
         val transactionResponse = mutableMapOf<String, JsonElement>()
         for (data in transactionData) {
-            val response = data.applyJson(credential as Credential)
+            val response = data.applyJson(credential as Credential, transactionUserInput[data.type.identifier])
             if (response != null || docRequestId != null) {
                 transactionResponse[data.type.kbJwtResponseClaimName] = if (docRequestId == null) {
                     response!!
@@ -796,6 +801,7 @@ object OpenID4VP {
         clientId: String,
         nonce: String,
         responseMode: ResponseMode,
+        transactionUserInput: Map<String, TransactionUserInput>
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
         val sdjwtVcCredential = match.credential as SdJwtVcCredential
@@ -807,7 +813,7 @@ object OpenID4VP {
 
         (sdjwtVcCredential as Credential).increaseUsageCount()
 
-        val transactionResponse = processTransactions(sdjwtVcCredential, match.transactionData)
+        val transactionResponse = processTransactions(sdjwtVcCredential, match.transactionData, transactionUserInput)
 
         return if (sdjwtVcCredential is SecureAreaBoundCredential) {
             filteredSdJwt.present(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/ConsentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/ConsentData.kt
@@ -1,6 +1,7 @@
 package org.multipaz.presentment
 
 import org.multipaz.crypto.X509CertChain
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.request.Iso18013RequesterIdentity
 import org.multipaz.request.Requester
 import org.multipaz.trustmanagement.TrustMetadata
@@ -27,10 +28,13 @@ data class ConsentData private constructor(
      * Calculates a [CredentialSelection] from a list of selections.
      *
      * @param selections the solution selected for each use-case or -1 if not selecting an optional use-case.
+     * @param transactionUserInput additional user input for transactions, indexed by the transaction
+     *  type identifier
      * @return a [CredentialSelection].
      */
     fun toCredentialSelection(
-        selections: List<Int>
+        selections: List<Int>,
+        transactionUserInput: Map<String, TransactionUserInput>
     ): CredentialSelection {
         require(selections.size == useCases.size) {
             "Expected selectionPerUseCase length to be that of useCases"
@@ -50,7 +54,7 @@ data class ConsentData private constructor(
                 }
             }
         }
-        return CredentialSelection(matches)
+        return CredentialSelection(matches, transactionUserInput)
     }
 
     companion object {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialQueryResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialQueryResult.kt
@@ -45,7 +45,7 @@ data class CredentialQueryResult(
                 matches.add(member.matches[0])
             }
         }
-        return CredentialSelection(matches = matches)
+        return CredentialSelection(matches = matches, transactionUserInput = emptyMap())
     }
 
     private fun pickFromPreselectedDocuments(preselectedDocuments: List<Document>): CredentialSelection? {
@@ -83,7 +83,7 @@ data class CredentialQueryResult(
                     }
                     chosenMatches.add(match)
                 }
-                return CredentialSelection(chosenMatches)
+                return CredentialSelection(chosenMatches, emptyMap())
             }
         }
         Logger.w(TAG, "Error picking combination for pre-selected documents")
@@ -123,7 +123,7 @@ data class CredentialQueryResult(
             path.forEachIndexed { setIndex, selectionIndex ->
                 allMatches.addAll(allSetSelections[setIndex][selectionIndex])
             }
-            finalSelections.add(CredentialSelection(allMatches))
+            finalSelections.add(CredentialSelection(allMatches, emptyMap()))
         }
         return finalSelections
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialSelection.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialSelection.kt
@@ -1,6 +1,7 @@
 package org.multipaz.presentment
 
 import org.multipaz.documenttype.DocumentAttributeSensitivity
+import org.multipaz.documenttype.TransactionUserInput
 
 /**
  * A selection of credentials and claims in a [CredentialQueryResult].
@@ -11,9 +12,12 @@ import org.multipaz.documenttype.DocumentAttributeSensitivity
  * This is typically returned from a consent prompt user interface.
  *
  * @property matches the list of credentials and claims to return to the relying party.
+ * @property transactionUserInput additional user input for transactions, indexed by the transaction
+ *  type identifier
  */
 data class CredentialSelection(
     val matches: List<CredentialPresentmentSetOptionMemberMatch>,
+    val transactionUserInput: Map<String, TransactionUserInput>
 ) {
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
@@ -7,6 +7,7 @@ import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.document.Document
 import org.multipaz.documenttype.TransactionType
+import org.multipaz.documenttype.TransactionUserInput
 
 /**
  * An object that holds transaction data.
@@ -59,9 +60,13 @@ class TransactionData<PayloadT: Any>(
      * See [TransactionType.applyJson]
      *
      * @param credential credential being presented
+     * @param userInput additional data specified by the user
      * @return transaction-specific data that should be added to the presentment.
      */
-    suspend fun applyJson(credential: Credential) = type.applyJson(this, credential)
+    suspend fun applyJson(
+        credential: Credential,
+        userInput: TransactionUserInput?
+    ) = type.applyJson(this, credential, userInput)
 
     /**
      * Applies transaction in the context of ISO ISO/IEC 18013 presentment.
@@ -69,9 +74,13 @@ class TransactionData<PayloadT: Any>(
      * See [TransactionType.applyCbor]
      *
      * @param credential credential being presented
+     * @param userInput additional data specified by the user
      * @return transaction-specific data that should be added to the presentment.
      */
-    suspend fun applyCbor(credential: Credential) = type.applyCbor(this, credential)
+    suspend fun applyCbor(
+        credential: Credential,
+        userInput: TransactionUserInput?
+    ) = type.applyCbor(this, credential, userInput)
 
     /**
      * Creates equivalent transaction data for use in ISO ISO/IEC 18013 protocols.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -15,6 +15,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.document.Document
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.eventlogger.EventPresentmentData
 import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.mdoc.devicesigned.DeviceNamespaces
@@ -233,7 +234,7 @@ suspend fun mdocPresentmentGenerateResponse(
                         eReaderKey = eReaderKey,
                         credential = match.credential,
                         requestedClaims = match.claims.keys.toList() as List<MdocRequestedClaim>,
-                        deviceNamespaces = computeTransactionResponse(match),
+                        deviceNamespaces = computeTransactionResponse(match, selection.transactionUserInput),
                         errors = mapOf()
                     )
 
@@ -315,7 +316,8 @@ suspend fun mdocPresentmentGenerateResponse(
                     val transactionResponse = processTransactions(
                         credential = match.credential,
                         transactionData = match.transactionData,
-                        docRequestId = match.source.docRequest.docRequestId
+                        docRequestId = match.source.docRequest.docRequestId,
+                        transactionUserInput = selection.transactionUserInput
                     )
                     val sdJwtKb = filteredSdJwtVc.present(
                         signingKey = AsymmetricKey.AnonymousSecureAreaBased(
@@ -452,11 +454,15 @@ suspend fun mdocPresentment(
 }
 
 internal suspend fun computeTransactionResponse(
-    match: CredentialPresentmentSetOptionMemberMatch
+    match: CredentialPresentmentSetOptionMemberMatch,
+    transactionUserInput: Map<String, TransactionUserInput>
 ): DeviceNamespaces {
     val transactionResponseMap = match.transactionData.associate { transaction ->
         Pair(transaction.type.mdocResponseNamespace, buildMap {
-            putAll(transaction.applyCbor(match.credential))
+            putAll(transaction.applyCbor(
+                credential = match.credential,
+                userInput = transactionUserInput[transaction.type.identifier]
+            ))
             (match.source as? CredentialMatchSourceIso18013)?.let { source ->
                 // This is generally not available anywhere is the ISO 18013 response,
                 // but it is needed to verify the transaction, so we keep it in the

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
@@ -41,6 +41,7 @@ import org.multipaz.crypto.X500Name
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.document.Document
 import org.multipaz.documenttype.TransactionType
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.mdoc.response.DeviceResponse
 import org.multipaz.mdoc.util.MdocUtil
 import org.multipaz.openid.OpenID4VP
@@ -169,16 +170,20 @@ class DigitalCredentialsPresentmentTest {
 
         override suspend fun applyJson(
             transactionData: TransactionData<Boolean>,
-            credential: Credential
+            credential: Credential,
+            userInput: TransactionUserInput?
         ): JsonElement = buildJsonObject {
+            check(userInput == null)
             put("result", 42)
         }
 
         override suspend fun applyCbor(
             transactionData: TransactionData<Boolean>,
-            credential: Credential
+            credential: Credential,
+            userInput: TransactionUserInput?
         ): Map<String, DataItem> = buildMap {
-            putAll(super.applyCbor(transactionData, credential))
+            check(userInput == null)
+            putAll(super.applyCbor(transactionData, credential, userInput))
             put("result", Uint(42UL))
         }
     }
@@ -189,16 +194,20 @@ class DigitalCredentialsPresentmentTest {
     ) {
         override suspend fun applyJson(
             transactionData: TransactionData<Boolean>,
-            credential: Credential
+            credential: Credential,
+            userInput: TransactionUserInput?
         ): JsonElement = buildJsonObject {
+            check(userInput == null)
             put("result", 57)
         }
 
         override suspend fun applyCbor(
             transactionData: TransactionData<Boolean>,
-            credential: Credential
+            credential: Credential,
+            userInput: TransactionUserInput?
         ): Map<String, DataItem> = buildMap {
-            putAll(super.applyCbor(transactionData, credential))
+            check(userInput == null)
+            putAll(super.applyCbor(transactionData, credential, userInput))
             put("result", Uint(57UL))
         }
     }
@@ -318,7 +327,6 @@ class DigitalCredentialsPresentmentTest {
 
         val shownConsentPrompts = mutableListOf<ShownConsentPrompt>()
 
-        val dismissable = MutableStateFlow<Boolean>(true)
         val dcResponseObject = digitalCredentialsPresentment(
             protocol = protocol,
             data = request,


### PR DESCRIPTION


https://github.com/user-attachments/assets/1c4b12eb-7a15-41ee-9916-f20f4b01a34d

Display transaction data for transaction types we support. Also added `TransactionUserInput` object and plumbing for it to represent user input for transaction processing. Implemented this to allow for tipping for payment transactions.

Added tip request in the pre-cut transaction data for verifier.

Test: tested with local verifier server with both openid4vp and 18013 requests.

Fixes #1911
