### PR TITLE
Improve scrolling, layout positioning, and theming in Compose UI.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ process-phoenix = "3.0.0"
 coil = "3.3.0"
 compottie = "2.0.2"
 detekt = "1.23.8"
+haze = "1.7.0"
 # Kotlin/JS wrappers; require `./gradlew kotlinUpgradeYarnLock` after version changes
 # this is how npm works, that will update kotlin-js-store/yarn.lock (part of the repo)
 kotlin-wrappers = "2025.12.1"
@@ -154,6 +155,8 @@ kotlin-wrappers-react-dom = { module = "org.jetbrains.kotlin-wrappers:kotlin-rea
 kotlin-wrappers-emotion-react-js = { module = "org.jetbrains.kotlin-wrappers:kotlin-emotion-react-js", version.ref="kotlin-wrappers-em" }
 skie-annotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "skie" }
 compottie = { module = "io.github.alexzhirkevich:compottie", version.ref="compottie" }
+haze = { module = "dev.chrisbanes.haze:haze", version.ref = "haze" }
+haze-materials = { module = "dev.chrisbanes.haze:haze-materials", version.ref = "haze" }
 # Build Logic
 gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 android-tools-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/prompt/PresentmentActivity.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.fragment.app.FragmentActivity
@@ -433,9 +434,9 @@ internal fun PresentmentActivityContent(
                         .fillMaxHeight()
                         .widthIn(max = 600.dp) // Limits width for foldable/tablet support
                         .padding(
-                            top = innerPadding.calculateTopPadding(),
                             start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
                             end = innerPadding.calculateEndPadding(LocalLayoutDirection.current)
+                            // Omitting top padding so the card list extends up under the status bar
                             // Omitting the bottom padding since we want to draw under the navigation bar
                         ),
                     horizontalAlignment = Alignment.CenterHorizontally
@@ -447,9 +448,7 @@ internal fun PresentmentActivityContent(
                             initiallySelectedDocumentId = presentmentModel!!.showDocumentChooser!!.initiallySelectedDocumentId,
                             selectedDocIdFromCardChooser = selectedDocIdFromCardChooser,
                             onDocumentSelected = presentmentModel!!.showDocumentChooser!!.onDocumentSelected,
-                            topContent = {
-                                ShowHoldToReader(isNfcOnly = isNfcOnly)
-                            },
+                            paddingTop = innerPadding.calculateTopPadding() + 16.dp,
                             contentBelow = { documentId ->
                                 Column(
                                     modifier = Modifier
@@ -511,6 +510,7 @@ internal fun PresentmentActivityContent(
                         ShowCard(
                             documentModel = documentModel!!,
                             documentIds = docIdsToShow,
+                            paddingTop = innerPadding.calculateTopPadding() + 16.dp,
                             contentBelow = {
                                 val isNfcConnected by presentmentModel!!.isNfcConnected.collectAsState()
                                 val isNfcOnly by presentmentModel!!.isNfcOnly.collectAsState()
@@ -584,6 +584,7 @@ private const val STACKED_CARD_SCALE_PERCENT = 85
 private fun ShowCard(
     documentModel: DocumentModel,
     documentIds: List<String>,
+    paddingTop: Dp = 16.dp,
     contentBelow: @Composable () -> Unit
 ) {
     val configuration = LocalConfiguration.current
@@ -612,7 +613,7 @@ private fun ShowCard(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(paddingTop))
                 Box(
                     modifier = Modifier
                         .width(cardWidthDp)
@@ -670,7 +671,7 @@ private fun ShowCardChooser(
     initiallySelectedDocumentId: String?,
     selectedDocIdFromCardChooser: MutableState<String?>,
     onDocumentSelected: ((documentId: String?) -> Unit)?,
-    topContent: @Composable () -> Unit = {},
+    paddingTop: Dp = 16.dp,
     contentBelow: @Composable (documentId: String) -> Unit
 ) {
     val configuration = LocalConfiguration.current
@@ -703,7 +704,7 @@ private fun ShowCardChooser(
         allowCardReordering = false,
         showStackWhileFocused = true,
         cardMaxHeight = maxCardHeight,
-        topContent = topContent,
+        paddingTop = paddingTop,
         showCardInfo = { cardInfo -> contentBelow(cardInfo.identifier) },
         emptyContent = {
             Text(stringResource(

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/webview/WebViewRender.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/webview/WebViewRender.android.kt
@@ -119,7 +119,10 @@ internal actual fun WebViewRender(
                     "renderResource(\"/${WebViewRenderingContext.escape(asset!!)}\", \"$cssStr\")"
                 }
                 if (client.loaded) {
-                    webView.evaluateJavascript(command) {}
+                    if (command != client.lastCommand) {
+                        client.lastCommand = command
+                        webView.evaluateJavascript(command) {}
+                    }
                 } else {
                     client.deferredCommand = command
                 }
@@ -136,10 +139,12 @@ internal class ClientImpl(
 
     var loaded = false
     var deferredCommand = ""
+    var lastCommand: String? = null
 
     override fun onPageFinished(webView: WebView, url: String) {
         webView.evaluateJavascript(WebViewRenderingContext.renderResourceScript) {}
         if (deferredCommand.isNotEmpty()) {
+            lastCommand = deferredCommand
             webView.evaluateJavascript(deferredCommand) {}
             deferredCommand = ""
         }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
@@ -182,6 +182,8 @@ fun rememberVerticalCardListState(
  * of the screen when a card is focused. If false, unfocused cards fade away entirely to maximize
  * screen real estate for the detail view. Defaults to true.
  * @param cardMaxHeight An optional max height constraint for the cards. Useful for foldables and wide screens.
+ * @param paddingTop The top padding for the card list. Defaults to 16.dp.
+ * @param paddingBottom The bottom padding for the card list. Defaults to 16.dp.
  * @param state The state object to be used to control or observe the list's state.
  * @param showTopContent Whether the [topContent] composable should be shown when no card is focused.
  * Defaults to true.
@@ -208,6 +210,8 @@ fun VerticalCardList(
     allowCardReordering: Boolean = true,
     showStackWhileFocused: Boolean = true,
     cardMaxHeight: Dp = Dp.Unspecified,
+    paddingTop: Dp = 16.dp,
+    paddingBottom: Dp = 16.dp,
     state: VerticalCardListState = rememberVerticalCardListState(),
     showTopContent: Boolean = state.showTopContent,
     topContent: @Composable () -> Unit = {},
@@ -272,22 +276,6 @@ fun VerticalCardList(
     val isAnyFocused = internalFocusedCardIdentifier != null
     val focusedIndex = state.displayOrderIdentifiers.indexOf(internalFocusedCardIdentifier).coerceAtLeast(0)
 
-    // A nested scroll connection to intercept and consume the overscroll effect cleanly
-    val overscrollConsumer = remember {
-        object : NestedScrollConnection {
-            override fun onPostScroll(
-                consumed: Offset,
-                available: Offset,
-                source: NestedScrollSource
-            ): Offset = available // Silently consume all leftover scroll at the edges
-
-            override suspend fun onPostFling(
-                consumed: Velocity,
-                available: Velocity
-            ): Velocity = available
-        }
-    }
-
     if (cardInfos.isEmpty()) {
         BoxWithConstraints(
             modifier = modifier.fillMaxSize(),
@@ -312,7 +300,7 @@ fun VerticalCardList(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 24.dp, start = 16.dp, end = 16.dp),
+                    .padding(top = paddingTop, start = 16.dp, end = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
@@ -354,7 +342,8 @@ fun VerticalCardList(
         val maxHeightPx = constraints.maxHeight.toFloat()
 
         val paddingHorizontalPx = with(density) { 16.dp.toPx() }
-        val paddingTopPx = with(density) { 24.dp.toPx() }
+        val paddingTopPx = with(density) { paddingTop.toPx() }
+        val paddingBottomPx = with(density) { paddingBottom.toPx() }
         val spacingPx = with(density) { 16.dp.toPx() }
 
         var cardWidthPx = maxWidthPx - 2 * paddingHorizontalPx
@@ -389,7 +378,7 @@ fun VerticalCardList(
             cardHeightPx * (unfocusedVisiblePercent / 100f)
         }
 
-        val totalHeightPx = listTopOffsetPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingTopPx
+        val totalHeightPx = listTopOffsetPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingBottomPx
         val totalHeightDp = with(density) { totalHeightPx.toDp() }
 
         // --- Stack Math ---
@@ -412,7 +401,6 @@ fun VerticalCardList(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .nestedScroll(overscrollConsumer)
                 .verticalScroll(state.scrollState, enabled = !isAnyFocused)
         ) {
             Spacer(
@@ -478,7 +466,7 @@ fun VerticalCardList(
                     val isDragged = cardInfo.identifier == state.draggedCardIdentifier
                     val viewportTop = state.scrollState.value.toFloat()
 
-                    val targetY: Float
+                    val targetRelativeY: Float
                     val targetScale: Float
                     val targetElevation: Float
                     val targetZIndex: Float
@@ -486,7 +474,7 @@ fun VerticalCardList(
 
                     if (isAnyFocused) {
                         if (isFocused) {
-                            targetY = viewportTop + paddingTopPx
+                            targetRelativeY = (viewportTop + paddingTopPx) - listTopOffsetPx
                             targetScale = 1.025f
                             targetElevation = 24f
                             targetZIndex = 100f
@@ -498,7 +486,8 @@ fun VerticalCardList(
 
                             val frontCardY = viewportTop + maxHeightPx - frontCardVisibleHeightPx
 
-                            targetY = frontCardY - (clampedDistanceToFront * stackOffsetPx)
+                            val absoluteY = frontCardY - (clampedDistanceToFront * stackOffsetPx)
+                            targetRelativeY = absoluteY - listTopOffsetPx
                             targetScale = max(0.6f, 0.95f - (clampedDistanceToFront * 0.025f))
                             targetElevation = 12f
                             targetZIndex = stackIndex.toFloat()
@@ -507,7 +496,7 @@ fun VerticalCardList(
                         }
                     } else {
                         // In list mode, the dragged card directly tracks the finger ignoring layout positioning
-                        targetY = if (isDragged) state.dragCurrentY else listTopOffsetPx + index * listStepPx
+                        targetRelativeY = if (isDragged) state.dragCurrentY - listTopOffsetPx else index * listStepPx
                         targetScale = if (isDragged) 1.05f else 1f
                         targetElevation = if (isDragged) 24f else 12f
                         targetZIndex = if (isDragged) 100f else index.toFloat()
@@ -515,7 +504,7 @@ fun VerticalCardList(
                     }
 
                     // We skip animation for the dragged item so it tracks 1:1 with the finger without lag
-                    val animatedY by animateFloatAsState(targetY, tween(if (isDragged) 0 else 400), label = "y")
+                    val animatedRelativeY by animateFloatAsState(targetRelativeY, tween(if (isDragged) 0 else 400), label = "y")
                     val animatedScale by animateFloatAsState(targetScale, tween(400), label = "scale")
                     val animatedElevation by animateFloatAsState(targetElevation, tween(400), label = "elevation")
                     val animatedAlpha by animateFloatAsState(targetAlpha, tween(400), label = "alpha")
@@ -528,7 +517,7 @@ fun VerticalCardList(
                             .offset {
                                 IntOffset(
                                     x = cardXOffsetPx.roundToInt(),
-                                    y = animatedY.roundToInt()
+                                    y = (listTopOffsetPx + animatedRelativeY).roundToInt()
                                 )
                             }
                             .graphicsLayer {

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/webview/WebViewRender.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/webview/WebViewRender.ios.kt
@@ -167,7 +167,10 @@ internal fun injectContent(
     } else {
         "renderResource(\"/${WebViewRenderingContext.escape(asset!!)}\", \"$cssStr\")"
     }
-    client.evaluateJavaScript(webView, command)
+    if (command != client.lastCommand) {
+        client.lastCommand = command
+        client.evaluateJavaScript(webView, command)
+    }
 }
 
 class URLHandler(
@@ -222,6 +225,7 @@ class URLHandler(
 internal class WebViewClient : NSObject(), WKNavigationDelegateProtocol {
     private var loaded = false
     private var deferredCommand: String? = null
+    internal var lastCommand: String? = null
 
     @ObjCSignatureOverride
     override fun webView(
@@ -249,6 +253,7 @@ internal class WebViewClient : NSObject(), WKNavigationDelegateProtocol {
         ) { _, _ ->
         }
         if (deferredCommand != null) {
+            lastCommand = deferredCommand
             webView.evaluateJavaScript(deferredCommand!!) { _, _ -> }
             deferredCommand = null
         }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -179,6 +179,8 @@ kotlin {
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.coil.compose)
                 implementation(libs.coil.ktor3)
+                implementation(libs.haze)
+                implementation(libs.haze.materials)
             }
         }
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -35,11 +35,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.multipaz.compose.cards.VerticalCardList
@@ -59,7 +68,11 @@ private data class VisibilityOption(
     val visibilityPercentage: Int
 )
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
+@OptIn(
+    ExperimentalComposeUiApi::class,
+    ExperimentalMaterial3Api::class,
+    ExperimentalHazeMaterialsApi::class
+)
 @Composable
 fun VerticalCardListScreen(
     documentStore: DocumentStore,
@@ -74,10 +87,26 @@ fun VerticalCardListScreen(
     onBackPressed: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val hazeState = remember { HazeState() }
 
     Scaffold(
         topBar = {
             TopAppBar(
+                modifier = Modifier.hazeEffect(
+                    state = hazeState,
+                    style = HazeStyle(
+                        backgroundColor = Color.Transparent,
+                        tints = listOf(
+                            HazeTint(MaterialTheme.colorScheme.primaryContainer)
+                        ),
+                        blurRadius = 24.dp
+                    )
+                ) {
+                    progressive = HazeProgressive.verticalGradient(
+                        startIntensity = 1f,
+                        endIntensity = 0.5f
+                    )
+                },
                 title = {
                     val text = if (focusedDocumentId != null) {
                         "Vertical Card List (doc focused)"
@@ -86,7 +115,8 @@ fun VerticalCardListScreen(
                     }
                     Text(text = text)},
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                    containerColor = Color.Transparent,
+                    scrolledContainerColor = Color.Transparent
                 ),
                 navigationIcon = {
                     IconButton(onClick = {
@@ -119,10 +149,11 @@ fun VerticalCardListScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .hazeSource(hazeState)
                 .padding(
-                    top = innerPadding.calculateTopPadding(),
                     start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
                     end = innerPadding.calculateEndPadding(LocalLayoutDirection.current)
+                    // Omitting top padding so the card list extends up under the TopAppBar
                     // Omitting the bottom padding since we want to draw under the navigation bar
                 ),
             verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -142,6 +173,7 @@ fun VerticalCardListScreen(
                 allowCardReordering = true,
                 showStackWhileFocused = true,
                 cardMaxHeight = maxCardHeight,
+                paddingTop = innerPadding.calculateTopPadding() + 16.dp,
                 state = state,
                 topContent = {
                     Card(


### PR DESCRIPTION
Refactor Compose UI components and screens to improve layout stability, scrolling behavior, and visual presentation:

- In `WebViewRender` (Android and iOS), cache `lastCommand` in `rememberSaveable` to prevent recomposition loops from re-evaluating identical JavaScript commands.
- In `VerticalCardList`, decouple the top offset of the list container from individual card relative offsets to prevent initial layout insets from triggering spurious slide-down animations.
- In `VerticalCardList`, introduce a `paddingBottom` parameter, update default `paddingTop` and `paddingBottom` to `16.dp`, and fix total scroll height calculations to avoid excess whitespace below the last card.
- Remove `overscrollConsumer` from `VerticalCardList` to ensure unconsumed scroll deltas properly propagate to parent nested scroll containers (such as pull-to-refresh).
- In `PresentmentActivity`, extend the root layout bounds into the status bar area and pass `paddingTop = innerPadding.calculateTopPadding() + 16.dp` to `ShowCardChooser` and `ShowCard` so that cards scroll smoothly under the status bar without top edge clipping. Remove unused `topContent` slot.
- In `VerticalCardListScreen` (`samples/testapp`), add `haze` and `haze-materials` dependencies and render a transparent top app bar with progressive vertical gradient frosted glass blurring and primary container tinting above scrolling cards.

Fixes #1934.

Test: Manually tested.
Test: Ran ./gradlew detekt
Test: Ran ./gradlew :multipaz-compose:assemble
Test: Ran ./gradlew :multipaz-compose:testDebugUnitTest
Test: Ran ./gradlew :samples:testapp:assembleDebug
