### PR TITLE
Unify vertical card list layout engine and enhance UI components.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/VerticalCardList.kt
@@ -2,11 +2,12 @@ package org.multipaz.compose.cards
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
@@ -20,53 +21,51 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import kotlinx.coroutines.yield
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.delay
-import kotlin.math.max
-import kotlin.math.min
+import kotlinx.coroutines.yield
+import org.multipaz.cards.CardDimensions
+import org.multipaz.cards.CardLayoutItem
+import org.multipaz.cards.CardListLayout
+import org.multipaz.cards.CardListLayoutCalculator
+import org.multipaz.cards.CardListLayoutParameters
+import org.multipaz.cards.CardTapAction
+import org.multipaz.cards.CardVisualState
+import org.multipaz.cards.VerticalCardListModel
 import kotlin.math.roundToInt
 
 /**
@@ -75,61 +74,80 @@ import kotlin.math.roundToInt
  * Use [rememberVerticalCardListState] to create an instance.
  *
  * @param scrollState the scroll state for the list.
+ * @param model underlying platform-agnostic [VerticalCardListModel].
  */
 @Stable
 class VerticalCardListState(
-    val scrollState: ScrollState
+    val scrollState: ScrollState,
+    val model: VerticalCardListModel = VerticalCardListModel()
 ) {
     /**
      * The current display order of the cards, tracked by identifier.
      */
-    var displayOrderIdentifiers by mutableStateOf<List<String>>(emptyList())
+    var displayOrderIdentifiers by mutableStateOf(model.displayOrderIdentifiers)
         internal set
 
     /**
      * The identifier of the card currently being dragged, if any.
      */
-    var draggedCardIdentifier by mutableStateOf<String?>(null)
+    var draggedCardIdentifier by mutableStateOf(model.draggedCardIdentifier)
         internal set
 
     /**
      * The current Y position of the dragged card.
      */
-    var dragCurrentY by mutableFloatStateOf(0f)
+    var dragCurrentY by mutableFloatStateOf(model.dragCurrentY.toFloat())
         internal set
 
     /**
      * Whether a drag operation just ended.
      */
-    var dragJustEnded by mutableStateOf(false)
+    var dragJustEnded by mutableStateOf(model.dragJustEnded)
         internal set
 
     /**
      * The identifier of the last focused card, used to preserve animations across navigation.
      */
-    var lastFocusedCardIdentifier by mutableStateOf<String?>(null)
+    var lastFocusedCardIdentifier by mutableStateOf(model.lastFocusedCardIdentifier)
         internal set
 
     /**
-     * Whether to animate spatial transitions (like sliding cards) when entering this screen.
-     * This should typically be set to true only when navigating directly between two list states.
+     * Trigger counter for requesting an in-place unfocus animation.
      */
-    var animateListTransitions by mutableStateOf(false)
+    var unfocusTrigger by mutableIntStateOf(0)
+        internal set
+
+    /**
+     * Unfocuses the currently focused card with an animation.
+     *
+     * Suspends until the 400ms transition animation completes.
+     */
+    suspend fun unfocus() {
+        unfocusTrigger++
+        lastFocusedCardIdentifier = null
+        model.lastFocusedCardIdentifier = null
+        delay(400)
+    }
+
+    /**
+     * Whether to animate spatial transitions (like sliding cards) when entering this screen.
+     */
+    var animateListTransitions by mutableStateOf(model.animateListTransitions)
 
     /**
      * Whether the top content composable should be shown when no card is focused.
      */
-    var showTopContent by mutableStateOf(true)
+    var showTopContent by mutableStateOf(model.showTopContent)
 
     /**
      * Whether to show a dashed placeholder card when the card list is empty.
      */
-    var showPlaceholderWhenEmpty by mutableStateOf(true)
+    var showPlaceholderWhenEmpty by mutableStateOf(model.showPlaceholderWhenEmpty)
 
     /**
      * The measured height of the top content in pixels.
      */
-    var topContentHeightPx by mutableFloatStateOf(0f)
+    var topContentHeightPx by mutableFloatStateOf(model.topContentHeight.toFloat())
         internal set
 }
 
@@ -160,19 +178,6 @@ fun rememberVerticalCardListState(
  * below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
  * bottom of the screen.
  *
- * This composable uses [VerticalCardListState] to store state and this state object uses
- * [CardInfo.identifier] as the identifiers, meaning it's allowable to pass ephemeral [CardInfo]
- * instances into this composable as long as they keep using the same stable identifiers. This
- * in turn means that it works directly with [DocumentModel] in the following way:
- *
- * ```
- * val cardInfos by documentModel.documentInfos.collectAsState()
- * VerticalCardList(
- *   cardInfos = cardInfos,
- *   [...]
- * )
- * ```
- *
  * @param modifier The modifier to be applied to the list container.
  * @param cardInfos The list of [CardInfo] objects to display.
  * @param focusedCard The currently focused card. When null, the component operates in
@@ -184,29 +189,20 @@ fun rememberVerticalCardListState(
  * @param allowCardReordering If true, users can long-press and drag cards to reorder them
  * when in standard list mode. Defaults to true.
  * @param showStackWhileFocused If true, unfocused cards will collapse into a 3D stack at the bottom
- * of the screen when a card is focused. If false, unfocused cards fade away entirely to maximize
- * screen real estate for the detail view. Defaults to true.
+ * of the screen when a card is focused. If false, unfocused cards fade away entirely. Defaults to true.
  * @param cardMaxHeight An optional max height constraint for the cards. Useful for foldables and wide screens.
  * @param paddingTop The top padding for the card list. Defaults to 16.dp.
  * @param paddingBottom The bottom padding for the card list. Defaults to 16.dp.
  * @param state The state object to be used to control or observe the list's state.
  * @param showTopContent Whether the [topContent] composable should be shown when no card is focused.
- * Defaults to true.
  * @param showPlaceholderWhenEmpty Whether to show a dashed placeholder card when the card list is empty.
- * Defaults to true.
  * @param topContent A composable slot displayed at the top of the list when no card is focused.
- * When a card is focused or [showTopContent] becomes false, this content animates away.
  * @param showCardInfo A composable slot that renders the detailed content below the focused card.
- * It is horizontally centered by default.
- * @param emptyContent A composable slot displayed inside a dashed placeholder card when the
- * [cardInfos] list is empty.
+ * @param emptyContent A composable slot displayed inside a dashed placeholder card when empty.
  * @param onCardReordered Callback invoked when a drag-and-drop reordering operation completes.
- * Provides the [CardInfo] of the moved card and its new index position in the list.
  * @param onCardFocused Callback invoked when a card is tapped to be focused.
  * @param onCardFocusedTapped Callback invoked when the currently focused card is tapped.
  * @param onCardFocusedStackTapped Callback invoked when the unfocused card stack is tapped while another card is in focus.
- *
- * @throws IllegalArgumentException if [unfocusedVisiblePercent] is not between 0 and 100.
  */
 @Composable
 fun VerticalCardList(
@@ -219,418 +215,428 @@ fun VerticalCardList(
     cardMaxHeight: Dp = Dp.Unspecified,
     paddingTop: Dp = 16.dp,
     paddingBottom: Dp = 16.dp,
+    animateListTransitions: Boolean = false,
     state: VerticalCardListState = rememberVerticalCardListState(),
     showTopContent: Boolean = state.showTopContent,
     showPlaceholderWhenEmpty: Boolean = state.showPlaceholderWhenEmpty,
     topContent: @Composable () -> Unit = {},
     showCardInfo: @Composable (CardInfo) -> Unit = {},
-    emptyContent: @Composable () -> Unit = { },
+    emptyContent: @Composable () -> Unit = {},
     onCardReordered: (cardInfo: CardInfo, newPosition: Int) -> Unit = { _, _ -> },
     onCardFocused: (cardInfo: CardInfo) -> Unit = {},
     onCardFocusedTapped: (cardInfo: CardInfo) -> Unit = {},
     onCardFocusedStackTapped: (cardInfo: CardInfo) -> Unit = {}
 ) {
-    if (unfocusedVisiblePercent !in 0..100) {
-        throw IllegalArgumentException("unfocusedVisiblePercent must be between 0 and 100")
-    }
-
-    // Sync cardInfos with state.displayOrderIdentifiers
     val currentCardIdentifiers = cardInfos.map { it.identifier }
     if (state.draggedCardIdentifier == null && state.displayOrderIdentifiers != currentCardIdentifiers) {
-        state.displayOrderIdentifiers = currentCardIdentifiers
+        state.model.syncCards(currentCardIdentifiers)
+        state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
     }
 
-    // Resolve CardInfo objects based on the current display order
     val displayOrder = remember(state.displayOrderIdentifiers, cardInfos) {
         state.displayOrderIdentifiers.mapNotNull { id -> cardInfos.find { it.identifier == id } }
     }
 
-    // To preserve animations across navigation, we use an internal focused card identifier state
-    // initialized from the state's last focused card identifier ONLY if we are animating a list transition.
-    var internalFocusedCardIdentifier by remember(state) {
-        mutableStateOf(if (state.animateListTransitions) state.lastFocusedCardIdentifier else focusedCard?.identifier)
+    var internalFocusedCardIdentifier by remember(focusedCard?.identifier) {
+        mutableStateOf(if (animateListTransitions) state.lastFocusedCardIdentifier else focusedCard?.identifier)
     }
 
-    // We use LaunchedEffect to detect when this screen enters the composition or focusedCard changes.
     LaunchedEffect(focusedCard?.identifier) {
-        if (state.animateListTransitions && state.lastFocusedCardIdentifier != focusedCard?.identifier) {
-            // We are transitioning from another list state, and the focus changed.
-            // Snap to the global state so we can animate from it.
+        if (animateListTransitions && state.lastFocusedCardIdentifier != focusedCard?.identifier) {
             internalFocusedCardIdentifier = state.lastFocusedCardIdentifier
-            // Yield to allow Compose to render the snapshot before we change it
             yield()
-            // The next frame will animate to our intended state
             state.lastFocusedCardIdentifier = focusedCard?.identifier
+            state.model.lastFocusedCardIdentifier = focusedCard?.identifier
             internalFocusedCardIdentifier = focusedCard?.identifier
-        } else if (internalFocusedCardIdentifier != focusedCard?.identifier || state.lastFocusedCardIdentifier != focusedCard?.identifier) {
-            // Normal forward navigation without transition animation, or local state change
+        } else {
             internalFocusedCardIdentifier = focusedCard?.identifier
             state.lastFocusedCardIdentifier = focusedCard?.identifier
+            state.model.lastFocusedCardIdentifier = focusedCard?.identifier
+        }
+    }
+
+    var lastHandledUnfocusTrigger by remember { mutableIntStateOf(state.unfocusTrigger) }
+
+    LaunchedEffect(state.unfocusTrigger) {
+        if (state.unfocusTrigger != lastHandledUnfocusTrigger) {
+            lastHandledUnfocusTrigger = state.unfocusTrigger
+            internalFocusedCardIdentifier = null
         }
     }
 
     val internalFocusedCard = cardInfos.find { it.identifier == internalFocusedCardIdentifier }
-
     val haptic = LocalHapticFeedback.current
 
-    // Automatically reset the block on clicks after a short delay
     LaunchedEffect(state.dragJustEnded) {
         if (state.dragJustEnded) {
             delay(300)
             state.dragJustEnded = false
+            state.model.clearDragJustEnded()
         }
     }
 
     val isAnyFocused = internalFocusedCardIdentifier != null
-    val focusedIndex = state.displayOrderIdentifiers.indexOf(internalFocusedCardIdentifier).coerceAtLeast(0)
 
-    if (cardInfos.isEmpty()) {
-        BoxWithConstraints(
-            modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            val density = LocalDensity.current
-            val maxWidthPx = constraints.maxWidth.toFloat()
-            val paddingHorizontalPx = with(density) { 16.dp.toPx() }
+    SubcomposeLayout(modifier = modifier.fillMaxSize()) { constraints ->
+        val density = this
+        val maxWidthPx = constraints.maxWidth.toDouble()
+        val maxHeightPx = constraints.maxHeight.toDouble()
 
-            var cardWidthPx = maxWidthPx - 2 * paddingHorizontalPx
-            var cardHeightPx = cardWidthPx / 1.586f
+        val paddingHorizontalPx = with(density) { 16.dp.toPx().toDouble() }
+        val paddingTopPx = with(density) { paddingTop.toPx().toDouble() }
+        val paddingBottomPx = with(density) { paddingBottom.toPx().toDouble() }
+        val spacingPx = with(density) { 16.dp.toPx().toDouble() }
+        val cardMaxHeightPx = if (cardMaxHeight.isSpecified) with(density) { cardMaxHeight.toPx().toDouble() } else null
 
-            // Apply height limitation and scale down width if needed to keep ratio
-            if (cardMaxHeight.isSpecified) {
-                val maxAllowedCardHeightPx = with(density) { cardMaxHeight.toPx() }
-                if (cardHeightPx > maxAllowedCardHeightPx) {
-                    cardHeightPx = maxAllowedCardHeightPx
-                    cardWidthPx = cardHeightPx * 1.586f
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = paddingTop, start = 16.dp, end = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                AnimatedVisibility(
-                    visible = showTopContent,
-                    enter = fadeIn(tween(400)),
-                    exit = fadeOut(tween(400))
-                ) {
-                    topContent()
-                }
-
-                if (showPlaceholderWhenEmpty) {
-                    Box(
-                        modifier = Modifier
-                            .width(with(density) { cardWidthPx.toDp() })
-                            .height(with(density) { cardHeightPx.toDp() })
-                            .drawBehind {
-                                drawRoundRect(
-                                    color = Color.Gray,
-                                    style = Stroke(
-                                        width = 3.dp.toPx(),
-                                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(30f, 30f), 0f)
-                                    ),
-                                    cornerRadius = CornerRadius(24.dp.toPx(), 24.dp.toPx())
-                                )
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        emptyContent()
-                    }
-                }
-            }
-        }
-        return
-    }
-
-    // OUTER BoxWithConstraints: Grabs the exact screen dimensions before any scrolling alters them.
-    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-        val density = LocalDensity.current
-        val maxWidthPx = constraints.maxWidth.toFloat()
-        val maxHeightPx = constraints.maxHeight.toFloat()
-
-        val paddingHorizontalPx = with(density) { 16.dp.toPx() }
-        val paddingTopPx = with(density) { paddingTop.toPx() }
-        val paddingBottomPx = with(density) { paddingBottom.toPx() }
-        val spacingPx = with(density) { 16.dp.toPx() }
-
-        var cardWidthPx = maxWidthPx - 2 * paddingHorizontalPx
-        var cardHeightPx = cardWidthPx / 1.586f
-
-        // Apply height limitation and scale down width if needed to keep ratio
-        if (cardMaxHeight.isSpecified) {
-            val maxAllowedCardHeightPx = with(density) { cardMaxHeight.toPx() }
-            if (cardHeightPx > maxAllowedCardHeightPx) {
-                cardHeightPx = maxAllowedCardHeightPx
-                cardWidthPx = cardHeightPx * 1.586f
-            }
-        }
-
-        // Determine X offset to keep the card centered if its width shrank due to max height
-        val cardXOffsetPx = (maxWidthPx - cardWidthPx) / 2f
-
-        val isTopContentEffectivelyVisible = showTopContent && !isAnyFocused
-        val topContentProgress by animateFloatAsState(
-            targetValue = if (isTopContentEffectivelyVisible) 1f else 0f,
-            animationSpec = tween(400),
-            label = "topContentProgress"
-        )
-        val topContentSpacingPx = if (state.topContentHeightPx > 0f) spacingPx else 0f
-        val effectiveTopContentHeightPx = (state.topContentHeightPx + topContentSpacingPx) * topContentProgress
-        val listTopOffsetPx = paddingTopPx + effectiveTopContentHeightPx
-
-        // --- List Math ---
-        val listStepPx = if (unfocusedVisiblePercent == 100) {
-            cardHeightPx + spacingPx
-        } else {
-            cardHeightPx * (unfocusedVisiblePercent / 100f)
-        }
-
-        val totalHeightPx = listTopOffsetPx + (max(0, state.displayOrderIdentifiers.size - 1) * listStepPx) + cardHeightPx + paddingBottomPx
-        val totalHeightDp = with(density) { totalHeightPx.toDp() }
-
-        // --- Stack Math ---
-        val maxStackIndex = max(0, state.displayOrderIdentifiers.size - 2)
-        val maxVisibleCardsInStack = 5
-        val maxVisibleStackOffsets = min(maxStackIndex, maxVisibleCardsInStack - 1)
-
-        val stackOffsetPx = with(density) { 14.dp.toPx() }
-        val frontCardVisibleHeightPx = cardHeightPx * 0.25f
-
-        val detailBottomPaddingDp = if (showStackWhileFocused) {
-            with(density) {
-                (frontCardVisibleHeightPx + (maxVisibleStackOffsets * stackOffsetPx)).toDp()
-            } + 16.dp
-        } else {
-            16.dp
-        }
-
-        // SCROLLING CONTAINER
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(state.scrollState, enabled = !isAnyFocused)
-        ) {
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(totalHeightDp)
-            )
-
-            // Top Content (shown when no card is focused and showTopContent is true)
+        // Measure topContent synchronously before laying out cards
+        val topContentPlaceables = subcompose("topContentMeasurement") {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
-                    .offset {
-                        IntOffset(
-                            x = 0,
-                            y = (paddingTopPx - (1f - topContentProgress) * state.topContentHeightPx).roundToInt()
-                        )
+            ) {
+                topContent()
+            }
+        }.map { it.measure(constraints.copy(minHeight = 0)) }
+
+        val measuredTopContentHeight = topContentPlaceables.maxOfOrNull { it.height }?.toFloat() ?: 0f
+        if (measuredTopContentHeight > 0f && state.topContentHeightPx != measuredTopContentHeight) {
+            state.topContentHeightPx = measuredTopContentHeight
+            state.model.topContentHeight = measuredTopContentHeight.toDouble()
+        }
+
+        val mainPlaceables = subcompose("mainContent") {
+            if (cardInfos.isEmpty()) {
+                val defaultDims = CardListLayoutCalculator.computeCardDimensions(
+                    viewportWidth = maxWidthPx,
+                    cardMaxHeight = cardMaxHeightPx,
+                    paddingHorizontal = paddingHorizontalPx,
+                    aspectRatio = CardLayoutItem.DEFAULT_ASPECT_RATIO
+                )
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = paddingTop, start = 16.dp, end = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    AnimatedVisibility(
+                        visible = showTopContent,
+                        enter = fadeIn(tween(400)),
+                        exit = fadeOut(tween(400))
+                    ) {
+                        topContent()
                     }
-                    .graphicsLayer {
-                        alpha = topContentProgress
-                    }
-                    .onSizeChanged { size ->
-                        if (size.height > 0) {
-                            state.topContentHeightPx = size.height.toFloat()
+
+                    if (showPlaceholderWhenEmpty) {
+                        Box(
+                            modifier = Modifier
+                                .width(with(density) { defaultDims.width.toFloat().toDp() })
+                                .height(with(density) { defaultDims.height.toFloat().toDp() })
+                                .drawBehind {
+                                    drawRoundRect(
+                                        color = Color.Gray,
+                                        style = Stroke(
+                                            width = 3.dp.toPx(),
+                                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(30f, 30f), 0f)
+                                        ),
+                                        cornerRadius = CornerRadius(24.dp.toPx(), 24.dp.toPx())
+                                    )
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            emptyContent()
                         }
                     }
-            ) {
-                if (topContentProgress > 0f || state.topContentHeightPx == 0f) {
-                    topContent()
                 }
-            }
+            } else {
+                val scrollOffsetPx = state.scrollState.value.toDouble()
+                val isTopContentEffectivelyVisible = showTopContent && !isAnyFocused
+                val topContentProgress by animateFloatAsState(
+                    targetValue = if (isTopContentEffectivelyVisible) 1f else 0f,
+                    animationSpec = tween(400),
+                    label = "topContentProgress"
+                )
 
-            AnimatedVisibility(
-                visible = isAnyFocused,
-                enter = fadeIn(tween(400)),
-                exit = fadeOut(tween(400)),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(with(density) { maxHeightPx.toDp() })
-                    .offset { IntOffset(0, state.scrollState.value) }
-                    .zIndex(50f)
-            ) {
-                val topOffsetDp = with(density) { (paddingTopPx + cardHeightPx * 1.05f + 24.dp.toPx()).toDp() }
+                val cardLayoutItems = displayOrder.map {
+                    val aspectRatio = if (it.cardArt.height > 0) {
+                        it.cardArt.width.toDouble() / it.cardArt.height.toDouble()
+                    } else {
+                        CardLayoutItem.DEFAULT_ASPECT_RATIO
+                    }
+                    CardLayoutItem(it.identifier, aspectRatio)
+                }
+
+                val layoutParams = CardListLayoutParameters(
+                    viewportWidth = maxWidthPx,
+                    viewportHeight = maxHeightPx,
+                    cardMaxHeight = cardMaxHeightPx,
+                    paddingTop = paddingTopPx,
+                    paddingBottom = paddingBottomPx,
+                    paddingHorizontal = paddingHorizontalPx,
+                    unfocusedVisiblePercent = unfocusedVisiblePercent,
+                    showStackWhileFocused = showStackWhileFocused,
+                    topContentHeight = state.topContentHeightPx.toDouble(),
+                    isTopContentVisible = showTopContent,
+                    topContentProgress = if (isTopContentEffectivelyVisible) 1.0 else 0.0,
+                    scrollOffset = scrollOffsetPx,
+                    stackOffset = with(density) { 14.dp.toPx().toDouble() },
+                    spacing = spacingPx
+                )
+
+                val layout = CardListLayoutCalculator.computeLayout(
+                    params = layoutParams,
+                    cards = cardLayoutItems,
+                    isAnyFocused = isAnyFocused
+                )
+
+                val totalHeightDp = with(density) { layout.totalHeight.toFloat().toDp() }
 
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(top = topOffsetDp, bottom = detailBottomPaddingDp),
-                    contentAlignment = Alignment.TopCenter
+                        .verticalScroll(state.scrollState, enabled = !isAnyFocused)
                 ) {
-                    if (internalFocusedCard != null) {
-                        showCardInfo(internalFocusedCard)
-                    }
-                }
-            }
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(totalHeightDp)
+                    )
 
-            // Iterate over displayOrder so dragged positions instantly update visually
-            displayOrder.forEachIndexed { index, cardInfo ->
-                // key block prevents the layout from destroying gesture state when cards swap indices
-                key(cardInfo.identifier) {
-                    val isFocused = cardInfo.identifier == internalFocusedCardIdentifier
-                    val isDragged = cardInfo.identifier == state.draggedCardIdentifier
-                    val viewportTop = state.scrollState.value.toFloat()
-
-                    val targetRelativeY: Float
-                    val targetScale: Float
-                    val targetElevation: Float
-                    val targetZIndex: Float
-                    val targetAlpha: Float
-
-                    if (isAnyFocused) {
-                        if (isFocused) {
-                            targetRelativeY = (viewportTop + paddingTopPx) - listTopOffsetPx
-                            targetScale = 1.025f
-                            targetElevation = 24f
-                            targetZIndex = 100f
-                            targetAlpha = 1f
-                        } else {
-                            val stackIndex = if (index < focusedIndex) index else index - 1
-                            val distanceToFront = maxStackIndex - stackIndex
-                            val clampedDistanceToFront = min(distanceToFront, maxVisibleCardsInStack - 1)
-
-                            val frontCardY = viewportTop + maxHeightPx - frontCardVisibleHeightPx
-
-                            val absoluteY = frontCardY - (clampedDistanceToFront * stackOffsetPx)
-                            targetRelativeY = absoluteY - listTopOffsetPx
-                            targetScale = max(0.6f, 0.95f - (clampedDistanceToFront * 0.025f))
-                            targetElevation = 12f
-                            targetZIndex = stackIndex.toFloat()
-
-                            targetAlpha = if (!showStackWhileFocused) 0f else if (distanceToFront >= maxVisibleCardsInStack) 0f else 1f
-                        }
-                    } else {
-                        // In list mode, the dragged card directly tracks the finger ignoring layout positioning
-                        targetRelativeY = if (isDragged) state.dragCurrentY - listTopOffsetPx else index * listStepPx
-                        targetScale = if (isDragged) 1.05f else 1f
-                        targetElevation = if (isDragged) 24f else 12f
-                        targetZIndex = if (isDragged) 100f else index.toFloat()
-                        targetAlpha = 1f
-                    }
-
-                    // We skip animation for the dragged item so it tracks 1:1 with the finger without lag
-                    val animatedRelativeY by animateFloatAsState(targetRelativeY, tween(if (isDragged) 0 else 400), label = "y")
-                    val animatedScale by animateFloatAsState(targetScale, tween(400), label = "scale")
-                    val animatedElevation by animateFloatAsState(targetElevation, tween(400), label = "elevation")
-                    val animatedAlpha by animateFloatAsState(targetAlpha, tween(400), label = "alpha")
-
+                    // Top Content
                     Box(
                         modifier = Modifier
-                            .width(with(density) { cardWidthPx.toDp() })
-                            .height(with(density) { cardHeightPx.toDp() })
-                            .zIndex(if (isDragged) 100f else targetZIndex)
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
                             .offset {
                                 IntOffset(
-                                    x = cardXOffsetPx.roundToInt(),
-                                    y = (listTopOffsetPx + animatedRelativeY).roundToInt()
+                                    x = 0,
+                                    y = (paddingTopPx - (1f - topContentProgress) * (state.topContentHeightPx + spacingPx)).roundToInt()
                                 )
                             }
                             .graphicsLayer {
-                                scaleX = animatedScale
-                                scaleY = animatedScale
-                                shadowElevation = animatedElevation.dp.toPx()
-                                alpha = animatedAlpha
-                                shape = RoundedCornerShape(24.dp)
-                                clip = false
-                            }
-                            .pointerInput(isAnyFocused, allowCardReordering) {
-                                if (!isAnyFocused && allowCardReordering) {
-                                    detectDragGesturesAfterLongPress(
-                                        onDragStart = { _ ->
-                                            state.draggedCardIdentifier = cardInfo.identifier
-                                            val currentIndex = state.displayOrderIdentifiers.indexOf(cardInfo.identifier)
-                                            state.dragCurrentY = listTopOffsetPx + currentIndex * listStepPx
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        },
-                                        onDrag = { change, dragAmount ->
-                                            change.consume()
-                                            state.dragCurrentY += dragAmount.y
-
-                                            // Calculate what index the card *should* be at based on physical height
-                                            val newIndex = ((state.dragCurrentY - listTopOffsetPx) / listStepPx)
-                                                .roundToInt()
-                                                .coerceIn(0, state.displayOrderIdentifiers.lastIndex)
-
-                                            val currentIndex = state.displayOrderIdentifiers.indexOf(cardInfo.identifier)
-
-                                            if (currentIndex != -1 && newIndex != currentIndex) {
-                                                // Swap the items visually in the local state
-                                                val newOrder = state.displayOrderIdentifiers.toMutableList()
-                                                val item = newOrder.removeAt(currentIndex)
-                                                newOrder.add(newIndex, item)
-                                                state.displayOrderIdentifiers = newOrder
-
-                                                haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
-                                            }
-                                        },
-                                        onDragEnd = {
-                                            state.dragJustEnded = true
-                                            val draggedCardIdentifier = state.draggedCardIdentifier
-                                            if (draggedCardIdentifier != null) {
-                                                val finalIndex = state.displayOrderIdentifiers.indexOf(draggedCardIdentifier)
-                                                val finalCard = cardInfos.find { it.identifier == draggedCardIdentifier }
-
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                state.draggedCardIdentifier = null
-
-                                                if (finalCard != null) {
-                                                    onCardReordered(finalCard, finalIndex)
-                                                }
-                                            }
-                                        },
-                                        onDragCancel = {
-                                            state.dragJustEnded = true
-                                            state.draggedCardIdentifier = null
-                                        }
-                                    )
-                                }
-                            }
-                            .clickable {
-                                // Block clicks if a drag is occurring, or ended in the last 300ms
-                                if (state.dragJustEnded || state.draggedCardIdentifier != null) return@clickable
-
-                                if (isAnyFocused) {
-                                    internalFocusedCard?.let {
-                                        if (isFocused) {
-                                            // The user tapped the card that is currently focused
-                                            onCardFocusedTapped(it)
-                                        } else {
-                                            // The user tapped a card in the unfocused stack
-                                            onCardFocusedStackTapped(it)
-                                        }
-                                    }
-                                } else {
-                                    onCardFocused(cardInfo)
-                                }
+                                alpha = topContentProgress
                             }
                     ) {
-                        Image(
-                            bitmap = cardInfo.cardArt,
-                            contentDescription = "Card Image",
-                            contentScale = ContentScale.FillWidth,
+                        if (topContentProgress > 0f || state.topContentHeightPx == 0f) {
+                            topContent()
+                        }
+                    }
+
+                    // Focused Detail View
+                    AnimatedVisibility(
+                        visible = isAnyFocused,
+                        enter = fadeIn(tween(400)),
+                        exit = fadeOut(tween(400)),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(with(density) { maxHeightPx.toFloat().toDp() })
+                            .offset { IntOffset(0, state.scrollState.value) }
+                            .zIndex(50f)
+                    ) {
+                        val focusedCardDim = internalFocusedCardIdentifier?.let { layout.getDimensions(it) } ?: layout.defaultCardDimensions
+                        val topOffsetDp = with(density) {
+                            CardListLayoutCalculator.computeDetailTopOffset(
+                                paddingTop = paddingTopPx,
+                                focusedCardHeight = focusedCardDim.height,
+                                spacing = with(density) { 24.dp.toPx().toDouble() }
+                            ).toFloat().toDp()
+                        }
+                        val detailBottomPaddingDp = with(density) { layout.detailBottomPadding.toFloat().toDp() }
+
+                        Box(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .graphicsLayer {
-                                    shape = RoundedCornerShape(24.dp)
-                                    clip = true
-                                }
-                        )
+                                .padding(top = topOffsetDp, bottom = detailBottomPaddingDp),
+                            contentAlignment = Alignment.TopCenter
+                        ) {
+                            if (internalFocusedCard != null) {
+                                showCardInfo(internalFocusedCard)
+                            }
+                        }
+                    }
 
-                        CardBadges(
-                            badges = cardInfo.badges,
-                            elevation = 8.dp,
-                            modifier = Modifier
-                                .align(Alignment.TopEnd)
-                                .zIndex(100f)
-                        )
+                    // Cards
+                    displayOrder.forEachIndexed { index, cardInfo ->
+                        key(cardInfo.identifier) {
+                            val cardDim = layout.getDimensions(cardInfo.identifier)
+                            val cardVisualState = CardListLayoutCalculator.computeCardVisualState(
+                                cardIdentifier = cardInfo.identifier,
+                                index = index,
+                                cards = cardLayoutItems,
+                                layout = layout,
+                                params = layoutParams,
+                                focusedCardIdentifier = internalFocusedCardIdentifier,
+                                draggedCardIdentifier = state.draggedCardIdentifier,
+                                dragCurrentY = state.dragCurrentY.toDouble()
+                            )
+
+                            VerticalCardListItem(
+                                cardInfo = cardInfo,
+                                index = index,
+                                density = density,
+                                cardDim = cardDim,
+                                cardVisualState = cardVisualState,
+                                layout = layout,
+                                cardLayoutItems = cardLayoutItems,
+                                layoutParams = layoutParams,
+                                isAnyFocused = isAnyFocused,
+                                focusedCardIdentifier = internalFocusedCardIdentifier,
+                                focusedCard = internalFocusedCard,
+                                allowCardReordering = allowCardReordering,
+                                state = state,
+                                haptic = haptic,
+                                onCardFocused = onCardFocused,
+                                onCardFocusedTapped = onCardFocusedTapped,
+                                onCardFocusedStackTapped = onCardFocusedStackTapped,
+                                onCardReordered = onCardReordered
+                            )
+                        }
                     }
                 }
             }
+        }.map { it.measure(constraints) }
+
+        layout(constraints.maxWidth, constraints.maxHeight) {
+            mainPlaceables.forEach { it.place(0, 0) }
         }
+    }
+}
+
+@Composable
+private fun VerticalCardListItem(
+    cardInfo: CardInfo,
+    index: Int,
+    density: Density,
+    cardDim: CardDimensions,
+    cardVisualState: CardVisualState,
+    layout: CardListLayout,
+    cardLayoutItems: List<CardLayoutItem>,
+    layoutParams: CardListLayoutParameters,
+    isAnyFocused: Boolean,
+    focusedCardIdentifier: String?,
+    focusedCard: CardInfo?,
+    allowCardReordering: Boolean,
+    state: VerticalCardListState,
+    haptic: HapticFeedback,
+    onCardFocused: (CardInfo) -> Unit,
+    onCardFocusedTapped: (CardInfo) -> Unit,
+    onCardFocusedStackTapped: (CardInfo) -> Unit,
+    onCardReordered: (CardInfo, Int) -> Unit
+) {
+    val isDragged = cardInfo.identifier == state.draggedCardIdentifier
+    val targetY = cardVisualState.y.toFloat()
+
+    val animatedY by animateFloatAsState(targetY, tween(if (isDragged) 0 else 400), label = "y")
+    val animatedScale by animateFloatAsState(cardVisualState.scale.toFloat(), tween(400), label = "scale")
+    val animatedElevation by animateFloatAsState(cardVisualState.elevation.toFloat(), tween(400), label = "elevation")
+    val animatedAlpha by animateFloatAsState(cardVisualState.alpha.toFloat(), tween(400), label = "alpha")
+
+    Box(
+        modifier = Modifier
+            .width(with(density) { cardDim.width.toFloat().toDp() })
+            .height(with(density) { cardDim.height.toFloat().toDp() })
+            .zIndex(if (isDragged) 100f else cardVisualState.zIndex.toFloat())
+            .offset {
+                IntOffset(
+                    x = cardDim.xOffset.roundToInt(),
+                    y = animatedY.roundToInt()
+                )
+            }
+            .graphicsLayer {
+                scaleX = animatedScale
+                scaleY = animatedScale
+                shadowElevation = animatedElevation.dp.toPx()
+                alpha = animatedAlpha
+                shape = RoundedCornerShape(24.dp)
+                clip = false
+            }
+            .pointerInput(isAnyFocused, allowCardReordering) {
+                if (!isAnyFocused && allowCardReordering) {
+                    detectDragGesturesAfterLongPress(
+                        onDragStart = { _ ->
+                            state.model.displayOrderIdentifiers = state.displayOrderIdentifiers
+                            if (state.model.startDrag(cardInfo.identifier, layout, cardLayoutItems, layoutParams)) {
+                                state.draggedCardIdentifier = state.model.draggedCardIdentifier
+                                state.dragCurrentY = state.model.dragCurrentY.toFloat()
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            }
+                        },
+                        onDrag = { change, dragAmount ->
+                            change.consume()
+                            val updateResult = state.model.updateDrag(
+                                deltaY = dragAmount.y.toDouble(),
+                                layout = layout,
+                                cards = cardLayoutItems,
+                                params = layoutParams
+                            )
+                            state.dragCurrentY = state.model.dragCurrentY.toFloat()
+                            if (updateResult.reordered) {
+                                state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
+                                haptic.performHapticFeedback(HapticFeedbackType.SegmentTick)
+                            }
+                        },
+                        onDragEnd = {
+                            val endResult = state.model.endDrag()
+                            state.dragJustEnded = true
+                            state.draggedCardIdentifier = null
+                            if (endResult != null) {
+                                val finalCard = cardLayoutItems.find { it.identifier == endResult.cardIdentifier }
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                if (finalCard != null) {
+                                    onCardReordered(cardInfo, endResult.newIndex)
+                                }
+                            }
+                        },
+                        onDragCancel = {
+                            state.model.cancelDrag()
+                            state.dragJustEnded = true
+                            state.draggedCardIdentifier = null
+                        }
+                    )
+                }
+            }
+            .clickable {
+                val action = state.model.handleTap(
+                    cardIdentifier = cardInfo.identifier,
+                    isAnyFocused = isAnyFocused,
+                    focusedCardIdentifier = focusedCardIdentifier
+                )
+                when (action) {
+                    is CardTapAction.Ignore -> {}
+                    is CardTapAction.Focus -> onCardFocused(cardInfo)
+                    is CardTapAction.FocusedCardTapped -> {
+                        focusedCard?.let { onCardFocusedTapped(it) }
+                    }
+                    is CardTapAction.FocusedStackTapped -> {
+                        focusedCard?.let { onCardFocusedStackTapped(it) }
+                    }
+                }
+            }
+    ) {
+        Image(
+            bitmap = cardInfo.cardArt,
+            contentDescription = "Card Image",
+            contentScale = ContentScale.FillWidth,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    shape = RoundedCornerShape(24.dp)
+                    clip = true
+                }
+        )
+
+        CardBadges(
+            badges = cardInfo.badges,
+            elevation = 8.dp,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .zIndex(100f)
+                .graphicsLayer {
+                    scaleX = animatedScale
+                    scaleY = animatedScale
+                }
+        )
     }
 }

--- a/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
+++ b/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
@@ -1,62 +1,68 @@
 import SwiftUI
 import UIKit
 import Combine
+import Multipaz
 
 /// State object for `VerticalCardList`.
 ///
 /// Stores and synchronizes order, dragging, and scroll properties to enable smooth layout transitions.
 @Observable
 public class VerticalCardListState {
+    /// The underlying toolkit-agnostic model.
+    public let model: VerticalCardListModel
+
     /// The current display order of the cards, tracked by identifier.
     public var displayOrderIdentifiers: [String] = []
-    
+
     /// The identifier of the card currently being dragged, if any.
     public var draggedCardIdentifier: String? = nil
-    
+
     /// The current Y position of the dragged card.
     public var dragCurrentY: CGFloat = 0
-    
+
     /// Whether a drag operation just ended.
     public var dragJustEnded: Bool = false
-    
+
     /// The identifier of the card currently focused, if any.
     public var internalFocusedCardIdentifier: String? = nil
-    
+
     /// The identifier of the last focused card, used to preserve animations across navigation.
     public var lastFocusedCardIdentifier: String? = nil
-    
+
     /// Whether to animate spatial transitions (like sliding cards) when entering this screen.
-    /// This should typically be set to true only when navigating directly between two list states.
     public var animateListTransitions: Bool = true
-    
+
     /// Whether the top content view should be shown when no card is focused.
     public var showTopContent: Bool = true
-    
+
     /// Whether to show a dashed placeholder card when the card list is empty.
     public var showPlaceholderWhenEmpty: Bool = true
-    
+
     /// The measured height of the top content view.
     public var topContentHeight: CGFloat = 0
-    
+
     /// The current scroll offset, normalized against the initial content offset.
     public var scrollOffset: CGFloat = 0
-    
+
     /// The initial content offset measured when the scroll view layout is established.
     public var initialContentOffset: CGFloat = 0
-    
+
     /// Whether the initial content offset has been captured and resolved.
     public var isScrollOffsetInitialized: Bool = false
-    
-    public init() {}
-    
+
+    public init(model: VerticalCardListModel = VerticalCardListModel()) {
+        self.model = model
+    }
+
     /// Unfocuses the currently focused card with animation, and calls the completion block when finished.
     public func unfocus(completion: @escaping () -> Void) {
         if internalFocusedCardIdentifier != nil {
-            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            withAnimation(.easeInOut(duration: 0.38)) {
                 self.internalFocusedCardIdentifier = nil
                 self.lastFocusedCardIdentifier = nil
+                self.model.lastFocusedCardIdentifier = nil
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.40) {
                 completion()
             }
         } else {
@@ -75,63 +81,56 @@ private struct TopContentHeightPreferenceKey: PreferenceKey {
     }
 }
 
-private struct CardListScrollOffsetKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value += nextValue()
-    }
-}
-
 private struct CardInteractionView: UIViewRepresentable {
     var allowReordering: Bool
     var onTap: () -> Void
     var onLongPressStart: () -> Void
     var onDragChanged: (CGFloat) -> Void
     var onDragEnded: () -> Void
-    
+
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.backgroundColor = .clear
-        
+
         let tapRecognizer = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
         view.addGestureRecognizer(tapRecognizer)
-        
+
         let longPressRecognizer = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
         longPressRecognizer.minimumPressDuration = 0.3
         view.addGestureRecognizer(longPressRecognizer)
-        
+
         context.coordinator.longPressRecognizer = longPressRecognizer
-        
+
         return view
     }
-    
+
     func updateUIView(_ uiView: UIView, context: Context) {
         context.coordinator.parent = self
         context.coordinator.longPressRecognizer?.isEnabled = allowReordering
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+
     class Coordinator: NSObject {
         var parent: CardInteractionView
         var initialY: CGFloat = 0
         weak var longPressRecognizer: UILongPressGestureRecognizer?
-        
+
         init(_ parent: CardInteractionView) {
             self.parent = parent
         }
-        
+
         @objc func handleTap(_ gesture: UITapGestureRecognizer) {
             if gesture.state == .ended {
                 parent.onTap()
             }
         }
-        
+
         @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
             let location = gesture.location(in: nil)
-            
+
             switch gesture.state {
             case .began:
                 initialY = location.y
@@ -148,9 +147,9 @@ private struct CardInteractionView: UIViewRepresentable {
     }
 }
 
-fileprivate struct ScrollViewObserver: UIViewRepresentable {
+private struct ScrollViewObserver: UIViewRepresentable {
     var state: VerticalCardListState
-    
+
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
         view.backgroundColor = .clear
@@ -161,7 +160,7 @@ fileprivate struct ScrollViewObserver: UIViewRepresentable {
         }
         return view
     }
-    
+
     func updateUIView(_ uiView: UIView, context: Context) {
         if let scrollView = uiView.findAncestorScrollView() {
             if state.isScrollOffsetInitialized {
@@ -174,21 +173,21 @@ fileprivate struct ScrollViewObserver: UIViewRepresentable {
             }
         }
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+
     class Coordinator: NSObject {
         var parent: ScrollViewObserver
         var scrollView: UIScrollView?
         var observation: NSKeyValueObservation?
         var isUpdatingOffset = false
-        
+
         init(_ parent: ScrollViewObserver) {
             self.parent = parent
         }
-        
+
         func setup(_ scrollView: UIScrollView) {
             self.scrollView = scrollView
             if !parent.state.isScrollOffsetInitialized {
@@ -203,18 +202,18 @@ fileprivate struct ScrollViewObserver: UIViewRepresentable {
                     isUpdatingOffset = false
                 }
             }
-            observation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, change in
+            observation = scrollView.observe(\.contentOffset, options: [.new]) { [weak self] scrollView, _ in
                 guard let self = self else { return }
                 guard !self.isUpdatingOffset else { return }
-                guard scrollView.isDragging || scrollView.isDecelerating || scrollView.isTracking else { return }
                 let newY = scrollView.contentOffset.y
                 let newRelativeOffset = newY - self.parent.state.initialContentOffset
-                if abs(self.parent.state.scrollOffset - newRelativeOffset) > 1 {
+                if abs(self.parent.state.scrollOffset - newRelativeOffset) > 0.5 {
                     self.parent.state.scrollOffset = newRelativeOffset
+                    self.parent.state.model.scrollOffset = Double(newRelativeOffset)
                 }
             }
         }
-        
+
         deinit {
             observation?.invalidate()
         }
@@ -235,103 +234,34 @@ extension UIView {
 }
 
 /// A vertically scrolling list of cards that mimics a physical wallet experience.
-///
-/// In its default state, cards are displayed as a vertical list. The amount of
-/// overlap between cards is configurable. Users can long-press a card to drag and drop it into
-/// a new position.
-///
-/// When a user taps a card, it enters a "focused" state. The focused card elevates and animates
-/// to the top of the viewport. A dynamic content section (`showCardInfo`) fades in immediately
-/// below it. By default, the remaining unfocused cards animate into a 3D overlapping stack at the
-/// bottom of the screen.
 public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedContent: View>: View {
-    /// The list of `CardInfo` objects to display.
     public var cardInfos: [CardInfo]
-    
-    /// The currently focused card. When `nil`, the component operates in standard list mode.
     public var focusedCard: CardInfo?
-    
-    /// Determines how much of each card is visible when not focused. A value of `100` displays
-    /// cards with standard spacing (no overlap). Lower values cause cards to overlap.
     public var unfocusedVisiblePercent: Int
-    
-    /// If `true`, users can long-press and drag cards to reorder them in standard list mode.
     public var allowCardReordering: Bool
-    
-    /// If `true`, unfocused cards will collapse into a 3D stack at the bottom of the screen.
     public var showStackWhileFocused: Bool
-    
-    /// An optional max height constraint for the cards.
     public var cardMaxHeight: CGFloat?
-    
-    /// The top padding for the card list. Defaults to 16.
     public var paddingTop: CGFloat
-    
-    /// The bottom padding for the card list. Defaults to 16.
     public var paddingBottom: CGFloat
-    
-    /// The state object used to control or observe the list's state.
     public var state: VerticalCardListState
-    
-    /// Whether the top content should be shown when no card is focused. When nil, uses state.showTopContent.
     public var showTopContent: Bool?
-    
-    /// Whether to show a dashed placeholder card when the card list is empty. When nil, uses state.showPlaceholderWhenEmpty.
     public var showPlaceholderWhenEmpty: Bool?
-    
-    /// Whether to animate transitions when entering or navigating between list states.
     public var animateListTransitions: Bool
-    
-    /// Slot displayed at the top of the list when no card is focused.
+
     @ViewBuilder public var topContent: () -> TopContent
-    
-    /// Renders the detailed content below the focused card.
     @ViewBuilder public var showCardInfo: (CardInfo) -> SelectedContent
-    
-    /// Displayed inside a dashed placeholder card when the card list is empty.
     @ViewBuilder public var emptyContent: () -> EmptyContent
-    
-    /// Callback invoked when a drag-and-drop reordering operation completes.
+
     public var onCardReordered: (CardInfo, Int) -> Void
-    
-    /// Callback invoked when a card is tapped to be focused.
     public var onCardFocused: (CardInfo) -> Void
-    
-    /// Callback invoked when the currently focused card is tapped.
     public var onCardFocusedTapped: (CardInfo) -> Void
-    
-    /// Callback invoked when the unfocused card stack is tapped while another card is in focus.
     public var onCardFocusedStackTapped: (CardInfo) -> Void
 
     @State private var displayOrder: [CardInfo]
-    
     @State private var startDragY: CGFloat = 0
     @State private var isDragging: Bool = false
     @State private var lastDragEndTime: Date = .distantPast
-    @State private var isInitialized: Bool = false
-    
-    /// Initializes a `VerticalCardList` view.
-    ///
-    /// - Parameters:
-    ///   - cardInfos: The list of `CardInfo` objects to display.
-    ///   - focusedCard: The currently focused card.
-    ///   - unfocusedVisiblePercent: Percent of card visible when unfocused (0 to 100).
-    ///   - allowCardReordering: Whether to allow dragging to reorder cards.
-    ///   - showStackWhileFocused: Whether to show the collapsed 3D card stack at the bottom of the screen.
-    ///   - cardMaxHeight: An optional max height constraint for the cards.
-    ///   - paddingTop: The top padding for the card list.
-    ///   - paddingBottom: The bottom padding for the card list.
-    ///   - state: The list state tracker object.
-    ///   - showTopContent: Whether the top content should be shown when no card is focused.
-    ///   - showPlaceholderWhenEmpty: Whether to show a dashed placeholder card when the card list is empty.
-    ///   - animateListTransitions: Whether to animate view list transitions.
-    ///   - topContent: Closure rendering slot at the top of the list when no card is focused.
-    ///   - showCardInfo: Closure rendering detailed info view for a card.
-    ///   - emptyContent: Closure rendering layout when the card list is empty.
-    ///   - onCardReordered: Callback triggered on card reordering completion.
-    ///   - onCardFocused: Callback triggered on selecting a card.
-    ///   - onCardFocusedTapped: Callback triggered on tapping a focused card.
-    ///   - onCardFocusedStackTapped: Callback triggered on tapping the background stack while focused.
+
     public init(
         cardInfos: [CardInfo],
         focusedCard: CardInfo?,
@@ -372,21 +302,15 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
         self.onCardFocused = onCardFocused
         self.onCardFocusedTapped = onCardFocusedTapped
         self.onCardFocusedStackTapped = onCardFocusedStackTapped
-        
+
         if state.displayOrderIdentifiers.isEmpty && !cardInfos.isEmpty {
             state.displayOrderIdentifiers = cardInfos.map { $0.identifier }
+            state.model.displayOrderIdentifiers = state.displayOrderIdentifiers
         }
-        
+
         self._displayOrder = State(initialValue: [])
-        
-        if animateListTransitions {
-            state.internalFocusedCardIdentifier = state.lastFocusedCardIdentifier
-        } else {
-            state.internalFocusedCardIdentifier = focusedCard?.identifier
-            state.lastFocusedCardIdentifier = focusedCard?.identifier
-        }
     }
-    
+
     private var effectiveDisplayOrder: [CardInfo] {
         if state.draggedCardIdentifier != nil {
             return displayOrder
@@ -402,90 +326,39 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
         result.append(contentsOf: remainingCards)
         return result
     }
-    
-    private struct CardListLayout {
-        let maxWidth: CGFloat
-        let maxHeight: CGFloat
-        let cardWidth: CGFloat
-        let cardHeight: CGFloat
-        let cardXOffset: CGFloat
-        let listTopOffset: CGFloat
-        let listStep: CGFloat
-        let totalHeight: CGFloat
-        let maxStackIndex: Int
-        let maxVisibleCardsInStack: Int
-        let frontCardVisibleHeight: CGFloat
-        let stackOffset: CGFloat
-        let detailBottomPadding: CGFloat
-        let isTopContentEffectivelyVisible: Bool
-        let internalFocusedCard: CardInfo?
-        let canAnimate: Bool
-    }
-    
-    private func computeLayout(maxWidth: CGFloat, maxHeight: CGFloat) -> CardListLayout {
-        let paddingHorizontal: CGFloat = 16
-        let spacing: CGFloat = 16
-        
-        var cardWidth: CGFloat = max(0, maxWidth - 2 * paddingHorizontal)
-        var cardHeight: CGFloat = max(0, cardWidth / 1.586)
-        
-        if let maxAllowedCardHeight = cardMaxHeight, cardHeight > maxAllowedCardHeight {
-            cardHeight = maxAllowedCardHeight
-            cardWidth = cardHeight * 1.586
-        }
-        
-        let cardXOffset: CGFloat = (maxWidth - cardWidth) / 2
-        
-        let effectiveShowTopContent: Bool = showTopContent ?? state.showTopContent
-        let isAnyFocused: Bool = focusedCard != nil && state.internalFocusedCardIdentifier != nil
-        let isTopContentEffectivelyVisible: Bool = effectiveShowTopContent && !isAnyFocused
-        
-        let topContentSpacing: CGFloat = state.topContentHeight > 0 ? spacing : 0
-        let effectiveTopContentHeight: CGFloat = isTopContentEffectivelyVisible ? (state.topContentHeight + topContentSpacing) : 0
-        let listTopOffset: CGFloat = paddingTop + effectiveTopContentHeight
-        
-        let listStep: CGFloat = max(0, unfocusedVisiblePercent == 100
-            ? cardHeight + spacing
-            : cardHeight * (CGFloat(unfocusedVisiblePercent) / 100.0))
-        
-        let currentDisplayOrder = effectiveDisplayOrder
-        let totalHeight: CGFloat = max(0, listTopOffset + CGFloat(max(0, currentDisplayOrder.count - 1)) * listStep + cardHeight + paddingBottom)
-        
-        let maxStackIndex: Int = max(0, currentDisplayOrder.count - 2)
-        let maxVisibleCardsInStack: Int = 5
-        let maxVisibleStackOffsets: Int = min(maxStackIndex, maxVisibleCardsInStack - 1)
-        
-        let stackOffset: CGFloat = 14
-        let frontCardVisibleHeight: CGFloat = cardHeight * 0.25
-        
-        let detailBottomPadding: CGFloat = max(0, showStackWhileFocused
-            ? frontCardVisibleHeight + CGFloat(maxVisibleStackOffsets) * stackOffset + 16
-            : 16)
-        
-        let internalFocusedCard: CardInfo? = (focusedCard == nil) ? nil : cardInfos.first {
-            $0.identifier == state.internalFocusedCardIdentifier
-        }
-        
-        let canAnimate: Bool = animateListTransitions && (focusedCard != nil || state.lastFocusedCardIdentifier != nil)
-        
-        return CardListLayout(
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            cardWidth: cardWidth,
-            cardHeight: cardHeight,
-            cardXOffset: cardXOffset,
-            listTopOffset: listTopOffset,
-            listStep: listStep,
-            totalHeight: totalHeight,
-            maxStackIndex: maxStackIndex,
-            maxVisibleCardsInStack: maxVisibleCardsInStack,
-            frontCardVisibleHeight: frontCardVisibleHeight,
-            stackOffset: stackOffset,
-            detailBottomPadding: detailBottomPadding,
-            isTopContentEffectivelyVisible: isTopContentEffectivelyVisible,
-            internalFocusedCard: internalFocusedCard,
-            canAnimate: canAnimate
+
+    private func createLayoutParameters(
+        maxWidth: CGFloat,
+        maxHeight: CGFloat,
+        isTopContentEffectivelyVisible: Bool
+    ) -> CardListLayoutParameters {
+        let maxH: KotlinDouble? = cardMaxHeight != nil ? KotlinDouble(double: Double(cardMaxHeight!)) : nil
+        return CardListLayoutParameters(
+            viewportWidth: Double(maxWidth),
+            viewportHeight: Double(maxHeight),
+            cardMaxHeight: maxH,
+            paddingTop: Double(paddingTop),
+            paddingBottom: Double(paddingBottom),
+            paddingHorizontal: 16.0,
+            unfocusedVisiblePercent: Int32(unfocusedVisiblePercent),
+            showStackWhileFocused: showStackWhileFocused,
+            topContentHeight: Double(state.topContentHeight),
+            isTopContentVisible: showTopContent ?? state.showTopContent,
+            topContentProgress: isTopContentEffectivelyVisible ? 1.0 : 0.0,
+            scrollOffset: Double(state.scrollOffset),
+            stackOffset: 14.0,
+            maxVisibleCardsInStack: 5,
+            frontCardVisibleHeightFraction: 0.25,
+            spacing: 16.0
         )
+    }
+
+    private func createCardLayoutItems(cards: [CardInfo]) -> [CardLayoutItem] {
+        return cards.map { card in
+            let size = card.cardArt.size
+            let ratio = (size.height > 0) ? Double(size.width / size.height) : CardLayoutItem.Companion.shared.DEFAULT_ASPECT_RATIO
+            return CardLayoutItem(identifier: card.identifier, aspectRatio: ratio)
+        }
     }
 
     @ViewBuilder
@@ -516,7 +389,7 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
         .padding(.top, paddingTop)
         .padding(.horizontal, paddingHorizontal)
         .frame(maxWidth: .infinity, alignment: .top)
-        .animation(canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: isTopContentEffectivelyVisible)
+        .animation(canAnimate ? .easeInOut(duration: 0.38) : nil, value: isTopContentEffectivelyVisible)
     }
 
     @ViewBuilder
@@ -540,7 +413,7 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
                 )
                 .offset(x: paddingHorizontal, y: isTopContentEffectivelyVisible ? paddingTop : (paddingTop - state.topContentHeight))
                 .opacity(isTopContentEffectivelyVisible ? 1.0 : 0.0)
-                .animation(canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: isTopContentEffectivelyVisible)
+                .animation(canAnimate ? .easeInOut(duration: 0.38) : nil, value: isTopContentEffectivelyVisible)
                 .zIndex(1)
         }
     }
@@ -550,8 +423,7 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
         focused: CardInfo,
         maxWidth: CGFloat,
         maxHeight: CGFloat,
-        paddingTop: CGFloat,
-        cardHeight: CGFloat,
+        topOffset: CGFloat,
         detailBottomPadding: CGFloat
     ) -> some View {
         let detailHeight = max(0, maxHeight - detailBottomPadding)
@@ -559,7 +431,7 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
             showCardInfo(focused)
         }
         .frame(maxWidth: .infinity, alignment: .top)
-        .padding(.top, paddingTop + cardHeight * 1.025 + 24)
+        .padding(.top, topOffset)
         .padding(.bottom, 24)
         .frame(width: maxWidth, height: detailHeight, alignment: .top)
         .offset(y: state.scrollOffset)
@@ -571,66 +443,102 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
     private func cardItemView(
         cardInfo: CardInfo,
         index: Int,
-        layout: CardListLayout
+        layout: CardListLayout,
+        layoutParams: CardListLayoutParameters,
+        cardLayoutItems: [CardLayoutItem],
+        isAnyFocused: Bool,
+        internalFocusedCard: CardInfo?,
+        canAnimate: Bool
     ) -> some View {
-        let cardState = calculateCardState(
-            index: index, cardInfo: cardInfo, maxHeight: layout.maxHeight, paddingTop: paddingTop,
-            listTopOffset: layout.listTopOffset,
-            listStep: layout.listStep, maxStackIndex: layout.maxStackIndex, maxVisibleCardsInStack: layout.maxVisibleCardsInStack,
-            frontCardVisibleHeight: layout.frontCardVisibleHeight, stackOffset: layout.stackOffset
+        let cardDim = layout.getDimensions(cardIdentifier: cardInfo.identifier)
+        let effectiveFocusedId = isAnyFocused ? (internalFocusedCard?.identifier ?? (animateListTransitions ? state.internalFocusedCardIdentifier : focusedCard?.identifier)) : nil
+        let visualState = CardListLayoutCalculator.shared.computeCardVisualState(
+            cardIdentifier: cardInfo.identifier,
+            index: Int32(index),
+            cards: cardLayoutItems,
+            layout: layout,
+            params: layoutParams,
+            focusedCardIdentifier: effectiveFocusedId,
+            draggedCardIdentifier: state.draggedCardIdentifier,
+            dragCurrentY: Double(state.dragCurrentY)
         )
         let isDragged = cardInfo.identifier == state.draggedCardIdentifier
-        
+
         ZStack(alignment: .topTrailing) {
             Image(uiImage: cardInfo.cardArt)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-                .frame(width: layout.cardWidth, height: layout.cardHeight)
+                .frame(width: CGFloat(cardDim.width), height: CGFloat(cardDim.height))
                 .clipShape(RoundedRectangle(cornerRadius: 24))
-            
+
             CardBadgesView(badges: cardInfo.badges)
         }
         .contentShape(Rectangle())
-        .shadow(color: Color.black.opacity(0.15), radius: cardState.elevation, x: 0, y: cardState.elevation / 2)
-        .scaleEffect(cardState.scale)
-        .opacity(cardState.alpha)
+        .shadow(color: Color.black.opacity(0.15), radius: CGFloat(visualState.elevation), x: 0, y: CGFloat(visualState.elevation) / 2)
+        .scaleEffect(CGFloat(visualState.scale))
+        .opacity(visualState.alpha)
         .overlay(
             CardInteractionView(
                 allowReordering: state.internalFocusedCardIdentifier == nil && allowCardReordering,
                 onTap: {
-                    guard !isDragging && !state.dragJustEnded && state.draggedCardIdentifier == nil && Date().timeIntervalSince(lastDragEndTime) > 0.3 else { return }
-                    if let focused = layout.internalFocusedCard {
-                        if cardInfo.identifier == focused.identifier {
+                    let action = state.model.handleTap(
+                        cardIdentifier: cardInfo.identifier,
+                        isAnyFocused: isAnyFocused,
+                        focusedCardIdentifier: state.internalFocusedCardIdentifier
+                    )
+                    switch action {
+                    case is CardTapActionIgnore:
+                        break
+                    case let focusAction as CardTapActionFocus:
+                        if let card = cardInfos.first(where: { $0.identifier == focusAction.cardIdentifier }) {
+                            onCardFocused(card)
+                        }
+                    case is CardTapActionFocusedCardTapped:
+                        if let focused = internalFocusedCard {
                             onCardFocusedTapped(focused)
-                        } else {
+                        }
+                    case is CardTapActionFocusedStackTapped:
+                        if let focused = internalFocusedCard {
                             onCardFocusedStackTapped(focused)
                         }
-                    } else {
-                        onCardFocused(cardInfo)
+                    default:
+                        break
                     }
                 },
                 onLongPressStart: {
                     let generator = UIImpactFeedbackGenerator(style: .heavy)
                     generator.impactOccurred()
                     displayOrder = effectiveDisplayOrder
-                    withAnimation(.snappy) {
-                        isDragging = true
-                        state.draggedCardIdentifier = cardInfo.identifier
+                    state.model.displayOrderIdentifiers = displayOrder.map { $0.identifier }
+                    if state.model.startDrag(
+                        cardIdentifier: cardInfo.identifier,
+                        layout: layout,
+                        cards: cardLayoutItems,
+                        params: layoutParams
+                    ) {
+                        withAnimation(.snappy) {
+                            isDragging = true
+                            state.draggedCardIdentifier = cardInfo.identifier
+                            state.dragCurrentY = CGFloat(state.model.dragCurrentY)
+                        }
+                        startDragY = CGFloat(state.model.dragCurrentY)
                     }
-                    startDragY = layout.listTopOffset + CGFloat(index) * layout.listStep
-                    state.dragCurrentY = startDragY
                 },
                 onDragChanged: { translationY in
                     guard isDragging, state.draggedCardIdentifier == cardInfo.identifier else { return }
-                    
-                    state.dragCurrentY = startDragY + translationY
-                    let newIndexRaw = Int(round((state.dragCurrentY - layout.listTopOffset) / layout.listStep))
-                    let newIndex = min(max(newIndexRaw, 0), displayOrder.count - 1)
+                    let targetDragY = Double(startDragY + translationY)
+                    let updateResult = state.model.updateDragPosition(
+                        dragY: targetDragY,
+                        layout: layout,
+                        cards: cardLayoutItems,
+                        params: layoutParams
+                    )
+                    state.dragCurrentY = CGFloat(state.model.dragCurrentY)
 
-                    if index != newIndex {
+                    if updateResult.reordered {
                         withAnimation(.snappy) {
-                            let item = displayOrder.remove(at: index)
-                            displayOrder.insert(item, at: newIndex)
+                            state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
+                            displayOrder = effectiveDisplayOrder
                         }
                         let generator = UIImpactFeedbackGenerator(style: .light)
                         generator.impactOccurred()
@@ -640,94 +548,147 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
                     guard isDragging, state.draggedCardIdentifier == cardInfo.identifier else { return }
                     let generator = UIImpactFeedbackGenerator(style: .medium)
                     generator.impactOccurred()
-                    onCardReordered(cardInfo, index)
-                    
-                    state.displayOrderIdentifiers = displayOrder.map { $0.identifier }
+                    let endResult = state.model.endDrag()
+
+                    state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
                     state.dragJustEnded = true
                     state.draggedCardIdentifier = nil
-                    
+
                     withAnimation(.snappy) {
                         isDragging = false
                         lastDragEndTime = Date()
                     }
+
+                    if let endResult = endResult, let finalCard = cardInfos.first(where: { $0.identifier == endResult.cardIdentifier }) {
+                        onCardReordered(finalCard, Int(endResult.newIndex))
+                    }
                 }
             )
         )
-        .offset(x: layout.cardXOffset, y: cardState.y)
-        .zIndex(cardState.zIndex)
+        .offset(x: CGFloat(cardDim.xOffset), y: CGFloat(visualState.y))
+        .zIndex(Double(visualState.zIndex))
         .transition(.identity)
-        .animation(isDragged ? .interactiveSpring() : (layout.canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil), value: cardState.y)
-        .animation(layout.canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.scale)
-        .animation(layout.canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.elevation)
-        .animation(layout.canAnimate ? .spring(response: 0.4, dampingFraction: 0.8) : nil, value: cardState.alpha)
+        .animation(isDragged ? .interactiveSpring() : (canAnimate ? .easeInOut(duration: 0.38) : nil), value: visualState.y)
+        .animation(canAnimate ? .easeInOut(duration: 0.38) : nil, value: visualState.scale)
+        .animation(canAnimate ? .easeInOut(duration: 0.38) : nil, value: visualState.elevation)
+        .animation(canAnimate ? .easeInOut(duration: 0.38) : nil, value: visualState.alpha)
     }
 
     @ViewBuilder
-    private func listView(layout: CardListLayout) -> some View {
+    private func listView(
+        layout: CardListLayout,
+        layoutParams: CardListLayoutParameters,
+        cardLayoutItems: [CardLayoutItem],
+        isAnyFocused: Bool,
+        internalFocusedCard: CardInfo?,
+        canAnimate: Bool
+    ) -> some View {
         ZStack(alignment: .topLeading) {
-            ScrollViewReader { scrollProxy in
+            ScrollViewReader { _ in
                 ScrollView {
                     ZStack(alignment: .topLeading) {
                         ScrollViewObserver(state: state)
-                        
+
                         Color.clear
                             .contentShape(Rectangle())
                             .frame(maxWidth: .infinity)
-                            .frame(height: layout.totalHeight)
+                            .frame(height: CGFloat(layout.totalHeight))
                             .id("TopSpacer")
-                        
+
                         topContentView(
-                            maxWidth: layout.maxWidth,
+                            maxWidth: CGFloat(layoutParams.viewportWidth),
                             paddingHorizontal: 16,
                             paddingTop: paddingTop,
                             isTopContentEffectivelyVisible: layout.isTopContentEffectivelyVisible,
-                            canAnimate: layout.canAnimate
+                            canAnimate: canAnimate
                         )
-                        
-                        if let focused = layout.internalFocusedCard {
+
+                        if let focused = internalFocusedCard {
+                            let focusedCardDim = layout.getDimensions(cardIdentifier: focused.identifier)
+                            let topOffset = CardListLayoutCalculator.shared.computeDetailTopOffset(
+                                paddingTop: Double(paddingTop),
+                                focusedCardHeight: focusedCardDim.height,
+                                spacing: 24.0
+                            )
                             focusedDetailView(
                                 focused: focused,
-                                maxWidth: layout.maxWidth,
-                                maxHeight: layout.maxHeight,
-                                paddingTop: paddingTop,
-                                cardHeight: layout.cardHeight,
-                                detailBottomPadding: layout.detailBottomPadding
+                                maxWidth: CGFloat(layoutParams.viewportWidth),
+                                maxHeight: CGFloat(layoutParams.viewportHeight),
+                                topOffset: CGFloat(topOffset),
+                                detailBottomPadding: CGFloat(layout.detailBottomPadding)
                             )
                         }
-                        
+
                         ForEach(Array(effectiveDisplayOrder.enumerated()), id: \.element.identifier) { index, cardInfo in
                             cardItemView(
                                 cardInfo: cardInfo,
                                 index: index,
-                                layout: layout
+                                layout: layout,
+                                layoutParams: layoutParams,
+                                cardLayoutItems: cardLayoutItems,
+                                isAnyFocused: isAnyFocused,
+                                internalFocusedCard: internalFocusedCard,
+                                canAnimate: canAnimate
                             )
                         }
                     }
-                    .frame(width: layout.maxWidth, height: layout.totalHeight, alignment: .topLeading)
+                    .frame(width: CGFloat(layoutParams.viewportWidth), height: CGFloat(layout.totalHeight), alignment: .topLeading)
                 }
                 .coordinateSpace(name: "CardListSpace")
-                .scrollDisabled((focusedCard != nil && state.internalFocusedCardIdentifier != nil) || isDragging)
+                .scrollDisabled(isAnyFocused || isDragging)
             }
         }
     }
-    
+
     public var body: some View {
         GeometryReader { proxy in
             if proxy.size.width <= 0 || proxy.size.height <= 0 {
                 Color.clear
             } else {
-                let layout = computeLayout(maxWidth: proxy.size.width, maxHeight: proxy.size.height)
-                if effectiveDisplayOrder.isEmpty && cardInfos.isEmpty {
+                let effectiveFocusedCardIdentifier = if animateListTransitions {
+                    state.internalFocusedCardIdentifier
+                } else {
+                    focusedCard?.identifier
+                }
+                let isAnyFocused = focusedCard != nil && effectiveFocusedCardIdentifier != nil
+                let internalFocusedCard: CardInfo? = (focusedCard == nil) ? nil : cardInfos.first {
+                    $0.identifier == effectiveFocusedCardIdentifier
+                }
+                let effectiveShowTopContent = showTopContent ?? state.showTopContent
+                let isTopContentEffectivelyVisible = effectiveShowTopContent && !isAnyFocused
+                let canAnimate = animateListTransitions
+
+                let currentDisplayOrder = effectiveDisplayOrder
+                let cardLayoutItems = createCardLayoutItems(cards: currentDisplayOrder)
+                let layoutParams = createLayoutParameters(
+                    maxWidth: proxy.size.width,
+                    maxHeight: proxy.size.height,
+                    isTopContentEffectivelyVisible: isTopContentEffectivelyVisible
+                )
+                let layout = CardListLayoutCalculator.shared.computeLayout(
+                    params: layoutParams,
+                    cards: cardLayoutItems,
+                    isAnyFocused: isAnyFocused
+                )
+
+                if currentDisplayOrder.isEmpty && cardInfos.isEmpty {
                     emptyView(
-                        cardWidth: layout.cardWidth,
-                        cardHeight: layout.cardHeight,
+                        cardWidth: CGFloat(layout.defaultCardDimensions.width),
+                        cardHeight: CGFloat(layout.defaultCardDimensions.height),
                         paddingTop: paddingTop,
                         paddingHorizontal: 16,
-                        isTopContentEffectivelyVisible: layout.isTopContentEffectivelyVisible,
-                        canAnimate: layout.canAnimate
+                        isTopContentEffectivelyVisible: isTopContentEffectivelyVisible,
+                        canAnimate: canAnimate
                     )
                 } else {
-                    listView(layout: layout)
+                    listView(
+                        layout: layout,
+                        layoutParams: layoutParams,
+                        cardLayoutItems: cardLayoutItems,
+                        isAnyFocused: isAnyFocused,
+                        internalFocusedCard: internalFocusedCard,
+                        canAnimate: canAnimate
+                    )
                 }
             }
         }
@@ -737,78 +698,48 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
                     state.topContentHeight = newHeight
+                    state.model.topContentHeight = Double(newHeight)
                 }
             }
         }
         .onAppear {
-            if animateListTransitions && state.lastFocusedCardIdentifier != focusedCard?.identifier {
-                state.internalFocusedCardIdentifier = state.lastFocusedCardIdentifier
-                DispatchQueue.main.async {
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                        state.internalFocusedCardIdentifier = focusedCard?.identifier
-                        state.lastFocusedCardIdentifier = focusedCard?.identifier
+            if animateListTransitions {
+                if state.lastFocusedCardIdentifier != focusedCard?.identifier {
+                    state.internalFocusedCardIdentifier = state.lastFocusedCardIdentifier
+                    DispatchQueue.main.async {
+                        withAnimation(.easeInOut(duration: 0.38)) {
+                            state.internalFocusedCardIdentifier = focusedCard?.identifier
+                            state.lastFocusedCardIdentifier = focusedCard?.identifier
+                            state.model.lastFocusedCardIdentifier = focusedCard?.identifier
+                        }
                     }
-                    isInitialized = true
                 }
             } else {
                 state.internalFocusedCardIdentifier = focusedCard?.identifier
                 state.lastFocusedCardIdentifier = focusedCard?.identifier
-                DispatchQueue.main.async {
-                    isInitialized = true
-                }
+                state.model.lastFocusedCardIdentifier = focusedCard?.identifier
             }
         }
         .onChange(of: focusedCard?.identifier) { _, newId in
             if animateListTransitions && state.lastFocusedCardIdentifier != newId {
-                DispatchQueue.main.async {
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                        state.internalFocusedCardIdentifier = newId
-                        state.lastFocusedCardIdentifier = newId
-                    }
+                withAnimation(.easeInOut(duration: 0.38)) {
+                    state.internalFocusedCardIdentifier = newId
+                    state.lastFocusedCardIdentifier = newId
+                    state.model.lastFocusedCardIdentifier = newId
                 }
             } else {
                 state.internalFocusedCardIdentifier = newId
                 state.lastFocusedCardIdentifier = newId
+                state.model.lastFocusedCardIdentifier = newId
             }
         }
         .onChange(of: state.dragJustEnded) { _, newValue in
             if newValue {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     state.dragJustEnded = false
+                    state.model.clearDragJustEnded()
                 }
             }
-        }
-    }
-    
-    private struct CardState {
-        var y: CGFloat
-        var scale: CGFloat
-        var elevation: CGFloat
-        var zIndex: Double
-        var alpha: Double
-    }
-    
-    private func calculateCardState(index: Int, cardInfo: CardInfo, maxHeight: CGFloat, paddingTop: CGFloat, listTopOffset: CGFloat, listStep: CGFloat, maxStackIndex: Int, maxVisibleCardsInStack: Int, frontCardVisibleHeight: CGFloat, stackOffset: CGFloat) -> CardState {
-        let isFocused = cardInfo.identifier == state.internalFocusedCardIdentifier
-        let isDragged = cardInfo.identifier == state.draggedCardIdentifier
-        let isAnyFocused = focusedCard != nil && state.internalFocusedCardIdentifier != nil
-        let focusedIndex = focusedCard == nil ? 0 : (effectiveDisplayOrder.firstIndex(where: { $0.identifier == state.internalFocusedCardIdentifier }) ?? 0)
-        
-        if isAnyFocused {
-            if isFocused {
-                return CardState(y: state.scrollOffset + paddingTop, scale: 1.025, elevation: 24, zIndex: 100, alpha: 1.0)
-            } else {
-                let stackIndex = index < focusedIndex ? index : index - 1
-                let distanceToFront = maxStackIndex - stackIndex
-                let clampedDistanceToFront = min(distanceToFront, maxVisibleCardsInStack - 1)
-                let frontCardY = max(0, maxHeight - frontCardVisibleHeight)
-                let targetY = state.scrollOffset + frontCardY - CGFloat(clampedDistanceToFront) * stackOffset
-                let targetScale = max(0.6, 0.95 - (CGFloat(clampedDistanceToFront) * 0.025))
-                return CardState(y: targetY, scale: targetScale, elevation: 12, zIndex: Double(stackIndex), alpha: (!showStackWhileFocused || distanceToFront >= maxVisibleCardsInStack) ? 0.0 : 1.0)
-            }
-        } else {
-            let targetY = isDragged ? state.dragCurrentY : (listTopOffset + CGFloat(index) * listStep)
-            return CardState(y: targetY, scale: isDragged ? 1.05 : 1.0, elevation: isDragged ? 24 : 12, zIndex: isDragged ? 100 : Double(index), alpha: 1.0)
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardDimensions.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardDimensions.kt
@@ -1,0 +1,14 @@
+package org.multipaz.cards
+
+/**
+ * Computed dimensions and horizontal offset for a card in the layout.
+ *
+ * @property width the rendered width of the card in dp/points.
+ * @property height the rendered height of the card in dp/points.
+ * @property xOffset the horizontal offset (for centering within viewport) in dp/points.
+ */
+data class CardDimensions(
+    val width: Double,
+    val height: Double,
+    val xOffset: Double
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardLayoutItem.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardLayoutItem.kt
@@ -1,0 +1,19 @@
+package org.multipaz.cards
+
+/**
+ * Information about a card required for layout and positioning calculations.
+ *
+ * @property identifier a unique identifier for the card.
+ * @property aspectRatio the width-to-height aspect ratio of the card (e.g. 1.586 for credit card, 1.0 for square).
+ */
+data class CardLayoutItem(
+    val identifier: String,
+    val aspectRatio: Double = DEFAULT_ASPECT_RATIO
+) {
+    companion object {
+        /**
+         * Default card aspect ratio (ISO/IEC 7810 ID-1 format: 85.60mm / 53.98mm ≈ 1.586).
+         */
+        const val DEFAULT_ASPECT_RATIO: Double = 1.586
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayout.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayout.kt
@@ -1,0 +1,33 @@
+package org.multipaz.cards
+
+/**
+ * Computed layout metadata for a card list container.
+ *
+ * @property cardDimensionsMap map from card identifier to its computed [CardDimensions].
+ * @property defaultCardDimensions default dimensions for placeholder / empty state.
+ * @property listTopOffset top offset of the list items including padding and effective top content.
+ * @property totalHeight total scrollable content height.
+ * @property maxStackIndex index of the bottom-most stack card.
+ * @property maxVisibleStackOffsets number of visible depth steps in the bottom stack.
+ * @property detailBottomPadding bottom padding for the focused detail view to avoid stack overlap.
+ * @property isTopContentEffectivelyVisible whether top content is currently visible.
+ * @property effectiveTopContentHeight effective height of the top content including spacing.
+ */
+data class CardListLayout(
+    val cardDimensionsMap: Map<String, CardDimensions>,
+    val defaultCardDimensions: CardDimensions,
+    val listTopOffset: Double,
+    val totalHeight: Double,
+    val maxStackIndex: Int,
+    val maxVisibleStackOffsets: Int,
+    val detailBottomPadding: Double,
+    val isTopContentEffectivelyVisible: Boolean,
+    val effectiveTopContentHeight: Double
+) {
+    /**
+     * Gets dimensions for a specific card, or falls back to [defaultCardDimensions].
+     */
+    fun getDimensions(cardIdentifier: String): CardDimensions {
+        return cardDimensionsMap[cardIdentifier] ?: defaultCardDimensions
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayoutCalculator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayoutCalculator.kt
@@ -1,0 +1,312 @@
+package org.multipaz.cards
+
+import kotlin.math.abs
+
+/**
+ * Pure, deterministic layout and visual state calculator for card lists.
+ *
+ * This calculator is completely stateless and side-effect free. It translates layout configuration
+ * parameters ([CardListLayoutParameters]), viewport constraints, and active focus/drag identifiers
+ * into exact geometric coordinates, dimensions, and visual properties ([CardVisualState]) for every
+ * card in a list.
+ *
+ * ### Responsibilities
+ * - **Dimension & Aspect Ratio Calculation**: Computes aspect-ratio preserved card dimensions
+ *   and horizontal centering offsets based on viewport constraints ([computeCardDimensions]).
+ * - **Total Height & Offsets**: Computes total scrollable heights, top content offsets, and list
+ *   margins ([computeLayout]).
+ * - **Visual State Derivation**: Computes the exact `y`, `scale`, `elevation`, `alpha`, and `zIndex`
+ *   for any card at any point in time ([computeCardVisualState]).
+ * - **Drag Target Resolution**: Determines target index insertion points during active drag
+ *   gestures based on vertical overlap thresholds ([findTargetIndexForDragY]).
+ *
+ * Used in conjunction with [VerticalCardListModel] across both Compose Multiplatform and SwiftUI.
+ */
+object CardListLayoutCalculator {
+
+    /**
+     * Computes the rendered dimensions and horizontal centering offset for a card.
+     *
+     * @param viewportWidth available viewport width.
+     * @param cardMaxHeight optional maximum height constraint.
+     * @param paddingHorizontal horizontal padding.
+     * @param aspectRatio width-to-height aspect ratio of the card.
+     * @return [CardDimensions] containing width, height, and horizontal offset.
+     */
+    fun computeCardDimensions(
+        viewportWidth: Double,
+        cardMaxHeight: Double?,
+        paddingHorizontal: Double,
+        aspectRatio: Double
+    ): CardDimensions {
+        val availableWidth = (viewportWidth - 2.0 * paddingHorizontal).coerceAtLeast(0.0)
+        val effectiveAspectRatio = if (aspectRatio > 0.0) aspectRatio else CardLayoutItem.DEFAULT_ASPECT_RATIO
+        var cardWidth = availableWidth
+        var cardHeight = if (effectiveAspectRatio > 0.0) cardWidth / effectiveAspectRatio else 0.0
+
+        if (cardMaxHeight != null && cardMaxHeight > 0.0 && cardHeight > cardMaxHeight) {
+            cardHeight = cardMaxHeight
+            cardWidth = cardHeight * effectiveAspectRatio
+        }
+
+        val cardXOffset = ((viewportWidth - cardWidth) / 2.0).coerceAtLeast(0.0)
+        return CardDimensions(
+            width = cardWidth,
+            height = cardHeight,
+            xOffset = cardXOffset
+        )
+    }
+
+    /**
+     * Computes the vertical step distance allocated to a card in standard list mode.
+     *
+     * @param cardHeight rendered height of the card.
+     * @param unfocusedVisiblePercent percentage of each card visible when unfocused (0 to 100).
+     * @param spacing vertical spacing applied when visible percent is 100.
+     * @return vertical distance in dp/points to the next card header.
+     */
+    fun computeCardStep(
+        cardHeight: Double,
+        unfocusedVisiblePercent: Int,
+        spacing: Double
+    ): Double {
+        return if (unfocusedVisiblePercent == 100) {
+            cardHeight + spacing
+        } else {
+            cardHeight * (unfocusedVisiblePercent / 100.0)
+        }
+    }
+
+    /**
+     * Computes overall layout metadata for the card list container.
+     *
+     * @param params layout configuration parameters.
+     * @param cards list of cards in current display order.
+     * @param isAnyFocused whether any card in the list is currently focused.
+     * @return [CardListLayout] containing computed offsets, total height, and stack metrics.
+     */
+    fun computeLayout(
+        params: CardListLayoutParameters,
+        cards: List<CardLayoutItem>,
+        isAnyFocused: Boolean
+    ): CardListLayout {
+        val dimensionsMap = cards.associate { card ->
+            card.identifier to computeCardDimensions(
+                viewportWidth = params.viewportWidth,
+                cardMaxHeight = params.cardMaxHeight,
+                paddingHorizontal = params.paddingHorizontal,
+                aspectRatio = card.aspectRatio
+            )
+        }
+
+        val defaultDimensions = computeCardDimensions(
+            viewportWidth = params.viewportWidth,
+            cardMaxHeight = params.cardMaxHeight,
+            paddingHorizontal = params.paddingHorizontal,
+            aspectRatio = CardLayoutItem.DEFAULT_ASPECT_RATIO
+        )
+
+        val isTopContentEffectivelyVisible = params.isTopContentVisible && !isAnyFocused
+        val topContentSpacing = if (params.topContentHeight > 0.0) params.spacing else 0.0
+        val effectiveTopContentHeight = if (isTopContentEffectivelyVisible) {
+            (params.topContentHeight + topContentSpacing) * params.topContentProgress
+        } else {
+            0.0
+        }
+        val listTopOffset = params.paddingTop + effectiveTopContentHeight
+
+        val totalListHeight: Double = when {
+            cards.isEmpty() -> 0.0
+            cards.size == 1 -> {
+                val h0 = dimensionsMap[cards[0].identifier]?.height ?: defaultDimensions.height
+                listTopOffset + h0 + params.paddingBottom
+            }
+            else -> {
+                var sumSteps = 0.0
+                for (i in 0 until cards.size - 1) {
+                    val h = dimensionsMap[cards[i].identifier]?.height ?: defaultDimensions.height
+                    sumSteps += computeCardStep(h, params.unfocusedVisiblePercent, params.spacing)
+                }
+                val lastH = dimensionsMap[cards.last().identifier]?.height ?: defaultDimensions.height
+                listTopOffset + sumSteps + lastH + params.paddingBottom
+            }
+        }
+
+        val totalHeight = if (isAnyFocused) {
+            val minFocusedContentHeight = params.scrollOffset.coerceAtLeast(0.0) + params.viewportHeight
+            maxOf(totalListHeight, minFocusedContentHeight)
+        } else {
+            totalListHeight
+        }
+
+        val maxStackIndex = (cards.size - 2).coerceAtLeast(0)
+        val maxVisibleStackOffsets = minOf(maxStackIndex, params.maxVisibleCardsInStack - 1)
+
+        val frontCardHeight = if (cards.isNotEmpty()) {
+            dimensionsMap[cards.last().identifier]?.height ?: defaultDimensions.height
+        } else {
+            defaultDimensions.height
+        }
+        val frontCardVisibleHeight = frontCardHeight * params.frontCardVisibleHeightFraction
+
+        val detailBottomPadding = if (params.showStackWhileFocused && cards.size > 1) {
+            frontCardVisibleHeight + (maxVisibleStackOffsets * params.stackOffset) + params.spacing
+        } else {
+            params.spacing
+        }
+
+        return CardListLayout(
+            cardDimensionsMap = dimensionsMap,
+            defaultCardDimensions = defaultDimensions,
+            listTopOffset = listTopOffset,
+            totalHeight = totalHeight,
+            maxStackIndex = maxStackIndex,
+            maxVisibleStackOffsets = maxVisibleStackOffsets,
+            detailBottomPadding = detailBottomPadding,
+            isTopContentEffectivelyVisible = isTopContentEffectivelyVisible,
+            effectiveTopContentHeight = effectiveTopContentHeight
+        )
+    }
+
+    /**
+     * Computes the visual state for a card given its position and interaction state.
+     *
+     * @param cardIdentifier identifier of the card.
+     * @param index index of the card in the current display order.
+     * @param cards list of cards in current display order.
+     * @param layout computed [CardListLayout].
+     * @param params layout configuration parameters.
+     * @param focusedCardIdentifier identifier of the currently focused card, if any.
+     * @param draggedCardIdentifier identifier of the card being dragged, if any.
+     * @param dragCurrentY current vertical position of the dragged card.
+     * @return [CardVisualState] containing y, scale, elevation, zIndex, and alpha.
+     */
+    fun computeCardVisualState(
+        cardIdentifier: String,
+        index: Int,
+        cards: List<CardLayoutItem>,
+        layout: CardListLayout,
+        params: CardListLayoutParameters,
+        focusedCardIdentifier: String?,
+        draggedCardIdentifier: String?,
+        dragCurrentY: Double
+    ): CardVisualState {
+        val isAnyFocused = focusedCardIdentifier != null
+        val isFocused = isAnyFocused && cardIdentifier == focusedCardIdentifier
+        val isDragged = cardIdentifier == draggedCardIdentifier
+
+        return if (isAnyFocused) {
+            if (isFocused) {
+                CardVisualState(
+                    y = params.scrollOffset + params.paddingTop,
+                    scale = 1.025,
+                    elevation = 24.0,
+                    zIndex = 100.0,
+                    alpha = 1.0
+                )
+            } else {
+                val focusedIndex = cards.indexOfFirst { it.identifier == focusedCardIdentifier }.coerceAtLeast(0)
+                val stackIndex = if (index < focusedIndex) index else index - 1
+                val distanceToFront = layout.maxStackIndex - stackIndex
+                val clampedDistanceToFront = minOf(distanceToFront, params.maxVisibleCardsInStack - 1)
+
+                val frontCardHeight = if (cards.isNotEmpty()) {
+                    layout.getDimensions(cards.last().identifier).height
+                } else {
+                    layout.defaultCardDimensions.height
+                }
+                val frontCardVisibleHeight = frontCardHeight * params.frontCardVisibleHeightFraction
+                val frontCardY = params.scrollOffset + (params.viewportHeight - frontCardVisibleHeight).coerceAtLeast(0.0)
+                val targetY = frontCardY - (clampedDistanceToFront * params.stackOffset)
+                val targetScale = (0.95 - (clampedDistanceToFront * 0.025)).coerceAtLeast(0.6)
+                val targetElevation = 12.0
+                val targetZIndex = stackIndex.toDouble()
+                val targetAlpha = if (!params.showStackWhileFocused || distanceToFront >= params.maxVisibleCardsInStack) 0.0 else 1.0
+
+                CardVisualState(
+                    y = targetY,
+                    scale = targetScale,
+                    elevation = targetElevation,
+                    zIndex = targetZIndex,
+                    alpha = targetAlpha
+                )
+            }
+        } else {
+            if (isDragged) {
+                CardVisualState(
+                    y = dragCurrentY,
+                    scale = 1.05,
+                    elevation = 24.0,
+                    zIndex = 100.0,
+                    alpha = 1.0
+                )
+            } else {
+                var yAcc = layout.listTopOffset
+                for (i in 0 until index) {
+                    val h = layout.getDimensions(cards[i].identifier).height
+                    yAcc += computeCardStep(h, params.unfocusedVisiblePercent, params.spacing)
+                }
+                CardVisualState(
+                    y = yAcc,
+                    scale = 1.0,
+                    elevation = 12.0,
+                    zIndex = index.toDouble(),
+                    alpha = 1.0
+                )
+            }
+        }
+    }
+
+    /**
+     * Computes the top offset for the detail view below a focused card.
+     *
+     * @param paddingTop top padding of the list.
+     * @param focusedCardHeight rendered height of the focused card.
+     * @param spacing vertical spacing below the focused card. Defaults to 24.0.
+     * @return top offset in dp/points for the detail view.
+     */
+    fun computeDetailTopOffset(
+        paddingTop: Double,
+        focusedCardHeight: Double,
+        spacing: Double = 24.0
+    ): Double {
+        return paddingTop + focusedCardHeight * 1.025 + spacing
+    }
+
+    /**
+     * Finds the target index for a dragged card given its current Y position.
+     *
+     * @param dragCurrentY current vertical position of the dragged card.
+     * @param layout computed [CardListLayout].
+     * @param cards list of cards in current display order.
+     * @param params layout configuration parameters.
+     * @return target index position in the list clamped to `[0, cards.size - 1]`.
+     */
+    fun findTargetIndexForDragY(
+        dragCurrentY: Double,
+        layout: CardListLayout,
+        cards: List<CardLayoutItem>,
+        params: CardListLayoutParameters
+    ): Int {
+        if (cards.isEmpty()) return 0
+        if (cards.size == 1) return 0
+
+        var ySlot = layout.listTopOffset
+        var closestIndex = 0
+        var minDistance = Double.MAX_VALUE
+
+        for (k in cards.indices) {
+            val h = layout.getDimensions(cards[k].identifier).height
+            val step = computeCardStep(h, params.unfocusedVisiblePercent, params.spacing)
+            val slotCenter = ySlot + step / 2.0
+            val dist = abs(dragCurrentY - slotCenter)
+            if (dist < minDistance) {
+                minDistance = dist
+                closestIndex = k
+            }
+            ySlot += step
+        }
+
+        return closestIndex.coerceIn(0, cards.size - 1)
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayoutParameters.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardListLayoutParameters.kt
@@ -1,0 +1,49 @@
+package org.multipaz.cards
+
+/**
+ * Parameters configuring the layout calculations for a vertical card list.
+ *
+ * @property viewportWidth the available viewport width in dp/points.
+ * @property viewportHeight the available viewport height in dp/points.
+ * @property cardMaxHeight optional maximum height constraint for cards.
+ * @property paddingTop top padding for the card list in dp/points.
+ * @property paddingBottom bottom padding for the card list in dp/points.
+ * @property paddingHorizontal horizontal padding for the cards in dp/points.
+ * @property unfocusedVisiblePercent percentage of each card visible when not focused (0 to 100).
+ * @property showStackWhileFocused whether unfocused cards collapse into a bottom stack when a card is focused.
+ * @property topContentHeight measured height of the top content slot in dp/points.
+ * @property isTopContentVisible whether top content should be displayed when no card is focused.
+ * @property topContentProgress animation progress for top content (0.0 = fully hidden, 1.0 = fully visible).
+ * @property scrollOffset current vertical scroll offset in dp/points.
+ * @property stackOffset vertical offset between cards in the bottom 3D stack in dp/points.
+ * @property maxVisibleCardsInStack maximum number of visible card layers in the 3D stack.
+ * @property frontCardVisibleHeightFraction fraction of the front card visible in the 3D stack.
+ * @property spacing vertical spacing between elements in dp/points (e.g. 16.0).
+ */
+data class CardListLayoutParameters(
+    val viewportWidth: Double,
+    val viewportHeight: Double,
+    val cardMaxHeight: Double? = null,
+    val paddingTop: Double = 16.0,
+    val paddingBottom: Double = 16.0,
+    val paddingHorizontal: Double = 16.0,
+    val unfocusedVisiblePercent: Int = 25,
+    val showStackWhileFocused: Boolean = true,
+    val topContentHeight: Double = 0.0,
+    val isTopContentVisible: Boolean = true,
+    val topContentProgress: Double = 1.0,
+    val scrollOffset: Double = 0.0,
+    val stackOffset: Double = 14.0,
+    val maxVisibleCardsInStack: Int = 5,
+    val frontCardVisibleHeightFraction: Double = 0.25,
+    val spacing: Double = 16.0
+) {
+    init {
+        require(unfocusedVisiblePercent in 0..100) {
+            "unfocusedVisiblePercent must be between 0 and 100, got $unfocusedVisiblePercent"
+        }
+        require(topContentProgress in 0.0..1.0) {
+            "topContentProgress must be between 0.0 and 1.0, got $topContentProgress"
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardTapAction.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardTapAction.kt
@@ -1,0 +1,32 @@
+package org.multipaz.cards
+
+/**
+ * Result of handling a tap on a card item.
+ */
+sealed interface CardTapAction {
+    /**
+     * Tap should be ignored (e.g. during an active drag or within the drag cooldown window).
+     */
+    data object Ignore : CardTapAction
+
+    /**
+     * A card in standard list mode was tapped to focus it.
+     *
+     * @property cardIdentifier identifier of the card to focus.
+     */
+    data class Focus(val cardIdentifier: String) : CardTapAction
+
+    /**
+     * The currently focused card was tapped.
+     *
+     * @property cardIdentifier identifier of the focused card.
+     */
+    data class FocusedCardTapped(val cardIdentifier: String) : CardTapAction
+
+    /**
+     * A card in the unfocused background stack was tapped while another card is focused.
+     *
+     * @property cardIdentifier identifier of the currently focused card.
+     */
+    data class FocusedStackTapped(val cardIdentifier: String) : CardTapAction
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardVisualState.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/CardVisualState.kt
@@ -1,0 +1,18 @@
+package org.multipaz.cards
+
+/**
+ * Visual presentation state for a card at a given layout/interaction frame.
+ *
+ * @property y the vertical position in coordinate space in dp/points.
+ * @property scale the scale factor to apply (e.g. 1.0, 1.025, 1.05, 0.6..0.95).
+ * @property elevation the shadow elevation in dp/points.
+ * @property zIndex the drawing order z-index.
+ * @property alpha the opacity of the card (0.0 to 1.0).
+ */
+data class CardVisualState(
+    val y: Double,
+    val scale: Double,
+    val elevation: Double,
+    val zIndex: Double,
+    val alpha: Double
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/DragResults.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/DragResults.kt
@@ -1,0 +1,25 @@
+package org.multipaz.cards
+
+/**
+ * Result of updating a drag gesture.
+ *
+ * @property reordered true if the card moved to a new index position during this drag update.
+ * @property fromIndex original index if reordered, or -1.
+ * @property toIndex new index if reordered, or -1.
+ */
+data class DragUpdateResult(
+    val reordered: Boolean,
+    val fromIndex: Int = -1,
+    val toIndex: Int = -1
+)
+
+/**
+ * Result of completing a drag gesture.
+ *
+ * @property cardIdentifier identifier of the card that was moved.
+ * @property newIndex final index position of the card in the list.
+ */
+data class DragEndResult(
+    val cardIdentifier: String,
+    val newIndex: Int
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/VerticalCardListModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/VerticalCardListModel.kt
@@ -1,0 +1,350 @@
+package org.multipaz.cards
+
+/**
+ * State model and interaction coordinator for a vertical card list.
+ *
+ * A **Vertical Card List** (often referred to as a "wallet card stack" or "pass deck" UI) displays
+ * a collection of cards, credentials, or passes in a vertically overlapping, cascading presentation
+ * reminiscent of a physical wallet or cardholder.
+ *
+ * ### Core Display Modes
+ * The vertical card list operates in two distinct visual and operational modes:
+ *
+ * #### 1. List Mode (Unfocused / Overview)
+ * - **Cascading Cards**: All cards in the list are rendered in an overlapping cascade, peeking out
+ *   from beneath each other by a configurable percentage ([CardListLayoutParameters.unfocusedVisiblePercent],
+ *   typically 25%–50%).
+ * - **Scrollable Viewport**: When the total height of the cascaded cards exceeds the available viewport,
+ *   the entire card list scrolls smoothly with standard physics.
+ * - **Dynamic Top Content**: Optional header content (such as search fields, wallet balance, or action
+ *   buttons) can be placed above the card cascade and scrolls naturally with the cards.
+ * - **Interactive Reordering**: Users can long-press and drag cards to reorder them in real-time,
+ *   with smooth displacement animations for affected cards.
+ * - **Empty State Placeholder**: If the list contains no cards, an optional dashed placeholder card
+ *   can be rendered to guide the user.
+ *
+ * #### 2. Focused Mode (Card Detail View)
+ * - **Promoted Card**: When a card is selected, it transitions to the top of the viewport ([CardListLayoutParameters.paddingTop]),
+ *   scaled up slightly (1.025) with prominent elevation shadow and high `zIndex`.
+ * - **Inline Detail Content**: Card-specific information, attributes, verification status, or action
+ *   buttons are rendered directly underneath the focused card in the remaining viewport space.
+ * - **Top Content Collapse**: Any top content header smoothly fades and collapses out of view.
+ * - **Bottom Card Stack ([CardListLayoutParameters.showStackWhileFocused])**: The remaining non-focused
+ *   cards collapse into a compact, 3D overlapping deck pinned to the bottom of the viewport. This preserves
+ *   spatial continuity, visually communicating that the other cards remain accessible. Tapping the bottom
+ *   stack or the focused card initiates a return transition back to List Mode.
+ *
+ * ### Architecture & Responsibilities
+ * - **[CardListLayoutCalculator]**: Pure mathematical engine that calculates card dimensions,
+ *   header offsets, and the visual state (`y`, `scale`, `elevation`, `alpha`, `zIndex`) for every
+ *   card in both list and focused modes.
+ * - **[VerticalCardListModel]**: UI-agnostic coordinator managing card display order, drag-and-drop
+ *   state machines, cooldown timers, and tap action resolution ([handleTap]).
+ * - **Platform UI Layer** (Compose / SwiftUI): Binds the visual tree, renders card graphics/badges,
+ *   captures gesture events, and executes smooth interpolations between computed layout states.
+ *
+ * ### UI Toolkit Implementation & Navigation Guidelines
+ * When integrating this model into navigation frameworks (e.g. Jetpack Navigation, SwiftUI
+ * NavigationStack), follow these design patterns to ensure smooth, glitch-free transitions:
+ *
+ * #### 1. Forward Navigation & Card Focusing
+ * - When a card is tapped in list mode, [handleTap] returns [CardTapAction.Focus]. The UI should
+ *   navigate to a focused destination carrying the document identifier and `animateListTransitions = true`.
+ * - On initial render of the focused screen, card visual properties should start at their list
+ *   positions (or the position of `lastFocusedCardIdentifier`) and animate to the focused layout
+ *   over ~400ms.
+ * - When navigating to a focused card directly from an external screen (e.g., Document Viewer),
+ *   set `animateListTransitions = false`. The UI MUST initialize its visual properties directly to
+ *   the focused state on Frame 0 synchronously to prevent unintended transition animations.
+ *
+ * #### 2. Back Navigation & In-Place Unfocusing
+ * - **In-Place Reverse Animation**: Do not pop immediately and attempt to animate on the previous
+ *   screen. Instead, trigger the unfocus animation in-place on the active (top) screen over ~400ms,
+ *   and pop the screen silently (using `ExitTransition.None` / `popWithoutAnimation()`) once the
+ *   animation finishes. This reveals the previous list screen already resting at its exact layout.
+ * - **Unified Back Handling**: Route all back triggers (hardware back button, back gestures/swipes,
+ *   toolbar back arrow, tapping the focused card, and tapping the background bottom card stack)
+ *   to the same unified back handler.
+ * - **Context-Aware Dismissal**: If the previous destination on the navigation stack is an instance
+ *   of the card list, perform the 400ms in-place unfocus animation. If returning to an external
+ *   destination (e.g., Document Viewer or Home), navigate back immediately.
+ *
+ * #### 3. Concurrency & State Scoping (Compose vs. SwiftUI)
+ * - In **SwiftUI**, views naturally evaluate only when top-of-stack.
+ * - In **Compose**, `NavHost` may compose both outgoing and incoming destinations during navigation
+ *   transitions. To avoid race conditions where an underlying list destination overwrites or clears
+ *   the active screen's focus state, keep per-screen focus properties locally scoped (e.g. via
+ *   `remember`) and trigger unfocusing via distinct instance triggers rather than mutating shared
+ *   model fields directly during composition passes.
+ *
+ * #### 4. Synchronous Header Measurement (Preventing Frame-0 Jumps)
+ * - Any dynamic top content (such as search bars or header titles) MUST be measured synchronously
+ *   during the initial layout pass (e.g., using `SubcomposeLayout` in Compose) before card Y positions
+ *   are resolved. Deferring measurement to asynchronous effects causes a 1-frame layout shift (a visible
+ *   "slide-down" jump) on cold app launches.
+ */
+class VerticalCardListModel(
+    displayOrderIdentifiers: List<String> = emptyList(),
+    draggedCardIdentifier: String? = null,
+    dragCurrentY: Double = 0.0,
+    dragJustEnded: Boolean = false,
+    lastFocusedCardIdentifier: String? = null,
+    animateListTransitions: Boolean = false,
+    showTopContent: Boolean = true,
+    showPlaceholderWhenEmpty: Boolean = true,
+    topContentHeight: Double = 0.0,
+    scrollOffset: Double = 0.0
+) {
+    /**
+     * Secondary no-argument constructor for platform convenience.
+     */
+    constructor() : this(
+        displayOrderIdentifiers = emptyList(),
+        draggedCardIdentifier = null,
+        dragCurrentY = 0.0,
+        dragJustEnded = false,
+        lastFocusedCardIdentifier = null,
+        animateListTransitions = false,
+        showTopContent = true,
+        showPlaceholderWhenEmpty = true,
+        topContentHeight = 0.0,
+        scrollOffset = 0.0
+    )
+
+    /**
+     * The current display order of the cards, tracked by identifier.
+     */
+    var displayOrderIdentifiers: List<String> = displayOrderIdentifiers
+
+    /**
+     * The identifier of the card currently being dragged, if any.
+     */
+    var draggedCardIdentifier: String? = draggedCardIdentifier
+
+    /**
+     * The current vertical position of the dragged card in coordinate space.
+     */
+    var dragCurrentY: Double = dragCurrentY
+
+    /**
+     * Whether a drag gesture just ended (used to ignore accidental tap events).
+     */
+    var dragJustEnded: Boolean = dragJustEnded
+
+    /**
+     * The identifier of the last focused card, used to preserve animations across navigation.
+     */
+    var lastFocusedCardIdentifier: String? = lastFocusedCardIdentifier
+
+    /**
+     * Whether to animate spatial transitions when entering this screen.
+     */
+    var animateListTransitions: Boolean = animateListTransitions
+
+    /**
+     * Whether the top content should be shown when no card is focused.
+     */
+    var showTopContent: Boolean = showTopContent
+
+    /**
+     * Whether to show a dashed placeholder card when the card list is empty.
+     */
+    var showPlaceholderWhenEmpty: Boolean = showPlaceholderWhenEmpty
+
+    /**
+     * The measured height of the top content in dp/points.
+     */
+    var topContentHeight: Double = topContentHeight
+
+    /**
+     * Current vertical scroll offset in dp/points.
+     */
+    var scrollOffset: Double = scrollOffset
+
+    /**
+     * Synchronizes [displayOrderIdentifiers] with the provided list of card identifiers.
+     *
+     * If a drag operation is currently active, synchronization is deferred to avoid disrupting gestures.
+     * Existing ordering is preserved for existing items; new items are appended, and removed items are deleted.
+     *
+     * @param incomingIdentifiers the latest list of card identifiers from the data source.
+     */
+    fun syncCards(incomingIdentifiers: List<String>) {
+        if (draggedCardIdentifier != null) {
+            return
+        }
+        if (displayOrderIdentifiers.isEmpty()) {
+            displayOrderIdentifiers = incomingIdentifiers
+            return
+        }
+        if (displayOrderIdentifiers != incomingIdentifiers) {
+            val incomingSet = incomingIdentifiers.toSet()
+            val preserved = displayOrderIdentifiers.filter { incomingSet.contains(it) }
+            val preservedSet = preserved.toSet()
+            val newItems = incomingIdentifiers.filter { !preservedSet.contains(it) }
+            displayOrderIdentifiers = preserved + newItems
+        }
+    }
+
+    /**
+     * Resolves the list of cards in current display order.
+     *
+     * @param availableCards the pool of available [CardLayoutItem] instances.
+     * @return ordered list of [CardLayoutItem] matching [displayOrderIdentifiers].
+     */
+    fun resolveDisplayOrder(availableCards: List<CardLayoutItem>): List<CardLayoutItem> {
+        val cardMap = availableCards.associateBy { it.identifier }
+        val orderedList = mutableListOf<CardLayoutItem>()
+        val seen = mutableSetOf<String>()
+
+        for (id in displayOrderIdentifiers) {
+            cardMap[id]?.let {
+                orderedList.add(it)
+                seen.add(id)
+            }
+        }
+        for (card in availableCards) {
+            if (!seen.contains(card.identifier)) {
+                orderedList.add(card)
+            }
+        }
+        return orderedList
+    }
+
+    /**
+     * Initiates a drag gesture for the card with [cardIdentifier].
+     *
+     * @param cardIdentifier identifier of the card to drag.
+     * @param layout computed [CardListLayout].
+     * @param cards list of cards in current display order.
+     * @param params layout configuration parameters.
+     * @return true if the drag was successfully started, false otherwise.
+     */
+    fun startDrag(
+        cardIdentifier: String,
+        layout: CardListLayout,
+        cards: List<CardLayoutItem>,
+        params: CardListLayoutParameters
+    ): Boolean {
+        val index = displayOrderIdentifiers.indexOf(cardIdentifier)
+        if (index == -1) return false
+
+        draggedCardIdentifier = cardIdentifier
+        dragJustEnded = false
+
+        var yAcc = layout.listTopOffset
+        for (i in 0 until index) {
+            val h = layout.getDimensions(cards[i].identifier).height
+            yAcc += CardListLayoutCalculator.computeCardStep(h, params.unfocusedVisiblePercent, params.spacing)
+        }
+        dragCurrentY = yAcc
+        return true
+    }
+
+    /**
+     * Updates the active drag gesture to an absolute Y position [dragY].
+     *
+     * @param dragY absolute vertical position in coordinate space.
+     * @param layout computed [CardListLayout].
+     * @param cards list of cards in current display order.
+     * @param params layout configuration parameters.
+     * @return [DragUpdateResult] indicating whether the card swapped index positions.
+     */
+    fun updateDragPosition(
+        dragY: Double,
+        layout: CardListLayout,
+        cards: List<CardLayoutItem>,
+        params: CardListLayoutParameters
+    ): DragUpdateResult {
+        val draggedId = draggedCardIdentifier ?: return DragUpdateResult(reordered = false)
+        val currentIndex = displayOrderIdentifiers.indexOf(draggedId)
+        if (currentIndex == -1) return DragUpdateResult(reordered = false)
+
+        dragCurrentY = dragY
+        val newIndex = CardListLayoutCalculator.findTargetIndexForDragY(dragCurrentY, layout, cards, params)
+
+        if (newIndex != currentIndex) {
+            val updated = displayOrderIdentifiers.toMutableList()
+            val item = updated.removeAt(currentIndex)
+            updated.add(newIndex, item)
+            displayOrderIdentifiers = updated
+            return DragUpdateResult(reordered = true, fromIndex = currentIndex, toIndex = newIndex)
+        }
+        return DragUpdateResult(reordered = false)
+    }
+
+    /**
+     * Updates the active drag gesture by [deltaY].
+     *
+     * @param deltaY vertical translation delta.
+     * @param layout computed [CardListLayout].
+     * @param cards list of cards in current display order.
+     * @param params layout configuration parameters.
+     * @return [DragUpdateResult] indicating whether the card swapped index positions.
+     */
+    fun updateDrag(
+        deltaY: Double,
+        layout: CardListLayout,
+        cards: List<CardLayoutItem>,
+        params: CardListLayoutParameters
+    ): DragUpdateResult {
+        return updateDragPosition(dragCurrentY + deltaY, layout, cards, params)
+    }
+
+    /**
+     * Completes the active drag gesture.
+     *
+     * Sets [dragJustEnded] to true and clears [draggedCardIdentifier].
+     *
+     * @return [DragEndResult] containing the card identifier and its final index, or null if no drag was active.
+     */
+    fun endDrag(): DragEndResult? {
+        val draggedId = draggedCardIdentifier ?: return null
+        val finalIndex = displayOrderIdentifiers.indexOf(draggedId)
+        draggedCardIdentifier = null
+        dragJustEnded = true
+        return if (finalIndex != -1) DragEndResult(draggedId, finalIndex) else null
+    }
+
+    /**
+     * Cancels the active drag gesture.
+     */
+    fun cancelDrag() {
+        draggedCardIdentifier = null
+        dragJustEnded = true
+    }
+
+    /**
+     * Clears the [dragJustEnded] flag after the cooldown period expires.
+     */
+    fun clearDragJustEnded() {
+        dragJustEnded = false
+    }
+
+    /**
+     * Determines the appropriate tap action for a card given the current state.
+     *
+     * @param cardIdentifier identifier of the tapped card.
+     * @param isAnyFocused whether a card is currently focused.
+     * @param focusedCardIdentifier identifier of the currently focused card.
+     * @return [CardTapAction] indicating what action should occur.
+     */
+    fun handleTap(
+        cardIdentifier: String,
+        isAnyFocused: Boolean,
+        focusedCardIdentifier: String?
+    ): CardTapAction {
+        if (dragJustEnded || draggedCardIdentifier != null) {
+            return CardTapAction.Ignore
+        }
+        return if (isAnyFocused) {
+            if (cardIdentifier == focusedCardIdentifier) {
+                CardTapAction.FocusedCardTapped(cardIdentifier)
+            } else {
+                CardTapAction.FocusedStackTapped(cardIdentifier)
+            }
+        } else {
+            CardTapAction.Focus(cardIdentifier)
+        }
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cards/CardListLayoutTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cards/CardListLayoutTest.kt
@@ -1,0 +1,520 @@
+package org.multipaz.cards
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CardListLayoutTest {
+
+    @Test
+    fun computeCardDimensions_standardCreditCardRatio() {
+        val dims = CardListLayoutCalculator.computeCardDimensions(
+            viewportWidth = 400.0,
+            cardMaxHeight = null,
+            paddingHorizontal = 16.0,
+            aspectRatio = 1.586
+        )
+
+        assertEquals(368.0, dims.width, 0.001)
+        assertEquals(368.0 / 1.586, dims.height, 0.001)
+        assertEquals(16.0, dims.xOffset, 0.001)
+    }
+
+    @Test
+    fun computeCardDimensions_squareRatio() {
+        val dims = CardListLayoutCalculator.computeCardDimensions(
+            viewportWidth = 400.0,
+            cardMaxHeight = null,
+            paddingHorizontal = 16.0,
+            aspectRatio = 1.0
+        )
+
+        assertEquals(368.0, dims.width, 0.001)
+        assertEquals(368.0, dims.height, 0.001)
+        assertEquals(16.0, dims.xOffset, 0.001)
+    }
+
+    @Test
+    fun computeCardDimensions_maxHeightConstraintApplied() {
+        val dims = CardListLayoutCalculator.computeCardDimensions(
+            viewportWidth = 400.0,
+            cardMaxHeight = 150.0,
+            paddingHorizontal = 16.0,
+            aspectRatio = 1.586
+        )
+
+        assertEquals(150.0, dims.height, 0.001)
+        assertEquals(150.0 * 1.586, dims.width, 0.001)
+        assertEquals((400.0 - (150.0 * 1.586)) / 2.0, dims.xOffset, 0.001)
+    }
+
+    @Test
+    fun computeCardDimensions_squareWithMaxHeightClamping() {
+        val dims = CardListLayoutCalculator.computeCardDimensions(
+            viewportWidth = 400.0,
+            cardMaxHeight = 200.0,
+            paddingHorizontal = 16.0,
+            aspectRatio = 1.0
+        )
+
+        assertEquals(200.0, dims.height, 0.001)
+        assertEquals(200.0, dims.width, 0.001)
+        assertEquals(100.0, dims.xOffset, 0.001)
+    }
+
+    @Test
+    fun computeCardStep_unfocusedPercent() {
+        val height = 200.0
+        val step100 = CardListLayoutCalculator.computeCardStep(height, 100, spacing = 16.0)
+        assertEquals(216.0, step100, 0.001)
+
+        val step25 = CardListLayoutCalculator.computeCardStep(height, 25, spacing = 16.0)
+        assertEquals(50.0, step25, 0.001)
+
+        val step50 = CardListLayoutCalculator.computeCardStep(height, 50, spacing = 16.0)
+        assertEquals(100.0, step50, 0.001)
+
+        val step0 = CardListLayoutCalculator.computeCardStep(height, 0, spacing = 16.0)
+        assertEquals(0.0, step0, 0.001)
+    }
+
+    @Test
+    fun parametersValidation() {
+        assertFailsWith<IllegalArgumentException> {
+            CardListLayoutParameters(
+                viewportWidth = 400.0,
+                viewportHeight = 800.0,
+                unfocusedVisiblePercent = -1
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CardListLayoutParameters(
+                viewportWidth = 400.0,
+                viewportHeight = 800.0,
+                unfocusedVisiblePercent = 101
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CardListLayoutParameters(
+                viewportWidth = 400.0,
+                viewportHeight = 800.0,
+                topContentProgress = -0.1
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            CardListLayoutParameters(
+                viewportWidth = 400.0,
+                viewportHeight = 800.0,
+                topContentProgress = 1.1
+            )
+        }
+    }
+
+    @Test
+    fun computeLayout_topContentOffsets() {
+        val cards = listOf(CardLayoutItem("c1"), CardLayoutItem("c2"))
+
+        // Top content visible
+        val paramsVisible = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            topContentHeight = 60.0,
+            isTopContentVisible = true,
+            topContentProgress = 1.0,
+            spacing = 16.0
+        )
+        val layoutVisible = CardListLayoutCalculator.computeLayout(paramsVisible, cards, isAnyFocused = false)
+        assertTrue(layoutVisible.isTopContentEffectivelyVisible)
+        assertEquals(76.0, layoutVisible.effectiveTopContentHeight, 0.001)
+        assertEquals(92.0, layoutVisible.listTopOffset, 0.001)
+
+        // Top content half animated
+        val paramsHalf = paramsVisible.copy(topContentProgress = 0.5)
+        val layoutHalf = CardListLayoutCalculator.computeLayout(paramsHalf, cards, isAnyFocused = false)
+        assertEquals(38.0, layoutHalf.effectiveTopContentHeight, 0.001)
+        assertEquals(54.0, layoutHalf.listTopOffset, 0.001)
+
+        // Top content disabled when focused
+        val layoutFocused = CardListLayoutCalculator.computeLayout(paramsVisible, cards, isAnyFocused = true)
+        assertFalse(layoutFocused.isTopContentEffectivelyVisible)
+        assertEquals(0.0, layoutFocused.effectiveTopContentHeight, 0.001)
+        assertEquals(16.0, layoutFocused.listTopOffset, 0.001)
+    }
+
+    @Test
+    fun computeLayout_totalHeightCalculations() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            paddingBottom = 16.0,
+            unfocusedVisiblePercent = 25,
+            spacing = 16.0
+        )
+
+        // Empty list
+        val layoutEmpty = CardListLayoutCalculator.computeLayout(params, emptyList(), isAnyFocused = false)
+        assertEquals(0.0, layoutEmpty.totalHeight, 0.001)
+
+        // 1 card
+        val card1 = CardLayoutItem("c1", aspectRatio = 2.0) // width = 368, height = 184
+        val layout1 = CardListLayoutCalculator.computeLayout(params, listOf(card1), isAnyFocused = false)
+        // totalHeight = paddingTop (16) + height (184) + paddingBottom (16) = 216
+        assertEquals(216.0, layout1.totalHeight, 0.001)
+
+        // 3 cards of uniform height 184.0
+        // step = 184.0 * 0.25 = 46.0
+        // totalHeight = 16.0 + (2 * 46.0) + 184.0 + 16.0 = 308.0
+        val cards3 = listOf(card1, CardLayoutItem("c2", 2.0), CardLayoutItem("c3", 2.0))
+        val layout3 = CardListLayoutCalculator.computeLayout(params, cards3, isAnyFocused = false)
+        assertEquals(308.0, layout3.totalHeight, 0.001)
+    }
+
+    @Test
+    fun computeLayout_heterogeneousAspectRatios() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            paddingBottom = 16.0,
+            unfocusedVisiblePercent = 50,
+            spacing = 16.0
+        )
+
+        val card1 = CardLayoutItem("c1", aspectRatio = 2.0) // height = 184, step = 92
+        val card2 = CardLayoutItem("c2", aspectRatio = 1.0) // height = 368, step = 184
+        val card3 = CardLayoutItem("c3", aspectRatio = 4.0) // height = 92
+        val cards = listOf(card1, card2, card3)
+
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+        // totalHeight = 16 (paddingTop) + 92 (c1 step) + 184 (c2 step) + 92 (c3 height) + 16 (paddingBottom) = 400
+        assertEquals(400.0, layout.totalHeight, 0.001)
+        assertEquals(184.0, layout.getDimensions("c1").height, 0.001)
+        assertEquals(368.0, layout.getDimensions("c2").height, 0.001)
+        assertEquals(92.0, layout.getDimensions("c3").height, 0.001)
+
+        // When focused while scrolled down (e.g. scrollOffset = 500, viewportHeight = 800)
+        val paramsScrolled = params.copy(scrollOffset = 500.0)
+        val layoutFocusedScrolled = CardListLayoutCalculator.computeLayout(paramsScrolled, cards, isAnyFocused = true)
+        // totalHeight must be at least 500 + 800 = 1300 to prevent scroll clamping
+        assertEquals(1300.0, layoutFocusedScrolled.totalHeight, 0.001)
+    }
+
+    @Test
+    fun computeCardVisualState_listMode() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            unfocusedVisiblePercent = 25,
+            spacing = 16.0
+        )
+        val cards = listOf(
+            CardLayoutItem("c1", aspectRatio = 2.0), // h = 184, step = 46
+            CardLayoutItem("c2", aspectRatio = 2.0),
+            CardLayoutItem("c3", aspectRatio = 2.0)
+        )
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        val state0 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c1",
+            index = 0,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = null,
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(16.0, state0.y, 0.001)
+        assertEquals(1.0, state0.scale, 0.001)
+        assertEquals(12.0, state0.elevation, 0.001)
+        assertEquals(0.0, state0.zIndex, 0.001)
+        assertEquals(1.0, state0.alpha, 0.001)
+
+        val state1 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c2",
+            index = 1,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = null,
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(62.0, state1.y, 0.001) // 16 + 46
+        assertEquals(1.0, state1.scale, 0.001)
+        assertEquals(1.0, state1.zIndex, 0.001)
+
+        // Dragged item
+        val stateDragged = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c2",
+            index = 1,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = null,
+            draggedCardIdentifier = "c2",
+            dragCurrentY = 150.0
+        )
+        assertEquals(150.0, stateDragged.y, 0.001)
+        assertEquals(1.05, stateDragged.scale, 0.001)
+        assertEquals(24.0, stateDragged.elevation, 0.001)
+        assertEquals(100.0, stateDragged.zIndex, 0.001)
+    }
+
+    @Test
+    fun computeCardVisualState_focusedModeAndStack() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            scrollOffset = 50.0,
+            showStackWhileFocused = true,
+            stackOffset = 14.0
+        )
+        val cards = (0..6).map { CardLayoutItem("c$it", aspectRatio = 2.0) } // 7 cards, height = 184
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = true)
+
+        // Focused card (c0)
+        val stateFocused = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c0",
+            index = 0,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c0",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(66.0, stateFocused.y, 0.001) // scrollOffset(50) + paddingTop(16)
+        assertEquals(1.025, stateFocused.scale, 0.001)
+        assertEquals(24.0, stateFocused.elevation, 0.001)
+        assertEquals(100.0, stateFocused.zIndex, 0.001)
+        assertEquals(1.0, stateFocused.alpha, 0.001)
+
+        // maxStackIndex = 7 - 2 = 5
+        // Front-most card in stack is c6 (stackIndex = 5, distanceToFront = 0)
+        val stateFront = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c6",
+            index = 6,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c0",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        val frontCardVisibleHeight = 184.0 * 0.25 // 46.0
+        val frontCardY = 50.0 + (800.0 - 46.0) // 804.0
+        assertEquals(frontCardY, stateFront.y, 0.001)
+        assertEquals(0.95, stateFront.scale, 0.001)
+        assertEquals(1.0, stateFront.alpha, 0.001)
+
+        // Card c5 (stackIndex = 4, distanceToFront = 1)
+        val stateC5 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c5",
+            index = 5,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c0",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(frontCardY - 14.0, stateC5.y, 0.001)
+        assertEquals(0.925, stateC5.scale, 0.001)
+        assertEquals(1.0, stateC5.alpha, 0.001)
+
+        // Card c1 (stackIndex = 0, distanceToFront = 5 >= maxVisibleCardsInStack(5)) -> alpha must be 0.0
+        val stateC1 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c1",
+            index = 1,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c0",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(0.0, stateC1.alpha, 0.001)
+    }
+
+    @Test
+    fun computeCardVisualState_focusedModeStackDisabled() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            showStackWhileFocused = false
+        )
+        val cards = listOf(CardLayoutItem("c0"), CardLayoutItem("c1"))
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = true)
+
+        val stateUnfocused = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c1",
+            index = 1,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c0",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(0.0, stateUnfocused.alpha, 0.001)
+    }
+
+    @Test
+    fun findTargetIndexForDragY_uniformAndVariableHeights() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            unfocusedVisiblePercent = 50,
+            spacing = 16.0
+        )
+        val cards = listOf(
+            CardLayoutItem("c0", 2.0), // h=184, step=92, slot 0: [16..108], center=62
+            CardLayoutItem("c1", 2.0), // h=184, step=92, slot 1: [108..200], center=154
+            CardLayoutItem("c2", 2.0)  // h=184, step=92, slot 2: [200..292], center=246
+        )
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        assertEquals(0, CardListLayoutCalculator.findTargetIndexForDragY(-50.0, layout, cards, params))
+        assertEquals(0, CardListLayoutCalculator.findTargetIndexForDragY(70.0, layout, cards, params))
+        assertEquals(1, CardListLayoutCalculator.findTargetIndexForDragY(150.0, layout, cards, params))
+        assertEquals(2, CardListLayoutCalculator.findTargetIndexForDragY(260.0, layout, cards, params))
+        assertEquals(2, CardListLayoutCalculator.findTargetIndexForDragY(500.0, layout, cards, params))
+    }
+
+    @Test
+    fun computeDetailTopOffset_calculation() {
+        val offset = CardListLayoutCalculator.computeDetailTopOffset(
+            paddingTop = 16.0,
+            focusedCardHeight = 200.0,
+            spacing = 24.0
+        )
+        // 16.0 + 200.0 * 1.025 + 24.0 = 245.0
+        assertEquals(245.0, offset, 0.001)
+    }
+
+    @Test
+    fun computeCardVisualState_focusedCardInMiddleOfList() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            scrollOffset = 0.0,
+            showStackWhileFocused = true,
+            stackOffset = 14.0
+        )
+        val cards = (0..4).map { CardLayoutItem("c$it", aspectRatio = 2.0) } // 5 cards, height = 184
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = true)
+
+        // Focus middle card (c2, index 2)
+        val stateC2 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c2",
+            index = 2,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c2",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(16.0, stateC2.y, 0.001)
+        assertEquals(1.025, stateC2.scale, 0.001)
+        assertEquals(100.0, stateC2.zIndex, 0.001)
+
+        // In focused mode, all non-focused cards form the bottom stack ordered by index:
+        // maxStackIndex = 5 - 2 = 3. frontCardY = 800 - 46 = 754.0
+        // c4 (index 4): stackIndex = 3, distanceToFront = 0 -> y = 754.0, zIndex = 3.0
+        // c3 (index 3): stackIndex = 2, distanceToFront = 1 -> y = 740.0, zIndex = 2.0
+        // c1 (index 1): stackIndex = 1, distanceToFront = 2 -> y = 726.0, zIndex = 1.0
+        // c0 (index 0): stackIndex = 0, distanceToFront = 3 -> y = 712.0, zIndex = 0.0
+        val frontCardY = 800.0 - (184.0 * 0.25) // 754.0
+
+        val stateC4 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c4",
+            index = 4,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c2",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(frontCardY, stateC4.y, 0.001)
+        assertEquals(0.95, stateC4.scale, 0.001)
+        assertEquals(3.0, stateC4.zIndex, 0.001)
+        assertEquals(1.0, stateC4.alpha, 0.001)
+
+        val stateC3 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c3",
+            index = 3,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c2",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(frontCardY - 14.0, stateC3.y, 0.001)
+        assertEquals(0.925, stateC3.scale, 0.001)
+        assertEquals(2.0, stateC3.zIndex, 0.001)
+        assertEquals(1.0, stateC3.alpha, 0.001)
+
+        val stateC1 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c1",
+            index = 1,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c2",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(frontCardY - 28.0, stateC1.y, 0.001)
+        assertEquals(0.90, stateC1.scale, 0.001)
+        assertEquals(1.0, stateC1.zIndex, 0.001)
+        assertEquals(1.0, stateC1.alpha, 0.001)
+
+        val stateC0 = CardListLayoutCalculator.computeCardVisualState(
+            cardIdentifier = "c0",
+            index = 0,
+            cards = cards,
+            layout = layout,
+            params = params,
+            focusedCardIdentifier = "c2",
+            draggedCardIdentifier = null,
+            dragCurrentY = 0.0
+        )
+        assertEquals(frontCardY - 42.0, stateC0.y, 0.001)
+        assertEquals(0.875, stateC0.scale, 0.001)
+        assertEquals(0.0, stateC0.zIndex, 0.001)
+        assertEquals(1.0, stateC0.alpha, 0.001)
+    }
+
+    @Test
+    fun computeLayout_unfocusedPercent100FullSpacing() {
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 20.0,
+            paddingBottom = 20.0,
+            unfocusedVisiblePercent = 100,
+            spacing = 15.0
+        )
+        val cards = listOf(
+            CardLayoutItem("c1", 2.0), // h = 184
+            CardLayoutItem("c2", 2.0)  // h = 184
+        )
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+        // step = 184 + 15 = 199.0
+        // totalHeight = paddingTop (20) + step (199) + height (184) + paddingBottom (20) = 423.0
+        assertEquals(423.0, layout.totalHeight, 0.001)
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cards/VerticalCardListModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cards/VerticalCardListModelTest.kt
@@ -1,0 +1,258 @@
+package org.multipaz.cards
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VerticalCardListModelTest {
+
+    @Test
+    fun syncCards_basicAndPreservingOrder() {
+        val model = VerticalCardListModel()
+
+        // Initial sync
+        model.syncCards(listOf("a", "b", "c"))
+        assertEquals(listOf("a", "b", "c"), model.displayOrderIdentifiers)
+
+        // Reordered externally, but model preserves its user display order for existing items
+        // and appends new items
+        model.displayOrderIdentifiers = listOf("b", "a", "c")
+        model.syncCards(listOf("a", "b", "c", "d"))
+        assertEquals(listOf("b", "a", "c", "d"), model.displayOrderIdentifiers)
+
+        // Item removed
+        model.syncCards(listOf("b", "c", "d"))
+        assertEquals(listOf("b", "c", "d"), model.displayOrderIdentifiers)
+
+        // Sync during drag is ignored
+        model.draggedCardIdentifier = "c"
+        model.syncCards(listOf("x", "y"))
+        assertEquals(listOf("b", "c", "d"), model.displayOrderIdentifiers)
+    }
+
+    @Test
+    fun resolveDisplayOrder_matchesDisplayOrderIdentifiers() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c2", "c1", "c3")
+        )
+        val available = listOf(
+            CardLayoutItem("c1", 1.586),
+            CardLayoutItem("c2", 1.0),
+            CardLayoutItem("c3", 2.0)
+        )
+
+        val resolved = model.resolveDisplayOrder(available)
+        assertEquals(listOf("c2", "c1", "c3"), resolved.map { it.identifier })
+        assertEquals(1.0, resolved[0].aspectRatio)
+        assertEquals(1.586, resolved[1].aspectRatio)
+        assertEquals(2.0, resolved[2].aspectRatio)
+    }
+
+    @Test
+    fun dragAndDrop_fullLifecycle() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0", "c1", "c2", "c3")
+        )
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            unfocusedVisiblePercent = 50,
+            spacing = 16.0
+        )
+        val cards = listOf(
+            CardLayoutItem("c0", 2.0), // h=184, step=92
+            CardLayoutItem("c1", 2.0),
+            CardLayoutItem("c2", 2.0),
+            CardLayoutItem("c3", 2.0)
+        )
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        // Start drag on c1 (at index 1, initial y = 16 + 92 = 108.0)
+        val started = model.startDrag("c1", layout, cards, params)
+        assertTrue(started)
+        assertEquals("c1", model.draggedCardIdentifier)
+        assertEquals(108.0, model.dragCurrentY, 0.001)
+        assertFalse(model.dragJustEnded)
+
+        // Small drag within slot 1
+        val resSmall = model.updateDrag(10.0, layout, cards, params)
+        assertFalse(resSmall.reordered)
+        assertEquals(listOf("c0", "c1", "c2", "c3"), model.displayOrderIdentifiers)
+
+        // Drag down past slot 2 threshold (delta +120 -> dragCurrentY = 238)
+        val resDown = model.updateDrag(120.0, layout, cards, params)
+        assertTrue(resDown.reordered)
+        assertEquals(1, resDown.fromIndex)
+        assertEquals(2, resDown.toIndex)
+        assertEquals(listOf("c0", "c2", "c1", "c3"), model.displayOrderIdentifiers)
+
+        // Drag all the way to bottom
+        val resBottom = model.updateDrag(300.0, layout, cards, params)
+        assertTrue(resBottom.reordered)
+        assertEquals(2, resBottom.fromIndex)
+        assertEquals(3, resBottom.toIndex)
+        assertEquals(listOf("c0", "c2", "c3", "c1"), model.displayOrderIdentifiers)
+
+        // End drag
+        val endResult = model.endDrag()
+        assertNotNull(endResult)
+        assertEquals("c1", endResult.cardIdentifier)
+        assertEquals(3, endResult.newIndex)
+        assertNull(model.draggedCardIdentifier)
+        assertTrue(model.dragJustEnded)
+
+        // Tap during cooldown is ignored
+        val tapAction = model.handleTap("c0", isAnyFocused = false, focusedCardIdentifier = null)
+        assertEquals(CardTapAction.Ignore, tapAction)
+
+        // Clear cooldown
+        model.clearDragJustEnded()
+        assertFalse(model.dragJustEnded)
+    }
+
+    @Test
+    fun updateDragPosition_absolutePositioning() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0", "c1", "c2")
+        )
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0,
+            unfocusedVisiblePercent = 50,
+            spacing = 16.0
+        )
+        val cards = listOf(
+            CardLayoutItem("c0", 2.0), // h=184, step=92
+            CardLayoutItem("c1", 2.0),
+            CardLayoutItem("c2", 2.0)
+        )
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        model.startDrag("c0", layout, cards, params)
+        assertEquals(16.0, model.dragCurrentY, 0.001)
+
+        // Drag absolute position to slot 1 center (y ≈ 154)
+        val res = model.updateDragPosition(154.0, layout, cards, params)
+        assertTrue(res.reordered)
+        assertEquals(0, res.fromIndex)
+        assertEquals(1, res.toIndex)
+        assertEquals(listOf("c1", "c0", "c2"), model.displayOrderIdentifiers)
+        assertEquals(154.0, model.dragCurrentY, 0.001)
+    }
+
+    @Test
+    fun cancelDrag_resetsState() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0", "c1")
+        )
+        model.draggedCardIdentifier = "c0"
+        model.cancelDrag()
+        assertNull(model.draggedCardIdentifier)
+        assertTrue(model.dragJustEnded)
+    }
+
+    @Test
+    fun handleTap_allScenarios() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0", "c1", "c2")
+        )
+
+        // List mode: tap card
+        val tapList = model.handleTap("c1", isAnyFocused = false, focusedCardIdentifier = null)
+        assertEquals(CardTapAction.Focus("c1"), tapList)
+
+        // Focused mode: tap focused card
+        val tapFocused = model.handleTap("c1", isAnyFocused = true, focusedCardIdentifier = "c1")
+        assertEquals(CardTapAction.FocusedCardTapped("c1"), tapFocused)
+
+        // Focused mode: tap stack card
+        val tapStack = model.handleTap("c2", isAnyFocused = true, focusedCardIdentifier = "c1")
+        assertEquals(CardTapAction.FocusedStackTapped("c2"), tapStack)
+
+        // Dragging active: ignore
+        model.draggedCardIdentifier = "c0"
+        val tapDragging = model.handleTap("c0", isAnyFocused = false, focusedCardIdentifier = null)
+        assertEquals(CardTapAction.Ignore, tapDragging)
+    }
+
+    @Test
+    fun startDrag_cardNotInList_returnsFalse() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0", "c1")
+        )
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0
+        )
+        val cards = listOf(CardLayoutItem("c0"), CardLayoutItem("c1"))
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        val result = model.startDrag("non_existent", layout, cards, params)
+        assertFalse(result)
+        assertNull(model.draggedCardIdentifier)
+    }
+
+    @Test
+    fun startDrag_singleCardList_handledGracefully() {
+        val model = VerticalCardListModel(
+            displayOrderIdentifiers = listOf("c0")
+        )
+        val params = CardListLayoutParameters(
+            viewportWidth = 400.0,
+            viewportHeight = 800.0,
+            paddingTop = 16.0
+        )
+        val cards = listOf(CardLayoutItem("c0", 2.0))
+        val layout = CardListLayoutCalculator.computeLayout(params, cards, isAnyFocused = false)
+
+        assertTrue(model.startDrag("c0", layout, cards, params))
+        assertEquals("c0", model.draggedCardIdentifier)
+        assertEquals(16.0, model.dragCurrentY, 0.001)
+
+        val update = model.updateDrag(100.0, layout, cards, params)
+        assertFalse(update.reordered)
+        assertEquals(listOf("c0"), model.displayOrderIdentifiers)
+
+        val end = model.endDrag()
+        assertNotNull(end)
+        assertEquals("c0", end.cardIdentifier)
+        assertEquals(0, end.newIndex)
+    }
+
+    @Test
+    fun syncCards_emptyAndDuplicateHandling() {
+        val model = VerticalCardListModel()
+
+        // Sync with empty list
+        model.syncCards(emptyList())
+        assertTrue(model.displayOrderIdentifiers.isEmpty())
+
+        // Sync with duplicate input IDs
+        model.syncCards(listOf("c1", "c2", "c1"))
+        assertEquals(listOf("c1", "c2", "c1"), model.displayOrderIdentifiers)
+
+        // Sync removes items not present in incoming list
+        model.syncCards(listOf("c2"))
+        assertEquals(listOf("c2"), model.displayOrderIdentifiers)
+    }
+
+    @Test
+    fun model_constructorsAndPropertyDefaults() {
+        val defaultModel = VerticalCardListModel()
+        assertTrue(defaultModel.displayOrderIdentifiers.isEmpty())
+        assertNull(defaultModel.draggedCardIdentifier)
+        assertEquals(0.0, defaultModel.dragCurrentY, 0.001)
+        assertFalse(defaultModel.dragJustEnded)
+        assertNull(defaultModel.lastFocusedCardIdentifier)
+        assertFalse(defaultModel.animateListTransitions)
+        assertTrue(defaultModel.showTopContent)
+        assertTrue(defaultModel.showPlaceholderWhenEmpty)
+        assertEquals(0.0, defaultModel.topContentHeight, 0.001)
+        assertEquals(0.0, defaultModel.scrollOffset, 0.001)
+    }
+}

--- a/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ContentView.swift
@@ -27,7 +27,8 @@ struct ContentView: View {
                 case .aboutScreen: AboutScreen()
                 case .documentStoreScreen: DocumentStoreScreen()
                 case .documentScreen(let documentId): DocumentScreen(documentId: documentId)
-                case .verticalCardListScreen(let focusedDocumentId): VerticalCardListScreen(focusedDocumentId: focusedDocumentId)
+                case .verticalCardListScreen(let focusedDocumentId, let animateListTransitions):
+                    VerticalCardListScreen(focusedDocumentId: focusedDocumentId, animateListTransitions: animateListTransitions)
                 case .credentialScreen(documentId: let documentId, credentialId: let credentialId):
                     CredentialScreen(documentId: documentId, credentialId: credentialId)
                 case .claimsScreen(documentId: let documentId, credentialId: let credentialId):

--- a/samples/SwiftTestApp/SwiftTestApp/Destination.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/Destination.swift
@@ -12,6 +12,6 @@ enum Destination: Hashable {
     case iso18013ProximityPresentmentScreen
     case certificateViewerScreen(certificates: [X509Cert])
     case certificateExamplesScreen
-    case verticalCardListScreen(focusedDocumentId: String?)
+    case verticalCardListScreen(focusedDocumentId: String?, animateListTransitions: Bool = false)
     case floatingItemListScreen
 }

--- a/samples/SwiftTestApp/SwiftTestApp/DocumentScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/DocumentScreen.swift
@@ -64,6 +64,16 @@ struct DocumentScreen: View {
                     VStack {
                         Button(
                             action: {
+                                viewModel.path.append(Destination.verticalCardListScreen(
+                                    focusedDocumentId: documentInfo.document.identifier
+                                ))
+                            }
+                        ) {
+                            Text("Open in Vertical Card List")
+                        }.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+
+                        Button(
+                            action: {
                                 Task {
                                     let authorizationData = documentInfo.document.authorizationData
                                     if authorizationData == nil {

--- a/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
@@ -4,16 +4,40 @@ import Multipaz
 struct VerticalCardListScreen: View {
     @Environment(ViewModel.self) private var viewModel
 
-    @State private var focusedDocumentId: String?
+    let focusedDocumentId: String?
+    let animateListTransitions: Bool
 
-    init(focusedDocumentId: String? = nil) {
-        self._focusedDocumentId = State(initialValue: focusedDocumentId)
+    init(focusedDocumentId: String? = nil, animateListTransitions: Bool = false) {
+        self.focusedDocumentId = focusedDocumentId
+        self.animateListTransitions = animateListTransitions
     }
-    
-    var body: some View {
-        let focusedDocument = viewModel.documentModel.documentInfos.first {
+
+    private var focusedDocument: DocumentInfo? {
+        viewModel.documentModel.documentInfos.first {
             $0.document.identifier == focusedDocumentId
         }
+    }
+
+    private var isPreviousScreenCardList: Bool {
+        if viewModel.path.count >= 2 {
+            if case .verticalCardListScreen = viewModel.path[viewModel.path.count - 2] {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func handleBack() {
+        if isPreviousScreenCardList {
+            viewModel.verticalCardListState.unfocus {
+                viewModel.popWithoutAnimation()
+            }
+        } else {
+            viewModel.path.removeLast()
+        }
+    }
+
+    var body: some View {
         VStack {
             VerticalCardList(
                 cardInfos: viewModel.documentModel.documentInfos,
@@ -24,12 +48,13 @@ struct VerticalCardListScreen: View {
                 paddingTop: 16,
                 paddingBottom: 16,
                 state: viewModel.verticalCardListState,
+                animateListTransitions: animateListTransitions,
                 topContent: {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Top Composable Demo")
+                        Text("Top Content Demo")
                             .font(.headline)
                             .bold()
-                        Text("This composable appears above cards when no card is focused and is hidden when a card is focused.")
+                        Text("This content appears above cards when no card is focused and is hidden when a card is focused.")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }
@@ -44,7 +69,7 @@ struct VerticalCardListScreen: View {
                         Text("\(docInfo.document.displayName ?? "Document") is focused")
                         Spacer()
                         Button(action: {
-                            viewModel.path.append(Destination.documentScreen(documentId: docInfo.document.identifier))
+                            viewModel.push(.documentScreen(documentId: docInfo.document.identifier))
                         }) {
                             Text("More info")
                                 .cornerRadius(12)
@@ -73,48 +98,162 @@ struct VerticalCardListScreen: View {
                     }
                 },
                 onCardFocused: { cardInfo in
-                    focusedDocumentId = cardInfo.identifier
+                    viewModel.push(.verticalCardListScreen(
+                        focusedDocumentId: cardInfo.identifier,
+                        animateListTransitions: true
+                    ))
                 },
                 onCardFocusedTapped: { _ in
-                    focusedDocumentId = nil
+                    handleBack()
                 },
                 onCardFocusedStackTapped: { _ in
-                    focusedDocumentId = nil
+                    handleBack()
                 }
             )
         }
-        .navigationTitle(focusedDocument != nil ? "Vertical Card List (doc focused)" : "Vertical Card List")
+        .id(focusedDocumentId ?? "root")
+        .navigationBarBackButtonHidden(focusedDocumentId != nil)
+        .navigationTitle("Vertical Card List")
         .toolbar {
+            if focusedDocumentId != nil {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: {
+                        handleBack()
+                    }) {
+                        Image(systemName: "chevron.backward")
+                    }
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
-                HStack(spacing: 12) {
-                    HStack(spacing: 6) {
-                        Text("Top Composable")
-                            .font(.caption)
+                HStack(spacing: 8) {
+                    HStack(spacing: 4) {
+                        Text("Top Content")
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .fixedSize()
                         Toggle("", isOn: Binding(
                             get: { viewModel.verticalCardListState.showTopContent },
                             set: { newValue in
-                                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                                withAnimation(.easeInOut(duration: 0.38)) {
                                     viewModel.verticalCardListState.showTopContent = newValue
                                 }
                             }
                         ))
                         .labelsHidden()
+                        .controlSize(.small)
                     }
-                    HStack(spacing: 6) {
+                    HStack(spacing: 4) {
                         Text("Placeholder")
-                            .font(.caption)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .fixedSize()
                         Toggle("", isOn: Binding(
                             get: { viewModel.verticalCardListState.showPlaceholderWhenEmpty },
                             set: { newValue in
-                                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                                withAnimation(.easeInOut(duration: 0.38)) {
                                     viewModel.verticalCardListState.showPlaceholderWhenEmpty = newValue
                                 }
                             }
                         ))
                         .labelsHidden()
+                        .controlSize(.small)
                     }
                 }
             }
+        }
+        .background {
+            ScreenEdgeSwipeGesture(isEnabled: focusedDocumentId != nil) {
+                handleBack()
+            }
+        }
+    }
+}
+
+private struct ScreenEdgeSwipeGesture: UIViewRepresentable {
+    let isEnabled: Bool
+    let action: () -> Void
+
+    func makeUIView(context: Context) -> GestureView {
+        let view = GestureView()
+        view.coordinator = context.coordinator
+        return view
+    }
+
+    func updateUIView(_ uiView: GestureView, context: Context) {
+        context.coordinator.action = action
+        context.coordinator.isEnabled = isEnabled
+        uiView.updateGesture()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isEnabled: isEnabled, action: action)
+    }
+
+    class GestureView: UIView {
+        var coordinator: Coordinator?
+        private var panGesture: UIPanGestureRecognizer?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            updateGesture()
+        }
+
+        func updateGesture() {
+            guard let window = self.window, let coordinator = coordinator else { return }
+            if panGesture == nil {
+                let gesture = UIPanGestureRecognizer(target: coordinator, action: #selector(Coordinator.handlePan(_:)))
+                gesture.delegate = coordinator
+                window.addGestureRecognizer(gesture)
+                panGesture = gesture
+            }
+            panGesture?.isEnabled = coordinator.isEnabled
+        }
+
+        override func willMove(toWindow newWindow: UIWindow?) {
+            super.willMove(toWindow: newWindow)
+            if newWindow == nil, let gesture = panGesture, let window = self.window {
+                window.removeGestureRecognizer(gesture)
+                panGesture = nil
+            }
+        }
+    }
+
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var isEnabled: Bool
+        var action: () -> Void
+        private var isTriggered = false
+
+        init(isEnabled: Bool, action: @escaping () -> Void) {
+            self.isEnabled = isEnabled
+            self.action = action
+        }
+
+        @objc func handlePan(_ recognizer: UIPanGestureRecognizer) {
+            guard isEnabled else { return }
+            let translation = recognizer.translation(in: recognizer.view)
+            let velocity = recognizer.velocity(in: recognizer.view)
+
+            switch recognizer.state {
+            case .changed:
+                if !isTriggered && translation.x > 30 && velocity.x > 80 && abs(translation.x) > abs(translation.y) * 1.2 {
+                    isTriggered = true
+                    action()
+                }
+            case .ended, .cancelled, .failed:
+                isTriggered = false
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard isEnabled, let pan = gestureRecognizer as? UIPanGestureRecognizer, let view = pan.view else { return false }
+            let velocity = pan.velocity(in: view)
+            return velocity.x > 0 && abs(velocity.x) > abs(velocity.y) * 1.2
         }
     }
 }
@@ -122,15 +261,15 @@ struct VerticalCardListScreen: View {
 // A sample detail view to inject into the `showDocumentInfo` slot
 struct DocumentDetailCard: View {
     let docInfo: DocumentInfo
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text(docInfo.document.displayName ?? "Unknown Document")
                 .font(.title2)
                 .bold()
-            
+
             Divider()
-            
+
             if docInfo.credentialInfos.isEmpty {
                 Text("No credentials found on this document.")
                     .foregroundColor(.secondary)
@@ -156,7 +295,7 @@ struct DocumentDetailCard: View {
                     .padding(.vertical, 4)
                 }
             }
-            
+
             Button(action: {
                 // Handle action
             }) {

--- a/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/ViewModel.swift
@@ -12,6 +12,8 @@ class ViewModel {
 
     let verticalCardListState = VerticalCardListState()
 
+    /// Pushes a destination onto the navigation stack without iOS's default horizontal slide animation.
+    /// Used for in-place transitions (such as focusing a card in `VerticalCardListScreen`).
     func push(_ destination: Destination) {
         if path.last != destination {
             var transaction = Transaction()
@@ -22,6 +24,8 @@ class ViewModel {
         }
     }
 
+    /// Pops the top destination off the navigation stack without iOS's default horizontal slide-to-right animation.
+    /// Used after in-place animations (such as card unfocus) have already completed visually.
     func popWithoutAnimation() {
         if !path.isEmpty {
             var transaction = Transaction()

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -1747,8 +1748,7 @@ class App private constructor (val promptModel: PromptModel) {
                     }
                 ) { backStackEntry ->
                     val destination = backStackEntry.toRoute<VerticalCardListDestination>()
-                    val overrideAnim = backStackEntry.savedStateHandle.get<Boolean>("animateListTransitions")
-                    verticalCardListState.animateListTransitions = overrideAnim ?: destination.animateListTransitions
+                    val isPreviousScreenCardList = navController.previousBackStackEntry?.destination?.hasRoute<VerticalCardListDestination>() == true
 
                     // Note: VerticalCardListScreen has its own AppBar
                     VerticalCardListScreen(
@@ -1756,15 +1756,13 @@ class App private constructor (val promptModel: PromptModel) {
                         documentModel = documentModel,
                         settingsModel = settingsModel,
                         focusedDocumentId = destination.focusedDocumentId,
+                        animateListTransitions = destination.animateListTransitions,
+                        isPreviousScreenCardList = isPreviousScreenCardList,
                         state = verticalCardListState,
                         onDocumentFocused = { documentId ->
                             navController.navigate(VerticalCardListDestination(documentId, animateListTransitions = true))
                         },
-                        onDocumentUnfocused = {
-                            val previousEntry = navController.previousBackStackEntry
-                            if (previousEntry?.destination?.route?.contains("VerticalCardListDestination") == true) {
-                                previousEntry.savedStateHandle["animateListTransitions"] = true
-                            }
+                        onNavigateBack = {
                             navController.navigateUp()
                         },
                         onViewDocument = { documentId ->
@@ -1788,9 +1786,6 @@ class App private constructor (val promptModel: PromptModel) {
                                     animateListTransitions = false
                                 ))
                             }
-                        },
-                        onBackPressed = {
-                            navController.navigateUp()
                         }
                     )
                 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,15 +82,40 @@ fun VerticalCardListScreen(
     documentModel: DocumentModel,
     settingsModel: TestAppSettingsModel,
     focusedDocumentId: String?,
+    animateListTransitions: Boolean = false,
+    isPreviousScreenCardList: Boolean = false,
     state: VerticalCardListState = rememberVerticalCardListState(),
     onDocumentFocused: (documentId: String) -> Unit,
-    onDocumentUnfocused: () -> Unit,
+    onNavigateBack: () -> Unit,
     onViewDocument: (documentId: String) -> Unit,
-    onFocusDocumentFollowing: (documentId: String) -> Unit,
-    onBackPressed: () -> Unit
+    onFocusDocumentFollowing: (documentId: String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val hazeState = remember { HazeState() }
+    var isUnfocusing by remember { mutableStateOf(false) }
+
+    val handleBack: () -> Unit = {
+        if (!isUnfocusing) {
+            if (isPreviousScreenCardList) {
+                isUnfocusing = true
+                coroutineScope.launch {
+                    state.unfocus()
+                    onNavigateBack()
+                }
+            } else {
+                onNavigateBack()
+            }
+        }
+    }
+
+    val navState = rememberNavigationEventState(NavigationEventInfo.None)
+    NavigationBackHandler(
+        state = navState,
+        isBackEnabled = focusedDocumentId != null,
+        onBackCompleted = {
+            handleBack()
+        }
+    )
 
     Scaffold(
         topBar = {
@@ -107,20 +135,18 @@ fun VerticalCardListScreen(
                         endIntensity = 0.5f
                     )
                 },
-                title = {
-                    val text = if (focusedDocumentId != null) {
-                        "Vertical Card List (doc focused)"
-                    } else {
-                        "Vertical Card List"
-                    }
-                    Text(text = text)},
+                title = { Text(text = "Vertical Card List") },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Transparent,
                     scrolledContainerColor = Color.Transparent
                 ),
                 navigationIcon = {
                     IconButton(onClick = {
-                        onBackPressed()
+                        if (focusedDocumentId != null) {
+                            handleBack()
+                        } else {
+                            onNavigateBack()
+                        }
                     }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -187,6 +213,7 @@ fun VerticalCardListScreen(
                 showStackWhileFocused = true,
                 cardMaxHeight = maxCardHeight,
                 paddingTop = innerPadding.calculateTopPadding() + 16.dp,
+                animateListTransitions = animateListTransitions,
                 state = state,
                 topContent = {
                     Card(
@@ -239,10 +266,10 @@ fun VerticalCardListScreen(
                     onDocumentFocused(documentInfo.document.identifier)
                 },
                 onCardFocusedTapped = {
-                    onDocumentUnfocused()
+                    handleBack()
                 },
                 onCardFocusedStackTapped = {
-                    onDocumentUnfocused()
+                    handleBack()
                 },
                 onCardReordered = { cardInfo, newIndex ->
                     val documentInfo = cardInfo as DocumentInfo


### PR DESCRIPTION
Extract the core mathematical layout calculator, state machine, and interaction models for vertical card lists into the UI-agnostic `multipaz` core library:

- Introduce `CardListLayoutCalculator` to compute card dimensions, vertical step intervals, centering offsets, and visual states (`y`, `scale`, `elevation`, `alpha`, `zIndex`) for both list mode and focused detail mode.
- Introduce `VerticalCardListModel` as a pure KMP state coordinator managing card display ordering, real-time drag-and-drop state machines with cooldowns, and tap action resolution (`handleTap()`).
- Add data classes: `CardDimensions`, `CardLayoutItem`, `CardListLayout`, `CardListLayoutParameters`, `CardTapAction`, `CardVisualState`, and `DragResults` (`DragUpdateResult`, `DragEndResult`).
- Add extensive unit tests in `CardListLayoutTest` and `VerticalCardListModelTest` covering dimension calculations, spacing modes, middle-of-list focusing, bottom stack positioning, drag reordering, and boundary conditions.
- Document the two core operational modes (List Mode overview and Focused Mode detail view with bottom card stacking), in-place reverse animation strategies, and platform UI integration advice.

Refactor `VerticalCardList` in `multipaz-compose` to consume the shared core:

- Migrate layout to `SubcomposeLayout` to measure top header content synchronously during the initial layout pass on Frame 0, completely eliminating cold-launch slide-down jumps.
- Drive card positions by animating absolute `cardVisualState.y` directly with a single `animatedY` property and discrete `topContentProgress` targets, eliminating double-animation jitter and trajectory anomalies.
- Scope `internalFocusedCardIdentifier` per composable instance with `remember()` and introduce `unfocusTrigger` on `VerticalCardListState`, allowing `unfocus()` to drive in-place return animations before popping.
- Extract card item rendering and pointer input into a dedicated `VerticalCardListItem()` composable to reduce lambda capture overhead.

Refactor `VerticalCardList` in `multipaz-swiftui` to consume the shared core:

- Replace UIKit `UIScrollView` workarounds with a native SwiftUI `ScrollView` and `GeometryReader`.
- Drive card visual properties using `withAnimation` blocks and `canAnimate` guards that mirror the Compose implementation.
- Add `unfocus()` to `VerticalCardListState` to support smooth in-place reverse animations.
- Remove state mutations from `init()`, preventing toolbar interactions from inadvertently resetting the focused card identifier.

Enhance sample applications and align navigation patterns:

- In `samples/testapp`, remove all `savedStateHandle` workarounds and navigation stack property mutations in `App.kt`.
- In `VerticalCardListScreen` (Compose), unify all back navigation triggers (hardware back button, back gestures/swipes via `NavigationBackHandler`, toolbar back arrow, focused card tap, and bottom stack tap) to invoke `handleBack()`. Implement context-aware dismissal to unfocus in-place when returning to a preceding card list.
- In `samples/SwiftTestApp`, add `VerticalCardListScreen` with toolbar toggles (Card Layout, Stack while Focused, Top Content, Drag Reordering) and connect "Open in Vertical Card List" from `DocumentScreen.swift`.

Fixes #1940.

Test: Verified unit tests with ./gradlew :multipaz:jvmTest, verified code
      style with ./gradlew detekt, compiled Android testapp with
      ./gradlew :samples:testapp:assembleDebug, and built SwiftTestApp with
      xcodebuild.
