### PR TITLE
Scope transaction user input to credential match in presentment.

### DIFF
--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/presentment/Consent.kt
@@ -129,6 +129,7 @@ import org.multipaz.multipaz_compose.generated.resources.credential_presentment_
 import org.multipaz.multipaz_compose.generated.resources.credential_presentment_warning_verifier_not_in_trust_list_website
 import org.multipaz.presentment.CredentialMatchSourceIso18013
 import org.multipaz.presentment.CredentialMatchSourceOpenID4VP
+import org.multipaz.presentment.CredentialPresentmentSetOptionMemberMatch
 import org.multipaz.presentment.CredentialSelection
 import org.multipaz.presentment.ConsentData
 import org.multipaz.presentment.ConsentUseCase
@@ -217,7 +218,7 @@ fun Consent(
 
     var selections by remember(initialSelections) { mutableStateOf(initialSelections) }
     var transactionUserInput by remember {
-        mutableStateOf(emptyMap<String, TransactionUserInput>())
+        mutableStateOf(emptyMap<CredentialPresentmentSetOptionMemberMatch, Map<String, TransactionUserInput>>())
     }
     var activeUseCaseIndex by remember { mutableStateOf(0) }
     var isFlipped by remember { mutableStateOf(false) }
@@ -294,8 +295,11 @@ fun Consent(
                                 newList[index] = value
                                 selections = newList
                             },
-                            onTransactionUserInputChanged = { type, userInput ->
-                                transactionUserInput = transactionUserInput.plus(type to userInput)
+                            onTransactionUserInputChanged = { match, type, userInput ->
+                                val current = transactionUserInput[match] ?: emptyMap()
+                                transactionUserInput = transactionUserInput.plus(
+                                    match to current.plus(type to userInput)
+                                )
                             },
                             onShowRequesterInfo = {
                                 navController.navigate("showRequesterInfo")
@@ -452,9 +456,9 @@ private fun ConsentPage(
     imageLoader: ImageLoader?,
     consentData: ConsentData,
     selections: List<Int>,
-    transactionUserInput: Map<String, TransactionUserInput>,
+    transactionUserInput: Map<CredentialPresentmentSetOptionMemberMatch, Map<String, TransactionUserInput>>,
     onSelectionChanged: (Int, Int) -> Unit,
-    onTransactionUserInputChanged: (String, TransactionUserInput) -> Unit,
+    onTransactionUserInputChanged: (CredentialPresentmentSetOptionMemberMatch, String, TransactionUserInput) -> Unit,
     onShowRequesterInfo: () -> Unit,
     onNavigateToPickSolution: (Int) -> Unit,
     onConfirm: (selection: CredentialSelection) -> Unit,
@@ -574,11 +578,11 @@ private fun UseCaseViewer(
     selectionIndex: Int,
     requester: Requester,
     requesterDisplayData: RequesterDisplayData,
-    transactionUserInput: Map<String, TransactionUserInput>,
+    transactionUserInput: Map<CredentialPresentmentSetOptionMemberMatch, Map<String, TransactionUserInput>>,
     trustMetadata: TrustMetadata?,
     appInfo: ApplicationInfo?,
     onSelectionChanged: (Int) -> Unit,
-    onTransactionUserInputChanged: (String, TransactionUserInput) -> Unit,
+    onTransactionUserInputChanged: (CredentialPresentmentSetOptionMemberMatch, String, TransactionUserInput) -> Unit,
     onNavigateToPickSolution: () -> Unit
 ) {
     val isSelected = selectionIndex >= 0
@@ -670,9 +674,10 @@ private fun UseCaseViewer(
                                     DisplayTransactionData(
                                         transactionData = data,
                                         hasClaims = hasClaims,
-                                        userInput = transactionUserInput[data.type.identifier],
+                                        userInput = transactionUserInput[credential.match]?.get(data.type.identifier),
                                         onUserInputChanged = { userInput ->
                                             onTransactionUserInputChanged.invoke(
+                                                credential.match,
                                                 data.type.identifier,
                                                 userInput
                                             )

--- a/multipaz-swiftui/src/iosMain/swift/Consent.swift
+++ b/multipaz-swiftui/src/iosMain/swift/Consent.swift
@@ -468,7 +468,7 @@ public struct Consent: View {
 
     @State private var path = NavigationPath()
     @State private var selections: [Int] = []
-    @State private var transactionUserInput: [String: TransactionUserInput] = [:]
+    @State private var transactionUserInput: [CredentialPresentmentSetOptionMemberMatch: [String: TransactionUserInput]] = [:]
     @State private var sheetHeight: CGFloat = 450
 
     private func getDocumentsForSelections(_ selections: [Int]) -> [Document] {
@@ -693,7 +693,7 @@ private struct ConsentMain: View {
     let requester: Requester
     let trustMetadata: TrustMetadata?
     let selections: [Int]
-    @Binding var transactionUserInput: [String: TransactionUserInput]
+    @Binding var transactionUserInput: [CredentialPresentmentSetOptionMemberMatch: [String: TransactionUserInput]]
     @Binding var sheetHeight: CGFloat
     let isActive: Bool
     let onRequesterClicked: () -> Void
@@ -723,8 +723,10 @@ private struct ConsentMain: View {
                                 useCase: consentData.useCases[idx],
                                 selectionIndex: selections[idx],
                                 transactionUserInput: transactionUserInput,
-                                onTransactionUserInputChanged: { typeId, input in
-                                    transactionUserInput[typeId] = input
+                                onTransactionUserInputChanged: { match, typeId, input in
+                                    var current = transactionUserInput[match] ?? [:]
+                                    current[typeId] = input
+                                    transactionUserInput[match] = current
                                 },
                                 onNavigateToPickSolution: {
                                     onNavigateToPickSolution(idx)
@@ -799,8 +801,8 @@ private struct UseCaseSection: View {
     let trustMetadata: TrustMetadata?
     let useCase: ConsentUseCase
     let selectionIndex: Int
-    let transactionUserInput: [String: TransactionUserInput]
-    let onTransactionUserInputChanged: (String, TransactionUserInput) -> Void
+    let transactionUserInput: [CredentialPresentmentSetOptionMemberMatch: [String: TransactionUserInput]]
+    let onTransactionUserInputChanged: (CredentialPresentmentSetOptionMemberMatch, String, TransactionUserInput) -> Void
     let onNavigateToPickSolution: () -> Void
 
     var body: some View {
@@ -882,8 +884,10 @@ private struct UseCaseSection: View {
                                     retainedClaims: retainedClaims,
                                     notRetainedClaims: notRetainedClaims,
                                     transactionData: match.transactionData,
-                                    transactionUserInput: transactionUserInput,
-                                    onTransactionUserInputChanged: onTransactionUserInputChanged,
+                                    transactionUserInput: transactionUserInput[match] ?? [:],
+                                    onTransactionUserInputChanged: { typeId, input in
+                                        onTransactionUserInputChanged(match, typeId, input)
+                                    },
                                     showOptionsButton: showChevron && (credIdx == 0),
                                     onOptionsTapped: onNavigateToPickSolution
                                 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -519,8 +519,7 @@ object OpenID4VP {
                     nonce = nonce,
                     reReaderPublicKey = reReaderPublicKey,
                     responseUri = responseUri,
-                    requestIsForZk = requestIsForZk,
-                    transactionUserInput = selection.transactionUserInput
+                    requestIsForZk = requestIsForZk
                 )
             } else if (match.source.credentialQuery.vctValues != null) {
                 openID4VPSdJwt(
@@ -529,8 +528,7 @@ object OpenID4VP {
                     origin = origin,
                     clientId = clientId,
                     nonce = nonce,
-                    responseMode = responseMode,
-                    transactionUserInput = selection.transactionUserInput
+                    responseMode = responseMode
                 )
             } else {
                 throw IllegalArgumentException("Expected ISO mdoc or IETF SD-JWT, got neither")
@@ -615,7 +613,6 @@ object OpenID4VP {
         reReaderPublicKey: EcPublicKey?,
         responseUri: String?,
         requestIsForZk: Boolean,
-        transactionUserInput: Map<String, TransactionUserInput>,
         onDocumentsInFocus: (documents: List<Document>) -> Unit = {},
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
@@ -721,7 +718,7 @@ object OpenID4VP {
             sessionTranscript = Cbor.decode(encodedSessionTranscript),
             credential = mdocCredential,
             requestedClaims = match.source.credentialQuery.claims as List<MdocRequestedClaim>,
-            deviceNamespaces = computeTransactionResponse(match, transactionUserInput)
+            deviceNamespaces = computeTransactionResponse(match)
         )
         val deviceResponse = buildDeviceResponse(
             sessionTranscript = Cbor.decode(encodedSessionTranscript),
@@ -802,8 +799,7 @@ object OpenID4VP {
         origin: String?,
         clientId: String,
         nonce: String,
-        responseMode: ResponseMode,
-        transactionUserInput: Map<String, TransactionUserInput>
+        responseMode: ResponseMode
     ): String {
         match.source as CredentialMatchSourceOpenID4VP
         val sdjwtVcCredential = match.credential as SdJwtVcCredential
@@ -815,7 +811,7 @@ object OpenID4VP {
 
         (sdjwtVcCredential as Credential).increaseUsageCount()
 
-        val transactionResponse = processTransactions(sdjwtVcCredential, match.transactionData, transactionUserInput)
+        val transactionResponse = processTransactions(sdjwtVcCredential, match.transactionData, match.transactionUserInput)
 
         return if (sdjwtVcCredential is SecureAreaBoundCredential) {
             filteredSdJwt.present(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/ConsentData.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/ConsentData.kt
@@ -28,13 +28,13 @@ data class ConsentData private constructor(
      * Calculates a [CredentialSelection] from a list of selections.
      *
      * @param selections the solution selected for each use-case or -1 if not selecting an optional use-case.
-     * @param transactionUserInput additional user input for transactions, indexed by the transaction
-     *  type identifier
+     * @param transactionUserInput additional user input for transactions, indexed by credential match and transaction
+     *  type identifier.
      * @return a [CredentialSelection].
      */
     fun toCredentialSelection(
         selections: List<Int>,
-        transactionUserInput: Map<String, TransactionUserInput>
+        transactionUserInput: Map<CredentialPresentmentSetOptionMemberMatch, Map<String, TransactionUserInput>> = emptyMap()
     ): CredentialSelection {
         require(selections.size == useCases.size) {
             "Expected selectionPerUseCase length to be that of useCases"
@@ -50,11 +50,12 @@ data class ConsentData private constructor(
                 solution.credentials.forEach { credential ->
                     // TODO: In the future, if encryption is requested, we may need to pass that
                     // information along in the selection or a separate structure.
-                    matches.add(credential.match)
+                    val input = transactionUserInput[credential.match] ?: emptyMap()
+                    matches.add(credential.match.copy(transactionUserInput = input))
                 }
             }
         }
-        return CredentialSelection(matches, transactionUserInput)
+        return CredentialSelection(matches)
     }
 
     companion object {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSetOptionMemberMatch.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialPresentmentSetOptionMemberMatch.kt
@@ -2,6 +2,7 @@ package org.multipaz.presentment
 
 import org.multipaz.claim.Claim
 import org.multipaz.credential.Credential
+import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.request.RequestedClaim
 
 /**
@@ -11,11 +12,14 @@ import org.multipaz.request.RequestedClaim
  * @property claims the claims to present along with their request.
  * @property source the source for the request for the match
  * @property transactionData list of transaction data to use for this credential presentment
+ * @property transactionUserInput additional user input for transactions, indexed by the transaction
+ *  type identifier
  */
 data class CredentialPresentmentSetOptionMemberMatch(
     val credential: Credential,
     val claims: Map<RequestedClaim, Claim>,
     val source: CredentialMatchSource,
-    val transactionData: List<TransactionData<*>>
+    val transactionData: List<TransactionData<*>>,
+    val transactionUserInput: Map<String, TransactionUserInput> = emptyMap()
 )
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialQueryResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialQueryResult.kt
@@ -45,7 +45,7 @@ data class CredentialQueryResult(
                 matches.add(member.matches[0])
             }
         }
-        return CredentialSelection(matches = matches, transactionUserInput = emptyMap())
+        return CredentialSelection(matches = matches)
     }
 
     private fun pickFromPreselectedDocuments(preselectedDocuments: List<Document>): CredentialSelection? {
@@ -83,7 +83,7 @@ data class CredentialQueryResult(
                     }
                     chosenMatches.add(match)
                 }
-                return CredentialSelection(chosenMatches, emptyMap())
+                return CredentialSelection(chosenMatches)
             }
         }
         Logger.w(TAG, "Error picking combination for pre-selected documents")
@@ -123,7 +123,7 @@ data class CredentialQueryResult(
             path.forEachIndexed { setIndex, selectionIndex ->
                 allMatches.addAll(allSetSelections[setIndex][selectionIndex])
             }
-            finalSelections.add(CredentialSelection(allMatches, emptyMap()))
+            finalSelections.add(CredentialSelection(allMatches))
         }
         return finalSelections
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialSelection.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/CredentialSelection.kt
@@ -1,7 +1,6 @@
 package org.multipaz.presentment
 
 import org.multipaz.documenttype.DocumentAttributeSensitivity
-import org.multipaz.documenttype.TransactionUserInput
 
 /**
  * A selection of credentials and claims in a [CredentialQueryResult].
@@ -12,12 +11,9 @@ import org.multipaz.documenttype.TransactionUserInput
  * This is typically returned from a consent prompt user interface.
  *
  * @property matches the list of credentials and claims to return to the relying party.
- * @property transactionUserInput additional user input for transactions, indexed by the transaction
- *  type identifier
  */
 data class CredentialSelection(
-    val matches: List<CredentialPresentmentSetOptionMemberMatch>,
-    val transactionUserInput: Map<String, TransactionUserInput>
+    val matches: List<CredentialPresentmentSetOptionMemberMatch>
 ) {
 
     /**

--- a/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/presentment/mdocPresentment.kt
@@ -236,7 +236,7 @@ suspend fun mdocPresentmentGenerateResponse(
                         eReaderKey = eReaderKey,
                         credential = match.credential,
                         requestedClaims = match.claims.keys.toList() as List<MdocRequestedClaim>,
-                        deviceNamespaces = computeTransactionResponse(match, selection.transactionUserInput),
+                        deviceNamespaces = computeTransactionResponse(match),
                         errors = mapOf()
                     )
 
@@ -319,7 +319,7 @@ suspend fun mdocPresentmentGenerateResponse(
                         credential = match.credential,
                         transactionData = match.transactionData,
                         docRequestId = match.source.docRequest.docRequestId,
-                        transactionUserInput = selection.transactionUserInput
+                        transactionUserInput = match.transactionUserInput
                     )
                     val sdJwtKb = filteredSdJwtVc.present(
                         signingKey = AsymmetricKey.AnonymousSecureAreaBased(
@@ -456,8 +456,7 @@ suspend fun mdocPresentment(
 }
 
 internal suspend fun computeTransactionResponse(
-    match: CredentialPresentmentSetOptionMemberMatch,
-    transactionUserInput: Map<String, TransactionUserInput>
+    match: CredentialPresentmentSetOptionMemberMatch
 ): DeviceNamespaces {
     if (match.transactionData.isEmpty()) {
         return buildDeviceNamespaces {}
@@ -470,7 +469,7 @@ internal suspend fun computeTransactionResponse(
         for (transaction in match.transactionData) {
             val responseMap = transaction.generateMdocResponseElements(
                 credential = match.credential,
-                userInput = transactionUserInput[transaction.type.identifier],
+                userInput = match.transactionUserInput[transaction.type.identifier],
                 docRequestId = docRequestId
             )
             val cborMap = buildCborMap {
@@ -485,7 +484,7 @@ internal suspend fun computeTransactionResponse(
         for (transaction in match.transactionData) {
             val responseMap = transaction.generateMdocResponseElements(
                 credential = match.credential,
-                userInput = transactionUserInput[transaction.type.identifier],
+                userInput = match.transactionUserInput[transaction.type.identifier],
                 docRequestId = null
             )
             val ns = transaction.type.getMdocResponseNamespace(TransactionProtocol.OPENID4VP)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
@@ -54,8 +54,11 @@ import org.multipaz.documenttype.TransactionType
 import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.documenttype.knowntypes.PaymentTransaction
 import org.multipaz.mdoc.devicesigned.DeviceAuth
+import org.multipaz.mdoc.request.DeviceRequestInfo
 import org.multipaz.mdoc.request.DocRequestInfo
+import org.multipaz.mdoc.request.DocumentSet
 import org.multipaz.mdoc.request.TransactionsInfo
+import org.multipaz.mdoc.request.UseCase
 import org.multipaz.mdoc.request.buildDeviceRequest
 import org.multipaz.mdoc.response.DeviceResponse
 import org.multipaz.mdoc.util.MdocUtil
@@ -277,9 +280,14 @@ class DigitalCredentialsPresentmentTest {
         documentTypeRepository = documentTypeRepository
     ) {
         var tipPercent: Double? = null
+        val tipPercentByCredential = mutableMapOf<Credential, Double>()
 
         fun insertTip(tipPercent: Double) {
             this.tipPercent = tipPercent
+        }
+
+        fun insertTipForCredential(credential: Credential, tipPercent: Double) {
+            tipPercentByCredential[credential] = tipPercent
         }
 
         private val delegate = SimplePresentmentSource(
@@ -300,13 +308,38 @@ class DigitalCredentialsPresentmentTest {
             preselectedDocuments: List<Document>,
             onDocumentsInFocus: (documents: List<Document>) -> Unit
         ): CredentialSelection? {
-            val ret = consentData.credentialQueryResult.select(preselectedDocuments)
-            onDocumentsInFocus(ret.matches.map { it.credential.document })
-            val userInputMap = mutableMapOf<String, TransactionUserInput>()
-            tipPercent?.let { tip ->
-                userInputMap[PaymentTransaction.identifier] = PaymentTransaction.UserInput(tipPercent = tip)
+            val selections = consentData.useCases.mapIndexed { useCaseIndex, useCase ->
+                if (preselectedDocuments.isNotEmpty()) {
+                    val targetDoc = preselectedDocuments.getOrNull(useCaseIndex)
+                    if (targetDoc != null) {
+                        val matchingIndex = useCase.solutions.indexOfFirst { solution ->
+                            solution.credentials.any { it.match.credential.document == targetDoc }
+                        }
+                        if (matchingIndex != -1) matchingIndex else 0
+                    } else {
+                        0
+                    }
+                } else {
+                    if (useCase.solutions.isNotEmpty()) 0 else -1
+                }
             }
-            return ret.copy(transactionUserInput = userInputMap)
+            val userInput = mutableMapOf<CredentialPresentmentSetOptionMemberMatch, Map<String, TransactionUserInput>>()
+            consentData.useCases.forEachIndexed { index, useCase ->
+                val selection = selections[index]
+                if (selection >= 0 && selection < useCase.solutions.size) {
+                    for (cred in useCase.solutions[selection].credentials) {
+                        val tip = tipPercentByCredential[cred.match.credential] ?: tipPercent
+                        if (tip != null) {
+                            userInput[cred.match] = mapOf(
+                                PaymentTransaction.identifier to PaymentTransaction.UserInput(tipPercent = tip)
+                            )
+                        }
+                    }
+                }
+            }
+            val ret = consentData.toCredentialSelection(selections, userInput)
+            onDocumentsInFocus(ret.matches.map { it.credential.document })
+            return ret
         }
 
         override suspend fun getBadges(document: Document): List<DocumentBadge> =
@@ -1452,8 +1485,8 @@ class DigitalCredentialsPresentmentTest {
         val sdJwtKb = SdJwtKb.fromCompactSerialization(compactSerialization)
 
         val transactionData = source.documentTypeRepository.parseJsonTransactions(
-            base64UrlEncodedJson = listOf(requestJsonString.encodeToByteArray().toBase64Url())
-        ).values.first()
+            base64UrlEncodedJson = request["transaction_data"]!!.jsonArray.map { it.jsonPrimitive.content }
+        )["payment_credential"]!!
 
         sdJwtKb.verify(
             issuerKey = documentStoreTestHarness.dsKey.publicKey,
@@ -1618,8 +1651,8 @@ class DigitalCredentialsPresentmentTest {
         }
 
         val transactionData = source.documentTypeRepository.parseJsonTransactions(
-            base64UrlEncodedJson = listOf(requestJsonString.encodeToByteArray().toBase64Url())
-        ).values.first()
+            base64UrlEncodedJson = request["transaction_data"]!!.jsonArray.map { it.jsonPrimitive.content }
+        )["payment_credential"]!!
 
         deviceResponse.verifySingleDoc(
             sessionTranscript = sessionTranscript,
@@ -1723,6 +1756,298 @@ class DigitalCredentialsPresentmentTest {
             }
         """.trimIndent()
         assertEquals(expectedResponseCdn, normalizeMdocResponseCdn(responseCdn.trim()))
+    }
+
+    @Test
+    fun payment_Iso18013_TwoCards_DifferentTips() = runTestWithSetup {
+        val sessionTranscript = buildCborArray { add(Simple.NULL); add(Simple.NULL); add(byteArrayOf(1, 2, 3)) }
+
+        val secondCard = documentStoreTestHarness.provisionMdoc(
+            displayName = "Second Payment Card Mdoc",
+            docType = "org.multipaz.payment.sca.1",
+            data = mapOf(
+                "org.multipaz.payment.sca.1" to listOf(
+                    Pair("account_id", Tstr("acc-67890"))
+                )
+            ),
+            keyAuthorizedNamespaces = listOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                PaymentTransaction.openId4VpMdocResponseNamespace
+            )
+        )
+        val firstCard = documentStoreTestHarness.documentStore.listDocuments().first { it.displayName == "Payment Card Mdoc" }
+        val firstCardCred = firstCard.getCredentials().first()
+        val secondCardCred = secondCard.getCredentials().first()
+
+        val source = TipPresentmentSource(
+            documentStore = documentStoreTestHarness.documentStore,
+            documentTypeRepository = documentStoreTestHarness.documentTypeRepository,
+        )
+        source.insertTipForCredential(firstCardCred, 15.0)
+        source.insertTipForCredential(secondCardCred, 20.0)
+
+        // 1. Verifier prepares entire DeviceRequest with two DocRequests in ISO 18013-5
+        val payload1 = PaymentTransaction.Payload(
+            transactionId = "3AD99006-6E0D-4D07-AE75-5DAEF0FE21D9",
+            currency = "USD",
+            amount = 100.0,
+            payee = PaymentTransaction.Payee("Store 1", "001"),
+            tipRequested = true
+        )
+        val payload2 = PaymentTransaction.Payload(
+            transactionId = "4BE00117-7F1E-5E18-BF86-6EBF01AF32EA",
+            currency = "USD",
+            amount = 50.0,
+            payee = PaymentTransaction.Payee("Store 2", "002"),
+            tipRequested = true
+        )
+        val requestDataItem1 = PaymentTransaction.serializeIso18013Request(payload1)
+        val requestDataItem2 = PaymentTransaction.serializeIso18013Request(payload2)
+
+        val deviceRequest = buildDeviceRequest(
+            sessionTranscript = sessionTranscript,
+            deviceRequestInfo = DeviceRequestInfo.fromValues(
+                useCases = listOf(
+                    UseCase(
+                        mandatory = true,
+                        documentSets = listOf(DocumentSet(listOf(0))),
+                        purposeHints = emptyMap()
+                    ),
+                    UseCase(
+                        mandatory = true,
+                        documentSets = listOf(DocumentSet(listOf(1))),
+                        purposeHints = emptyMap()
+                    )
+                )
+            )
+        ) {
+            addDocRequest(
+                docType = "org.multipaz.payment.sca.1",
+                nameSpaces = mapOf(
+                    "org.multipaz.payment.sca.1" to mapOf("account_id" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(PaymentTransaction.identifier to true)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    transactionData = TransactionsInfo(
+                        data = mapOf(PaymentTransaction.identifier to requestDataItem1)
+                    )
+                )
+            )
+            addDocRequest(
+                docType = "org.multipaz.payment.sca.1",
+                nameSpaces = mapOf(
+                    "org.multipaz.payment.sca.1" to mapOf("account_id" to false),
+                    ISO_18013_TRANSACTION_DATA_NAMESPACE to mapOf(PaymentTransaction.identifier to true)
+                ),
+                docRequestInfo = DocRequestInfo(
+                    transactionData = TransactionsInfo(
+                        data = mapOf(PaymentTransaction.identifier to requestDataItem2)
+                    )
+                )
+            )
+        }
+
+        // 2. Wallet presentment
+        val creationTime = Clock.System.now()
+        val isoResponse = mdocPresentment(
+            deviceRequest = deviceRequest,
+            eReaderKey = null,
+            sessionTranscript = sessionTranscript,
+            source = source,
+            keyAgreementPossible = emptyList(),
+            requesterAppId = null,
+            requesterOrigin = ORIGIN,
+            creationTime = creationTime,
+            preselectedDocuments = listOf(firstCard, secondCard),
+            onWaitingForUserInput = {},
+            onDocumentsInFocus = {}
+        )
+        val deviceResponse = isoResponse.deviceResponse
+
+        // 3. Verifier processes and verifies response
+        deviceResponse.verify(
+            sessionTranscript = sessionTranscript,
+            eReaderKey = null,
+            deviceRequest = deviceRequest,
+            documentTypeRepository = source.documentTypeRepository,
+            atTime = creationTime
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
+        assertEquals(2, deviceResponse.documents.size)
+
+        val doc1 = deviceResponse.documents.first {
+            it.issuerNamespaces.data["org.multipaz.payment.sca.1"]?.get("account_id")?.dataElementValue?.asTstr == "acc-12345"
+        }
+        val tx1 = doc1.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]!![PaymentTransaction.identifier]!!
+        assertEquals(0L, tx1["docRequestId"].asNumber)
+        assertEquals(15.00, tx1["tipAmount"].asDouble)
+        assertEquals(100.00, tx1["amount"].asDouble)
+
+        val doc2 = deviceResponse.documents.first {
+            it.issuerNamespaces.data["org.multipaz.payment.sca.1"]?.get("account_id")?.dataElementValue?.asTstr == "acc-67890"
+        }
+        val tx2 = doc2.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]!![PaymentTransaction.identifier]!!
+        assertEquals(1L, tx2["docRequestId"].asNumber)
+        assertEquals(10.00, tx2["tipAmount"].asDouble)
+        assertEquals(50.00, tx2["amount"].asDouble)
+    }
+
+    @Test
+    fun payment_OpenID4VP_TwoCards_DifferentTips() = runTestWithSetup {
+        val secondCard = documentStoreTestHarness.provisionMdoc(
+            displayName = "Second Payment Card Mdoc",
+            docType = "org.multipaz.payment.sca.1",
+            data = mapOf(
+                "org.multipaz.payment.sca.1" to listOf(
+                    Pair("account_id", Tstr("acc-67890"))
+                )
+            ),
+            keyAuthorizedNamespaces = listOf(
+                ISO_18013_TRANSACTION_DATA_NAMESPACE,
+                PaymentTransaction.openId4VpMdocResponseNamespace
+            )
+        )
+        val firstCard = documentStoreTestHarness.documentStore.listDocuments().first { it.displayName == "Payment Card Mdoc" }
+        val firstCardCred = firstCard.getCredentials().first()
+        val secondCardCred = secondCard.getCredentials().first()
+
+        val source = TipPresentmentSource(
+            documentStore = documentStoreTestHarness.documentStore,
+            documentTypeRepository = documentStoreTestHarness.documentTypeRepository,
+        )
+        source.insertTipForCredential(firstCardCred, 15.0)
+        source.insertTipForCredential(secondCardCred, 20.0)
+
+        // 1. Verifier prepares DCQL query and transaction_data for OpenID4VP request
+        val dcql = buildJsonObject {
+            put("credentials", buildJsonArray {
+                add(buildJsonObject {
+                    put("id", "payment_credential_1")
+                    put("format", "mso_mdoc")
+                    put("meta", buildJsonObject {
+                        put("doctype_value", "org.multipaz.payment.sca.1")
+                    })
+                    put("claims", buildJsonArray {
+                        add(buildJsonObject {
+                            put("path", buildJsonArray {
+                                add("org.multipaz.payment.sca.1")
+                                add("account_id")
+                            })
+                        })
+                    })
+                })
+                add(buildJsonObject {
+                    put("id", "payment_credential_2")
+                    put("format", "mso_mdoc")
+                    put("meta", buildJsonObject {
+                        put("doctype_value", "org.multipaz.payment.sca.1")
+                    })
+                    put("claims", buildJsonArray {
+                        add(buildJsonObject {
+                            put("path", buildJsonArray {
+                                add("org.multipaz.payment.sca.1")
+                                add("account_id")
+                            })
+                        })
+                    })
+                })
+            })
+        }
+
+        val tx1JsonString = PaymentTransaction.serializeOpenId4VpRequest(
+            payload = PaymentTransaction.Payload(
+                transactionId = "TX-CARD-1",
+                currency = "USD",
+                amount = 100.0,
+                payee = PaymentTransaction.Payee("Store 1", "001"),
+                tipRequested = true
+            ),
+            credentialIds = listOf("payment_credential_1"),
+            hashAlgorithms = listOf(Algorithm.SHA256)
+        )
+        val tx2JsonString = PaymentTransaction.serializeOpenId4VpRequest(
+            payload = PaymentTransaction.Payload(
+                transactionId = "TX-CARD-2",
+                currency = "USD",
+                amount = 50.0,
+                payee = PaymentTransaction.Payee("Store 2", "002"),
+                tipRequested = true
+            ),
+            credentialIds = listOf("payment_credential_2"),
+            hashAlgorithms = listOf(Algorithm.SHA256)
+        )
+
+        val nonce = "openid4vp-nonce-twocards"
+        val request = OpenID4VP.generateRequest(
+            version = OpenID4VP.Version.DRAFT_29,
+            origin = ORIGIN,
+            nonce = nonce,
+            responseEncryptionKey = null,
+            verifierIdentities = emptyList(),
+            responseMode = OpenID4VP.ResponseMode.DC_API,
+            responseUri = null,
+            dcqlQuery = dcql,
+            jsonTransactionData = listOf(tx1JsonString, tx2JsonString)
+        )
+
+        // 2. Wallet presentment
+        val response = OpenID4VP.generateResponse(
+            version = OpenID4VP.Version.DRAFT_29,
+            preselectedDocuments = listOf(firstCard, secondCard),
+            source = source,
+            appId = null,
+            origin = ORIGIN,
+            request = request,
+            requesterIdentities = emptyList(),
+        )
+
+        // 3. Verifier processes and verifies responses
+        val vpTokens = response.response["vp_token"]!!.jsonObject
+        val encodedDeviceResponse1 = vpTokens["payment_credential_1"]!!.jsonArray[0].jsonPrimitive.content.fromBase64Url()
+        val deviceResponse1 = DeviceResponse.fromDataItem(Cbor.decode(encodedDeviceResponse1))
+        val encodedDeviceResponse2 = vpTokens["payment_credential_2"]!!.jsonArray[0].jsonPrimitive.content.fromBase64Url()
+        val deviceResponse2 = DeviceResponse.fromDataItem(Cbor.decode(encodedDeviceResponse2))
+
+        val handoverInfo = Cbor.encode(
+            buildCborArray {
+                add(ORIGIN)
+                add(nonce)
+                add(Simple.NULL)
+            }
+        )
+        val handoverInfoDigest = Crypto.digest(Algorithm.SHA256, handoverInfo)
+        val sessionTranscript = buildCborArray {
+            add(Simple.NULL)
+            add(Simple.NULL)
+            addCborArray {
+                add("OpenID4VPDCAPIHandover")
+                add(handoverInfoDigest)
+            }
+        }
+
+        val txMap = source.documentTypeRepository.parseJsonTransactions(
+            base64UrlEncodedJson = request["transaction_data"]!!.jsonArray.map { it.jsonPrimitive.content }
+        )
+        val tx1Parsed = txMap["payment_credential_1"]!!
+        val tx2Parsed = txMap["payment_credential_2"]!!
+
+        deviceResponse1.verifySingleDoc(
+            sessionTranscript = sessionTranscript,
+            transactionData = tx1Parsed
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse1.status)
+        val mdoc1 = deviceResponse1.documents[0]
+        val txElements1 = mdoc1.deviceNamespaces.data[PaymentTransaction.openId4VpMdocResponseNamespace]!!
+        assertEquals(15.0, txElements1["tipAmount"]!!.asDouble)
+
+        deviceResponse2.verifySingleDoc(
+            sessionTranscript = sessionTranscript,
+            transactionData = tx2Parsed
+        )
+        assertEquals(DeviceResponse.STATUS_OK, deviceResponse2.status)
+        val mdoc2 = deviceResponse2.documents[0]
+        val txElements2 = mdoc2.deviceNamespaces.data[PaymentTransaction.openId4VpMdocResponseNamespace]!!
+        assertEquals(10.0, txElements2["tipAmount"]!!.asDouble)
     }
 
     @Test


### PR DESCRIPTION
Previously, `CredentialSelection` held user inputs for transactions in a map keyed solely by the transaction type identifier. In multi-document or multi-card presentment scenarios where multiple credentials respond to the same transaction type (e.g. two payment cards receiving separate tips), user input for one credential could conflict with or overwrite another.

Associate transaction user input directly with each matched credential:
- In `CredentialPresentmentSetOptionMemberMatch`, add `transactionUserInput` defaulting to an empty map.
- In `CredentialSelection`, remove `transactionUserInput` and rely on the underlying `matches` as the single source of truth.
- In `ConsentData.toCredentialSelection()`, accept a nested mapping keyed by `CredentialPresentmentSetOptionMemberMatch` and copy the inputs into each match without exposing a flat convenience overload.
- In `computeTransactionResponse()`, `openID4VPMsoMdoc()`, and `openID4VPSdJwt()`, read user inputs directly from the match rather than passing transaction user input maps through the pipeline.
- In Compose and SwiftUI consent prompt implementations, maintain user input state indexed by credential match and forward inputs accordingly.
- In `DigitalCredentialsPresentmentTest`, update `TipPresentmentSource` to support per-credential tips and add end-to-end multi-card presentment tests for both ISO/IEC 18013-5 and OpenID4VP protocols verifying distinct tip amounts on each payment credential.

Fixes #1980.

Test: Ran ./gradlew :multipaz:jvmTest
Test: Ran ./gradlew :multipaz-compose:assemble
Test: Ran ./gradlew detekt
Test: Ran xcodebuild -project samples/SwiftTestApp/SwiftTestApp.xcodeproj -scheme SwiftTestApp -sdk iphonesimulator build

