### PR TITLE
Recover gracefully from invalid nonces during RPC authentication.

### DIFF
--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/rpc/RpcAuthAssertionTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/rpc/RpcAuthAssertionTest.kt
@@ -144,12 +144,8 @@ class RpcAuthAssertionTest {
         val session = RpcAuthClientSession()
         session.nonce = "badNonce".encodeToByteString()
         withContext(session) {
-            try {
-                target.test("foo")
-                fail()
-            } catch (err: RpcAuthException) {
-                assertEquals(RpcAuthError.FAILED, err.rpcAuthError)
-            }
+            val result = target.test("foo")
+            assertTrue(result.startsWith("foo@clientId."))
         }
     }
 
@@ -160,12 +156,8 @@ class RpcAuthAssertionTest {
         val session = RpcAuthClientSession()
         session.nonce = "badNonce-MustBeRelativelyLongToTestAnotherPath".encodeToByteString()
         withContext(session) {
-            try {
-                target.test("foo")
-                fail()
-            } catch (err: RpcAuthException) {
-                assertEquals(RpcAuthError.FAILED, err.rpcAuthError)
-            }
+            val result = target.test("foo")
+            assertTrue(result.startsWith("foo@clientId."))
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcNonceAndSession.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcNonceAndSession.kt
@@ -15,8 +15,6 @@ import org.multipaz.util.Logger
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 import kotlin.concurrent.Volatile
-import kotlin.experimental.xor
-import kotlin.math.min
 import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -51,6 +49,15 @@ class RpcNonceAndSession(
             supportExpiration = false
         )
 
+        /**
+         * Validates a client nonce and returns the next nonce and session ID.
+         *
+         * @param clientId identifier of the client.
+         * @param nonce current nonce sent by the client.
+         * @param expiration expiration timestamp for the session.
+         * @return [RpcNonceAndSession] containing the next nonce and session ID.
+         * @throws RpcAuthNonceException if the nonce is empty, invalid, or out of sequence, providing a fresh nonce.
+         */
         suspend fun checkNonce(
             clientId: String,
             nonce: ByteString,
@@ -58,7 +65,7 @@ class RpcNonceAndSession(
         ): RpcNonceAndSession {
             val storage = BackendEnvironment.getInterface(Storage::class)!!
             val table = storage.getTable(rpcNonceTableSpec)
-            val cipher = getNonceCipher(clientId)
+            val cipher = getNonceCipher()
             if (nonce.size == 0) {
                 val newNonce = nonceTableLock.withLock {
                     newSession(table, cipher, clientId, expiration)
@@ -67,9 +74,12 @@ class RpcNonceAndSession(
             }
             val sessionId = try {
                 cipher.decrypt(nonce.toByteArray()).toBase64Url()
-            } catch (_: SimpleCipher.DataTamperedException) {
-                // Decryption failed. This is a fake nonce, not merely slate nonce!
-                throw RpcAuthException("Invalid nonce", RpcAuthError.FAILED)
+            } catch (err: SimpleCipher.DataTamperedException) {
+                Logger.w(TAG, "Nonce decryption failed for client '$clientId', creating a new session", err)
+                val newNonce = nonceTableLock.withLock {
+                    newSession(table, cipher, clientId, expiration)
+                }
+                throw RpcAuthNonceException(newNonce)
             }
             val expectedNonce = table.get(key = sessionId, partitionId = clientId)
             val nextNonce = nonceTableLock.withLock {
@@ -84,6 +94,18 @@ class RpcNonceAndSession(
             )
         }
 
+        /**
+         * Validates an RPC authorization assertion and extracts the nonce and session.
+         *
+         * @param assertion the authorization assertion to validate.
+         * @param target RPC target endpoint.
+         * @param method RPC method name.
+         * @param payload payload CBOR bstr.
+         * @param timeout authorization validity timeout.
+         * @return [RpcNonceAndSession] containing the next nonce and session ID.
+         * @throws RpcAuthException if payload hash mismatch, target/method mismatch, or message expired.
+         * @throws RpcAuthNonceException if a fresh nonce must be issued.
+         */
         suspend fun validateAndExtractNonceAndSession(
             assertion: AssertionRpcAuth,
             target: String,
@@ -103,6 +125,19 @@ class RpcNonceAndSession(
             )
         }
 
+        /**
+         * Validates an RPC authorization assertion and extracts the nonce and session using a custom nonce checker.
+         *
+         * @param assertion the authorization assertion to validate.
+         * @param target RPC target endpoint.
+         * @param method RPC method name.
+         * @param payload payload CBOR bstr.
+         * @param timeout authorization validity timeout.
+         * @param nonceChecker lambda to check and advance the nonce.
+         * @return [RpcNonceAndSession] containing the next nonce and session ID.
+         * @throws RpcAuthException if payload hash mismatch, target/method mismatch, or message expired.
+         * @throws RpcAuthNonceException if a fresh nonce must be issued.
+         */
         suspend fun validateAndExtractNonceAndSession(
             assertion: AssertionRpcAuth,
             target: String,
@@ -138,7 +173,7 @@ class RpcNonceAndSession(
             return nonceChecker(assertion.clientId, assertion.nonce, expiration)
         }
 
-        private suspend fun getNonceCipher(clientId: String): SimpleCipher {
+        private suspend fun getNonceCipher(): SimpleCipher {
             val cipher = nonceCipher
             if (cipher != null) {
                 return cipher
@@ -152,15 +187,14 @@ class RpcNonceAndSession(
                         key = ByteString(Random.nextBytes(16))
                         table.insert("nonceCipherKey", key)
                     }
-                    val keyBytes = key.toByteArray()
-                    val pad = clientId.encodeToByteArray()
-                    for (i in 0..<min(keyBytes.size, pad.size)) {
-                        keyBytes[i] = keyBytes[i] xor pad[i]
-                    }
-                    nonceCipher = AesGcmCipher(keyBytes)
+                    nonceCipher = AesGcmCipher(key.toByteArray())
                 }
                 return nonceCipher!!
             }
+        }
+
+        internal fun resetForTesting() {
+            nonceCipher = null
         }
 
         private suspend fun newSession(

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcAuthAssertionJvmTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcAuthAssertionJvmTest.kt
@@ -1,0 +1,295 @@
+package org.multipaz.rpc
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
+import org.multipaz.device.DeviceCheck
+import org.multipaz.device.toCbor
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.handler.AesGcmCipher
+import org.multipaz.rpc.handler.RpcAuthClientSession
+import org.multipaz.rpc.handler.RpcAuthError
+import org.multipaz.rpc.handler.RpcAuthException
+import org.multipaz.rpc.handler.RpcAuthInspector
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+import org.multipaz.rpc.handler.RpcAuthIssuerAssertion
+import org.multipaz.rpc.handler.RpcDispatcher
+import org.multipaz.rpc.handler.RpcDispatcherAuth
+import org.multipaz.rpc.handler.RpcDispatcherLocal
+import org.multipaz.rpc.handler.RpcExceptionMap
+import org.multipaz.rpc.handler.RpcNonceAndSession
+import org.multipaz.rpc.handler.RpcNotifier
+import org.multipaz.rpc.test.TestInterfaceStub
+import org.multipaz.rpc.test.TestState
+import org.multipaz.rpc.test.register
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaProvider
+import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.storage.Storage
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import kotlin.random.Random
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class JvmTestBackendEnvironment(
+    val storage: Storage = EphemeralStorage()
+) : BackendEnvironment {
+    val secureAreaProvider = SecureAreaProvider(Dispatchers.Default) {
+        SoftwareSecureArea.create(storage)
+    }
+
+    override fun <T : Any> getInterface(clazz: KClass<T>): T {
+        return clazz.cast(when (clazz) {
+            Storage::class -> storage
+            SecureAreaProvider::class -> secureAreaProvider
+            RpcAuthInspector::class -> RpcAuthInspectorAssertion.Default
+            else -> throw IllegalArgumentException("no such class available: ${clazz.simpleName}")
+        })
+    }
+}
+
+class RpcAuthAssertionJvmTest {
+
+    @BeforeTest
+    fun setup() {
+        RpcNonceAndSession.resetForTesting()
+    }
+
+    private suspend fun setupClient(
+        environment: JvmTestBackendEnvironment,
+        clientId: String
+    ): Pair<SecureArea, String> {
+        val secureArea = environment.secureAreaProvider.get()
+        val challenge = clientId.encodeToByteString()
+        val deviceAttestation = DeviceCheck.generateAttestation(secureArea, challenge)
+        val deviceAttestationId = deviceAttestation.deviceAttestationId
+        val clientTable = environment.storage.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
+        clientTable.insert(
+            key = clientId,
+            data = ByteString(deviceAttestation.deviceAttestation.toCbor())
+        )
+        return Pair(secureArea, deviceAttestationId)
+    }
+
+    private suspend fun buildDispatcher(
+        environment: JvmTestBackendEnvironment,
+        authClientId: String? = "clientId",
+        clientCredentials: Pair<SecureArea, String>? = null
+    ): RpcDispatcher {
+        val builder = RpcDispatcherLocal.Builder()
+        TestState.register(builder)
+        val cipher = AesGcmCipher(Random.Default.nextBytes(16))
+        val local = builder.build(environment, cipher, RpcExceptionMap.Builder().build())
+
+        return if (authClientId != null) {
+            val (secureArea, deviceAttestationId) = clientCredentials
+                ?: setupClient(environment, authClientId)
+            val rpcAuth = RpcAuthIssuerAssertion(authClientId, secureArea, deviceAttestationId)
+            RpcDispatcherAuth(local, rpcAuth)
+        } else {
+            local
+        }
+    }
+
+    @Test
+    fun testValidAuth() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val dispatcher = buildDispatcher(environment)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session1 = withContext(RpcAuthClientSession()) {
+            val result0 = target.test("foo")
+            assertTrue(result0.startsWith("foo@clientId."))
+            val session = result0.substring(4)
+            val result1 = target.test("bar")
+            assertTrue(result1.startsWith("bar@clientId."))
+            assertEquals(session, result1.substring(4))
+            val result2 = target.test("buz")
+            assertTrue(result2.startsWith("buz@clientId."))
+            assertEquals(session, result2.substring(4))
+            session
+        }
+        val session2 = withContext(RpcAuthClientSession()) {
+            target.test("foobar").substring(7)
+        }
+        assertNotEquals(session1, session2)
+    }
+
+    @Test
+    fun testServerRestartRecovery() = runTest {
+        // Shared persistent storage for server restarts
+        val storage = EphemeralStorage()
+        val env1 = JvmTestBackendEnvironment(storage)
+        val clientCredentials = setupClient(env1, "clientId")
+
+        val dispatcher1 = buildDispatcher(env1, "clientId", clientCredentials)
+        val target1 = TestInterfaceStub("test", dispatcher1, RpcNotifier.SILENT)
+
+        val clientSession = RpcAuthClientSession()
+
+        // 1. Client communicates with server instance 1
+        withContext(clientSession) {
+            val result1 = target1.test("hello")
+            assertTrue(result1.startsWith("hello@clientId."))
+        }
+
+        // Nonce is populated in clientSession
+        assertTrue(clientSession.nonce.size > 0)
+
+        // 2. Simulate server restart: in-memory cipher reset and new dispatcher/environment
+        RpcNonceAndSession.resetForTesting()
+        val env2 = JvmTestBackendEnvironment(storage)
+        val dispatcher2 = buildDispatcher(env2, "clientId", clientCredentials)
+        val target2 = TestInterfaceStub("test", dispatcher2, RpcNotifier.SILENT)
+
+        // 3. Client continues using the same clientSession (carrying the pre-restart nonce)
+        withContext(clientSession) {
+            val result2 = target2.test("world")
+            assertTrue(result2.startsWith("world@clientId."))
+        }
+    }
+
+    @Test
+    fun testEphemeralStorageServerRestartRecovery() = runTest {
+        // Even if server storage is completely lost/ephemeral across restarts and client has old credentials
+        val env1 = JvmTestBackendEnvironment(EphemeralStorage())
+        val clientCredentials = setupClient(env1, "clientId")
+        val dispatcher1 = buildDispatcher(env1, "clientId", clientCredentials)
+        val target1 = TestInterfaceStub("test", dispatcher1, RpcNotifier.SILENT)
+
+        val clientSession = RpcAuthClientSession()
+
+        withContext(clientSession) {
+            val result1 = target1.test("hello")
+            assertTrue(result1.startsWith("hello@clientId."))
+        }
+
+        // Simulate server restart with fresh storage and fresh client registration
+        RpcNonceAndSession.resetForTesting()
+        val env2 = JvmTestBackendEnvironment(EphemeralStorage())
+        // Re-register device attestation on new server
+        val clientTable = env2.storage.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
+        val attestation = env1.storage.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec).get("clientId")!!
+        clientTable.insert("clientId", attestation)
+
+        val dispatcher2 = buildDispatcher(env2, "clientId", clientCredentials)
+        val target2 = TestInterfaceStub("test", dispatcher2, RpcNotifier.SILENT)
+
+        // Client presents nonce encrypted with old server key: should recover via NONCE_RETRY seamlessly
+        withContext(clientSession) {
+            val result2 = target2.test("world")
+            assertTrue(result2.startsWith("world@clientId."))
+        }
+    }
+
+    @Test
+    fun testShortFakeNonceRecovery() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val dispatcher = buildDispatcher(environment)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session = RpcAuthClientSession()
+        session.nonce = "badNonce".encodeToByteString()
+        withContext(session) {
+            val result = target.test("foo")
+            assertTrue(result.startsWith("foo@clientId."))
+        }
+    }
+
+    @Test
+    fun testLongFakeNonceRecovery() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val dispatcher = buildDispatcher(environment)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session = RpcAuthClientSession()
+        session.nonce = "badNonce-MustBeRelativelyLongToTestAnotherPath".encodeToByteString()
+        withContext(session) {
+            val result = target.test("foo")
+            assertTrue(result.startsWith("foo@clientId."))
+        }
+    }
+
+    @Test
+    fun testMultiClientIsolation() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val credsA = setupClient(environment, "clientA")
+        val credsB = setupClient(environment, "clientB")
+
+        val dispatcherA = buildDispatcher(environment, "clientA", credsA)
+        val dispatcherB = buildDispatcher(environment, "clientB", credsB)
+
+        val targetA = TestInterfaceStub("test", dispatcherA, RpcNotifier.SILENT)
+        val targetB = TestInterfaceStub("test", dispatcherB, RpcNotifier.SILENT)
+
+        val sessionA = RpcAuthClientSession()
+        val sessionB = RpcAuthClientSession()
+
+        // Interleaved calls from clientA and clientB
+        withContext(sessionA) {
+            val resA1 = targetA.test("msg1")
+            assertTrue(resA1.startsWith("msg1@clientA."))
+        }
+        withContext(sessionB) {
+            val resB1 = targetB.test("msg2")
+            assertTrue(resB1.startsWith("msg2@clientB."))
+        }
+        withContext(sessionA) {
+            val resA2 = targetA.test("msg3")
+            assertTrue(resA2.startsWith("msg3@clientA."))
+        }
+        withContext(sessionB) {
+            val resB2 = targetB.test("msg4")
+            assertTrue(resB2.startsWith("msg4@clientB."))
+        }
+    }
+
+    @Test
+    fun testNoSession() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val dispatcher = buildDispatcher(environment)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        try {
+            target.test("foo")
+            fail()
+        } catch (err: IllegalStateException) {
+            // expected: RpcAuthClientSession missing
+        }
+    }
+
+    @Test
+    fun testBadClient() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val creds = setupClient(environment, "registeredClient")
+        val dispatcher = buildDispatcher(environment, "unregisteredClient", creds)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        withContext(RpcAuthClientSession()) {
+            try {
+                target.test("foo")
+                fail()
+            } catch (err: RpcAuthException) {
+                assertEquals(RpcAuthError.UNKNOWN_CLIENT_ID, err.rpcAuthError)
+            }
+        }
+    }
+
+    @Test
+    fun testNoAuth() = runTest {
+        val environment = JvmTestBackendEnvironment()
+        val dispatcher = buildDispatcher(environment, null)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        withContext(RpcAuthClientSession()) {
+            try {
+                target.test("foo")
+                fail()
+            } catch (err: RpcAuthException) {
+                assertEquals(RpcAuthError.REQUIRED, err.rpcAuthError)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, when nonce decryption failed in `checkNonce()` (such as after restarting the backend server or when a client sent a stale nonce), an `RpcAuthException` was thrown with `RpcAuthError.FAILED`. This resulted in a fatal exception returned to the caller rather than triggering a fresh nonce challenge (`RpcReturnCode.NONCE_RETRY`), permanently wedging the client session until the client application was restarted.

Additionally, `getNonceCipher()` modified the cipher key using the client ID of whichever client connected first while caching the cipher instance across the process. Removing the client ID XORing is safe because client isolation is already enforced by partitioning the session storage table by client ID (`partitionId = clientId`) and authorization is cryptographically enforced via hardware-attested device signatures over the nonce payload.

Fix these issues by:
- Catching `SimpleCipher.DataTamperedException` in `checkNonce()` when nonce decryption fails, logging a warning, creating a new session, and throwing `RpcAuthNonceException` to challenge the client with a fresh nonce.
- Removing the client ID XOR padding in `getNonceCipher()` so the server cipher key is used uniformly across all clients.
- Adding `resetForTesting()` to reset the static cipher instance in tests.
- Adding comprehensive unit tests in `RpcAuthAssertionJvmTest` covering server restart recovery, ephemeral storage restarts, corrupted nonces, and multi-client concurrency.
- Updating `RpcAuthAssertionTest` to verify that invalid nonces prompt retry and succeed.

Fixes #1922.

Test: Manually tested with Multipaz Wallet Dev, restarting its backend.
Test: Ran ./gradlew detekt :multipaz:jvmTest
Test: Ran ./gradlew :backend:test :shared:allTests in multipaz-wallet
