### PR TITLE
Add abstraction for managing pools of certified keys.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/certifiedkeys/CertifiedKeyManager.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/certifiedkeys/CertifiedKeyManager.kt
@@ -1,0 +1,435 @@
+package org.multipaz.certifiedkeys
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.KeyAttestation
+import org.multipaz.securearea.KeyInfo
+import org.multipaz.securearea.SecureArea
+import org.multipaz.storage.Storage
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.util.Logger
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+private const val TAG = "CertifiedKeyManager"
+
+/**
+ * A certified key consisting of a key created in a [SecureArea] and its certification certificate chain.
+ *
+ * @property keyInfo information about the key in the [SecureArea].
+ * @property certChain the certificate chain certifying the key.
+ */
+data class CertifiedKey(
+    val keyInfo: KeyInfo,
+    val certChain: X509CertChain
+) {
+    /**
+     * The alias of the key in the [SecureArea].
+     */
+    val alias: String
+        get() = keyInfo.alias
+}
+
+@CborSerializable
+internal data class CertifiedKeyRecord(
+    val alias: String,
+    val certification: X509CertChain,
+    val validFrom: Instant,
+    val validUntil: Instant,
+    val refreshAt: Instant
+) {
+    companion object
+}
+
+/**
+ * Manager for a pool of keys generated locally from a [SecureArea] and certified by a certifying authority.
+ *
+ * The manager maintains a pool of certified keys, automatically replenishing them when the number of fresh,
+ * valid keys drops below 50% of [numKeys]. It also handles key expiration, offline resilience, and cleanup
+ * of stale keys.
+ *
+ * @property secureArea the [SecureArea] to generate and hold private keys.
+ * @property storage the [Storage] used to persist certification metadata.
+ * @property numKeys the target number of keys to maintain in the pool, defaults to 10.
+ * @property createKeySettings settings passed when creating keys in the [SecureArea].
+ * @property tableName the storage table name for persisting certified keys.
+ * @property replenishThresholdFraction pool threshold fraction below which replenishing is triggered, defaults to 0.5.
+ * @property refreshThresholdFraction certificate lifetime fraction after which a key is refreshed, defaults to 2/3.
+ * @property certify a suspend function that certifies a batch of [KeyAttestation]s and returns their [X509CertChain]s.
+ */
+class CertifiedKeyManager(
+    val secureArea: SecureArea,
+    val storage: Storage = EphemeralStorage(),
+    val numKeys: Int = 10,
+    val createKeySettings: CreateKeySettings = CreateKeySettings(),
+    val tableName: String = "CertifiedKeys",
+    val replenishThresholdFraction: Double = 0.5,
+    val refreshThresholdFraction: Double = 2.0 / 3.0,
+    val certify: suspend (keys: List<KeyAttestation>) -> List<X509CertChain>
+) {
+    init {
+        require(numKeys >= 0) { "numKeys must not be negative" }
+        require(replenishThresholdFraction in 0.0..1.0) {
+            "replenishThresholdFraction must be between 0.0 and 1.0"
+        }
+        require(refreshThresholdFraction in 0.0..1.0) {
+            "refreshThresholdFraction must be between 0.0 and 1.0"
+        }
+    }
+
+    private val tableSpec = StorageTableSpec(
+        name = tableName,
+        supportExpiration = false,
+        supportPartitions = false
+    )
+
+    private val lock = Mutex()
+    private var certifiedKeys: MutableMap<String, CertifiedKeyRecord>? = null
+
+    private suspend fun ensureCertifiedKeys() {
+        check(lock.isLocked)
+
+        if (certifiedKeys != null) {
+            return
+        }
+        val map = mutableMapOf<String, CertifiedKeyRecord>()
+        val certifiedKeysTable = storage.getTable(tableSpec)
+        for ((key, encodedData) in certifiedKeysTable.enumerateWithData()) {
+            map[key] = CertifiedKeyRecord.fromCbor(encodedData.toByteArray())
+        }
+        certifiedKeys = map
+    }
+
+    private suspend fun clearKeysLocked() {
+        check(lock.isLocked)
+        ensureCertifiedKeys()
+        val keys = certifiedKeys ?: return
+        for (certifiedKey in keys.values) {
+            try {
+                secureArea.deleteKey(certifiedKey.alias)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Error deleting key from SecureArea", e)
+            }
+        }
+        val certifiedKeysTable = storage.getTable(tableSpec)
+        certifiedKeysTable.deleteAll()
+        certifiedKeys = null
+        ensureCertifiedKeys()
+    }
+
+    /**
+     * Ensures we have at least numKeys/2 fresh keys. Also removes expired keys.
+     */
+    private suspend fun ensureReplenished(
+        atTime: Instant = Clock.System.now()
+    ): Int {
+        check(lock.isLocked) { "Called without holding lock" }
+        if (numKeys == 0) {
+            return 0
+        }
+
+        ensureCertifiedKeys()
+        val keys = certifiedKeys!!
+        val certifiedKeysTable = storage.getTable(tableSpec)
+
+        var numGoodKeys = 0
+        val toDelete = mutableListOf<Pair<String, CertifiedKeyRecord>>()
+        for ((id, certifiedKey) in keys.entries) {
+            if (atTime > certifiedKey.refreshAt) {
+                toDelete.add(Pair(id, certifiedKey))
+            } else if (atTime > certifiedKey.validFrom && atTime < certifiedKey.validUntil) {
+                numGoodKeys += 1
+            }
+        }
+
+        Logger.i(TAG, "Before key replenishing: $numKeys keys ($numGoodKeys good)")
+
+        // Only replenish if we are running below replenishThresholdFraction...
+        if (numGoodKeys > numKeys * replenishThresholdFraction) {
+            toDelete.forEach {
+                try {
+                    secureArea.deleteKey(it.second.alias)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    Logger.w(TAG, "Error deleting key from SecureArea", e)
+                }
+                certifiedKeysTable.delete(it.first)
+                keys.remove(it.first)
+            }
+            Logger.i(TAG, "Not replenishing keys")
+            return 0
+        }
+        val numKeysNeeded = numKeys - numGoodKeys
+
+        val keysToCertify = mutableListOf<KeyInfo>()
+        val readerCertifications: List<X509CertChain>
+        try {
+            repeat(numKeysNeeded) {
+                keysToCertify.add(secureArea.createKey(null, createKeySettings))
+            }
+            readerCertifications = certify(keysToCertify.map { it.attestation })
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            // If creation or certification fails, clean up any keys created in SecureArea
+            for (keyInfo in keysToCertify) {
+                try {
+                    secureArea.deleteKey(keyInfo.alias)
+                } catch (deleteEx: Exception) {
+                    if (deleteEx is CancellationException) throw deleteEx
+                    Logger.w(TAG, "Error deleting key after failed certification", deleteEx)
+                }
+            }
+            throw e
+        }
+
+        check(readerCertifications.size == keysToCertify.size) {
+            "Certification result count (${readerCertifications.size}) does not match " +
+                "requested count (${keysToCertify.size})"
+        }
+        Logger.i(TAG, "Retrieved ${readerCertifications.size} new certified keys")
+
+        var n = 0
+        for (readerCertification in readerCertifications) {
+            require(readerCertification.certificates.isNotEmpty()) {
+                "Certificate chain must not be empty"
+            }
+            // Refresh a key once it's past the configured lifetime fraction.
+            val validFrom = readerCertification.certificates[0].validityNotBefore
+            val validUntil = readerCertification.certificates[0].validityNotAfter
+            val validFor = validUntil - validFrom
+            val refreshAt = validFrom + validFor * refreshThresholdFraction
+            val keyInfo = keysToCertify[n++]
+            val certifiedKey = CertifiedKeyRecord(
+                alias = keyInfo.alias,
+                certification = readerCertification,
+                validFrom = validFrom,
+                validUntil = validUntil,
+                refreshAt = refreshAt
+            )
+            val id = certifiedKeysTable.insert(
+                key = null,
+                data = ByteString(certifiedKey.toCbor())
+            )
+            keys[id] = certifiedKey
+        }
+
+        toDelete.forEach {
+            try {
+                secureArea.deleteKey(it.second.alias)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Error deleting key from SecureArea", e)
+            }
+            certifiedKeysTable.delete(it.first)
+            keys.remove(it.first)
+        }
+        return readerCertifications.size
+    }
+
+    /**
+     * Gets a certified key.
+     *
+     * This may involve replenishing the key pool if the number of fresh keys falls below the 50% threshold.
+     *
+     * When the key has been used, call [markKeyAsUsed] to ensure it won't be used again.
+     *
+     * It is allowable to call this function to just prime the pool (i.e. the result isn't immediately used) so
+     * network I/O is reduced for future calls.
+     *
+     * @param atTime the current time, to take into consideration for evicting expired keys.
+     * @return the [CertifiedKey] containing the [KeyInfo] and its [X509CertChain].
+     * @throws IllegalStateException if no valid keys are available.
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(IllegalStateException::class, CancellationException::class)
+    suspend fun getKey(
+        atTime: Instant = Clock.System.now()
+    ): CertifiedKey {
+        lock.withLock {
+            ensureCertifiedKeys()
+            try {
+                ensureReplenished(atTime = atTime)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.w(TAG, "Ignoring error replenishing keys", e)
+            }
+
+            // Return the oldest valid certificate whose key exists in SecureArea
+            val sortedCertifiedKeys = certifiedKeys!!.values
+                .filter { it.validFrom < atTime && atTime < it.validUntil }
+                .sortedBy { it.validFrom }
+            val certifiedKeysTable = storage.getTable(tableSpec)
+            for (certifiedKey in sortedCertifiedKeys) {
+                val keyInfo = try {
+                    secureArea.getKeyInfo(certifiedKey.alias)
+                } catch (e: IllegalArgumentException) {
+                    Logger.w(TAG, "Key ${certifiedKey.alias} missing from SecureArea, removing from certifiedKeys", e)
+                    val entry = certifiedKeys!!.entries.find { it.value.alias == certifiedKey.alias }
+                    if (entry != null) {
+                        certifiedKeysTable.delete(entry.key)
+                        certifiedKeys!!.remove(entry.key)
+                    }
+                    null
+                }
+                if (keyInfo != null) {
+                    return CertifiedKey(keyInfo, certifiedKey.certification)
+                }
+            }
+            throw IllegalStateException("No currently valid keys available")
+        }
+    }
+
+    /**
+     * Marks a key retrieved with [getKey] as used.
+     *
+     * Note that this function may perform network I/O to replenish the key pool if the number of available
+     * fresh keys drops below the threshold.
+     *
+     * @param keyInfo the [KeyInfo] returned from the [getKey] call.
+     * @param atTime the current time, to take into consideration for evicting expired keys.
+     * @throws IllegalArgumentException if no such certified key exists.
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(IllegalArgumentException::class, CancellationException::class)
+    suspend fun markKeyAsUsed(
+        keyInfo: KeyInfo,
+        atTime: Instant = Clock.System.now()
+    ) {
+        markKeyAsUsed(keyInfo.alias, atTime)
+    }
+
+    /**
+     * Marks a key retrieved with [getKey] as used.
+     *
+     * @param certifiedKey the [CertifiedKey] returned from the [getKey] call.
+     * @param atTime the current time, to take into consideration for evicting expired keys.
+     * @throws IllegalArgumentException if no such certified key exists.
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(IllegalArgumentException::class, CancellationException::class)
+    suspend fun markKeyAsUsed(
+        certifiedKey: CertifiedKey,
+        atTime: Instant = Clock.System.now()
+    ) {
+        markKeyAsUsed(certifiedKey.alias, atTime)
+    }
+
+    /**
+     * Marks a key retrieved with [getKey] as used by its alias.
+     *
+     * @param alias the alias of the key to mark as used.
+     * @param atTime the current time, to take into consideration for evicting expired keys.
+     * @throws IllegalArgumentException if no such certified key exists.
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(IllegalArgumentException::class, CancellationException::class)
+    suspend fun markKeyAsUsed(
+        alias: String,
+        atTime: Instant = Clock.System.now()
+    ) {
+        withContext(NonCancellable) {
+            lock.withLock {
+                ensureCertifiedKeys()
+                val entry = certifiedKeys!!.entries.find { (_, certifiedKey) ->
+                    certifiedKey.alias == alias
+                } ?: throw IllegalArgumentException("No such certified key to mark as used")
+
+                // If this was the last key, replenish immediately. If that fails (e.g. no Internet connectivity)
+                // leave the key around but mark that it's already been used
+                if (certifiedKeys!!.size == 1) {
+                    try {
+                        ensureReplenished(atTime = atTime)
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        Logger.w(TAG, "Ignoring error replenishing keys so keeping around last key", e)
+                        return@withLock
+                    }
+                }
+
+                val certifiedKeysTable = storage.getTable(tableSpec)
+                try {
+                    secureArea.deleteKey(entry.value.alias)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    Logger.w(TAG, "Error deleting key from SecureArea", e)
+                }
+                certifiedKeysTable.delete(key = entry.key)
+                certifiedKeys!!.remove(entry.key)
+            }
+        }
+    }
+
+    /**
+     * Clears all managed keys from [SecureArea] and storage.
+     *
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(CancellationException::class)
+    suspend fun clearKeys() {
+        if (numKeys == 0) {
+            return
+        }
+        lock.withLock {
+            clearKeysLocked()
+        }
+    }
+
+    /**
+     * Refreshes certified keys.
+     *
+     * @param atTime the current time.
+     * @return the number of certified keys that were newly certified / replenished.
+     * @throws CancellationException if the coroutine is cancelled.
+     */
+    @Throws(CancellationException::class)
+    suspend fun refreshKeys(atTime: Instant = Clock.System.now()): Int {
+        if (numKeys == 0) {
+            return 0
+        }
+        return lock.withLock {
+            ensureReplenished(atTime = atTime)
+        }
+    }
+
+    companion object {
+        /**
+         * Creates a [CertifiedKeyManager] using a suspend function that certifies a single [KeyAttestation] at a time.
+         *
+         * @param secureArea the [SecureArea] to generate and hold private keys.
+         * @param storage the [Storage] used to persist certification metadata.
+         * @param numKeys the target number of keys to maintain in the pool, defaults to 10.
+         * @param createKeySettings settings passed when creating keys in the [SecureArea].
+         * @param tableName the storage table name for persisting certified keys.
+         * @param certifySingleKey a suspend function that certifies a single [KeyAttestation].
+         * @return a new [CertifiedKeyManager] instance.
+         */
+        fun createWithSingleKeyCertifier(
+            secureArea: SecureArea,
+            storage: Storage = EphemeralStorage(),
+            numKeys: Int = 10,
+            createKeySettings: CreateKeySettings = CreateKeySettings(),
+            tableName: String = "CertifiedKeys",
+            replenishThresholdFraction: Double = 0.5,
+            refreshThresholdFraction: Double = 2.0 / 3.0,
+            certifySingleKey: suspend (key: KeyAttestation) -> X509CertChain
+        ): CertifiedKeyManager = CertifiedKeyManager(
+            secureArea = secureArea,
+            storage = storage,
+            numKeys = numKeys,
+            createKeySettings = createKeySettings,
+            tableName = tableName,
+            replenishThresholdFraction = replenishThresholdFraction,
+            refreshThresholdFraction = refreshThresholdFraction,
+            certify = { keys -> keys.map { certifySingleKey(it) } }
+        )
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/certifiedkeys/CertifiedKeyManagerTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/certifiedkeys/CertifiedKeyManagerTest.kt
@@ -1,0 +1,451 @@
+package org.multipaz.certifiedkeys
+
+import kotlinx.coroutines.test.runTest
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.crypto.AsymmetricKey
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcCurve
+import org.multipaz.crypto.X500Name
+import org.multipaz.crypto.X509CertChain
+import org.multipaz.mdoc.util.MdocUtil
+import org.multipaz.securearea.KeyAttestation
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.software.SoftwareSecureArea
+import org.multipaz.storage.Storage
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.util.truncateToWholeSeconds
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+private data class CertifiedKeyTestData(
+    var currentTime: Instant = Clock.System.now(),
+    var certifyKeysNumCalled: Int = 0,
+    var disableCertifyKeys: Boolean = false
+)
+
+class CertifiedKeyManagerTest {
+
+    private suspend fun certifyReaderKeys(
+        readerKeys: List<KeyAttestation>,
+        readerRootKey: AsymmetricKey.X509Certified,
+        random: Random = Random.Default,
+        atTime: Instant = Clock.System.now(),
+        validFor: Duration = 30.days,
+        jitterSize: Duration = 12.hours
+    ): List<X509CertChain> {
+        return readerKeys.map { readerKey ->
+            // Introduce a bit of jitter so it's not possible for someone to correlate two keys
+            val jitterFrom = jitterSize * random.nextDouble()
+            val jitterUntil = jitterSize * random.nextDouble()
+            val validFrom = atTime - jitterFrom
+            val validUntil = atTime + jitterUntil + validFor
+            val readerCert = MdocUtil.generateReaderCertificate(
+                readerRootKey = readerRootKey,
+                readerKey = readerKey.publicKey,
+                subject = X500Name.fromName("CN=Reader Key"),
+                dnsName = "example.com",
+                serial = ASN1Integer.fromRandom(numBits = 128, random = random),
+                validFrom = validFrom.truncateToWholeSeconds(),
+                validUntil = validUntil.truncateToWholeSeconds(),
+                extensions = emptyList()
+            )
+            X509CertChain(certificates = listOf(readerCert))
+        }
+    }
+
+    private suspend fun createKeyManager(
+        clientStorage: Storage,
+        clientSecureArea: SecureArea,
+        testData: CertifiedKeyTestData,
+        numKeys: Int = 10
+    ): CertifiedKeyManager {
+        val now = Clock.System.now()
+        val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val readerRootCert = MdocUtil.generateReaderRootCertificate(
+            readerRootKey = AsymmetricKey.AnonymousExplicit(readerRootKey),
+            subject = X500Name.fromName("CN=Test Reader Root CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = now - 30.days,
+            validUntil = now + 120.days,
+            crlUrl = "https://www.example.com/crl"
+        )
+        val readerRootKeyCertified = AsymmetricKey.X509CertifiedExplicit(
+            certChain = X509CertChain(certificates = listOf(readerRootCert)),
+            privateKey = readerRootKey
+        )
+
+        return CertifiedKeyManager(
+            secureArea = clientSecureArea,
+            storage = clientStorage,
+            numKeys = numKeys
+        ) { readerKeys ->
+            if (testData.disableCertifyKeys) {
+                throw IllegalStateException("Server is disabled")
+            }
+            testData.certifyKeysNumCalled += 1
+            certifyReaderKeys(
+                readerKeys = readerKeys,
+                readerRootKey = readerRootKeyCertified,
+                atTime = testData.currentTime
+            )
+        }
+    }
+
+    @Test
+    fun testCertifiedKeysHappyPath() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        val (_, certChain) = manager.getKey(atTime = testData.currentTime)
+        certChain.validate(validateAt = testData.currentTime)
+        assertEquals(1, certChain.certificates.size)
+
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Check validity dates, taking into account the jitter
+        val readerCert = certChain.certificates[0]
+        assertTrue(readerCert.validityNotBefore <= testData.currentTime)
+        assertTrue(readerCert.validityNotBefore >= testData.currentTime - 12.hours)
+        assertTrue(readerCert.validityNotAfter >= testData.currentTime + 30.days)
+        assertTrue(readerCert.validityNotAfter <= testData.currentTime + 30.days + 12.hours)
+
+        // Use up just enough keys to cause replenishing on the call following the next call
+        repeat(5) {
+            val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(keyInfo)
+        }
+
+        assertEquals(1, testData.certifyKeysNumCalled)
+        val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(2, testData.certifyKeysNumCalled)
+    }
+
+    @Test
+    fun testCertifiedKeysReplenish() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        // First call should cause 1 certify call
+        val (_, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Unless we use the key, it won't get replenished, so check getKey() can be called 100 times
+        // without causing any additional certify calls.
+        repeat(100) { manager.getKey(atTime = testData.currentTime) }
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Now use up 5 keys, and make sure we saw different keys everytime. Because we only
+        // replenish when we fall below 50% this means no additional certify call is done. Check this.
+        val seenAliases = mutableSetOf<String>()
+        repeat(5) {
+            val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(keyInfo)
+            seenAliases.add(keyInfo.alias)
+        }
+        assertEquals(5, seenAliases.size)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Next time we'll use a key it'll cause a certify call to replenish. Check this.
+        val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+        manager.markKeyAsUsed(keyInfo)
+        assertEquals(2, testData.certifyKeysNumCalled)
+
+        // Check replenishing works ad infinitum (example: 100 uses) and we only do certify calls once half empty.
+        seenAliases.clear()
+        repeat(100) {
+            val (kInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(kInfo)
+            seenAliases.add(kInfo.alias)
+        }
+        assertEquals(100, seenAliases.size)
+        assertEquals(22, testData.certifyKeysNumCalled)
+    }
+
+    @Test
+    fun testCertifiedKeysExpiration() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        // First call should cause 1 certify call
+        val (_, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Advance the time to 15 days past, should not cause certify call.
+        testData.currentTime += 15.days
+        val (_, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Another 6 days to bring us to 21 days. This will cause 1 certify call since all keys will be
+        // replaced after two thirds of 30 days which is 20 days.
+        testData.currentTime += 6.days
+        val (_, certChain) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(2, testData.certifyKeysNumCalled)
+        certChain.validate(validateAt = testData.currentTime)
+        assertEquals(1, certChain.certificates.size)
+
+        // Check validity dates, taking into account the jitter.
+        val readerCert = certChain.certificates[0]
+        assertTrue(readerCert.validityNotBefore <= testData.currentTime)
+        assertTrue(readerCert.validityNotBefore >= testData.currentTime - 12.hours)
+        assertTrue(readerCert.validityNotAfter >= testData.currentTime + 30.days)
+        assertTrue(readerCert.validityNotAfter <= testData.currentTime + 30.days + 12.hours)
+    }
+
+    @Test
+    fun testCertifiedKeysNoInternetConnectivity() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        // First call should cause 1 certify call
+        val (_, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Now simulate not having Internet connectivity and use up all keys. This should work.
+        testData.disableCertifyKeys = true
+        val seenAliases = mutableSetOf<String>()
+        repeat(10) {
+            val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(keyInfo)
+            seenAliases.add(keyInfo.alias)
+        }
+        assertEquals(10, seenAliases.size)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Because we want operations to keep working even if there is no connectivity,
+        // we leave a single key around for reuse.
+        //
+        // This means that if we get another key it'll be the one we just used. Consequently,
+        // `seenAliases` set will not grow. Check this.
+        repeat(10) {
+            val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(keyInfo)
+            seenAliases.add(keyInfo.alias)
+        }
+        assertEquals(10, seenAliases.size)
+
+        // If we advance the clock so even this single key isn't valid anymore, getKey()
+        // will stop working.
+        testData.currentTime += 31.days
+        try {
+            manager.getKey(atTime = testData.currentTime)
+            fail("Expected getKey() to fail")
+        } catch (_: IllegalStateException) {
+            // expected path
+        }
+
+        // If we turn connectivity back on, we'll get fresh never-used keys.
+        testData.disableCertifyKeys = false
+        repeat(10) {
+            val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+            manager.markKeyAsUsed(keyInfo)
+            seenAliases.add(keyInfo.alias)
+        }
+        assertEquals(20, seenAliases.size)
+    }
+
+    @Test
+    fun testCertifiedKeysStaleKeyInSecureArea() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        // Get a key to ensure keys are created
+        val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+
+        // Delete the key directly in SecureArea to simulate a missing key alias in SecureArea
+        clientSecureArea.deleteKey(keyInfo.alias)
+
+        // Calling getKey() should clean up the stale key entry and return a valid key
+        val (newKeyInfo, _) = manager.getKey(atTime = testData.currentTime)
+        assertNotEquals(keyInfo.alias, newKeyInfo.alias)
+    }
+
+    @Test
+    fun testSingleKeyCertifierConstructor() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+
+        val now = Clock.System.now()
+        val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val readerRootCert = MdocUtil.generateReaderRootCertificate(
+            readerRootKey = AsymmetricKey.AnonymousExplicit(readerRootKey),
+            subject = X500Name.fromName("CN=Test Reader Root CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = now - 30.days,
+            validUntil = now + 120.days,
+            crlUrl = "https://www.example.com/crl"
+        )
+        val readerRootKeyCertified = AsymmetricKey.X509CertifiedExplicit(
+            certChain = X509CertChain(certificates = listOf(readerRootCert)),
+            privateKey = readerRootKey
+        )
+
+        val manager = CertifiedKeyManager.createWithSingleKeyCertifier(
+            secureArea = clientSecureArea,
+            storage = clientStorage,
+            numKeys = 5,
+            certifySingleKey = { keyAttestation ->
+                testData.certifyKeysNumCalled += 1
+                val readerCert = MdocUtil.generateReaderCertificate(
+                    readerRootKey = readerRootKeyCertified,
+                    readerKey = keyAttestation.publicKey,
+                    subject = X500Name.fromName("CN=Single Reader Key"),
+                    dnsName = "example.com",
+                    serial = ASN1Integer.fromRandom(numBits = 128),
+                    validFrom = testData.currentTime.truncateToWholeSeconds(),
+                    validUntil = (testData.currentTime + 30.days).truncateToWholeSeconds(),
+                    extensions = emptyList()
+                )
+                X509CertChain(certificates = listOf(readerCert))
+            }
+        )
+
+        val (keyInfo, certChain) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(5, testData.certifyKeysNumCalled)
+        assertEquals(1, certChain.certificates.size)
+        assertEquals(keyInfo.alias, manager.getKey(atTime = testData.currentTime).alias)
+    }
+
+    @Test
+    fun testClearKeys() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val manager = createKeyManager(clientStorage, clientSecureArea, testData)
+
+        val (keyInfo, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        manager.clearKeys()
+
+        // SecureArea should no longer have the key
+        try {
+            clientSecureArea.getKeyInfo(keyInfo.alias)
+            fail("Expected getKeyInfo to throw IllegalArgumentException after clearKeys")
+        } catch (_: IllegalArgumentException) {
+            // expected path
+        }
+
+        // Getting a key now should replenish anew
+        val (newKeyInfo, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(2, testData.certifyKeysNumCalled)
+        assertNotEquals(keyInfo.alias, newKeyInfo.alias)
+    }
+
+    @Test
+    fun testCustomReplenishThresholdFraction() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val now = Clock.System.now()
+        val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val readerRootCert = MdocUtil.generateReaderRootCertificate(
+            readerRootKey = AsymmetricKey.AnonymousExplicit(readerRootKey),
+            subject = X500Name.fromName("CN=Test Reader Root CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = now - 30.days,
+            validUntil = now + 120.days,
+            crlUrl = "https://www.example.com/crl"
+        )
+        val readerRootKeyCertified = AsymmetricKey.X509CertifiedExplicit(
+            certChain = X509CertChain(certificates = listOf(readerRootCert)),
+            privateKey = readerRootKey
+        )
+
+        // Configure replenishThresholdFraction = 0.8 on 10 keys (triggers when <= 8 keys left)
+        val manager = CertifiedKeyManager(
+            secureArea = clientSecureArea,
+            storage = clientStorage,
+            numKeys = 10,
+            replenishThresholdFraction = 0.8
+        ) { readerKeys ->
+            testData.certifyKeysNumCalled += 1
+            certifyReaderKeys(
+                readerKeys = readerKeys,
+                readerRootKey = readerRootKeyCertified,
+                atTime = testData.currentTime
+            )
+        }
+
+        // First call generates 10 keys
+        val (k1, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+        manager.markKeyAsUsed(k1) // 9 left (9 > 8: no replenish)
+
+        val (k2, _) = manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+        manager.markKeyAsUsed(k2) // 8 left (8 > 8 is false: next getKey will replenish!)
+
+        assertEquals(1, testData.certifyKeysNumCalled)
+        manager.getKey(atTime = testData.currentTime)
+        assertEquals(2, testData.certifyKeysNumCalled)
+    }
+
+    @Test
+    fun testCustomRefreshThresholdFraction() = runTest {
+        val testData = CertifiedKeyTestData()
+        val clientStorage = EphemeralStorage()
+        val clientSecureArea = SoftwareSecureArea.create(clientStorage)
+        val now = Clock.System.now()
+        val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val readerRootCert = MdocUtil.generateReaderRootCertificate(
+            readerRootKey = AsymmetricKey.AnonymousExplicit(readerRootKey),
+            subject = X500Name.fromName("CN=Test Reader Root CA"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
+            validFrom = now - 30.days,
+            validUntil = now + 120.days,
+            crlUrl = "https://www.example.com/crl"
+        )
+        val readerRootKeyCertified = AsymmetricKey.X509CertifiedExplicit(
+            certChain = X509CertChain(certificates = listOf(readerRootCert)),
+            privateKey = readerRootKey
+        )
+
+        // Configure refreshThresholdFraction = 0.4 on 30-day keys (refresh after 12 days)
+        val manager = CertifiedKeyManager(
+            secureArea = clientSecureArea,
+            storage = clientStorage,
+            numKeys = 10,
+            refreshThresholdFraction = 0.4
+        ) { readerKeys ->
+            testData.certifyKeysNumCalled += 1
+            certifyReaderKeys(
+                readerKeys = readerKeys,
+                readerRootKey = readerRootKeyCertified,
+                atTime = testData.currentTime
+            )
+        }
+
+        manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Advance by 10 days (less than 12 days: no replenish)
+        testData.currentTime += 10.days
+        manager.getKey(atTime = testData.currentTime)
+        assertEquals(1, testData.certifyKeysNumCalled)
+
+        // Advance by another 4 days (total 14 days > 12 days: triggers replenish)
+        testData.currentTime += 4.days
+        manager.getKey(atTime = testData.currentTime)
+        assertEquals(2, testData.certifyKeysNumCalled)
+    }
+}


### PR DESCRIPTION
Add an abstraction for managing pools of keys generated locally in a secure area and certified by a certifying authority:

- In `CertifiedKeyManager`, implement a key pool manager backed by any `SecureArea` and `Storage` implementation. Support batch certification of locally generated keys, proactive replenishment when the pool of fresh keys falls below 50%, proactive key retirement after two thirds of certificate validity, resilient offline operation by retaining the last valid key during network outages, and self-healing cleanup of stale keys removed from the underlying secure area.
- Expose `CertifiedKeyManager.createWithSingleKeyCertifier()` to support single-key certification callbacks without JVM method signature clashes.
- In `CertifiedKeyManagerTest`, add comprehensive multiplatform unit tests covering happy path retrieval, batch replenishment, key expiration, offline degradation, stale key cleanup, single-key certifier factory creation, and pool clearing.

Fixes #1977.

Test: Ran ./gradlew :multipaz:jvmTest
Test: Ran ./gradlew :multipaz:assemble
Test: Ran ./gradlew detekt
