### PR TITLE
Validate zlib header per RFC 1950 instead of comparing fixed bytes.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Compression.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Compression.kt
@@ -81,8 +81,18 @@ suspend fun ByteArray.zlibDeflate(compressionLevel: Int = 9): ByteArray =
  * @throws IllegalArgumentException if the given data is invalid
  */
 suspend fun ByteArray.zlibInflate(): ByteArray {
-    if (!(sliceArray(0..<2) contentEquals zlibWrapperHeader)) {
+    if (size < 6) {
+        throw IllegalArgumentException("invalid compression (truncated)")
+    }
+    val cmf = this[0].toInt() and 0xFF
+    val flg = this[1].toInt() and 0xFF
+    // RFC 1950 section 2.2. FLEVEL, the upper two bits of FLG, is informational only and varies
+    // with the compression level used by the producer, so it must not be part of the check.
+    if ((cmf and 0x0F) != 8 || (cmf shr 4) > 7 || (cmf * 256 + flg) % 31 != 0) {
         throw IllegalArgumentException("invalid compression (wrong header)")
+    }
+    if ((flg and 0x20) != 0) {
+        throw IllegalArgumentException("invalid compression (preset dictionary is not supported)")
     }
     val data = sliceArray(2..<size - 4).inflate()
     val checksum = data.adler32()

--- a/multipaz/src/commonTest/kotlin/org/multipaz/util/CompressionTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/util/CompressionTests.kt
@@ -82,6 +82,50 @@ class CompressionTests {
     }
 
     @Test
+    fun zlibHeaderAnyCompressionLevel() = runTest {
+        // FLEVEL, the upper two bits of the second header byte, depends on the compression level
+        // used by the producer: 0x7801 for level 1, 0x785E for 2-5, 0x789C for 6 and 0x78DA for
+        // 7-9. Level 6 is the default for java.util.zip.Deflater, Python zlib and Node zlib, so
+        // rejecting anything other than 0x78DA rejects most producers.
+        val expected = "Hello, Multipaz!".encodeToByteArray()
+        // "Hello, Multipaz!" deflated at level 6, header 0x789C.
+        val level6 = byteArrayOf(
+            120, -100, -13, 72, -51, -55, -55, -41, 81, -16, 45, -51, 41, -55, 44, 72,
+            -84, 82, 4, 0, 48, 69, 5, -72
+        )
+        // The same data at level 1, header 0x7801.
+        val level1 = byteArrayOf(
+            120, 1, -13, 72, -51, -55, -55, -41, 81, -16, 45, -51, 41, -55, 44, 72,
+            -84, 82, 4, 0, 48, 69, 5, -72
+        )
+        assertContentEquals(expected, level6.zlibInflate())
+        assertContentEquals(expected, level1.zlibInflate())
+    }
+
+    @Test
+    fun zlibHeaderRejectsInvalid() = runTest {
+        val data = byteArrayOf(42, 57, 70, 11, 17)
+        val compressed = data.zlibDeflate()
+
+        // Compression method other than DEFLATE.
+        val wrongMethod = compressed.copyOf()
+        wrongMethod[0] = 0x79
+        assertFailsWith(IllegalArgumentException::class) { wrongMethod.zlibInflate() }
+
+        // FCHECK does not make CMF*256 + FLG a multiple of 31.
+        val badCheck = compressed.copyOf()
+        badCheck[1] = (compressed[1].toInt() xor 1).toByte()
+        assertFailsWith(IllegalArgumentException::class) { badCheck.zlibInflate() }
+
+        // A preset dictionary is not supported: FDICT set, FCHECK adjusted to stay valid.
+        val presetDict = compressed.copyOf()
+        presetDict[1] = 0xBB.toByte()
+        assertFailsWith(IllegalArgumentException::class) { presetDict.zlibInflate() }
+
+        assertFailsWith(IllegalArgumentException::class) { byteArrayOf(120, -38).zlibInflate() }
+    }
+
+    @Test
     fun zlibChecksum() = runTest {
         val data = byteArrayOf(42, 57, 70, 11, 17)
         val compressed = data.zlibDeflate()


### PR DESCRIPTION
Fixes #1937

- [ ] Tests pass — see Testing below, they were not executed locally
- [x] Appropriate changes to README are included in PR — none needed

`zlibInflate()` compared the first two bytes against `0x78DA`, which is only the header emitted for compression levels 7-9. FLEVEL is informational per RFC 1950 section 2.2, so valid streams produced at other levels were rejected — notably `0x789C`, the default for `java.util.zip.Deflater`, Python `zlib` and Node `zlib`. Status lists from such issuers failed to decompress and revocation checking returned `UNKNOWN` with `invalid compression (wrong header)`.

The header is now validated per RFC 1950 section 2.2 — `CM`, `CINFO` and `FCHECK` — and a preset dictionary is rejected explicitly, since `inflate()` here cannot supply one. `zlibDeflate()` keeps emitting `0x78DA`, so round-tripping is unchanged, and the length guard keeps a short input producing an `IllegalArgumentException` rather than an index-out-of-bounds from `sliceArray(2..<size - 4)`.

## Testing

Two tests added to `CompressionTests`:

- `zlibHeaderAnyCompressionLevel` — fixed byte arrays for `"Hello, Multipaz!"` deflated at level 6 (`0x789C`) and level 1 (`0x7801`). Both fail before this change.
- `zlibHeaderRejectsInvalid` — a compression method other than DEFLATE, a broken FCHECK, a valid header with FDICT set, and an input too short to contain a wrapper. This keeps the relaxed check from becoming a no-op.

The existing `zlibHeader` and `zlibChecksum` tests are unaffected.

I was not able to run these locally: on macOS the build configures the iOS targets, `compileKotlinJvm` depends on `kspCommonMainKotlinMetadata`, and that needs `cinteropSwiftBridge*`, which requires Xcode rather than just the Command Line Tools. What I did verify by hand is that each fixture's header decodes as intended — `0x789C` and `0x7801` give `CM=8`, `CINFO=7`, `FCHECK=0`, `FDICT=0`; `0x79DA` gives `CM=9`; `0x78DB` leaves a remainder of 1; `0x78BB` is a well-formed header with `FDICT=1` — and that the fixtures are genuine zlib streams. CI runs on `ubuntu-latest`, where the iOS targets are not configured, so `./gradlew test` should exercise both tests there.
