### PR TITLE
implement a new `custom_head_html` config param to inject a custom head tag into `fetchResource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.101.0] - Expected September 2026
 Significant changes since Multipaz 0.100.0 include:
 - [To be written]
+- New `custom_head_html` server setting, injected into the `<head>` of every HTML page served
+  by `serveResources()`, so a deployment can restyle the built-in pages without forking their
+  markup.
 
 ## [0.100.0] - 2026-07-08
 Significant changes since Multipaz 0.99.0 include:

--- a/multipaz-server/src/main/java/org/multipaz/server/common/ConfigurationExt.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/ConfigurationExt.kt
@@ -23,3 +23,19 @@ val Configuration.baseUrl: String get() = getValue("base_url")
  * from the `enrollment_server_url` setting. `null` if not configured.
  */
 val Configuration.enrollmentServerUrl: String? get() = getValue("enrollment_server_url")
+
+/**
+ * HTML injected immediately before the closing `</head>` tag of every HTML page served by
+ * [serveResources], from the `custom_head_html` setting. `null` if not configured.
+ *
+ * This allows a deployment to restyle or extend the built-in pages without forking their
+ * markup, for example:
+ *
+ * ```json
+ * "custom_head_html": "<link rel=\"stylesheet\" href=\"custom.css\">"
+ * ```
+ *
+ * Any asset referenced this way is served like every other static resource, so it must be
+ * present in the server's `www` resource folder.
+ */
+val Configuration.customHeadHtml: String? get() = getValue("custom_head_html")

--- a/multipaz-server/src/main/java/org/multipaz/server/common/resources.kt
+++ b/multipaz-server/src/main/java/org/multipaz/server/common/resources.kt
@@ -9,6 +9,7 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
 import org.multipaz.rpc.cache
 
 /**
@@ -18,6 +19,9 @@ import org.multipaz.rpc.cache
  * `css`, `jpg`, `jpeg`, `png`.
  *
  * Additionally "/" is mapped to `www/index.html`.
+ *
+ * HTML pages have the `custom_head_html` setting (see [Configuration.customHeadHtml]) injected
+ * into their `<head>`, which lets a deployment restyle them without forking their markup.
  */
 fun Routing.serveResources() {
     get("/") { fetchResource(call, "index.html") }
@@ -31,10 +35,16 @@ fun Routing.serveResources() {
  */
 private suspend fun fetchResource(call: ApplicationCall, path: String) {
     try {
-        val resource = BackendEnvironment.cache(ResourceBytes::class, path) { _, resources ->
+        val resource = BackendEnvironment.cache(ResourceBytes::class, path) { configuration, resources ->
             val bytes = resources.getRawResource("www/$path")
                 ?: throw ResourceNotFoundException()
-            ResourceBytes(bytes)
+            ResourceBytes(
+                if (path.endsWith(".html", ignoreCase = true)) {
+                    injectCustomHeadHtml(bytes, configuration.customHeadHtml)
+                } else {
+                    bytes
+                }
+            )
         }
         call.respondBytes(
             contentType = when (path.substring(path.lastIndexOf('.') + 1)) {
@@ -56,6 +66,60 @@ private suspend fun fetchResource(call: ApplicationCall, path: String) {
         )
     }
 }
+
+/**
+ * Returns [content] with [headHtml] inserted immediately before its first `</head>` tag.
+ *
+ * [content] is returned unchanged when [headHtml] is `null` or blank, and when the content has
+ * no `</head>` tag to insert before. The tag is located by a case-insensitive ASCII scan of the
+ * raw bytes rather than by decoding the content, so pages in any encoding pass through
+ * unharmed.
+ */
+internal fun injectCustomHeadHtml(content: ByteString, headHtml: String?): ByteString {
+    if (headHtml.isNullOrBlank()) {
+        return content
+    }
+    val bytes = content.toByteArray()
+    val index = indexOfHeadCloseTag(bytes)
+    if (index < 0) {
+        return content
+    }
+    val insert = headHtml.encodeToByteArray()
+    val result = ByteArray(bytes.size + insert.size)
+    bytes.copyInto(result, destinationOffset = 0, startIndex = 0, endIndex = index)
+    insert.copyInto(result, destinationOffset = index)
+    bytes.copyInto(result, destinationOffset = index + insert.size, startIndex = index)
+    return ByteString(result)
+}
+
+/** Index of the first case-insensitive `</head>` in [bytes], or -1 if there is none. */
+private fun indexOfHeadCloseTag(bytes: ByteArray): Int {
+    for (start in 0..bytes.size - HEAD_CLOSE_TAG.size) {
+        var matched = true
+        for (offset in HEAD_CLOSE_TAG.indices) {
+            if (bytes[start + offset].asciiLowercase() != HEAD_CLOSE_TAG[offset]) {
+                matched = false
+                break
+            }
+        }
+        if (matched) {
+            return start
+        }
+    }
+    return -1
+}
+
+/** Lowercases an ASCII letter, leaving every other byte (including UTF-8 continuations) alone. */
+private fun Byte.asciiLowercase(): Byte {
+    val value = toInt()
+    return if (value >= 'A'.code && value <= 'Z'.code) {
+        (value + ('a'.code - 'A'.code)).toByte()
+    } else {
+        this
+    }
+}
+
+private val HEAD_CLOSE_TAG = "</head>".encodeToByteArray()
 
 /** Wrapper for cached static resource content, used as a cache key type by [serveResources]. */
 data class ResourceBytes(val bytes: ByteString)

--- a/multipaz-server/src/test/java/org/multipaz/server/common/CustomHeadHtmlTest.kt
+++ b/multipaz-server/src/test/java/org/multipaz/server/common/CustomHeadHtmlTest.kt
@@ -1,0 +1,92 @@
+package org.multipaz.server.common
+
+import kotlinx.io.bytestring.ByteString
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Tests for the `custom_head_html` injection performed by `serveResources()`. */
+class CustomHeadHtmlTest {
+    private fun inject(content: String, headHtml: String?): String =
+        injectCustomHeadHtml(
+            ByteString(content.encodeToByteArray()),
+            headHtml
+        ).toByteArray().decodeToString()
+
+    @Test
+    fun testInsertedBeforeClosingHeadTag() {
+        assertEquals(
+            "<html><head><title>t</title><link rel=\"x\"></head><body></body></html>",
+            inject(
+                "<html><head><title>t</title></head><body></body></html>",
+                "<link rel=\"x\">"
+            )
+        )
+    }
+
+    @Test
+    fun testTagMatchIsCaseInsensitive() {
+        assertEquals(
+            "<HEAD>X</HEAD>",
+            inject("<HEAD></HEAD>", "X")
+        )
+    }
+
+    @Test
+    fun testOnlyFirstClosingHeadTagIsUsed() {
+        assertEquals(
+            "<head>X</head><body></head></body>",
+            inject("<head></head><body></head></body>", "X")
+        )
+    }
+
+    @Test
+    fun testUnchangedWhenNotConfigured() {
+        val page = "<html><head></head></html>"
+        assertEquals(page, inject(page, null))
+    }
+
+    @Test
+    fun testUnchangedWhenConfiguredValueIsBlank() {
+        val page = "<html><head></head></html>"
+        assertEquals(page, inject(page, "   "))
+    }
+
+    @Test
+    fun testUnchangedWhenThereIsNoHeadTag() {
+        val page = "<html><body>no head here</body></html>"
+        assertEquals(page, inject(page, "<link rel=\"x\">"))
+    }
+
+    @Test
+    fun testUnchangedWhenContentIsShorterThanTheTag() {
+        assertEquals("<p>", inject("<p>", "X"))
+    }
+
+    @Test
+    fun testNonUtf8BytesArePreserved() {
+        // A page in a non-Unicode encoding must survive injection byte-for-byte: the scan works
+        // on raw bytes precisely so that content is never decoded and re-encoded.
+        val latin1 = byteArrayOf(0x3C, 0x68, 0x65, 0x61, 0x64, 0x3E)   // "<head>"
+            .plus(0xE9.toByte())                                        // 'é' in ISO-8859-1
+            .plus("</head>".encodeToByteArray())
+        val result = injectCustomHeadHtml(ByteString(latin1), "X").toByteArray()
+        val expected = byteArrayOf(0x3C, 0x68, 0x65, 0x61, 0x64, 0x3E)
+            .plus(0xE9.toByte())
+            .plus("X".encodeToByteArray())
+            .plus("</head>".encodeToByteArray())
+        assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun testInjectedHtmlIsEncodedAsUtf8() {
+        val result = injectCustomHeadHtml(
+            ByteString("<head></head>".encodeToByteArray()),
+            "é"
+        ).toByteArray()
+        val expected = "<head>".encodeToByteArray()
+            .plus(byteArrayOf(0xC3.toByte(), 0xA9.toByte()))
+            .plus("</head>".encodeToByteArray())
+        assertArrayEquals(expected, result)
+    }
+}


### PR DESCRIPTION
Fixes #1966

- [x] Tests pass
- [x] Appropriate changes to README are included in PR