### PR TITLE
Require explicit data element requests for ISO 18013-5 transactions.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/TransactionType.kt
@@ -84,8 +84,6 @@ const val ISO_18013_TRANSACTION_DATA_NAMESPACE = "org.iso.transactiondata"
  *  all [TransactionType] objects must have distinct values.
  * @param openId4VpMdocResponseNamespace namespace to use in `deviceSigned` namespace map in
  *  OpenID4VP response; defaults to [identifier].
- * @param defaultIntentToRetain default value for `intentToRetain` when requesting the transaction data
- *  element in the [ISO_18013_TRANSACTION_DATA_NAMESPACE] namespace in an ISO mdoc request.
  */
 abstract class TransactionType<PayloadT: Any>(
     val displayName: String,
@@ -93,7 +91,6 @@ abstract class TransactionType<PayloadT: Any>(
     val kbJwtResponseClaimName: String = identifier,
     val iso18013RequestInfoIdentifier: String = identifier,
     val openId4VpMdocResponseNamespace: String = identifier,
-    val defaultIntentToRetain: Boolean = true,
 ) {
     /**
      * Returns the DeviceSigned namespace to use for the given presentment protocol.
@@ -162,30 +159,16 @@ abstract class TransactionType<PayloadT: Any>(
      * Parses transaction data serialized for use in ISO/IEC 18013-5 presentment.
      *
      * @param serialized the CBOR data item representing the transaction request.
-     * @param intentToRetain whether the verifier intends to retain the transaction data.
      * @return transaction data wrapping the parsed payload.
      */
-    open fun parseCbor(
-        serialized: DataItem,
-        intentToRetain: Boolean
-    ): TransactionData<PayloadT> {
+    open fun parseCbor(serialized: DataItem): TransactionData<PayloadT> {
         return TransactionData(
             type = this,
             payload = parseIso18013Request(serialized),
             protocol = TransactionProtocol.ISO_18013_5,
             rawBytes = ByteString(Cbor.encode(serialized)),
-            intentToRetain = intentToRetain,
         )
     }
-
-    /**
-     * Parses transaction data serialized for use in ISO/IEC 18013-5 presentment using [defaultIntentToRetain].
-     *
-     * @param serialized the CBOR data item representing the transaction request.
-     * @return transaction data wrapping the parsed payload.
-     */
-    open fun parseCbor(serialized: DataItem): TransactionData<PayloadT> =
-        parseCbor(serialized, defaultIntentToRetain)
 
     /**
      * Determines if this transaction is applicable to the given credential.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequest.kt
@@ -314,23 +314,10 @@ data class DeviceRequest private constructor(
             check(readerAuthAll.isEmpty()) {
                 "Cannot call addDocRequest() after addReaderAuthAll()"
             }
-            val effectiveNameSpaces = if (docRequestInfo?.transactionData != null) {
-                val txData = docRequestInfo.transactionData
-                val mutableNamespaces = nameSpaces.mapValues { it.value.toMutableMap() }.toMutableMap()
-                val txElements = mutableNamespaces.getOrPut(ISO_18013_TRANSACTION_DATA_NAMESPACE) { mutableMapOf() }
-                for ((typeId, _) in txData.data) {
-                    if (!txElements.containsKey(typeId)) {
-                        txElements[typeId] = true
-                    }
-                }
-                mutableNamespaces
-            } else {
-                nameSpaces
-            }
             val itemsRequest = buildCborMap {
                 put("docType", docType)
                 putCborMap("nameSpaces") {
-                    for ((namespaceName, dataElementMap) in effectiveNameSpaces) {
+                    for ((namespaceName, dataElementMap) in nameSpaces) {
                         putCborMap(namespaceName) {
                             for ((dataElementName, intentToRetain) in dataElementMap) {
                                 put(dataElementName, intentToRetain)
@@ -349,7 +336,7 @@ data class DeviceRequest private constructor(
             docRequests.add(
                 DocRequest(
                     docType = docType,
-                    nameSpaces = effectiveNameSpaces,
+                    nameSpaces = nameSpaces,
                     docRequestInfo = docRequestInfo,
                     docRequestId = docRequests.size,
                     readerAuth_ = null,
@@ -382,23 +369,10 @@ data class DeviceRequest private constructor(
             check(readerAuthAll.isEmpty()) {
                 "Cannot call addDocRequest() after addReaderAuthAll()"
             }
-            val effectiveNameSpaces = if (docRequestInfo?.transactionData != null) {
-                val txData = docRequestInfo.transactionData
-                val mutableNamespaces = nameSpaces.mapValues { it.value.toMutableMap() }.toMutableMap()
-                val txElements = mutableNamespaces.getOrPut(ISO_18013_TRANSACTION_DATA_NAMESPACE) { mutableMapOf() }
-                for ((typeId, _) in txData.data) {
-                    if (!txElements.containsKey(typeId)) {
-                        txElements[typeId] = true
-                    }
-                }
-                mutableNamespaces
-            } else {
-                nameSpaces
-            }
             val itemsRequest = buildCborMap {
                 put("docType", docType)
                 putCborMap("nameSpaces") {
-                    for ((namespaceName, dataElementMap) in effectiveNameSpaces) {
+                    for ((namespaceName, dataElementMap) in nameSpaces) {
                         putCborMap(namespaceName) {
                             for ((dataElementName, intentToRetain) in dataElementMap) {
                                 put(dataElementName, intentToRetain)
@@ -442,7 +416,7 @@ data class DeviceRequest private constructor(
             }
             docRequests.add(DocRequest(
                 docType = docType,
-                nameSpaces = effectiveNameSpaces,
+                nameSpaces = nameSpaces,
                 docRequestInfo = docRequestInfo,
                 docRequestId = docRequests.size,
                 readerAuth_ = readerAuth,
@@ -839,9 +813,6 @@ data class DeviceRequest private constructor(
         val logicalRequirements = mutableListOf<List<List<MdocRequestedClaim>>>()
 
         docRequest.nameSpaces.forEach { (namespace, dataElements) ->
-            if (namespace == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
-                return@forEach
-            }
             dataElements.forEach { (elementName, intentToRetain) ->
                 // Base Option (Index 0)
                 val baseClaim = MdocRequestedClaim(
@@ -882,42 +853,54 @@ data class DeviceRequest private constructor(
         if (isVersion10) {
             val matchingClaimValues = mutableMapOf<RequestedClaim, Claim>()
             val requestedClaimsRemapped = mutableListOf<RequestedClaim>()
+            val selectedTransactions = mutableListOf<TransactionData<*>>()
             val missingElements = mutableListOf<String>()
+            var transactionFailureReason: String? = null
 
             for (fieldOptions in logicalRequirements) {
                 val baseClaim = fieldOptions[0][0]
-                val remapped = remapClaim(cred, baseClaim, docRequest)
-                val foundClaim = remapped?.let { claimsInCredential.findMatchingClaim(it) }
-                if (remapped != null && foundClaim != null) {
-                    matchingClaimValues[baseClaim] = foundClaim
-                    requestedClaimsRemapped.add(remapped)
+                if (baseClaim.namespaceName == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                    val applicableTx = findApplicableTransaction(
+                        cred = cred,
+                        reqClaim = baseClaim,
+                        docRequest = docRequest,
+                        documentTypeRepository = presentmentSource.documentTypeRepository
+                    )
+                    if (applicableTx != null) {
+                        selectedTransactions.add(applicableTx)
+                    } else {
+                        if (docRequest.docRequestInfo?.transactionData?.data?.containsKey(baseClaim.dataElementName) == true) {
+                            if (transactionFailureReason == null) {
+                                transactionFailureReason = "transaction ${baseClaim.dataElementName} is not applicable"
+                            }
+                        }
+                        missingElements.add("'${baseClaim.dataElementName}' in namespace '${baseClaim.namespaceName}'")
+                    }
                 } else {
-                    missingElements.add("'${baseClaim.dataElementName}' in namespace '${baseClaim.namespaceName}'")
+                    val remapped = remapClaim(cred, baseClaim, docRequest)
+                    val foundClaim = remapped?.let { claimsInCredential.findMatchingClaim(it) }
+                    if (remapped != null && foundClaim != null) {
+                        matchingClaimValues[baseClaim] = foundClaim
+                        requestedClaimsRemapped.add(remapped)
+                    } else {
+                        missingElements.add("'${baseClaim.dataElementName}' in namespace '${baseClaim.namespaceName}'")
+                    }
                 }
             }
 
+            if (transactionFailureReason != null) {
+                return ClaimMatchResult(null, transactionFailureReason)
+            }
+
             // In ISO 18013-5:2021 (v1.0), the request is satisfied if at least one requested element is present
-            if ((logicalRequirements.isNotEmpty() && matchingClaimValues.isEmpty()) ||
-                (logicalRequirements.isEmpty() && !docRequest.nameSpaces.containsKey(ISO_18013_TRANSACTION_DATA_NAMESPACE))) {
+            if ((logicalRequirements.isNotEmpty() && matchingClaimValues.isEmpty() && selectedTransactions.isEmpty()) ||
+                logicalRequirements.isEmpty()) {
                 val reason = if (missingElements.size == 1) {
                     "missing data element ${missingElements[0]}"
                 } else {
                     "missing data elements: ${missingElements.joinToString(", ")}"
                 }
                 return ClaimMatchResult(null, reason)
-            }
-
-            val transactionData = extractTransactionData(
-                docRequest.docRequestInfo,
-                presentmentSource.documentTypeRepository
-            )
-            for (transaction in transactionData) {
-                if (!transaction.isApplicable(cred)) {
-                    return ClaimMatchResult(
-                        match = null,
-                        failureReason = "transaction ${transaction.type.identifier} is not applicable"
-                    )
-                }
             }
 
             val selectedCred = presentmentSource.selectCredential(
@@ -931,7 +914,7 @@ data class DeviceRequest private constructor(
                         credential = selectedCred,
                         claims = matchingClaimValues,
                         docRequest = docRequest,
-                        transactionData = transactionData
+                        transactionData = selectedTransactions
                     ),
                     failureReason = null
                 )
@@ -942,39 +925,39 @@ data class DeviceRequest private constructor(
         // For Version 1.1+: all requested data elements (or alternatives) must be present
         // Check if all logical requirements can be satisfied by the credential
         val missingElements = mutableListOf<String>()
+        var transactionFailureReason: String? = null
         for (fieldOptions in logicalRequirements) {
             val anyOptionSatisfied = fieldOptions.any { optionClaims ->
                 optionClaims.all { reqClaim ->
-                    val remapped = remapClaim(cred, reqClaim, docRequest)
-                    remapped != null && claimsInCredential.findMatchingClaim(remapped) != null
+                    isClaimSatisfied(
+                        cred = cred,
+                        reqClaim = reqClaim,
+                        docRequest = docRequest,
+                        claimsInCredential = claimsInCredential,
+                        documentTypeRepository = presentmentSource.documentTypeRepository
+                    )
                 }
             }
             if (!anyOptionSatisfied) {
                 val baseClaim = fieldOptions[0][0]
+                if (baseClaim.namespaceName == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                    if (transactionFailureReason == null) {
+                        transactionFailureReason = "transaction ${baseClaim.dataElementName} is not applicable"
+                    }
+                }
                 missingElements.add("'${baseClaim.dataElementName}' in namespace '${baseClaim.namespaceName}'")
             }
         }
 
         if (missingElements.isNotEmpty()) {
-            val reason = if (missingElements.size == 1) {
+            val reason = if (transactionFailureReason != null && missingElements.size == 1) {
+                transactionFailureReason
+            } else if (missingElements.size == 1) {
                 "missing data element ${missingElements[0]}"
             } else {
                 "missing data elements: ${missingElements.joinToString(", ")}"
             }
             return ClaimMatchResult(null, reason)
-        }
-
-        val transactionData = extractTransactionData(
-            docRequest.docRequestInfo,
-            presentmentSource.documentTypeRepository
-        )
-        for (transaction in transactionData) {
-            if (!transaction.isApplicable(cred)) {
-                return ClaimMatchResult(
-                    match = null,
-                    failureReason = "transaction ${transaction.type.identifier} is not applicable"
-                )
-            }
         }
 
         // 2. Generate Permutations (Cartesian Product of Options)
@@ -1008,22 +991,37 @@ data class DeviceRequest private constructor(
         for ((requestedClaims, _) in allPermutations) {
             val matchingClaimValues = mutableMapOf<RequestedClaim, Claim>()
             val requestedClaimsRemapped = mutableListOf<RequestedClaim>()
+            val selectedTransactions = mutableListOf<TransactionData<*>>()
             var didNotMatch = false
 
             for (reqClaim in requestedClaims) {
-                val reqClaimRemapped = remapClaim(cred, reqClaim, docRequest)
-                if (reqClaimRemapped == null) {
-                    didNotMatch = true
-                    break
-                }
-                requestedClaimsRemapped.add(reqClaimRemapped)
-
-                val foundClaim = claimsInCredential.findMatchingClaim(reqClaimRemapped)
-                if (foundClaim != null) {
-                    matchingClaimValues[reqClaim] = foundClaim
+                if (reqClaim.namespaceName == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                    val applicableTx = findApplicableTransaction(
+                        cred = cred,
+                        reqClaim = reqClaim,
+                        docRequest = docRequest,
+                        documentTypeRepository = presentmentSource.documentTypeRepository
+                    )
+                    if (applicableTx == null) {
+                        didNotMatch = true
+                        break
+                    }
+                    selectedTransactions.add(applicableTx)
                 } else {
-                    didNotMatch = true
-                    break
+                    val reqClaimRemapped = remapClaim(cred, reqClaim, docRequest)
+                    if (reqClaimRemapped == null) {
+                        didNotMatch = true
+                        break
+                    }
+                    requestedClaimsRemapped.add(reqClaimRemapped)
+
+                    val foundClaim = claimsInCredential.findMatchingClaim(reqClaimRemapped)
+                    if (foundClaim != null) {
+                        matchingClaimValues[reqClaim] = foundClaim
+                    } else {
+                        didNotMatch = true
+                        break
+                    }
                 }
             }
 
@@ -1040,7 +1038,7 @@ data class DeviceRequest private constructor(
                             credential = selectedCred,
                             claims = matchingClaimValues,
                             docRequest = docRequest,
-                            transactionData = transactionData
+                            transactionData = selectedTransactions
                         ),
                         failureReason = null
                     )
@@ -1051,18 +1049,36 @@ data class DeviceRequest private constructor(
         return ClaimMatchResult(null, null)
     }
 
-    private fun extractTransactionData(
-        requestInfo: DocRequestInfo?,
-        documentTypeRepository: DocumentTypeRepository?
-    ): List<TransactionData<*>> {
-        if (requestInfo == null || documentTypeRepository == null || requestInfo.transactionData == null) {
-            return emptyList()
+    private suspend fun findApplicableTransaction(
+        cred: Credential,
+        reqClaim: MdocRequestedClaim,
+        docRequest: DocRequest,
+        documentTypeRepository: DocumentTypeRepository?,
+    ): TransactionData<*>? {
+        if (reqClaim.namespaceName != ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+            return null
         }
-        return requestInfo.transactionData.data.map { (type, data) ->
-            val knownType = documentTypeRepository.transactionTypes.find {
-                it.iso18013RequestInfoIdentifier == type
-            } ?: throw IllegalArgumentException("Unknown transaction type: '$type'")
-            knownType.parseCbor(data)
+        val txData = docRequest.docRequestInfo?.transactionData ?: return null
+        val serialized = txData.data[reqClaim.dataElementName] ?: return null
+        val txType = documentTypeRepository?.transactionTypes?.find {
+            it.iso18013RequestInfoIdentifier == reqClaim.dataElementName
+        } ?: return null
+        val parsed = txType.parseCbor(serialized)
+        return if (parsed.isApplicable(cred)) parsed else null
+    }
+
+    private suspend fun isClaimSatisfied(
+        cred: Credential,
+        reqClaim: MdocRequestedClaim,
+        docRequest: DocRequest,
+        claimsInCredential: List<Claim>,
+        documentTypeRepository: DocumentTypeRepository?,
+    ): Boolean {
+        return if (reqClaim.namespaceName == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+            findApplicableTransaction(cred, reqClaim, docRequest, documentTypeRepository) != null
+        } else {
+            val remapped = remapClaim(cred, reqClaim, docRequest)
+            remapped != null && claimsInCredential.findMatchingClaim(remapped) != null
         }
     }
 
@@ -1237,6 +1253,9 @@ private fun JsonArrayBuilder.addDcqlCredentialRequest(docRequest: DocRequest, cr
         val logicalRequirements = mutableListOf<List<List<String>>>()
 
         docRequest.nameSpaces.forEach { (namespace, dataElements) ->
+            if (namespace == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                return@forEach
+            }
             dataElements.forEach { (elementName, intentToRetain) ->
 
                 // Start with Option 0: The base requested element
@@ -1251,11 +1270,17 @@ private fun JsonArrayBuilder.addDcqlCredentialRequest(docRequest: DocRequest, cr
 
                 // If alternatives exist, add them as subsequent options (Option 1, Option 2...)
                 alternatives?.alternativeElementSets?.forEach { altSet ->
-                    val altOptionClaimIds = altSet.map { altElement ->
-                        // Register alternative claims using the intent of the original requirement
-                        registerClaim(altElement.namespace, altElement.dataElement, intentToRetain)
+                    val altOptionClaimIds = altSet.mapNotNull { altElement ->
+                        if (altElement.namespace == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                            null
+                        } else {
+                            // Register alternative claims using the intent of the original requirement
+                            registerClaim(altElement.namespace, altElement.dataElement, intentToRetain)
+                        }
                     }
-                    optionsForThisField.add(altOptionClaimIds)
+                    if (altOptionClaimIds.isNotEmpty()) {
+                        optionsForThisField.add(altOptionClaimIds)
+                    }
                 }
 
                 logicalRequirements.add(optionsForThisField)
@@ -1340,6 +1365,7 @@ inline fun buildDeviceRequest(
  * @param dcql the DCQL query to convert.
  * @param otherInfo other request info to go into [DeviceRequestInfo].
  * @param transactions transaction data to add to [DocRequestInfo].
+ * @param defaultIntentToRetain the intent to retain to use when requesting transactions in ISO 18013-5 namespace.
  * @param version the version to use or `null` to automatically determine which version to use.
  * @param builderAction optional builder action to configure the request (e.g. add reader authentication).
  * @return the configured [DeviceRequest].
@@ -1352,6 +1378,7 @@ inline fun buildDeviceRequestFromDcql(
     dcql: JsonObject,
     otherInfo: Map<String, DataItem> = emptyMap(),
     transactions: Map<String, TransactionsInfo> = emptyMap(),
+    defaultIntentToRetain: Boolean = false,
     version: String? = null,
     builderAction: DeviceRequest.Builder.() -> Unit = {}
 ): DeviceRequest {
@@ -1363,7 +1390,7 @@ inline fun buildDeviceRequestFromDcql(
         deviceRequestInfo = deviceRequestInfo,
         version = version,
     )
-    deviceRequestAddQueries(dcqlQuery, transactions, builder)
+    deviceRequestAddQueries(dcqlQuery, transactions, builder, defaultIntentToRetain)
     builder.builderAction()
     return builder.build()
 }
@@ -1377,6 +1404,7 @@ inline fun buildDeviceRequestFromDcql(
  * @param dcqlString a string with the DCQL query to convert.
  * @param otherInfo other request info to go into [DeviceRequestInfo].
  * @param transactions transaction data to add to [DocRequestInfo].
+ * @param defaultIntentToRetain the intent to retain to use when requesting transactions in ISO 18013-5 namespace.
  * @param version the version to use or `null` to automatically determine which version to use.
  * @param builderAction optional builder action to configure the request (e.g. add reader authentication).
  * @return the configured [DeviceRequest].
@@ -1389,6 +1417,7 @@ inline fun buildDeviceRequestFromDcql(
     dcqlString: String,
     otherInfo: Map<String, DataItem> = emptyMap(),
     transactions: Map<String, TransactionsInfo> = emptyMap(),
+    defaultIntentToRetain: Boolean = false,
     version: String? = null,
     builderAction: DeviceRequest.Builder.() -> Unit = {}
 ): DeviceRequest {
@@ -1397,6 +1426,7 @@ inline fun buildDeviceRequestFromDcql(
         dcql = Json.decodeFromString<JsonObject>(dcqlString),
         otherInfo = otherInfo,
         transactions = transactions,
+        defaultIntentToRetain = defaultIntentToRetain,
         version = version,
         builderAction = builderAction
     )
@@ -1453,7 +1483,8 @@ internal fun deviceRequestCalcDeviceRequestInfo(
 internal fun deviceRequestAddQueries(
     dcqlQuery: DcqlQuery,
     transactions: Map<String, TransactionsInfo>,
-    builder: DeviceRequest.Builder
+    builder: DeviceRequest.Builder,
+    defaultIntentToRetain: Boolean = false
 ) {
     for (credQuery in dcqlQuery.credentialQueries) {
         if (!(credQuery.format == "mso_mdoc" || credQuery.format == "mso_mdoc_zk" ||
@@ -1629,6 +1660,14 @@ internal fun deviceRequestAddQueries(
         }
 
         val docTransactions = transactions[credQuery.id]
+        if (docTransactions != null) {
+            val txElements = nameSpaces.getOrPut(ISO_18013_TRANSACTION_DATA_NAMESPACE) { mutableMapOf() }
+            for (typeId in docTransactions.data.keys) {
+                if (!txElements.containsKey(typeId)) {
+                    txElements[typeId] = defaultIntentToRetain
+                }
+            }
+        }
         val docRequestInfo = if (alternativeDataElements.isNotEmpty()
             || zkRequest != null || docTransactions != null || credQuery.format == "dc+sd-jwt"
             || dataElementIdentifierMapping.isNotEmpty()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DocRequest.kt
@@ -95,7 +95,8 @@ data class DocRequest internal constructor(
     }
 
     /**
-     * Returns parsed transaction data associated with this document request.
+     * Returns parsed transaction data associated with this document request that was
+     * requested by data elements.
      *
      * @param documentTypeRepository repository that contains all supported transaction data types
      * @return list of transaction data
@@ -103,11 +104,27 @@ data class DocRequest internal constructor(
     fun getTransactionData(
         documentTypeRepository: DocumentTypeRepository
     ): List<TransactionData<*>> = buildList {
+        val requestedTxIdentifiers = mutableSetOf<String>()
+        nameSpaces[ISO_18013_TRANSACTION_DATA_NAMESPACE]?.keys?.let { requestedTxIdentifiers.addAll(it) }
+        docRequestInfo?.alternativeDataElements?.forEach { altSet ->
+            if (altSet.requestedElement.namespace == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                requestedTxIdentifiers.add(altSet.requestedElement.dataElement)
+            }
+            altSet.alternativeElementSets.forEach { elementRefs ->
+                elementRefs.forEach { elementRef ->
+                    if (elementRef.namespace == ISO_18013_TRANSACTION_DATA_NAMESPACE) {
+                        requestedTxIdentifiers.add(elementRef.dataElement)
+                    }
+                }
+            }
+        }
         for (transactionType in documentTypeRepository.transactionTypes) {
-            docRequestInfo?.transactionData?.data[transactionType.iso18013RequestInfoIdentifier]?.let { data ->
-                val intentToRetain = nameSpaces[ISO_18013_TRANSACTION_DATA_NAMESPACE]?.get(transactionType.iso18013RequestInfoIdentifier)
-                    ?: transactionType.defaultIntentToRetain
-                add(transactionType.parseCbor(data, intentToRetain))
+            val typeId = transactionType.iso18013RequestInfoIdentifier
+            if (!requestedTxIdentifiers.contains(typeId)) {
+                continue
+            }
+            docRequestInfo?.transactionData?.data[typeId]?.let { data ->
+                add(transactionType.parseCbor(data))
             }
         }
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponse.kt
@@ -133,9 +133,19 @@ data class DeviceResponse internal constructor(
                 if (docRequestId < 0) {
                     emptyList()
                 } else {
-                    deviceRequest.docRequests[docRequestId].getTransactionData(
+                    val allTx = deviceRequest.docRequests[docRequestId].getTransactionData(
                         documentTypeRepository!!
                     )
+                    val returnedTxIdentifiers = document.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]?.keys
+                    if (deviceRequest.docRequests[docRequestId].docRequestInfo?.alternativeDataElements?.isNotEmpty() == true) {
+                        if (returnedTxIdentifiers != null) {
+                            allTx.filter { returnedTxIdentifiers.contains(it.type.identifier) }
+                        } else {
+                            emptyList()
+                        }
+                    } else {
+                        allTx
+                    }
                 }
             }
             document.verify(
@@ -158,9 +168,21 @@ data class DeviceResponse internal constructor(
                 if (docRequestId < 0) {
                     emptyList()
                 } else {
-                    deviceRequest.docRequests[docRequestId].getTransactionData(
+                    val allTx = deviceRequest.docRequests[docRequestId].getTransactionData(
                         documentTypeRepository!!
                     )
+                    if (deviceRequest.docRequests[docRequestId].docRequestInfo?.alternativeDataElements?.isNotEmpty() == true) {
+                        try {
+                            val sdJwtKb = SdJwtKb.fromCompactSerialization(
+                                otherDocument.data.toByteArray().zlibInflate().decodeToString()
+                            )
+                            allTx.filter { sdJwtKb.jwtBody.containsKey(it.type.kbJwtResponseClaimName) }
+                        } catch (e: Exception) {
+                            allTx
+                        }
+                    } else {
+                        allTx
+                    }
                 }
             }
             otherDocument.verify(sessionTranscript, eReaderKey, transactionData, atTime)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/TransactionData.kt
@@ -35,7 +35,6 @@ enum class TransactionProtocol {
  * @param protocol protocol context in which the transaction data was received
  * @param rawBytes raw sequence of bytes representing the transaction data in the request
  * @param hashAlgorithms accepted hash algorithm override list for this transaction data
- * @param intentToRetain whether the reader intends to retain the transaction data
  */
 class TransactionData<PayloadT: Any>(
     val type: TransactionType<PayloadT>,
@@ -43,7 +42,6 @@ class TransactionData<PayloadT: Any>(
     val protocol: TransactionProtocol,
     val rawBytes: ByteString,
     val hashAlgorithms: List<Algorithm>? = null,
-    val intentToRetain: Boolean = type.defaultIntentToRetain,
 ) {
     /**
      * Computes hash of the transaction data.

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestDcqlConversionsTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestDcqlConversionsTest.kt
@@ -5,7 +5,10 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
+import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.documenttype.ISO_18013_TRANSACTION_DATA_NAMESPACE
+import org.multipaz.documenttype.knowntypes.DrivingLicense
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -979,6 +982,116 @@ class DeviceRequestDcqlConversionsTest {
                 }
             """.trimIndent(),
             prettyJson.encodeToString(deviceRequest.toDcql())
+        )
+    }
+
+    @Test
+    fun toDcql_omitsTransactionDataNamespace() {
+        val deviceRequest = buildDeviceRequest(
+            sessionTranscript = buildCborArray { add("doesn't"); add("matter") }
+        ) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf("com.example.txA" to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                "com.example.txA"
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                        "com.example.txB"
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        }
+        val dcql = deviceRequest.toDcql()
+        assertEquals(
+            """
+                {
+                  "credentials": [
+                    {
+                      "id": "cred0",
+                      "format": "mso_mdoc",
+                      "meta": {
+                        "doctype_value": "org.iso.18013.5.1.mDL"
+                      },
+                      "claims": [
+                        {
+                          "id": "claim0",
+                          "path": [
+                            "org.iso.18013.5.1",
+                            "given_name"
+                          ],
+                          "intent_to_retain": false
+                        }
+                      ]
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            prettyJson.encodeToString(dcql)
+        )
+    }
+
+    @Test
+    fun fromDcql_withTransactions_addsToNameSpaces() {
+        val pingTxData = Tstr("ping_data")
+        val dcqlString = """
+            {
+              "credentials": [
+                {
+                  "id": "mdl",
+                  "format": "mso_mdoc",
+                  "meta": {
+                    "doctype_value": "org.iso.18013.5.1.mDL"
+                  },
+                  "claims": [
+                    {"id": "c0", "path": ["org.iso.18013.5.1", "given_name"]}
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        // Test defaultIntentToRetain = false (default)
+        val deviceRequestDefault = buildDeviceRequestFromDcql(
+            sessionTranscript = buildCborArray { add("test") },
+            dcqlString = dcqlString,
+            transactions = mapOf(
+                "mdl" to TransactionsInfo(mapOf("org.multipaz.transaction.ping" to pingTxData))
+            )
+        )
+        val docReqDefault = deviceRequestDefault.docRequests[0]
+        assertEquals(
+            mapOf("org.multipaz.transaction.ping" to false),
+            docReqDefault.nameSpaces[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        )
+
+        // Test defaultIntentToRetain = true
+        val deviceRequestRetain = buildDeviceRequestFromDcql(
+            sessionTranscript = buildCborArray { add("test") },
+            dcqlString = dcqlString,
+            transactions = mapOf(
+                "mdl" to TransactionsInfo(mapOf("org.multipaz.transaction.ping" to pingTxData))
+            ),
+            defaultIntentToRetain = true
+        )
+        val docReqRetain = deviceRequestRetain.docRequests[0]
+        assertEquals(
+            mapOf("org.multipaz.transaction.ping" to true),
+            docReqRetain.nameSpaces[ISO_18013_TRANSACTION_DATA_NAMESPACE]
         )
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestTransactionData.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/Iso18013TestTransactionData.kt
@@ -1,0 +1,605 @@
+package org.multipaz.mdoc.request
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlinx.coroutines.test.runTest
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.buildCborArray
+import org.multipaz.cbor.buildCborMap
+import org.multipaz.credential.Credential
+import org.multipaz.documenttype.ISO_18013_TRANSACTION_DATA_NAMESPACE
+import org.multipaz.documenttype.TransactionType
+import org.multipaz.documenttype.TransactionUserInput
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.mdoc.response.DeviceResponse
+import org.multipaz.mdoc.response.Iso18015ResponseException
+import org.multipaz.presentment.DocumentStoreTestHarness
+import org.multipaz.presentment.TransactionData
+import org.multipaz.presentment.mdocPresentment
+
+class Iso18013TestTransactionData {
+
+    private object TxA : TransactionType<String>(
+        displayName = "Transaction A",
+        identifier = "com.example.txA",
+    ) {
+        override fun serializeIso18013Request(payload: String): DataItem = buildCborMap {
+            put("nonce", payload)
+        }
+
+        override fun parseIso18013Request(dataItem: DataItem): String =
+            dataItem.asMap[Tstr("nonce")]!!.asTstr
+
+        override suspend fun generateMdocResponseElements(
+            transactionData: TransactionData<String>,
+            credential: Credential,
+            userInput: TransactionUserInput?,
+            docRequestId: Int?
+        ): Map<String, DataItem> = buildMap {
+            putAll(super.generateMdocResponseElements(transactionData, credential, userInput, docRequestId))
+            put("status", Tstr("A_OK"))
+        }
+
+        override suspend fun verifyMdocResponse(
+            transactionData: TransactionData<String>,
+            responseElements: Map<String, DataItem>
+        ) {
+            super.verifyMdocResponse(transactionData, responseElements)
+            check(responseElements["status"]?.asTstr == "A_OK")
+        }
+    }
+
+    private object TxB : TransactionType<String>(
+        displayName = "Transaction B",
+        identifier = "com.example.txB",
+    ) {
+        override fun serializeIso18013Request(payload: String): DataItem = buildCborMap {
+            put("nonce", payload)
+        }
+
+        override fun parseIso18013Request(dataItem: DataItem): String =
+            dataItem.asMap[Tstr("nonce")]!!.asTstr
+
+        override suspend fun generateMdocResponseElements(
+            transactionData: TransactionData<String>,
+            credential: Credential,
+            userInput: TransactionUserInput?,
+            docRequestId: Int?
+        ): Map<String, DataItem> = buildMap {
+            putAll(super.generateMdocResponseElements(transactionData, credential, userInput, docRequestId))
+            put("status", Tstr("B_OK"))
+        }
+
+        override suspend fun verifyMdocResponse(
+            transactionData: TransactionData<String>,
+            responseElements: Map<String, DataItem>
+        ) {
+            super.verifyMdocResponse(transactionData, responseElements)
+            check(responseElements["status"]?.asTstr == "B_OK")
+        }
+    }
+
+    @Test
+    fun alternativeTransactions_preferA_onlyASupported() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        harness.documentTypeRepository.addTransactionType(TxB)
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = mapOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE to listOf(TxA.identifier)
+            )
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        val txBData = TxB.serializeIso18013Request("nonceB")
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                TxA.identifier
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                        TxB.identifier
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    transactionData = TransactionsInfo(
+                        data = mapOf(
+                            TxA.identifier to txAData,
+                            TxB.identifier to txBData
+                        )
+                    )
+                )
+            )
+        }
+
+        // Query execution check
+        val queryResult = deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        val match = queryResult.credentialSets[0].options[0].members[0].matches[0]
+        assertEquals(1, match.transactionData.size)
+        assertEquals(TxA, match.transactionData[0].type)
+
+        // End-to-end presentment and verification check
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = harness.presentmentSource,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = "https://example.com",
+            creationTime = creationTime,
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = harness.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        val mdocDoc = deviceResponse.documents[0]
+        val txNamespaceData = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        assertNotNull(txNamespaceData)
+        assertTrue(txNamespaceData.containsKey(TxA.identifier))
+        assertFalse(txNamespaceData.containsKey(TxB.identifier))
+        assertEquals(1, mdocDoc.transactionData.size)
+        assertEquals(TxA, mdocDoc.transactionData[0].type)
+    }
+
+    @Test
+    fun alternativeTransactions_preferA_onlyBSupported() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        harness.documentTypeRepository.addTransactionType(TxB)
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = mapOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE to listOf(TxB.identifier)
+            )
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        val txBData = TxB.serializeIso18013Request("nonceB")
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                TxA.identifier
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                        TxB.identifier
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    transactionData = TransactionsInfo(
+                        data = mapOf(
+                            TxA.identifier to txAData,
+                            TxB.identifier to txBData
+                        )
+                    )
+                )
+            )
+        }
+
+        // Query execution check
+        val queryResult = deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        val match = queryResult.credentialSets[0].options[0].members[0].matches[0]
+        assertEquals(1, match.transactionData.size)
+        assertEquals(TxB, match.transactionData[0].type)
+
+        // End-to-end presentment and verification check
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = harness.presentmentSource,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = "https://example.com",
+            creationTime = creationTime,
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = harness.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        val mdocDoc = deviceResponse.documents[0]
+        val txNamespaceData = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        assertNotNull(txNamespaceData)
+        assertTrue(txNamespaceData.containsKey(TxB.identifier))
+        assertFalse(txNamespaceData.containsKey(TxA.identifier))
+        assertEquals(1, mdocDoc.transactionData.size)
+        assertEquals(TxB, mdocDoc.transactionData[0].type)
+    }
+
+    @Test
+    fun alternativeTransactions_preferA_bothSupported() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        harness.documentTypeRepository.addTransactionType(TxB)
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = mapOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE to listOf(TxA.identifier, TxB.identifier)
+            )
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        val txBData = TxB.serializeIso18013Request("nonceB")
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                TxA.identifier
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                        TxB.identifier
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    transactionData = TransactionsInfo(
+                        data = mapOf(
+                            TxA.identifier to txAData,
+                            TxB.identifier to txBData
+                        )
+                    )
+                )
+            )
+        }
+
+        // Query execution check: Option 0 (TxA) must be preferred over Option 1 (TxB)
+        val queryResult = deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        val match = queryResult.credentialSets[0].options[0].members[0].matches[0]
+        assertEquals(1, match.transactionData.size)
+        assertEquals(TxA, match.transactionData[0].type)
+
+        // End-to-end presentment and verification check
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = harness.presentmentSource,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = "https://example.com",
+            creationTime = creationTime,
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = harness.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        val mdocDoc = deviceResponse.documents[0]
+        val txNamespaceData = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        assertNotNull(txNamespaceData)
+        assertTrue(txNamespaceData.containsKey(TxA.identifier))
+        assertFalse(txNamespaceData.containsKey(TxB.identifier))
+        assertEquals(1, mdocDoc.transactionData.size)
+        assertEquals(TxA, mdocDoc.transactionData[0].type)
+    }
+
+    @Test
+    fun alternativeTransactions_preferA_neitherSupported() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        harness.documentTypeRepository.addTransactionType(TxB)
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = emptyMap()
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        val txBData = TxB.serializeIso18013Request("nonceB")
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                TxA.identifier
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                        TxB.identifier
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    transactionData = TransactionsInfo(
+                        data = mapOf(
+                            TxA.identifier to txAData,
+                            TxB.identifier to txBData
+                        )
+                    )
+                )
+            )
+        }
+
+        val exception = assertFailsWith(Iso18015ResponseException::class) {
+            deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        }
+        assertEquals(
+            "No matching credentials for first DocRequest: transaction com.example.txA is not applicable",
+            exception.message
+        )
+    }
+
+    @Test
+    fun alternativeTransactions_fallbackToNonTransactionDataElement() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        // Setup without transaction authorization, but with given_name and family_name
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "family_name" to Tstr("Mustermann"),
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = emptyMap()
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        // Request TxA with fallback to given_name
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("family_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    alternativeDataElements = listOf(
+                        AlternativeDataElementSet(
+                            requestedElement = ElementReference(
+                                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                                TxA.identifier
+                            ),
+                            alternativeElementSets = listOf(
+                                listOf(
+                                    ElementReference(
+                                        DrivingLicense.MDL_NAMESPACE,
+                                        "given_name"
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    transactionData = TransactionsInfo(
+                        data = mapOf(TxA.identifier to txAData)
+                    )
+                )
+            )
+        }
+
+        // Query execution check: fallback to given_name succeeded without transactions
+        val queryResult = deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        val match = queryResult.credentialSets[0].options[0].members[0].matches[0]
+        assertTrue(match.transactionData.isEmpty())
+
+        // End-to-end presentment and verification check
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = harness.presentmentSource,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = "https://example.com",
+            creationTime = creationTime,
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = harness.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        val mdocDoc = deviceResponse.documents[0]
+        val txNamespaceData = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        assertTrue(txNamespaceData.isNullOrEmpty())
+        assertTrue(mdocDoc.transactionData.isEmpty())
+    }
+
+    @Test
+    fun extraTransactionPayloadInRequestInfoNotRequestedByDataElements() = runTest {
+        val harness = DocumentStoreTestHarness()
+        harness.initialize()
+        harness.documentTypeRepository.addTransactionType(TxA)
+        harness.documentTypeRepository.addTransactionType(TxB)
+        // Wallet authorizes both TxA and TxB
+        harness.provisionMdoc(
+            displayName = "my-mDL",
+            docType = DrivingLicense.MDL_DOCTYPE,
+            data = mapOf(
+                DrivingLicense.MDL_NAMESPACE to listOf(
+                    "given_name" to Tstr("David")
+                )
+            ),
+            keyAuthorizedDataElements = mapOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE to listOf(TxA.identifier, TxB.identifier)
+            )
+        )
+
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+        val txAData = TxA.serializeIso18013Request("nonceA")
+        val txBData = TxB.serializeIso18013Request("nonceB")
+
+        // Verifier requests ONLY TxA in nameSpaces, but sends BOTH TxA and TxB in requestInfo.transactionData
+        val deviceRequest = buildDeviceRequest(sessionTranscript = sessionTranscript) {
+            addDocRequest(
+                docType = DrivingLicense.MDL_DOCTYPE,
+                nameSpaces = mapOf(
+                    DrivingLicense.MDL_NAMESPACE to mapOf("given_name" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(TxA.identifier to false)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    transactionData = TransactionsInfo(
+                        data = mapOf(
+                            TxA.identifier to txAData,
+                            TxB.identifier to txBData
+                        )
+                    )
+                )
+            )
+        }
+
+        // Query execution check: only TxA is included
+        val queryResult = deviceRequest.execute(presentmentSource = harness.presentmentSource)
+        val match = queryResult.credentialSets[0].options[0].members[0].matches[0]
+        assertEquals(1, match.transactionData.size)
+        assertEquals(TxA, match.transactionData[0].type)
+
+        // End-to-end presentment and verification check
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = harness.presentmentSource,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = "https://example.com",
+            creationTime = creationTime,
+            preselectedDocuments = emptyList(),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = harness.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        val mdocDoc = deviceResponse.documents[0]
+        val txNamespaceData = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]
+        assertNotNull(txNamespaceData)
+        assertTrue(txNamespaceData.containsKey(TxA.identifier))
+        assertFalse(txNamespaceData.containsKey(TxB.identifier))
+        assertEquals(1, mdocDoc.transactionData.size)
+        assertEquals(TxA, mdocDoc.transactionData[0].type)
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
@@ -1008,7 +1008,8 @@ class DigitalCredentialsPresentmentTest {
             addDocRequest(
                 docType = "org.multipaz.payment.sca.1",
                 nameSpaces = mapOf(
-                    "org.multipaz.payment.sca.1" to mapOf("account_id" to false)
+                    "org.multipaz.payment.sca.1" to mapOf("account_id" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(PaymentTransaction.identifier to true)
                 ),
                 docRequestInfo = DocRequestInfo(
                     transactionData = TransactionsInfo(
@@ -1203,7 +1204,8 @@ class DigitalCredentialsPresentmentTest {
             addDocRequest(
                 docType = "org.multipaz.payment.sca.1",
                 nameSpaces = mapOf(
-                    "_" to mapOf("sdjwtvc_account_id" to false)
+                    "_" to mapOf("sdjwtvc_account_id" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(PaymentTransaction.identifier to true)
                 ),
                 docRequestInfo = DocRequestInfo(
                     docFormat = "dc+sd-jwt",

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DocumentStoreTestHarness.kt
@@ -260,6 +260,7 @@ class DocumentStoreTestHarness {
         docType: String,
         data: Map<String, List<Pair<String, DataItem>>>,
         keyAuthorizedNamespaces: List<String> = listOf(),
+        keyAuthorizedDataElements: Map<String, List<String>> = emptyMap(),
         dsKey: AsymmetricKey.X509Certified? = null,
         readerIdentifiers: List<ByteString> = emptyList(),
     ): Document {
@@ -286,7 +287,8 @@ class DocumentStoreTestHarness {
             validFrom = validFrom,
             validUntil = validUntil,
             dsKey = effectiveDsKey,
-            keyAuthorizedNamespaces = keyAuthorizedNamespaces
+            keyAuthorizedNamespaces = keyAuthorizedNamespaces,
+            keyAuthorizedDataElements = keyAuthorizedDataElements,
         )
         return document
     }
@@ -504,7 +506,8 @@ class DocumentStoreTestHarness {
         validFrom: Instant,
         validUntil: Instant,
         dsKey: AsymmetricKey.X509Certified,
-        keyAuthorizedNamespaces: List<String>
+        keyAuthorizedNamespaces: List<String>,
+        keyAuthorizedDataElements: Map<String, List<String>> = emptyMap(),
     ) {
         // Create authentication keys...
         val mdocCredential = MdocCredential.create(
@@ -527,7 +530,8 @@ class DocumentStoreTestHarness {
             digestAlgorithm = Algorithm.SHA256,
             valueDigests = issuerNamespaces.getValueDigests(Algorithm.SHA256),
             deviceKey = mdocCredential.getAttestation().publicKey,
-            deviceKeyAuthorizedNamespaces = keyAuthorizedNamespaces
+            deviceKeyAuthorizedNamespaces = keyAuthorizedNamespaces,
+            deviceKeyAuthorizedDataElements = keyAuthorizedDataElements,
         )
         val taggedEncodedMso = Cbor.encode(Tagged(
             Tagged.ENCODED_CBOR,


### PR DESCRIPTION
Transactions in ISO/IEC 18013-5 are requested via data elements under the "org.iso.transactiondata" namespace. Previously, builder helpers automatically populated this namespace for any transaction payload provided in `DocRequestInfo.transactionData`, and `DocRequest` parsed all transaction payloads irrespective of whether they were requested. Additionally, `TransactionData` and `TransactionType.parseCbor()` carried an unnecessary `intentToRetain` property, which belongs strictly to requested claims rather than the transaction payload itself.

Refactor ISO 18013-5 transaction handling:
- Require explicit requests for transaction data elements in `DocRequest` namespaces or alternative data elements, removing auto-population in `DeviceRequest.Builder.addDocRequest()`.
- Update `DocRequest.getTransactionData()` to only parse transactions requested by data elements.
- In `DeviceRequest.findBestMatchingClaims()`, resolve transaction claims and alternative options by checking `isApplicable()`, and populate `DocRequestMatch.transactionData` for the selected permutation.
- In `DeviceResponse.verify()`, filter expected transactions to those actually returned by the device when alternative data elements are used.
- For DCQL conversions: omit transaction data elements in `DeviceRequest.toDcql()`, and in `buildDeviceRequestFromDcql()` automatically request all transactions with a configurable `defaultIntentToRetain` defaulting to false.
- Remove `intentToRetain` from `TransactionData` and `TransactionType.parseCbor()`.
- Support `keyAuthorizedDataElements` in `DocumentStoreTestHarness`.
- Add test scenarios in `Iso18013TestTransactionData` and DCQL conversion tests in `DeviceRequestDcqlConversionsTest`.

Fixes #1980.

Test: Ran ./gradlew :multipaz:jvmTest
Test: Ran ./gradlew :multipaz:assemble
Test: Ran ./gradlew detekt
