### PR TITLE
Support transaction data and document focus callbacks in iOS consent UI.

### DIFF
--- a/multipaz-swiftui/src/iosMain/swift/Consent.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Consent.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-func getIconName(claim: Claim) -> String {
+private func getIconName(claim: Claim) -> String {
     if let attribute = claim.attribute {
         switch attribute.icon {
         case .person: return "person"
@@ -39,8 +39,7 @@ func getIconName(claim: Claim) -> String {
     return "gear"
 }
 
-struct ClaimsSection : View {
-
+private struct ClaimsSection : View {
     let claims: [Claim]
 
     var body: some View {
@@ -53,7 +52,7 @@ struct ClaimsSection : View {
                 HStack {
                     Image(systemName: getIconName(claim: claim))
                         .imageScale(.small)
-                    Text("\(claim .displayName)")
+                    Text("\(claim.displayName)")
                         .font(.system(size: 14))
                 }
             }
@@ -62,8 +61,80 @@ struct ClaimsSection : View {
     }
 }
 
-struct RequestedDocumentSection : View {
- 
+private let tipOptions = ["No tip", "10%", "15%", "20%", "25%"]
+
+private struct DisplayTransactionData: View {
+    let transactionData: TransactionData<AnyObject>
+    let userInput: TransactionUserInput?
+    let onUserInputChanged: (TransactionUserInput) -> Void
+
+    var body: some View {
+        if transactionData.type == PaymentTransaction.shared || transactionData.type.identifier == PaymentTransaction.shared.identifier {
+            if let payload = transactionData.payload as? PaymentTransaction.Payload {
+                let tipPercent = (userInput as? PaymentTransaction.UserInput)?.tipPercent ?? 0.0
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Payment transaction")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("Amount: \(String(format: "%.2f", payload.amount)) \(payload.currency)")
+                        .font(.system(size: 14))
+                    if payload.tipRequested?.boolValue == true {
+                        HStack {
+                            Text("Add tip:")
+                                .font(.system(size: 14))
+                            Spacer()
+                            Picker("Add tip", selection: Binding<String>(
+                                get: {
+                                    if tipPercent == 0.0 {
+                                        return "No tip"
+                                    } else {
+                                        return "\(Int(tipPercent))%"
+                                    }
+                                },
+                                set: { (option: String) in
+                                    let percent: Double
+                                    if option.hasSuffix("%") {
+                                        percent = Double(option.dropLast()) ?? 0.0
+                                    } else {
+                                        percent = 0.0
+                                    }
+                                    onUserInputChanged(PaymentTransaction.UserInput(tipPercent: percent))
+                                }
+                            )) {
+                                ForEach(tipOptions, id: \.self) { option in
+                                    Text(option).tag(option)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else if transactionData.type == PingTransaction.shared || transactionData.type.identifier == PingTransaction.shared.identifier {
+            if let payload = transactionData.payload as? PingTransaction.Payload {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Test \"ping\" transaction")
+                        .font(.system(size: 15, weight: .semibold))
+                    if let str = payload.string {
+                        Text("String value: '\(str)'")
+                            .font(.system(size: 14))
+                    }
+                    if let blob = payload.blob {
+                        let byteArray = blob.toByteArray(startIndex: 0, endIndex: blob.size)
+                        Text("Blob value: '\(byteArray.toBase64Url())'")
+                            .font(.system(size: 14))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            Text("Unknown transaction type '\(transactionData.type.displayName)'")
+                .font(.system(size: 14))
+        }
+    }
+}
+
+private struct RequestedDocumentSection : View {
     let rpName: String
     let requester: Requester
     let encryptionRequested: Bool
@@ -71,6 +142,9 @@ struct RequestedDocumentSection : View {
     let document: Document
     let retainedClaims: [Claim]
     let notRetainedClaims: [Claim]
+    let transactionData: [TransactionData<AnyObject>]
+    let transactionUserInput: [String: TransactionUserInput]
+    let onTransactionUserInputChanged: (String, TransactionUserInput) -> Void
     let showOptionsButton: Bool
     let onOptionsTapped: () -> Void
 
@@ -126,6 +200,26 @@ struct RequestedDocumentSection : View {
             }
         }
 
+        if !transactionData.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(0..<transactionData.count, id: \.self) { idx in
+                    let data = transactionData[idx]
+                    DisplayTransactionData(
+                        transactionData: data,
+                        userInput: transactionUserInput[data.type.identifier],
+                        onUserInputChanged: { userInput in
+                            onTransactionUserInputChanged(data.type.identifier, userInput)
+                        }
+                    )
+                }
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.accentColor, lineWidth: 1.5)
+            )
+        }
+
         if (!notRetainedClaims.isEmpty) {
             VStack(alignment: .leading, spacing: 10) {
                 Text(sharedText)
@@ -147,9 +241,9 @@ struct RequestedDocumentSection : View {
     }
 }
 
-func getRelyingPartyName(
+private func getRelyingPartyName(
     requester: Requester,
-    trustMetadata: TrustMetadata?,
+    trustMetadata: TrustMetadata?
 ) -> String {
     if trustMetadata != nil {
         if let displayName = trustMetadata?.displayName {
@@ -164,14 +258,12 @@ func getRelyingPartyName(
     }
 }
 
-struct RelyingPartySection : View {
-
+private struct RelyingPartySection : View {
     let rpName: String
     let trustMetadata: TrustMetadata?
     let onRequesterClicked: () -> Void
 
     var body: some View {
-
         VStack(spacing: 10) {
             if let iconUrl = trustMetadata?.displayIconUrl {
                 AsyncImage(url: URL(string: iconUrl)) { phase in
@@ -209,7 +301,7 @@ struct RelyingPartySection : View {
     }
 }
 
-struct InfoSection: View {
+private struct InfoSection: View {
     let markdown: String
     let showWarning: Bool
     
@@ -227,20 +319,20 @@ struct InfoSection: View {
     }
 }
 
-
-
 private enum ConsentDestinations: Hashable {
     case showRequesterInfo
     case pickSolution(useCaseIndex: Int)
 }
 
-/// A ``View`` which asks the user to approve sharing of a credentials.
+/// A ``View`` which asks the user to approve sharing of credentials.
 ///
 /// - Parameters:
 ///   - consentData: the consent data containing use cases and solutions.
 ///   - requester: the relying party which is requesting the data.
-///   - trustMetadata:``TrustMetadata`` conveying the level of trust in the requester, if any.
+///   - trustedRequesterIdentity: the identity of the trusted requester, if any.
+///   - preselectedDocuments: list of documents that should be preselected.
 ///   - maxHeight: the maximum height of the view.
+///   - onDocumentsInFocus: callback invoked with the list of documents currently in focus as the user changes selections.
 ///   - onConfirm: callback when the user presses the Share button with the credentials that were selected.
 ///   - onCancel: callback when the user presses the Cancel button.
 public struct Consent: View {
@@ -248,6 +340,8 @@ public struct Consent: View {
     let consentData: ConsentData
     let requester: Requester
     let trustedRequesterIdentity: TrustedRequesterIdentity?
+    let preselectedDocuments: [Document]
+    let onDocumentsInFocus: ((_ documents: [Document]) -> Void)?
     let onConfirm: (_: CredentialSelection) -> Void
     let onCancel: () -> Void
 
@@ -255,21 +349,45 @@ public struct Consent: View {
         consentData: ConsentData,
         requester: Requester,
         trustedRequesterIdentity: TrustedRequesterIdentity?,
+        preselectedDocuments: [Document] = [],
         maxHeight: CGFloat = .infinity,
+        onDocumentsInFocus: ((_ documents: [Document]) -> Void)? = nil,
         onConfirm: @escaping (_: CredentialSelection) -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.consentData = consentData
         self.requester = requester
         self.trustedRequesterIdentity = trustedRequesterIdentity
+        self.preselectedDocuments = preselectedDocuments
         self.maxHeight = maxHeight
+        self.onDocumentsInFocus = onDocumentsInFocus
         self.onConfirm = onConfirm
         self.onCancel = onCancel
     }
 
     @State private var path = NavigationPath()
     @State private var selections: [Int] = []
+    @State private var transactionUserInput: [String: TransactionUserInput] = [:]
     @State private var sheetHeight: CGFloat = 450
+
+    private func getDocumentsForSelections(_ selections: [Int]) -> [Document] {
+        var documents: [Document] = []
+        for (useCaseIndex, solutionIndex) in selections.enumerated() {
+            if useCaseIndex < consentData.useCases.count && solutionIndex >= 0 {
+                let useCase = consentData.useCases[useCaseIndex]
+                if solutionIndex < useCase.solutions.count {
+                    let solution = useCase.solutions[solutionIndex]
+                    for credential in solution.credentials {
+                        let doc = credential.match.credential.document
+                        if !documents.contains(where: { $0.identifier == doc.identifier }) {
+                            documents.append(doc)
+                        }
+                    }
+                }
+            }
+        }
+        return documents
+    }
 
     private func getInitialSelections(preselectedDocuments: [Document]) -> [Int] {
         var result: [Int] = []
@@ -327,6 +445,7 @@ public struct Consent: View {
                         requester: requester,
                         trustMetadata: trustedRequesterIdentity?.trustMetadata,
                         selections: selections,
+                        transactionUserInput: $transactionUserInput,
                         sheetHeight: $sheetHeight,
                         isActive: path.isEmpty,
                         onRequesterClicked: {
@@ -351,7 +470,9 @@ public struct Consent: View {
             }
             .onAppear {
                 if selections.isEmpty {
-                    selections = getInitialSelections(preselectedDocuments: [])
+                    selections = getInitialSelections(preselectedDocuments: preselectedDocuments)
+                    let initialDocs = getDocumentsForSelections(selections)
+                    onDocumentsInFocus?(initialDocs)
                 }
             }
             .navigationDestination(for: ConsentDestinations.self) { destination in
@@ -369,6 +490,8 @@ public struct Consent: View {
                         currentSolutionIndex: selections[useCaseIndex],
                         onSolutionSelected: { solutionIndex in
                             selections[useCaseIndex] = solutionIndex
+                            let updatedDocs = getDocumentsForSelections(selections)
+                            onDocumentsInFocus?(updatedDocs)
                             path.removeLast()
                         }
                     )
@@ -469,6 +592,7 @@ private struct ConsentMain: View {
     let requester: Requester
     let trustMetadata: TrustMetadata?
     let selections: [Int]
+    @Binding var transactionUserInput: [String: TransactionUserInput]
     @Binding var sheetHeight: CGFloat
     let isActive: Bool
     let onRequesterClicked: () -> Void
@@ -497,6 +621,10 @@ private struct ConsentMain: View {
                                 trustMetadata: trustMetadata,
                                 useCase: consentData.useCases[idx],
                                 selectionIndex: selections[idx],
+                                transactionUserInput: transactionUserInput,
+                                onTransactionUserInputChanged: { typeId, input in
+                                    transactionUserInput[typeId] = input
+                                },
                                 onNavigateToPickSolution: {
                                     onNavigateToPickSolution(idx)
                                 }
@@ -545,7 +673,10 @@ private struct ConsentMain: View {
                         if (!isAtBottom) {
                             scrollDown()
                         } else {
-                            onConfirm(consentData.toCredentialSelection(selections: selections.map { KotlinInt(int: Int32($0)) }, transactionUserInput: [:]))
+                            onConfirm(consentData.toCredentialSelection(
+                                selections: selections.map { KotlinInt(int: Int32($0)) },
+                                transactionUserInput: transactionUserInput
+                            ))
                         }
                     }) {
                         Text(buttonText)
@@ -567,6 +698,8 @@ private struct UseCaseSection: View {
     let trustMetadata: TrustMetadata?
     let useCase: ConsentUseCase
     let selectionIndex: Int
+    let transactionUserInput: [String: TransactionUserInput]
+    let onTransactionUserInputChanged: (String, TransactionUserInput) -> Void
     let onNavigateToPickSolution: () -> Void
 
     var body: some View {
@@ -647,6 +780,9 @@ private struct UseCaseSection: View {
                                     document: match.credential.document,
                                     retainedClaims: retainedClaims,
                                     notRetainedClaims: notRetainedClaims,
+                                    transactionData: match.transactionData,
+                                    transactionUserInput: transactionUserInput,
+                                    onTransactionUserInputChanged: onTransactionUserInputChanged,
                                     showOptionsButton: showChevron && (credIdx == 0),
                                     onOptionsTapped: onNavigateToPickSolution
                                 )
@@ -730,7 +866,7 @@ private struct PickSolutionView: View {
     }
 }
 
-func getDisclaimer(
+private func getDisclaimer(
     requester: Requester,
     trustMetadata: TrustMetadata?,
     rpName: String

--- a/multipaz-swiftui/src/iosMain/swift/ConsentPromptDialog.swift
+++ b/multipaz-swiftui/src/iosMain/swift/ConsentPromptDialog.swift
@@ -35,6 +35,10 @@ struct ConsentPromptDialog: View {
                     consentData: data.state.parameters!.consentData,
                     requester: data.state.parameters!.requester,
                     trustedRequesterIdentity: data.state.parameters!.trustedRequesterIdentity,
+                    preselectedDocuments: data.state.parameters!.preselectedDocuments,
+                    onDocumentsInFocus: { documents in
+                        data.state.parameters!.onDocumentsInFocus(documents)
+                    },
                     onConfirm: { selection in
                         Task {
                             try await data.state.resultChannel.send(element: selection)

--- a/multipaz-swiftui/src/iosMain/swift/PassphrasePromptDialog.swift
+++ b/multipaz-swiftui/src/iosMain/swift/PassphrasePromptDialog.swift
@@ -90,7 +90,7 @@ struct PassphrasePromptDialog: View {
                                 return "Wrong \(kfType), try again, \(remaining) attempt left"
                             }
                         }
-                        assertionFailure("Shouldn't get here, evaluation: \(evaluation)")
+                        assertionFailure("Shouldn't get here, evaluation: \(String(describing: evaluation))")
                         return nil
                     },
                     onSuccess: { enteredPassphrase in

--- a/multipaz-swiftui/src/iosMain/swift/SimplePresentmentSourceExt.swift
+++ b/multipaz-swiftui/src/iosMain/swift/SimplePresentmentSourceExt.swift
@@ -91,6 +91,66 @@ extension SimplePresentmentSource.Companion {
 
 }
 
+private typealias ObjcBlockWithNSArray = @convention(block) (NSArray) -> Void
+private typealias ObjcBlockWithDocs = @convention(block) ([Document]) -> Void
+private typealias ObjcBlockWithAny = @convention(block) (AnyObject) -> Void
+private typealias ObjcBlockWithAnyOptional = @convention(block) (Any?) -> Void
+private typealias SwiftBlockWithDocs = ([Document]) -> Void
+private typealias SwiftBlockWithAny = (Any?) -> Void
+
+private func invokeOnDocumentsInFocus(callback: Any?, documents: [Document]) {
+    guard let callback = callback else { return }
+    
+    // 1. Try Obj-C blocks
+    if let block = callback as? ObjcBlockWithNSArray {
+        block(documents as NSArray)
+        return
+    }
+    if let block = callback as? ObjcBlockWithDocs {
+        block(documents)
+        return
+    }
+    if let block = callback as? ObjcBlockWithAny {
+        block(documents as NSArray)
+        return
+    }
+    if let block = callback as? ObjcBlockWithAnyOptional {
+        block(documents)
+        return
+    }
+    
+    // 2. Try Swift closures
+    if let block = callback as? SwiftBlockWithDocs {
+        block(documents)
+        return
+    }
+    if let block = callback as? SwiftBlockWithAny {
+        block(documents)
+        return
+    }
+    
+    // 3. Try unsafeBitCast for Objective-C block
+    if let obj = callback as? AnyObject, NSStringFromClass(type(of: obj)).contains("Block") {
+        let block = unsafeBitCast(obj, to: ObjcBlockWithNSArray.self)
+        block(documents as NSArray)
+        return
+    }
+    
+    // 4. Try selectors
+    if let obj = callback as? AnyObject {
+        let selector = Selector(("invoke:"))
+        if obj.responds(to: selector) {
+            _ = obj.perform(selector, with: documents)
+            return
+        }
+        let sel2 = Selector(("invokeWithDocuments:"))
+        if obj.responds(to: sel2) {
+            _ = obj.perform(sel2, with: documents)
+            return
+        }
+    }
+}
+
 private func runResolveTrust(
     requester: Requester,
     f: @escaping @MainActor @Sendable (Requester) async -> TrustedRequesterIdentity?,
@@ -107,6 +167,7 @@ private func runShowConsentPrompt(
     trustedRequesterIdentity: TrustedRequesterIdentity?,
     consentData: ConsentData,
     preselectedDocuments: [Document],
+    onDocumentsInFocusCallback: Any?,
     f: @escaping @MainActor @Sendable (
         _ requester: Requester,
         _ trustedRequesterIdentity: TrustedRequesterIdentity?,
@@ -117,13 +178,14 @@ private func runShowConsentPrompt(
     completionHandler: @escaping @Sendable (Any?, (any Error)?) -> Void
 ) {
     Task { @MainActor in
-        // TODO: The cast for onDocumentsInFocus fails at runtime, figure out how to make it work
         let value = await f(
             requester,
             trustedRequesterIdentity,
             consentData,
             preselectedDocuments,
-            { documents in }
+            { documents in
+                invokeOnDocumentsInFocus(callback: onDocumentsInFocusCallback, documents: documents)
+            }
         )
         completionHandler(value, nil)
     }
@@ -161,7 +223,7 @@ private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
         _ trustedRequesterIdentity: TrustedRequesterIdentity?,
         _ consentData: ConsentData,
         _ preselectedDocuments: [Document],
-        _ onDocumentsInFocus: @escaping @MainActor @Sendable (_ documents: [Document]) -> Void,
+        _ onDocumentsInFocus: @escaping @MainActor @Sendable (_ documents: [Document]) -> Void
     ) async -> CredentialSelection?
     
     init(f: @escaping @MainActor @Sendable (
@@ -169,7 +231,7 @@ private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
         _ trustedRequesterIdentity: TrustedRequesterIdentity?,
         _ consentData: ConsentData,
         _ preselectedDocuments: [Document],
-        _ onDocumentsInFocus: @escaping @MainActor @Sendable (_ documents: [Document]) -> Void,
+        _ onDocumentsInFocus: @escaping @MainActor @Sendable (_ documents: [Document]) -> Void
     ) async -> CredentialSelection?) {
         self.f = f
     }
@@ -179,11 +241,13 @@ private class ShowConsentPromptHandler: KotlinSuspendFunction5 {
         let trustedRequesterIdentity = p2 as! TrustedRequesterIdentity?
         let consentData = p3 as! ConsentData
         let preselectedDocuments = p4 as! [Document]
+        let onDocumentsInFocusCallback = p5
         runShowConsentPrompt(
             requester: requester,
             trustedRequesterIdentity: trustedRequesterIdentity,
             consentData: consentData,
             preselectedDocuments: preselectedDocuments,
+            onDocumentsInFocusCallback: onDocumentsInFocusCallback,
             f: self.f,
             completionHandler: completionHandler
         )


### PR DESCRIPTION
Add transaction data rendering, user input collection, and live document focus callbacks to the SwiftUI consent flow:

- In `Consent`, add support for displaying `TransactionData` (such as `PaymentTransaction` and `PingTransaction`) and capturing `TransactionUserInput` (e.g., tip percentage selection).
- In `Consent`, add `preselectedDocuments` and `onDocumentsInFocus` parameters to notify listeners when the documents in focus change on appear and when the user switches credentials in `PickSolutionView`.
- In `ConsentPromptDialog`, forward `preselectedDocuments` and `onDocumentsInFocus` from `ConsentPromptRequest` to `Consent`.
- In `SimplePresentmentSourceExt.swift`, wire the `onDocumentsInFocus` parameter from `ShowConsentPromptHandler.__invoke()` into `runShowConsentPrompt()` and implement `invokeOnDocumentsInFocus()` to safely bridge Kotlin lambdas (`__NSMallocBlock__`) across the Objective-C runtime using `@convention(block)` and `unsafeBitCast`.
- In `PassphrasePromptDialog`, use `String(describing:)` in `assertionFailure` for safe string interpolation.

Fixes #1953.

Test: Ran ./gradlew detekt
Test: Ran ./gradlew :multipaz:jvmTest
Test: Built multipaz-wallet iOS application via xcodebuild and verified
      interactive card switching and consent presentment.
