### PR TITLE
Support optional top composable in vertical card list.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -441,11 +441,15 @@ internal fun PresentmentActivityContent(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     if (state is PresentmentModel.State.Reset && presentmentModel!!.showDocumentChooser != null) {
+                        val isNfcOnly by presentmentModel!!.isNfcOnly.collectAsState()
                         ShowCardChooser(
                             documentModel = documentModel!!,
                             initiallySelectedDocumentId = presentmentModel!!.showDocumentChooser!!.initiallySelectedDocumentId,
                             selectedDocIdFromCardChooser = selectedDocIdFromCardChooser,
                             onDocumentSelected = presentmentModel!!.showDocumentChooser!!.onDocumentSelected,
+                            topContent = {
+                                ShowHoldToReader(isNfcOnly = isNfcOnly)
+                            },
                             contentBelow = { documentId ->
                                 Column(
                                     modifier = Modifier
@@ -666,6 +670,7 @@ private fun ShowCardChooser(
     initiallySelectedDocumentId: String?,
     selectedDocIdFromCardChooser: MutableState<String?>,
     onDocumentSelected: ((documentId: String?) -> Unit)?,
+    topContent: @Composable () -> Unit = {},
     contentBelow: @Composable (documentId: String) -> Unit
 ) {
     val configuration = LocalConfiguration.current
@@ -673,7 +678,7 @@ private fun ShowCardChooser(
 
     val docInfos by documentModel.documentInfos.collectAsState()
     var focusedDocumentId by rememberSaveable { mutableStateOf<String?>(
-        initiallySelectedDocumentId ?: docInfos.firstOrNull()?.document?.identifier
+        initiallySelectedDocumentId
     )}
     val focusedDocument = docInfos.find { documentInfo ->
         documentInfo.document.identifier == focusedDocumentId
@@ -698,6 +703,7 @@ private fun ShowCardChooser(
         allowCardReordering = false,
         showStackWhileFocused = true,
         cardMaxHeight = maxCardHeight,
+        topContent = topContent,
         showCardInfo = { cardInfo -> contentBelow(cardInfo.identifier) },
         emptyContent = {
             Text(stringResource(

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -52,6 +53,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.yield
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -113,6 +115,17 @@ class VerticalCardListState(
      * This should typically be set to true only when navigating directly between two list states.
      */
     var animateListTransitions by mutableStateOf(false)
+
+    /**
+     * Whether the top content composable should be shown when no card is focused.
+     */
+    var showTopContent by mutableStateOf(true)
+
+    /**
+     * The measured height of the top content in pixels.
+     */
+    var topContentHeightPx by mutableFloatStateOf(0f)
+        internal set
 }
 
 /**
@@ -170,6 +183,10 @@ fun rememberVerticalCardListState(
  * screen real estate for the detail view. Defaults to true.
  * @param cardMaxHeight An optional max height constraint for the cards. Useful for foldables and wide screens.
  * @param state The state object to be used to control or observe the list's state.
+ * @param showTopContent Whether the [topContent] composable should be shown when no card is focused.
+ * Defaults to true.
+ * @param topContent A composable slot displayed at the top of the list when no card is focused.
+ * When a card is focused or [showTopContent] becomes false, this content animates away.
  * @param showCardInfo A composable slot that renders the detailed content below the focused card.
  * It is horizontally centered by default.
  * @param emptyContent A composable slot displayed inside a dashed placeholder card when the
@@ -192,6 +209,8 @@ fun VerticalCardList(
     showStackWhileFocused: Boolean = true,
     cardMaxHeight: Dp = Dp.Unspecified,
     state: VerticalCardListState = rememberVerticalCardListState(),
+    showTopContent: Boolean = state.showTopContent,
+    topContent: @Composable () -> Unit = {},
     showCardInfo: @Composable (CardInfo) -> Unit = {},
     emptyContent: @Composable () -> Unit = { },
     onCardReordered: (cardInfo: CardInfo, newPosition: Int) -> Unit = { _, _ -> },
@@ -290,24 +309,39 @@ fun VerticalCardList(
                 }
             }
 
-            Box(
+            Column(
                 modifier = Modifier
-                    .padding(top = 24.dp)
-                    .width(with(density) { cardWidthPx.toDp() })
-                    .height(with(density) { cardHeightPx.toDp() })
-                    .drawBehind {
-                        drawRoundRect(
-                            color = Color.Gray,
-                            style = Stroke(
-                                width = 3.dp.toPx(),
-                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(30f, 30f), 0f)
-                            ),
-                            cornerRadius = CornerRadius(24.dp.toPx(), 24.dp.toPx())
-                        )
-                    },
-                contentAlignment = Alignment.Center
+                    .fillMaxSize()
+                    .padding(top = 24.dp, start = 16.dp, end = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                emptyContent()
+                AnimatedVisibility(
+                    visible = showTopContent,
+                    enter = fadeIn(tween(400)),
+                    exit = fadeOut(tween(400))
+                ) {
+                    topContent()
+                }
+
+                Box(
+                    modifier = Modifier
+                        .width(with(density) { cardWidthPx.toDp() })
+                        .height(with(density) { cardHeightPx.toDp() })
+                        .drawBehind {
+                            drawRoundRect(
+                                color = Color.Gray,
+                                style = Stroke(
+                                    width = 3.dp.toPx(),
+                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(30f, 30f), 0f)
+                                ),
+                                cornerRadius = CornerRadius(24.dp.toPx(), 24.dp.toPx())
+                            )
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    emptyContent()
+                }
             }
         }
         return
@@ -338,6 +372,16 @@ fun VerticalCardList(
         // Determine X offset to keep the card centered if its width shrank due to max height
         val cardXOffsetPx = (maxWidthPx - cardWidthPx) / 2f
 
+        val isTopContentEffectivelyVisible = showTopContent && !isAnyFocused
+        val topContentProgress by animateFloatAsState(
+            targetValue = if (isTopContentEffectivelyVisible) 1f else 0f,
+            animationSpec = tween(400),
+            label = "topContentProgress"
+        )
+        val topContentSpacingPx = if (state.topContentHeightPx > 0f) spacingPx else 0f
+        val effectiveTopContentHeightPx = (state.topContentHeightPx + topContentSpacingPx) * topContentProgress
+        val listTopOffsetPx = paddingTopPx + effectiveTopContentHeightPx
+
         // --- List Math ---
         val listStepPx = if (unfocusedVisiblePercent == 100) {
             cardHeightPx + spacingPx
@@ -345,7 +389,7 @@ fun VerticalCardList(
             cardHeightPx * (unfocusedVisiblePercent / 100f)
         }
 
-        val totalHeightPx = paddingTopPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingTopPx
+        val totalHeightPx = listTopOffsetPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingTopPx
         val totalHeightDp = with(density) { totalHeightPx.toDp() }
 
         // --- Stack Math ---
@@ -376,6 +420,31 @@ fun VerticalCardList(
                     .fillMaxWidth()
                     .height(totalHeightDp)
             )
+
+            // Top Content (shown when no card is focused and showTopContent is true)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .offset {
+                        IntOffset(
+                            x = 0,
+                            y = (paddingTopPx - (1f - topContentProgress) * state.topContentHeightPx).roundToInt()
+                        )
+                    }
+                    .graphicsLayer {
+                        alpha = topContentProgress
+                    }
+                    .onSizeChanged { size ->
+                        if (size.height > 0) {
+                            state.topContentHeightPx = size.height.toFloat()
+                        }
+                    }
+            ) {
+                if (topContentProgress > 0f || state.topContentHeightPx == 0f) {
+                    topContent()
+                }
+            }
 
             AnimatedVisibility(
                 visible = isAnyFocused,
@@ -438,7 +507,7 @@ fun VerticalCardList(
                         }
                     } else {
                         // In list mode, the dragged card directly tracks the finger ignoring layout positioning
-                        targetY = if (isDragged) state.dragCurrentY else paddingTopPx + index * listStepPx
+                        targetY = if (isDragged) state.dragCurrentY else listTopOffsetPx + index * listStepPx
                         targetScale = if (isDragged) 1.05f else 1f
                         targetElevation = if (isDragged) 24f else 12f
                         targetZIndex = if (isDragged) 100f else index.toFloat()
@@ -476,7 +545,7 @@ fun VerticalCardList(
                                         onDragStart = { _ ->
                                             state.draggedCardIdentifier = cardInfo.identifier
                                             val currentIndex = state.displayOrderIdentifiers.indexOf(cardInfo.identifier)
-                                            state.dragCurrentY = paddingTopPx + currentIndex * listStepPx
+                                            state.dragCurrentY = listTopOffsetPx + currentIndex * listStepPx
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         },
                                         onDrag = { change, dragAmount ->
@@ -484,7 +553,7 @@ fun VerticalCardList(
                                             state.dragCurrentY += dragAmount.y
 
                                             // Calculate what index the card *should* be at based on physical height
-                                            val newIndex = ((state.dragCurrentY - paddingTopPx) / listStepPx)
+                                            val newIndex = ((state.dragCurrentY - listTopOffsetPx) / listStepPx)
                                                 .roundToInt()
                                                 .coerceIn(0, state.displayOrderIdentifiers.lastIndex)
 

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppQuickAccessWalletService.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppQuickAccessWalletService.kt
@@ -53,7 +53,7 @@ class TestAppQuickAccessWalletService: QuickAccessWalletService() {
         }
         return TestAppConfiguration.getPendingIntentForLaunchingQuickAccessWallet(
             source = app.getPresentmentSource(),
-            initiallySelectedDocumentId = app.settingsModel.currentlyFocusedDocumentId.value
+            initiallySelectedDocumentId = null
         )
     }
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -1189,7 +1189,7 @@ class App private constructor (val promptModel: PromptModel) {
                                     try {
                                         TestAppConfiguration.launchQuickAccessWallet(
                                             source = getPresentmentSource(),
-                                            initiallySelectedDocumentId = settingsModel.currentlyFocusedDocumentId.value
+                                            initiallySelectedDocumentId = null
                                         )
                                     } catch (e: Exception) {
                                         if (e is CancellationException) throw e

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -35,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -94,6 +98,21 @@ fun VerticalCardListScreen(
                         )
                     }
                 },
+                actions = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(
+                            text = "Top Composable",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Checkbox(
+                            checked = state.showTopContent,
+                            onCheckedChange = { state.showTopContent = it }
+                        )
+                    }
+                }
             )
         },
     ) { innerPadding ->
@@ -124,6 +143,29 @@ fun VerticalCardListScreen(
                 showStackWhileFocused = true,
                 cardMaxHeight = maxCardHeight,
                 state = state,
+                topContent = {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = "Top Composable Demo",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "This composable appears above cards when no card is focused and is hidden when a card is focused.",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                },
                 showCardInfo = { cardInfo ->
                     val documentInfo = cardInfo as DocumentInfo
                     Column(


### PR DESCRIPTION
Add support for displaying an optional composable above the card stack when in unselected list mode in `VerticalCardList`:
- Add `topContent` slot and `showTopContent` property to `VerticalCardList` and `VerticalCardListState`.
- Coordinated smooth transition animations where the top content fades and slides in when cards are unfocused and fades/slides out when a card is focused or `showTopContent` is toggled to false.
- Maintain measured `topContentHeightPx` in `VerticalCardListState` to ensure spatial animations from list mode into focused card mode start from the correct card positions without jumpiness across navigation destinations.
- Update `ShowCardChooser()` in `PresentmentActivity` to display the hold-to-reader NFC animation and text via `topContent` when no document is focused.
- Fix initial document selection in `PresentmentActivity` so passing null for `initiallySelectedDocumentId` correctly starts in unselected list mode.
- Update `TestAppQuickAccessWalletService` and `App` to pass null for `initiallySelectedDocumentId` when launching the Quick Access Wallet.
- Update `VerticalCardListScreen` in the test app with a demo toggle checkbox and sample top composable card.

Fixes #1926.

Test: Ran ./gradlew detekt
Test: Ran ./gradlew :multipaz-compose:assemble
Test: Ran ./gradlew :samples:testapp:assembleDebug
