### PR TITLE
Add API to get and set document order across Compose and SwiftUI.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/branding/Branding.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/branding/Branding.android.kt
@@ -1,5 +1,6 @@
 package org.multipaz.compose.branding
 
+import android.content.Context
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -15,18 +16,39 @@ import androidx.compose.ui.text.font.createFontFamilyResolver
 import com.google.accompanist.drawablepainter.DrawablePainter
 import org.multipaz.context.applicationContext
 
+private fun getApplicationContextOrFallback(): Context? {
+    try {
+        return applicationContext
+    } catch (_: Throwable) {
+        // Fallback to ActivityThread.currentApplication() if not explicitly initialized yet
+    }
+    try {
+        val activityThread = Class.forName("android.app.ActivityThread")
+        val currentApp = activityThread.getMethod("currentApplication").invoke(null) as? Context
+        if (currentApp != null) {
+            return currentApp
+        }
+    } catch (_: Throwable) {
+    }
+    return null
+}
+
 internal actual val defaultAppName: String?
     get() {
-        val appInfo = applicationContext.applicationInfo
+        val context = getApplicationContextOrFallback() ?: return null
+        val appInfo = context.applicationInfo
         return if (appInfo.labelRes != 0) {
-            applicationContext.getString(appInfo.labelRes)
+            context.getString(appInfo.labelRes)
         } else {
-            appInfo.nonLocalizedLabel.toString()
+            appInfo.nonLocalizedLabel?.toString()
         }
     }
 
 internal actual val defaultAppIconPainter: Painter?
-    get() = DrawablePainter(applicationContext.packageManager.getApplicationIcon(applicationContext.packageName))
+    get() {
+        val context = getApplicationContextOrFallback() ?: return null
+        return DrawablePainter(context.packageManager.getApplicationIcon(context.packageName))
+    }
 
 @Composable
 private fun AppThemeDefault(content: @Composable () -> Unit) {
@@ -54,5 +76,7 @@ private fun AppThemeDefault(content: @Composable () -> Unit) {
 internal actual val defaultTheme: @Composable (content: @Composable () -> Unit) -> Unit = { AppThemeDefault(it) }
 
 internal actual fun createFontFamilyResolver(): FontFamily.Resolver {
-    return createFontFamilyResolver(applicationContext)
+    val context = getApplicationContextOrFallback()
+        ?: throw IllegalStateException("Android Context is required to create FontFamily.Resolver")
+    return createFontFamilyResolver(context)
 }

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/branding/Branding.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/branding/Branding.kt
@@ -118,11 +118,14 @@ interface Branding {
 }
 
 private object DefaultBranding: Branding {
-    override val appName = defaultAppName
+    override val appName: String?
+        get() = defaultAppName
 
-    override val appIconPainter = defaultAppIconPainter
+    override val appIconPainter: Painter?
+        get() = defaultAppIconPainter
 
-    override val theme = defaultTheme
+    override val theme: @Composable (content: @Composable () -> Unit) -> Unit
+        get() = defaultTheme
 
     override suspend fun renderFallbackCardArt(document: Document): ImageBitmap =
         defaultRenderFallbackCardArt(document)

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/document/DocumentModel.kt
@@ -169,6 +169,12 @@ class DocumentModel private constructor(
         }
     }
 
+    /**
+     * The list of document IDs in their current display order.
+     */
+    val documentOrder: List<String>
+        get() = _documentInfos.value.map { it.document.identifier }
+
     private fun List<DocumentInfo>.sorted(): List<DocumentInfo> {
         return this.sortedWith { a, b ->
             val sa = storageData.sortingOrder[a.document.identifier]
@@ -177,9 +183,42 @@ class DocumentModel private constructor(
                 if (sa != sb) {
                     return@sortedWith sa.compareTo(sb)
                 }
+            } else if (sa != null) {
+                return@sortedWith -1
+            } else if (sb != null) {
+                return@sortedWith 1
             }
             return@sortedWith a.document.created.compareTo(b.document.created)
         }
+    }
+
+    /**
+     * Sets the ordering of documents in the model.
+     *
+     * Any documents in the store that are not included in [documentOrder] will be placed
+     * after the specified documents, maintaining their relative order.
+     *
+     * @param documentOrder the list of document IDs in the desired order.
+     */
+    suspend fun setDocumentOrder(documentOrder: List<String>) {
+        val newOrder = mutableListOf<String>()
+        val seen = mutableSetOf<String>()
+        for (id in documentOrder) {
+            if (seen.add(id)) {
+                newOrder.add(id)
+            }
+        }
+        for (docInfo in _documentInfos.value) {
+            if (seen.add(docInfo.document.identifier)) {
+                newOrder.add(docInfo.document.identifier)
+            }
+        }
+        val sortingOrder = newOrder.mapIndexed { index, id -> id to index }.toMap()
+        storageData.sortingOrder = sortingOrder
+        documentStore.getTags().edit {
+            set(documentOrderKey, ByteString(Cbor.encode(storageData.toDataItem())))
+        }
+        _documentInfos.value = _documentInfos.value.sorted()
     }
 
     /**
@@ -188,29 +227,22 @@ class DocumentModel private constructor(
      * @param documentInfo the [DocumentInfo] to set the position for.
      * @param position the new position, zero-based.
      * @throws IllegalArgumentException if [documentInfo] doesn't exist in the model or if [position]
-     *   exceed the number of documents in the store.
+     *   exceeds the number of documents in the store.
      */
     suspend fun setDocumentPosition(
         documentInfo: DocumentInfo,
         position: Int
     ) {
-        val documentInfos = _documentInfos.value.toMutableList()
-        if (!documentInfos.remove(documentInfo)) {
+        val currentOrder = documentOrder.toMutableList()
+        val id = documentInfo.document.identifier
+        if (!currentOrder.remove(id)) {
             throw IllegalArgumentException("Passed in documentInfo is not in list")
         }
-        documentInfos.add(
-            index = position,
-            element = documentInfo,
-        )
-        val sortingOrder = mutableMapOf<String, Int>()
-        documentInfos.forEachIndexed { index, documentInfo ->
-            sortingOrder.put(documentInfo.document.identifier, index)
+        if (position < 0 || position > currentOrder.size) {
+            throw IllegalArgumentException("Position $position is out of range 0..${currentOrder.size}")
         }
-        storageData.sortingOrder = sortingOrder
-        documentStore.getTags().edit {
-            set(documentOrderKey, ByteString(Cbor.encode(storageData.toDataItem())))
-        }
-        _documentInfos.value = documentInfos
+        currentOrder.add(position, id)
+        setDocumentOrder(currentOrder)
     }
 
     // Use a simple LRU cache to avoid decoding the same cardArt over and over again

--- a/multipaz-compose/src/commonTest/kotlin/org/multipaz/compose/document/DocumentModelTest.kt
+++ b/multipaz-compose/src/commonTest/kotlin/org/multipaz/compose/document/DocumentModelTest.kt
@@ -1,0 +1,100 @@
+package org.multipaz.compose.document
+
+import kotlinx.coroutines.test.runTest
+import org.multipaz.document.DocumentStore
+import org.multipaz.document.buildDocumentStore
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DocumentModelTest {
+
+    private suspend fun createTestDocumentStore(): DocumentStore {
+        val storage = EphemeralStorage()
+        val softwareSecureArea = SoftwareSecureArea.create(storage)
+        val secureAreaRepository = SecureAreaRepository.Builder()
+            .add(softwareSecureArea)
+            .build()
+        return buildDocumentStore(storage, secureAreaRepository) {}
+    }
+
+    @Test
+    fun testGetAndSetDocumentOrder() = runTest {
+        val store = createTestDocumentStore()
+        val doc1 = store.createDocument(displayName = "Doc 1")
+        val doc2 = store.createDocument(displayName = "Doc 2")
+        val doc3 = store.createDocument(displayName = "Doc 3")
+
+        val model = DocumentModel.create(store, null)
+        val initialOrder = listOf(doc1.identifier, doc2.identifier, doc3.identifier)
+        assertEquals(initialOrder, model.documentOrder)
+
+        // Reorder documents
+        val newOrder = listOf(doc3.identifier, doc1.identifier, doc2.identifier)
+        model.setDocumentOrder(newOrder)
+
+        assertEquals(newOrder, model.documentOrder)
+        assertEquals(newOrder, model.documentInfos.value.map { it.document.identifier })
+
+        // Check persistence in new DocumentModel instance
+        val model2 = DocumentModel.create(store, null)
+        assertEquals(newOrder, model2.documentOrder)
+    }
+
+    @Test
+    fun testSetDocumentOrderPartialList() = runTest {
+        val store = createTestDocumentStore()
+        val doc1 = store.createDocument(displayName = "Doc 1")
+        val doc2 = store.createDocument(displayName = "Doc 2")
+        val doc3 = store.createDocument(displayName = "Doc 3")
+
+        val model = DocumentModel.create(store, null)
+
+        // Setting order for a subset moves specified doc to front, preserving relative order of rest
+        model.setDocumentOrder(listOf(doc2.identifier))
+        val expected = listOf(doc2.identifier, doc1.identifier, doc3.identifier)
+        assertEquals(expected, model.documentOrder)
+    }
+
+    @Test
+    fun testSetDocumentOrderWithDuplicatesAndUnknownIds() = runTest {
+        val store = createTestDocumentStore()
+        val doc1 = store.createDocument(displayName = "Doc 1")
+        val doc2 = store.createDocument(displayName = "Doc 2")
+        val doc3 = store.createDocument(displayName = "Doc 3")
+
+        val model = DocumentModel.create(store, null)
+
+        // Duplicates and unknown IDs handled gracefully
+        model.setDocumentOrder(listOf("unknown_id", doc2.identifier, doc2.identifier, doc1.identifier))
+        val expected = listOf(doc2.identifier, doc1.identifier, doc3.identifier)
+        assertEquals(expected, model.documentOrder)
+    }
+
+    @Test
+    fun testSetDocumentPosition() = runTest {
+        val store = createTestDocumentStore()
+        val doc1 = store.createDocument(displayName = "Doc 1")
+        val doc2 = store.createDocument(displayName = "Doc 2")
+        val doc3 = store.createDocument(displayName = "Doc 3")
+
+        val model = DocumentModel.create(store, null)
+        val docInfo3 = model.documentInfos.value.find { it.document.identifier == doc3.identifier }!!
+
+        // Move doc3 to position 0
+        model.setDocumentPosition(docInfo3, 0)
+        assertEquals(listOf(doc3.identifier, doc1.identifier, doc2.identifier), model.documentOrder)
+
+        // Move doc3 to position 2
+        model.setDocumentPosition(docInfo3, 2)
+        assertEquals(listOf(doc1.identifier, doc2.identifier, doc3.identifier), model.documentOrder)
+
+        // Invalid position throws
+        assertFailsWith<IllegalArgumentException> {
+            model.setDocumentPosition(docInfo3, 5)
+        }
+    }
+}

--- a/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
+++ b/multipaz-swiftui/src/iosMain/swift/DocumentModel.swift
@@ -128,14 +128,34 @@ public class DocumentModel {
     
     private var _documentInfos: [DocumentInfo] = []
 
+    /**
+     * The list of document IDs in their current display order.
+     */
+    public var documentOrder: [String] {
+        documentInfos.map { $0.document.identifier }
+    }
+
+    /**
+     * Gets the list of document IDs in their current display order.
+     *
+     * - Returns: list of document IDs in order.
+     */
+    public func getDocumentOrder() -> [String] {
+        return documentOrder
+    }
+
     public var documentInfos: [DocumentInfo] {
         _documentInfos.sorted { (a: DocumentInfo, b: DocumentInfo) -> Bool in
             let sa = storageData.sortingOrder[a.document.identifier]
             let sb = storageData.sortingOrder[b.document.identifier]
-            if sa != nil && sb != nil {
+            if let sa = sa, let sb = sb {
                 if sa != sb {
-                    return sa! < sb!
+                    return sa < sb
                 }
+            } else if sa != nil {
+                return true
+            } else if sb != nil {
+                return false
             }
             return Document.Comparator.shared.compare(a: a.document, b: b.document) < 0
         }
@@ -145,31 +165,31 @@ public class DocumentModel {
     private var storageData: DocumentModelStorageData!
     
     /**
-     * Sets the position of a document.
+     * Sets the ordering of documents in the model.
      *
-     * - Parameters:
-     *  - documentInfo: the ``DocumentInfo`` to set position for.
-     *  - position: the position to set.
-     * - Throws: ``DocumentError.noSuchDocument`` if the given ``DocumentInfo`` doesn't exist.
-     * - Throws: ``DocumentError.positionOutOfRange`` if the given position is out of range.
+     * Any documents in the store that are not included in `documentOrder` will be placed
+     * after the specified documents, maintaining their relative order.
+     *
+     * - Parameter documentOrder: the list of document IDs in the desired order.
      */
-    public func setDocumentPosition(
-        documentInfo: DocumentInfo,
-        position: Int
+    public func setDocumentOrder(
+        documentOrder: [String]
     ) async throws {
-        var documentInfos = self.documentInfos
-        let index = documentInfos.firstIndex(of: documentInfo)
-        if index == nil {
-            throw DocumentModelError.noSuchDocument
+        var newOrder: [String] = []
+        var seen = Set<String>()
+        for id in documentOrder {
+            if seen.insert(id).inserted {
+                newOrder.append(id)
+            }
         }
-        documentInfos.remove(at: index!)
-        if position < 0 || position > documentInfos.count {
-            throw DocumentModelError.positionOutOfRange
+        for docInfo in self.documentInfos {
+            if seen.insert(docInfo.document.identifier).inserted {
+                newOrder.append(docInfo.document.identifier)
+            }
         }
-        documentInfos.insert(documentInfo, at: position)
-        var sortingOrder: [String:Int] = [:]
-        documentInfos.enumerated().forEach { index, di in
-            sortingOrder[di.document.identifier] = index
+        var sortingOrder: [String: Int] = [:]
+        for (index, id) in newOrder.enumerated() {
+            sortingOrder[id] = index
         }
         storageData = DocumentModelStorageData(sortingOrder: sortingOrder)
         try await documentStore.getTags().edit(
@@ -180,6 +200,31 @@ public class DocumentModel {
                 )
             }
         )
+    }
+
+    /**
+     * Sets the position of a document.
+     *
+     * - Parameters:
+     *  - documentInfo: the ``DocumentInfo`` to set position for.
+     *  - position: the position to set.
+     * - Throws: ``DocumentModelError.noSuchDocument`` if the given ``DocumentInfo`` doesn't exist.
+     * - Throws: ``DocumentModelError.positionOutOfRange`` if the given position is out of range.
+     */
+    public func setDocumentPosition(
+        documentInfo: DocumentInfo,
+        position: Int
+    ) async throws {
+        var currentOrder = self.documentOrder
+        guard let index = currentOrder.firstIndex(of: documentInfo.document.identifier) else {
+            throw DocumentModelError.noSuchDocument
+        }
+        currentOrder.remove(at: index)
+        if position < 0 || position > currentOrder.count {
+            throw DocumentModelError.positionOutOfRange
+        }
+        currentOrder.insert(documentInfo.document.identifier, at: position)
+        try await setDocumentOrder(documentOrder: currentOrder)
     }
 
     private func getDocumentInfo(_ document: Document) async throws -> DocumentInfo {

--- a/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
+++ b/multipaz-swiftui/src/iosMain/swift/VerticalCardList.swift
@@ -780,8 +780,10 @@ public struct VerticalCardList<TopContent: View, EmptyContent: View, SelectedCon
             }
         }
         .onChange(of: cardInfos.map { $0.identifier }) { _, newIds in
-            state.model.syncCards(incomingIdentifiers: newIds)
-            state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
+            withAnimation(.easeInOut(duration: 0.38)) {
+                state.model.syncCards(incomingIdentifiers: newIds)
+                state.displayOrderIdentifiers = state.model.displayOrderIdentifiers
+            }
         }
         .onChange(of: state.dragJustEnded) { _, newValue in
             if newValue {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cards/VerticalCardListModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cards/VerticalCardListModel.kt
@@ -165,7 +165,6 @@ class VerticalCardListModel(
      * Synchronizes [displayOrderIdentifiers] with the provided list of card identifiers.
      *
      * If a drag operation is currently active, synchronization is deferred to avoid disrupting gestures.
-     * Existing ordering is preserved for existing items; new items are appended, and removed items are deleted.
      *
      * @param incomingIdentifiers the latest list of card identifiers from the data source.
      */
@@ -173,16 +172,8 @@ class VerticalCardListModel(
         if (draggedCardIdentifier != null) {
             return
         }
-        if (displayOrderIdentifiers.isEmpty()) {
-            displayOrderIdentifiers = incomingIdentifiers
-            return
-        }
         if (displayOrderIdentifiers != incomingIdentifiers) {
-            val incomingSet = incomingIdentifiers.toSet()
-            val preserved = displayOrderIdentifiers.filter { incomingSet.contains(it) }
-            val preservedSet = preserved.toSet()
-            val newItems = incomingIdentifiers.filter { !preservedSet.contains(it) }
-            displayOrderIdentifiers = preserved + newItems
+            displayOrderIdentifiers = incomingIdentifiers
         }
     }
 

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cards/VerticalCardListModelTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cards/VerticalCardListModelTest.kt
@@ -10,17 +10,15 @@ import kotlin.test.assertTrue
 class VerticalCardListModelTest {
 
     @Test
-    fun syncCards_basicAndPreservingOrder() {
+    fun syncCards_basicAndReordering() {
         val model = VerticalCardListModel()
 
         // Initial sync
         model.syncCards(listOf("a", "b", "c"))
         assertEquals(listOf("a", "b", "c"), model.displayOrderIdentifiers)
 
-        // Reordered externally, but model preserves its user display order for existing items
-        // and appends new items
-        model.displayOrderIdentifiers = listOf("b", "a", "c")
-        model.syncCards(listOf("a", "b", "c", "d"))
+        // Reordered externally when not dragging updates displayOrderIdentifiers
+        model.syncCards(listOf("b", "a", "c", "d"))
         assertEquals(listOf("b", "a", "c", "d"), model.displayOrderIdentifiers)
 
         // Item removed

--- a/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
+++ b/samples/SwiftTestApp/SwiftTestApp/VerticalCardListScreen.swift
@@ -126,7 +126,10 @@ struct VerticalCardListScreen: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                TopBarTogglesView(state: viewModel.verticalCardListState)
+                TopBarActionsView(
+                    state: viewModel.verticalCardListState,
+                    documentModel: viewModel.documentModel
+                )
             }
         }
         .background {
@@ -137,8 +140,9 @@ struct VerticalCardListScreen: View {
     }
 }
 
-private struct TopBarTogglesView: View {
+private struct TopBarActionsView: View {
     @Bindable var state: VerticalCardListState
+    let documentModel: DocumentModel
 
     var body: some View {
         HStack(spacing: 8) {
@@ -159,22 +163,15 @@ private struct TopBarTogglesView: View {
                 .labelsHidden()
                 .controlSize(.small)
             }
-            HStack(spacing: 4) {
-                Text("Placeholder")
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .fixedSize()
-                Toggle("", isOn: Binding(
-                    get: { state.showPlaceholderWhenEmpty },
-                    set: { newValue in
-                        withAnimation(.easeInOut(duration: 0.38)) {
-                            state.showPlaceholderWhenEmpty = newValue
-                        }
-                    }
-                ))
-                .toggleStyle(.switch)
-                .labelsHidden()
-                .controlSize(.small)
+            Button(action: {
+                Task {
+                    try? await documentModel.setDocumentOrder(
+                        documentOrder: documentModel.documentOrder.shuffled()
+                    )
+                }
+            }) {
+                Text("Shuffle")
+                    .font(.caption)
             }
         }
     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/VerticalCardListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -170,15 +171,14 @@ fun VerticalCardListScreen(
                                 onCheckedChange = { state.showTopContent = it }
                             )
                         }
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = "Placeholder",
-                                style = MaterialTheme.typography.bodySmall
-                            )
-                            Checkbox(
-                                checked = state.showPlaceholderWhenEmpty,
-                                onCheckedChange = { state.showPlaceholderWhenEmpty = it }
-                            )
+                        TextButton(
+                            onClick = {
+                                coroutineScope.launch {
+                                    documentModel.setDocumentOrder(documentModel.documentOrder.shuffled())
+                                }
+                            }
+                        ) {
+                            Text("Shuffle")
                         }
                     }
                 }


### PR DESCRIPTION
Add support for getting and setting the active document order in `DocumentModel` across both Compose and SwiftUI to facilitate synchronizing document order across apps and devices:

- In `DocumentModel` (Compose), expose `documentOrder` property and `setDocumentOrder()` method accepting a list of document IDs. Refactor `setDocumentPosition()` to delegate to `setDocumentOrder()`, and fix transitivity in comparator sorting when items are partially ordered.
- In `DocumentModel` (SwiftUI), expose `documentOrder` property, `getDocumentOrder()` and `setDocumentOrder()` methods accepting a list of document IDs, and refactor `setDocumentPosition()` to delegate to `setDocumentOrder()`.
- In `VerticalCardListModel`, update `syncCards()` to adopt incoming card identifiers when not dragging so external document reordering updates the display order.
- In `VerticalCardList` (SwiftUI), wrap display order updates in `withAnimation()` to smoothly animate card reordering transitions.
- In `VerticalCardListScreen` (testapp and SwiftTestApp), replace the placeholder toggle with a shuffle button for testing card reordering animations.
- Add unit tests for `DocumentModel` in `DocumentModelTest`.

Fixes #1971.

Test: Manually tested on both Android and iOS.
Test: Ran ./gradlew detekt
Test: Ran ./gradlew :multipaz:jvmTest :multipaz-compose:testDebugUnitTest
Test: Ran ./gradlew :samples:testapp:assembleDebug
Test: Built TestApp and SwiftTestApp via xcodebuild
