### PR TITLE
Exclude root CA certificates from MSO and CWT COSE x5chain headers.

### DIFF
--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryAgeVerification.kt
@@ -126,7 +126,7 @@ class CredentialFactoryAgeVerification : CredentialFactory {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingKey.certChain.toDataItem()
+                signingKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredential.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryDigitalPaymentCredential.kt
@@ -122,7 +122,7 @@ class CredentialFactoryDigitalPaymentCredential : CredentialFactory {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingKey.certChain.toDataItem()
+                signingKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdl.kt
@@ -260,7 +260,7 @@ class CredentialFactoryMdl : CredentialFactory {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingKey.certChain.toDataItem()
+                signingKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryMdocPid.kt
@@ -200,7 +200,7 @@ class CredentialFactoryMdocPid : CredentialFactory {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingKey.certChain.toDataItem()
+                signingKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
+++ b/multipaz-openid4vci/src/main/java/org/multipaz/openid4vci/credential/CredentialFactoryUtopiaLoyalty.kt
@@ -160,7 +160,7 @@ class CredentialFactoryUtopiaLoyalty : CredentialFactory {
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                signingKey.certChain.toDataItem()
+                signingKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
+++ b/multipaz-openid4vci/src/test/java/org/multipaz/openid4vci/server/ProvisioningClientTest.kt
@@ -42,6 +42,7 @@ import org.multipaz.crypto.X509Cert
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.mdoc.credential.MdocCredential
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredential
 import org.multipaz.openid4vci.credential.CredentialFactoryDigitalPaymentCredentialSdJwt
 import org.multipaz.openid4vci.credential.CredentialFactoryMdl
@@ -343,6 +344,10 @@ class ProvisioningClientTest {
             Assert.assertEquals(1, credentialData.certifications.size)
 
             credential.certify(credentialData.certifications.first().issuerData)
+            if (credential is MdocCredential) {
+                // Assert that the IACA root certificate is excluded from x5chain
+                Assert.assertEquals(1, credential.issuerCertChain.certificates.size)
+            }
 
             withContext(serverEnvironment.await()) {
                 // Run this in server environment!

--- a/multipaz-swiftui/src/iosMain/swift/Consent.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Consent.swift
@@ -545,7 +545,7 @@ private struct ConsentMain: View {
                         if (!isAtBottom) {
                             scrollDown()
                         } else {
-                            onConfirm(consentData.toCredentialSelection(selections: selections.map { KotlinInt(int: Int32($0)) }))
+                            onConfirm(consentData.toCredentialSelection(selections: selections.map { KotlinInt(int: Int32($0)) }, transactionUserInput: [:]))
                         }
                     }) {
                         Text(buttonText)

--- a/multipaz-swiftui/src/iosMain/swift/MdocProximityQrPresentment.swift
+++ b/multipaz-swiftui/src/iosMain/swift/MdocProximityQrPresentment.swift
@@ -71,6 +71,7 @@ final class MdocPresentmentViewModel: ObservableObject {
                     handover: Simple.companion.NULL,
                     source: source,
                     keyAgreementPossible: [eDeviceKeyCurve],
+                    preselectedDocuments: [],
                     insertSequenceNumbers: false,
                     timeout: KotlinDurationCompanion.shared.fromSeconds(seconds: 15),
                     timeoutSubsequentRequests: KotlinDurationCompanion.shared.fromSeconds(seconds: 30),

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassCreatorComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/MpzPassCreatorComponent.kt
@@ -353,7 +353,7 @@ val MpzPassCreatorComponent = FC {
                     Cose.COSE_LABEL_ALG.toCoseLabel to Algorithm.ES256.coseAlgorithmIdentifier!!.toDataItem()
                 )
                 val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
-                    Cose.COSE_LABEL_X5CHAIN.toCoseLabel to dsCertifiedKey.certChain.toDataItem()
+                    Cose.COSE_LABEL_X5CHAIN.toCoseLabel to dsCertifiedKey.certChain.toCoseX5Chain()
                 )
                 val now = Clock.System.now().truncateToWholeSeconds()
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509CertChain.kt
@@ -44,7 +44,7 @@ data class X509CertChain(
     }
 
     /**
-     * Encodes the certificate as JSON Array according to RFC 7515 Section 4.1.6.
+     * Encodes the certificate chain as JSON Array according to RFC 7515 Section 4.1.6.
      *
      * @param excludeRoot if the certificate chain has more than one certificate and the last certificate is a root
      *   certificate (self-signed), exclude it.
@@ -63,6 +63,35 @@ data class X509CertChain(
                 JsonPrimitive( Base64.encode(certificate.encoded.toByteArray()))
             }
         ) as JsonElement
+    }
+
+    /**
+     * Encodes the certificate chain as CBOR for use in COSE 'x5chain' header parameter (label 33)
+     * according to RFC 9360 Section 2.
+     *
+     * If [excludeRoot] is true, the certificate chain has more than one certificate, and the last
+     * certificate is a root certificate (self-signed), it is excluded.
+     *
+     * If the resulting chain has only one certificate, a [Bstr] containing the DER-encoded certificate
+     * is returned. Otherwise, a [CborArray] of [Bstr]s containing each DER-encoded certificate is returned.
+     *
+     * @param excludeRoot whether to exclude a self-signed root certificate if the chain has more than one certificate.
+     * @return a [DataItem] representing the COSE 'x5chain'.
+     */
+    fun toCoseX5Chain(excludeRoot: Boolean = true): DataItem {
+        val last = certificates.last()
+        val certs = if (excludeRoot && certificates.size > 1 && last.subject == last.issuer) {
+            certificates.subList(0, certificates.size - 1)
+        } else {
+            certificates
+        }
+        return if (certs.size == 1) {
+            certs[0].toDataItem()
+        } else {
+            buildCborArray {
+                certs.forEach { certificate -> add(certificate.toDataItem()) }
+            }
+        }
     }
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -467,7 +467,7 @@ class DocumentType private constructor(
         val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
             Pair(
                 CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                dsKey.certChain.toDataItem()
+                dsKey.certChain.toCoseX5Chain()
             )
         )
         val encodedIssuerAuth = Cbor.encode(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/KeyUnlockDataProvider.kt
@@ -37,6 +37,7 @@ interface KeyUnlockDataProvider : CoroutineContext.Element {
      * @param alias locked key's alias
      * @param algorithm the algorithm to use for the key,
      * @param unlockReason conveys the reason for the operation (e.g. credential presentment)
+     * @return a [KeyUnlockData].
      */
     suspend fun getKeyUnlockData(
         secureArea: SecureArea,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/buildCwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/webtoken/buildCwt.kt
@@ -100,7 +100,7 @@ private fun AsymmetricKey.addProtectedHeaders(
     when (this) {
         is AsymmetricKey.X509CertifiedSecureAreaBased,
         is AsymmetricKey.X509CertifiedExplicit -> {
-            protectedHeader[Cose.COSE_LABEL_X5CHAIN.toCoseLabel] = certChain.toDataItem()
+            protectedHeader[Cose.COSE_LABEL_X5CHAIN.toCoseLabel] = certChain.toCoseX5Chain(excludeRoot = true)
         }
         is AsymmetricKey.NamedExplicit,
         is AsymmetricKey.NamedSecureAreaBased -> {

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertChainTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertChainTests.kt
@@ -543,4 +543,94 @@ class X509CertChainTests {
         assertEquals(2, partialChainX5c.size)
         assertEquals(partialChain, X509CertChain.fromX5c(partialChainX5c))
     }
+
+    @Test
+    fun testToCoseX5Chain() = runTest {
+        initKeys()
+        val rootCert = buildX509Cert(
+            publicKey = rootKey.publicKey,
+            signingKey = rootKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Root"),
+            issuer = X500Name.fromName("CN=Root"),
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(ca = true, pathLenConstraint = 1)
+            includeSubjectKeyIdentifier()
+            includeAuthorityKeyIdentifierAsSubjectKeyIdentifier()
+        }
+        val intermediateCert = buildX509Cert(
+            publicKey = intermediateKey.publicKey,
+            signingKey = rootKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Intermediate"),
+            issuer = rootCert.subject,
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            setKeyUsage(setOf(X509KeyUsage.KEY_CERT_SIGN))
+            setBasicConstraints(ca = true, pathLenConstraint = 0)
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(rootCert)
+        }
+        val leafCert = buildX509Cert(
+            publicKey = leafKey.publicKey,
+            signingKey = intermediateKey,
+            serialNumber = ASN1Integer.fromRandom(128),
+            subject = X500Name.fromName("CN=Leaf"),
+            issuer = intermediateCert.subject,
+            validFrom = validFrom,
+            validUntil = validUntil,
+        ) {
+            includeSubjectKeyIdentifier()
+            setAuthorityKeyIdentifierToCertificate(intermediateCert)
+        }
+
+        // 1. Single self-signed root certificate chain (size == 1)
+        val singleRootChain = X509CertChain(listOf(rootCert))
+        val singleRootCoseDefault = singleRootChain.toCoseX5Chain() // excludeRoot = true by default
+        assertEquals(rootCert.toDataItem(), singleRootCoseDefault)
+        assertEquals(singleRootChain, X509CertChain.fromDataItem(singleRootCoseDefault))
+
+        val singleRootCoseExplicit = singleRootChain.toCoseX5Chain(excludeRoot = false)
+        assertEquals(rootCert.toDataItem(), singleRootCoseExplicit)
+        assertEquals(singleRootChain, X509CertChain.fromDataItem(singleRootCoseExplicit))
+
+        // 2. Single non-self-signed certificate chain (size == 1)
+        val singleLeafChain = X509CertChain(listOf(leafCert))
+        val singleLeafCose = singleLeafChain.toCoseX5Chain(excludeRoot = true)
+        assertEquals(leafCert.toDataItem(), singleLeafCose)
+        assertEquals(singleLeafChain, X509CertChain.fromDataItem(singleLeafCose))
+
+        // 3. Two-certificate chain ending in a self-signed root (size == 2) -> when root excluded, becomes single cert (Bstr)
+        val twoCertChain = X509CertChain(listOf(leafCert, rootCert))
+        val twoCertCoseExcluded = twoCertChain.toCoseX5Chain(excludeRoot = true)
+        assertEquals(leafCert.toDataItem(), twoCertCoseExcluded)
+        assertEquals(X509CertChain(listOf(leafCert)), X509CertChain.fromDataItem(twoCertCoseExcluded))
+
+        val twoCertCoseIncluded = twoCertChain.toCoseX5Chain(excludeRoot = false)
+        assertEquals(2, (twoCertCoseIncluded as org.multipaz.cbor.CborArray).items.size)
+        assertEquals(twoCertChain, X509CertChain.fromDataItem(twoCertCoseIncluded))
+
+        // 4. Multi-certificate chain ending in a self-signed root (size == 3) -> when root excluded, becomes array of 2
+        val fullChain = X509CertChain(listOf(leafCert, intermediateCert, rootCert))
+        val fullChainCoseExcluded = fullChain.toCoseX5Chain(excludeRoot = true)
+        assertEquals(2, (fullChainCoseExcluded as org.multipaz.cbor.CborArray).items.size)
+        assertEquals(
+            X509CertChain(listOf(leafCert, intermediateCert)),
+            X509CertChain.fromDataItem(fullChainCoseExcluded)
+        )
+
+        val fullChainCoseIncluded = fullChain.toCoseX5Chain(excludeRoot = false)
+        assertEquals(3, (fullChainCoseIncluded as org.multipaz.cbor.CborArray).items.size)
+        assertEquals(fullChain, X509CertChain.fromDataItem(fullChainCoseIncluded))
+
+        // 5. Multi-certificate chain ending in a non-self-signed certificate (size == 2)
+        val partialChain = X509CertChain(listOf(leafCert, intermediateCert))
+        val partialChainCose = partialChain.toCoseX5Chain(excludeRoot = true)
+        assertEquals(2, (partialChainCose as org.multipaz.cbor.CborArray).items.size)
+        assertEquals(partialChain, X509CertChain.fromDataItem(partialChainCose))
+    }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/revocation/IdentifierListTest.kt
@@ -41,16 +41,11 @@ class IdentifierListTest {
             18([ # COSE_Sign1
               /protected/ << {
                 16: "application/identifierlist+cwt",
-                /x5chain/ 33: [
-                  # Subject DN: C=US,CN=DS test key
-                  # Issuer DN: C=US,CN=IACA test key
-                  cert'''${"\n" + dsCert.toPem().trimEnd().prependIndent("                    ")}
-                  ''',
-                  # Subject DN: C=US,CN=IACA test key
-                  # Issuer DN: C=US,CN=IACA test key
-                  cert'''${"\n" + iacaCert.toPem().trimEnd().prependIndent("                    ")}
-                  '''
-                ],
+                /x5chain/ 33:
+                # Subject DN: C=US,CN=DS test key
+                # Issuer DN: C=US,CN=IACA test key
+                cert'''${"\n" + dsCert.toPem().trimEnd().prependIndent("                  ")}
+                ''',
                 /alg/ 1: -9 # ESP256: ECDSA using P-256 curve and SHA-256
               } >>,
               /unprotected/ {},

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveDefaultKeyUnlockDataProvider.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveDefaultKeyUnlockDataProvider.kt
@@ -1,0 +1,21 @@
+package org.multipaz.securearea
+
+import org.multipaz.crypto.Algorithm
+import org.multipaz.prompt.Reason
+import platform.LocalAuthentication.LAContext
+
+object SecureEnclaveDefaultKeyUnlockDataProvider: KeyUnlockDataProvider {
+    override suspend fun getKeyUnlockData(
+        secureArea: SecureArea,
+        alias: String,
+        algorithm: Algorithm,
+        unlockReason: Reason
+    ): KeyUnlockData {
+        check(secureArea is SecureEnclaveSecureArea)
+        return SecureEnclaveKeyUnlockData(
+            secureArea = secureArea,
+            alias = alias,
+            authenticationContext = LAContext()
+        )
+    }
+}

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
@@ -168,15 +168,20 @@ class SecureEnclaveSecureArea private constructor(
         val (keyBlob, keyInfo) = loadKey(alias)
         check(keyInfo.algorithm.isSigning)
         val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
+            ?: SecureEnclaveDefaultKeyUnlockDataProvider
         // TODO: implement default KeyUnlockDataProvider by converting
         //  OperationReason to OperationReason.HumanReadable using PromptModel
         //  and the creating LAContext with title/subtitle from OperationReason.HumanReadable
-        val unlockData = unlockDataProvider?.getKeyUnlockData(
-            secureArea = this,
-            alias = alias,
-            algorithm = getKeyInfo(alias).algorithm,
-            unlockReason = unlockReason
-        )
+        val unlockData = if (keyInfo.isUserAuthenticationRequired) {
+            unlockDataProvider.getKeyUnlockData(
+                secureArea = this,
+                alias = alias,
+                algorithm = getKeyInfo(alias).algorithm,
+                unlockReason = unlockReason
+            )
+        } else {
+            null
+        }
         check(unlockData is SecureEnclaveKeyUnlockData?)
         return Crypto.secureEnclaveEcSign(keyBlob, dataToSign, unlockData)
     }
@@ -190,20 +195,25 @@ class SecureEnclaveSecureArea private constructor(
         check(otherKey.curve == EcCurve.P256)
         check(keyInfo.algorithm.isKeyAgreement)
         val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
+            ?: SecureEnclaveDefaultKeyUnlockDataProvider
         // TODO: implement default KeyUnlockDataProvider by converting
         //  OperationReason to OperationReason.HumanReadable using PromptModel
         //  and the creating LAContext with title/subtitle from OperationReason.HumanReadable
-        val unlockData = unlockDataProvider?.getKeyUnlockData(
-            secureArea = this,
-            alias = alias,
-            algorithm = getKeyInfo(alias).algorithm,
-            unlockReason = unlockReason
-        )
+        val unlockData = if (keyInfo.isUserAuthenticationRequired) {
+            unlockDataProvider.getKeyUnlockData(
+                secureArea = this,
+                alias = alias,
+                algorithm = getKeyInfo(alias).algorithm,
+                unlockReason = unlockReason
+            )
+        } else {
+            null
+        }
         check(unlockData is SecureEnclaveKeyUnlockData?)
         return Crypto.secureEnclaveEcKeyAgreement(keyBlob, otherKey, unlockData)
     }
 
-    override suspend fun getKeyInfo(alias: String): KeyInfo {
+    override suspend fun getKeyInfo(alias: String): SecureEnclaveKeyInfo {
         val (_, keyInfo) = loadKey(alias)
         return keyInfo
     }
@@ -216,8 +226,18 @@ class SecureEnclaveSecureArea private constructor(
         alias: String,
         unlockReason: Reason
     ): List<KeyUnlockData> {
-        // Biometric prompts are automatically shown by iOS when using Secure Enclave keys,
-        // so explicit pre-unlock authentication is not required.
-        return emptyList()
+        val keyInfo = getKeyInfo(alias)
+        if (!keyInfo.isUserAuthenticationRequired) {
+            return emptyList()
+        }
+        val unlockDataProvider = coroutineContext[KeyUnlockDataProvider.Key]
+            ?: SecureEnclaveDefaultKeyUnlockDataProvider
+        val unlockData = unlockDataProvider.getKeyUnlockData(
+            secureArea = this,
+            alias = alias,
+            algorithm = keyInfo.algorithm,
+            unlockReason = unlockReason
+        )
+        return listOf(unlockData)
     }
 }

--- a/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ConsentPromptScreen.swift
@@ -180,6 +180,7 @@ private func calcRequestData(
         cardArt: mdlCardArt.toByteString(),
         issuerLogo: nil,
         authorizationData: nil,
+        appData: nil,
         created: now.toKotlinInstant(),
         metadata: nil
     )
@@ -216,6 +217,7 @@ private func calcRequestData(
         cardArt: photoIdCardArt.toByteString(),
         issuerLogo: nil,
         authorizationData: nil,
+        appData: nil,
         created: now.toKotlinInstant(),
         metadata: nil
     )
@@ -252,6 +254,7 @@ private func calcRequestData(
         cardArt: photoIdCardArt.toByteString(),
         issuerLogo: nil,
         authorizationData: nil,
+        appData: nil,
         created: now.toKotlinInstant(),
         metadata: nil
     )
@@ -288,6 +291,7 @@ private func calcRequestData(
         cardArt: boardingPassCardArt.toByteString(),
         issuerLogo: nil,
         authorizationData: nil,
+        appData: nil,
         created: now.toKotlinInstant(),
         metadata: nil
     )
@@ -855,6 +859,7 @@ private func calcRequestData(
                 ),
                 docFormat: nil,
                 dataElementIdentifierMapping: [:],
+                transactions: nil,
                 otherInfo: [:])
         )
         drBuilder.setDeviceRequestInfo(
@@ -1129,6 +1134,7 @@ extension DocumentStore {
             cardArt: nil,
             issuerLogo: nil,
             authorizationData: nil,
+            appData: nil,
             created: Date.now.toKotlinInstant(),
             metadata: nil
         )

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -102,7 +102,8 @@ struct ContentView: View {
                     viewModel.provisioningModel.launchOpenID4VCIProvisioning(
                         offerUri: url.absoluteString,
                         clientPreferences: viewModel.provisioningSupport.getOpenID4VCIClientPreferences(),
-                        backend: viewModel.provisioningSupport.getOpenID4VCIBackend()
+                        backend: viewModel.provisioningSupport.getOpenID4VCIBackend(),
+                        appData: nil
                     )
                 }
             } else {

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -207,7 +207,8 @@ class ViewModel {
                     sdJwtUserAuthDomain: "sdjwt_user_auth",
                     sdJwtNoUserAuthDomain: "sdjwt_no_user_auth",
                     sdJwtKeylessDomain: "sdjwt_keyless"
-                )
+                ),
+                selectSecureArea: nil
             ),
             httpClient: HttpClient(engineFactory: Darwin()) { config in
                 config.followRedirects = false
@@ -310,6 +311,7 @@ class ViewModel {
             cardArt: UIImage(named: cardArtResourceName)!.pngData()!.toByteString(),
             issuerLogo: nil,
             authorizationData: nil,
+            appData: nil,
             created: now.toKotlinInstant(),
             metadata: nil
         )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -841,7 +841,7 @@ object TestAppUtils {
                 val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
                     Pair(
                         CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                        dsKey.certChain.toDataItem()
+                        dsKey.certChain.toCoseX5Chain()
                     )
                 )
                 val encodedIssuerAuth = Cbor.encode(
@@ -977,7 +977,7 @@ object TestAppUtils {
             val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
                 Pair(
                     CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-                    dsKey.certChain.toDataItem()
+                    dsKey.certChain.toCoseX5Chain()
                 )
             )
             val encodedIssuerAuth = Cbor.encode(


### PR DESCRIPTION
ISO/IEC 18013-5:2021 Clause 9.1.2.4 and RFC 9360 specify that the COSE `x5chain` header parameter (label 33) in the MSO `issuerAuth` COSE_Sign1 structure should contain the Document Signer (DS) certificate or intermediate certificates up to, but not including, the self-signed root IACA certificate. When containing a single certificate, it must be encoded as a single CBOR byte string (`bstr`) rather than a single-element array.

- Add `toCoseX5Chain()` to `X509CertChain` to encode certificate chains per RFC 9360, stripping self-signed root certificates by default when the chain length is greater than 1.
- Update OpenID4VCI credential factories (`CredentialFactoryMdl`, `CredentialFactoryMdocPid`, `CredentialFactoryAgeVerification`, `CredentialFactoryDigitalPaymentCredential`, `CredentialFactoryUtopiaLoyalty`) to call `toCoseX5Chain()`.
- Update `buildCwt()`, `DocumentType.generateMso()`, `TestAppUtils`, and `MpzPassCreatorComponent` to use `toCoseX5Chain()`.
- Add unit tests in `X509CertChainTests` covering single-root, single-leaf, 2-cert, and 3-cert chains, update `IdentifierListTest`, and add an assertion in `ProvisioningClientTest`.

Additionally, update iOS Secure Enclave and Swift sample/UI code:
- Add `SecureEnclaveDefaultKeyUnlockDataProvider` and update `SecureEnclaveSecureArea.sign()`, `keyAgreement()`, and `unlockKey()` to only require key unlock data when user authentication is required.
- Update `Iso18013Presentment()`, `toCredentialSelection()`, `launchOpenID4VCIProvisioning()`, and `createDocument()` calls in `multipaz-swiftui` and `SwiftTestApp` to supply newly added default/optional parameters (`preselectedDocuments`, `transactionUserInput`, `appData`, `selectSecureArea`, and `transactions`).

Fixes #1917.

Test: Manually verified credentials issued does not include IACA in x5chain.
Test: Tested TestApp and SwiftTestApp on iOS
Test: Ran ./gradlew :multipaz:jvmTest :multipaz-openid4vci:test
Test: Ran ./gradlew :multipaz-backend-server:test :multipaz-verifier-server:test
Test: Ran ./gradlew :multipaz-doctypes:jvmTest :multipaz-utopia:jvmTest detekt
