### PR TITLE
Add detailed telemetry and specialized types for verification events.

### DIFF
--- a/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
+++ b/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/processor/CborSymbolProcessor.kt
@@ -144,6 +144,14 @@ class CborSymbolProcessor(
                 "kotlin.Double" -> return "${base}asDouble"
                 "kotlin.Boolean" -> return "${base}asBoolean"
                 "kotlin.time.Instant" -> "${base}asDateTimeString"
+                "kotlin.time.Duration" -> {
+                    codeBuilder.importQualifiedName("kotlin.time.Duration")
+                    return if (type.isMarkedNullable) {
+                        "${base}asNullable?.asTstr?.let { Duration.parse(it) }"
+                    } else {
+                        "Duration.parse(${base}asTstr)"
+                    }
+                }
                 "kotlinx.datetime.LocalDate" -> "${base}asDateString"
                 DATA_ITEM_CLASS -> return code
                 else -> return if (declaration is KSClassDeclaration &&
@@ -339,6 +347,16 @@ class CborSymbolProcessor(
                         "${base}toDataItemDateTimeString() ?: Simple.NULL"
                     } else {
                         "${base}toDataItemDateTimeString()"
+                    }
+                }
+
+                "kotlin.time.Duration" -> {
+                    codeBuilder.importQualifiedName(TSTR_TYPE)
+                    return if (nullable) {
+                        codeBuilder.importQualifiedName(SIMPLE_TYPE)
+                        "${base}let { Tstr(it.toIsoString()) } ?: Simple.NULL"
+                    } else {
+                        "Tstr(${base}toIsoString())"
                     }
                 }
 
@@ -771,16 +789,29 @@ class CborSymbolProcessor(
     }
 
     private fun getSealedSuperclass(classDeclaration: KSClassDeclaration): KSClassDeclaration? {
-        for (supertype in classDeclaration.superTypes) {
-            val superDeclaration = supertype.resolve().declaration
-            if (superDeclaration is KSClassDeclaration &&
-                superDeclaration.classKind == ClassKind.CLASS &&
-                superDeclaration.modifiers.contains(Modifier.SEALED)) {
-                return superDeclaration
+        var current = classDeclaration
+        while (true) {
+            var superClass: KSClassDeclaration? = null
+            for (supertype in current.superTypes) {
+                val superDeclaration = supertype.resolve().declaration
+                if (superDeclaration is KSClassDeclaration &&
+                    superDeclaration.classKind == ClassKind.CLASS &&
+                    superDeclaration.qualifiedName?.asString() != "kotlin.Any") {
+                    superClass = superDeclaration
+                    break
+                }
             }
+            if (superClass == null) {
+                return null
+            }
+            if (superClass.modifiers.contains(Modifier.SEALED) &&
+                findAnnotation(superClass, ANNOTATION_SERIALIZABLE) != null) {
+                return superClass
+            }
+            current = superClass
         }
-        return null
     }
+
 
     private fun getTypeKey(annotation: KSAnnotation?): String {
         annotation?.arguments?.forEach { arg ->
@@ -1158,6 +1189,7 @@ class CborSymbolProcessor(
             "kotlin.Double" -> simpleLeaf("Double")
             "kotlin.Boolean" -> simpleLeaf("Boolean")
             "kotlin.time.Instant" -> simpleLeaf("DateTimeString")
+            "kotlin.time.Duration" -> simpleLeaf("DurationString")
             "kotlinx.datetime.LocalDate" -> simpleLeaf("DateString")
             DATA_ITEM_CLASS -> simpleLeaf("Any")
             else -> {

--- a/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
+++ b/multipaz-tools/web/src/jsMain/kotlin/org/multipaz/tools/frontend/EventDecoderComponent.kt
@@ -27,6 +27,8 @@ import org.multipaz.eventlogger.EventProvisioningCredentialData
 import org.multipaz.eventlogger.EventProvisioningIssuerDataOpenID4VCI
 import org.multipaz.eventlogger.EventSimple
 import org.multipaz.eventlogger.EventVerification
+import org.multipaz.eventlogger.EventVerificationDigitalCredentials
+import org.multipaz.eventlogger.EventVerificationIso18013Proximity
 import org.multipaz.eventlogger.fromDataItem
 import org.multipaz.eventlogger.toDataItem
 import org.multipaz.provisioning.Display as ProvisioningDisplay
@@ -407,6 +409,8 @@ private fun react.ChildrenBuilder.renderEventHeaderSection(ev: Event, fileName: 
         is EventPresentmentIso18013Proximity -> "Presentment (ISO 18013-5 Proximity)"
         is EventPresentment -> "Presentment Event"
         is EventProvisioning -> "Provisioning Event"
+        is EventVerificationDigitalCredentials -> "Verification (W3C DC API)"
+        is EventVerificationIso18013Proximity -> "Verification (ISO 18013-5 Proximity)"
         is EventVerification -> "Verification Event"
         is EventSimple -> "Simple Event"
     }
@@ -1402,6 +1406,61 @@ private val EventVerificationBlock: FC<EventVerificationBlockProps> = FC { props
                 }
                 +if (isVerifying) "Verifying..." else "⚡ Verify Presentment Record"
             }
+        }
+
+        when (ev) {
+            is EventVerificationDigitalCredentials -> {
+                div {
+                    css { display = Display.flex; flexDirection = FlexDirection.column; gap = 6.px; marginBottom = 16.px; fontSize = 13.px }
+                    if (ev.appId != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"App ID: " }; span { css { color = Color("#f1f5f9") }; +ev.appId!! } }
+                    }
+                    if (ev.origin != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Origin: " }; span { css { color = Color("#38bdf8") }; +ev.origin!! } }
+                    }
+                    if (ev.durationRequestSentToResponseReceived != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Latency: " }; span { css { color = Color("#f1f5f9") }; +"${ev.durationRequestSentToResponseReceived}" } }
+                    }
+                }
+
+                TextDataBlock {
+                    title = "Request JSON"
+                    content = ev.requestJson
+                    copyLabel = "📋 Copy Request JSON"
+                }
+
+                TextDataBlock {
+                    title = "Response JSON"
+                    content = ev.responseJson
+                    copyLabel = "📋 Copy Response JSON"
+                }
+            }
+            is EventVerificationIso18013Proximity -> {
+                div {
+                    css { display = Display.flex; flexDirection = FlexDirection.column; gap = 6.px; marginBottom = 16.px; fontSize = 13.px }
+                    div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Engagement Channel: " }; span { css { color = Color("#38bdf8") }; +ev.engagementType.name } }
+                    if (ev.durationNfcTapToEngagement != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Tap to Engagement: " }; span { css { color = Color("#f1f5f9") }; +"${ev.durationNfcTapToEngagement}" } }
+                    }
+                    if (ev.durationEngagementReceivedToRequestSent != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Engagement to Request Sent: " }; span { css { color = Color("#f1f5f9") }; +"${ev.durationEngagementReceivedToRequestSent}" } }
+                    }
+                    if (ev.durationRequestSentToResponseReceived != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Request Sent to Response Received: " }; span { css { color = Color("#f1f5f9") }; +"${ev.durationRequestSentToResponseReceived}" } }
+                    }
+                    if (ev.durationScanningTime != null) {
+                        div { span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"Transport Scanning Time: " }; span { css { color = Color("#f1f5f9") }; +"${ev.durationScanningTime}" } }
+                    }
+                    if (ev.nfcHybridTransportStats != null) {
+                        val stats = ev.nfcHybridTransportStats!!
+                        div {
+                            span { css { color = Color("#94a3b8"); fontWeight = FontWeight.bold }; +"NFC Hybrid Stats: " }
+                            span { css { color = Color("#f1f5f9") }; +"Sent: ${stats.numSent} (${stats.numSentViaNfc} NFC, ${stats.numSentViaTransport} transport), Received: ${stats.numReceived} (${stats.numReceivedFirstOnNfc} NFC, ${stats.numReceivedFirstOnTransport} transport)" }
+                        }
+                    }
+                }
+            }
+            else -> {}
         }
 
         val vps = verifiedPresentations

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerification.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerification.kt
@@ -2,23 +2,26 @@ package org.multipaz.eventlogger
 
 import org.multipaz.cbor.DataItem
 import org.multipaz.verification.PresentmentRecord
+import kotlin.time.Duration
 import kotlin.time.Instant
 
 /**
- * An event representing a verification event.
+ * Base class for events recorded in [EventLogger] related to credential verification.
  *
+ * Specific subclasses exist for digital credentials API ([EventVerificationDigitalCredentials]) and
+ * proximity presentment ([EventVerificationIso18013Proximity]). Support for verification via URI
+ * schemes (such as ISO/IEC 18013-7 Annex A and OpenID4VP URI schemes) will be added in the future as needed.
+ *
+ * @property identifier a unique identifier for the event.
+ * @property timestamp the timestamp when the event was recorded.
+ * @property appData additional application-specific data.
  * @property presentmentRecord a [PresentmentRecord] with the result of the presentation.
+ * @property durationRequestSentToResponseReceived duration from sending the request until receiving the response, if known.
  */
-data class EventVerification(
+sealed class EventVerification(
     override val identifier: String = "",
     override val timestamp: Instant = Instant.DISTANT_PAST,
     override val appData: Map<String, DataItem> = emptyMap(),
-    val presentmentRecord: PresentmentRecord
-): Event(identifier, timestamp, appData) {
-    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
-        identifier = identifier,
-        timestamp = timestamp,
-        appData = appData,
-        presentmentRecord = this.presentmentRecord
-    )
-}
+    open val presentmentRecord: PresentmentRecord,
+    open val durationRequestSentToResponseReceived: Duration? = null,
+): Event(identifier, timestamp, appData)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationDefault.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationDefault.kt
@@ -1,0 +1,33 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.verification.PresentmentRecord
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * A fallback or general event representing a verification event.
+ *
+ * @property identifier a unique identifier for the event.
+ * @property timestamp the timestamp when the event was recorded.
+ * @property appData additional application-specific data.
+ * @property presentmentRecord a [PresentmentRecord] with the result of the presentation.
+ * @property durationRequestSentToResponseReceived duration from sending the request until receiving the response, if known.
+ */
+@CborSerializable(typeId = "Verification")
+data class EventVerificationDefault(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentRecord: PresentmentRecord,
+    override val durationRequestSentToResponseReceived: Duration? = null,
+): EventVerification(identifier, timestamp, appData, presentmentRecord, durationRequestSentToResponseReceived) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentRecord = this.presentmentRecord,
+        durationRequestSentToResponseReceived = this.durationRequestSentToResponseReceived,
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationDigitalCredentials.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationDigitalCredentials.kt
@@ -1,0 +1,45 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.verification.PresentmentRecord
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * An event representing credential verification requested via the W3C Digital Credentials API.
+ *
+ * @property identifier a unique identifier for the event.
+ * @property timestamp the timestamp when the event was recorded.
+ * @property appData additional application-specific data.
+ * @property presentmentRecord a [PresentmentRecord] with the result of the presentation.
+ * @property requestJson the W3C Digital Credentials API request JSON string.
+ * @property responseJson the W3C Digital Credentials API response JSON string.
+ * @property durationRequestSentToResponseReceived duration from sending the request until receiving the response, if known.
+ * @property origin the origin of the website making the request, if known.
+ * @property appId the identifier of the application making the request, if known.
+ */
+@CborSerializable
+data class EventVerificationDigitalCredentials(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentRecord: PresentmentRecord,
+    val requestJson: String,
+    val responseJson: String,
+    override val durationRequestSentToResponseReceived: Duration? = null,
+    val origin: String? = null,
+    val appId: String? = null,
+): EventVerification(identifier, timestamp, appData, presentmentRecord, durationRequestSentToResponseReceived) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentRecord = this.presentmentRecord,
+        requestJson = this.requestJson,
+        responseJson = this.responseJson,
+        durationRequestSentToResponseReceived = this.durationRequestSentToResponseReceived,
+        origin = this.origin,
+        appId = this.appId,
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationIso18013Proximity.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/eventlogger/EventVerificationIso18013Proximity.kt
@@ -1,0 +1,50 @@
+package org.multipaz.eventlogger
+
+import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.mdoc.engagement.EngagementType
+import org.multipaz.mdoc.transport.NfcHybridTransportStats
+import org.multipaz.verification.PresentmentRecord
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * An event representing credential verification via ISO/IEC 18013-5 proximity presentment.
+ *
+ * @property identifier a unique identifier for the event.
+ * @property timestamp the timestamp when the event was recorded.
+ * @property appData additional application-specific data.
+ * @property presentmentRecord a [PresentmentRecord] with the result of the presentation.
+ * @property engagementType the engagement channel type used.
+ * @property durationNfcTapToEngagement time elapsed from initial NFC tap until device engagement was received, if available.
+ * @property durationEngagementReceivedToRequestSent time elapsed from receiving device engagement until the request was sent, if available.
+ * @property durationRequestSentToResponseReceived time elapsed from sending the device request until receiving the response, if available.
+ * @property durationScanningTime time spent scanning for holder transport connections, if applicable.
+ * @property nfcHybridTransportStats statistics and diagnostics for NFC hybrid transport, if used.
+ */
+@CborSerializable
+data class EventVerificationIso18013Proximity(
+    override val identifier: String = "",
+    override val timestamp: Instant = Instant.DISTANT_PAST,
+    override val appData: Map<String, DataItem> = emptyMap(),
+    override val presentmentRecord: PresentmentRecord,
+    val engagementType: EngagementType,
+    val durationNfcTapToEngagement: Duration? = null,
+    val durationEngagementReceivedToRequestSent: Duration? = null,
+    override val durationRequestSentToResponseReceived: Duration? = null,
+    val durationScanningTime: Duration? = null,
+    val nfcHybridTransportStats: NfcHybridTransportStats? = null,
+): EventVerification(identifier, timestamp, appData, presentmentRecord, durationRequestSentToResponseReceived) {
+    override fun copy(identifier: String, timestamp: Instant, appData: Map<String, DataItem>): Event = copy(
+        identifier = identifier,
+        timestamp = timestamp,
+        appData = appData,
+        presentmentRecord = this.presentmentRecord,
+        engagementType = this.engagementType,
+        durationNfcTapToEngagement = this.durationNfcTapToEngagement,
+        durationEngagementReceivedToRequestSent = this.durationEngagementReceivedToRequestSent,
+        durationRequestSentToResponseReceived = this.durationRequestSentToResponseReceived,
+        durationScanningTime = this.durationScanningTime,
+        nfcHybridTransportStats = this.nfcHybridTransportStats,
+    )
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementType.kt
@@ -1,0 +1,31 @@
+package org.multipaz.mdoc.engagement
+
+import org.multipaz.mdoc.nfc.MdocHandoverType
+
+/**
+ * ISO/IEC 18013 engagement types.
+ */
+enum class EngagementType {
+    /** QR code engagement according to ISO/IEC 18013-5:2021 section 8.2. */
+    QR_CODE,
+
+    /** Static NFC handover according to ISO/IEC 18013-5:2021 section 8.3.3.1.1. */
+    NFC_STATIC_HANDOVER,
+
+    /** Negotiated NFC handover according to ISO/IEC 18013-5:2021 section 8.3.3.1.2. */
+    NFC_NEGOTIATED_HANDOVER,
+
+    /** NFC Concurrent Channel Engagement (CCE), formerly known as NFC handover v2. */
+    NFC_CONCURRENT_CHANNEL_ENGAGEMENT;
+
+    companion object
+}
+
+/**
+ * Converts a [MdocHandoverType] to an [EngagementType].
+ */
+fun MdocHandoverType.toEngagementType(): EngagementType = when (this) {
+    MdocHandoverType.STATIC_HANDOVER -> EngagementType.NFC_STATIC_HANDOVER
+    MdocHandoverType.NEGOTIATED_HANDOVER -> EngagementType.NFC_NEGOTIATED_HANDOVER
+    MdocHandoverType.V2_HANDOVER -> EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/verification/Iso18013PresentmentRecord.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/verification/Iso18013PresentmentRecord.kt
@@ -18,8 +18,6 @@ import kotlin.time.Instant
 /**
  * [PresentmentRecord] for ISO 18013-5 mdoc presentment.
  *
- * TODO: support recording Annex A, proximity and zero-knowledge presentations as well.
- *
  * @property response CBOR-encoded `DeviceResponse` as defined in ISO 18013-5.
  * @property sessionTranscript CBOR `SessionTranscript` used for presentment authentication.
  * @property request original ISO 18013 request

--- a/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/eventlogger/SimpleEventLoggerTests.kt
@@ -6,11 +6,18 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.multipaz.cbor.Simple
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.toDataItem
+import org.multipaz.cbor.toDataItemDateTimeString
 import org.multipaz.claim.MdocClaim
 import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.mdoc.engagement.EngagementType
+import org.multipaz.mdoc.transport.NfcHybridTransportStats
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.verification.Iso18013PresentmentRecord
+import org.multipaz.verification.toDataItem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,6 +27,7 @@ import kotlin.test.assertNotNull
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -558,6 +566,144 @@ class SimpleEventLoggerTests {
         val eventsInDb = logger.getEvents()
         assertEquals(1, eventsInDb.size)
         assertEquals(savedEvent.appData, eventsInDb.first().appData)
+    }
+
+    @Test
+    fun testAddAndGetEventVerificationDigitalCredentials() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(2000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val presentmentRecord = Iso18013PresentmentRecord(
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL,
+            request = Simple.NULL,
+            eDeviceKey = null,
+            encryptionInfo = null,
+            origin = null
+        )
+
+        val event = EventVerificationDigitalCredentials(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            presentmentRecord = presentmentRecord,
+            requestJson = """{"requests": []}""",
+            responseJson = """{"response": "ok"}""",
+            durationRequestSentToResponseReceived = 350.milliseconds,
+            origin = "https://example.com",
+            appId = "com.example.app"
+        )
+
+        val savedEvent = logger.addEvent(event)
+        assertNotNull(savedEvent)
+        assertTrue(savedEvent is EventVerificationDigitalCredentials)
+        assertEquals("https://example.com", savedEvent.origin)
+        assertEquals("com.example.app", savedEvent.appId)
+        assertEquals("""{"requests": []}""", savedEvent.requestJson)
+        assertEquals("""{"response": "ok"}""", savedEvent.responseJson)
+        assertEquals(350.milliseconds, savedEvent.durationRequestSentToResponseReceived)
+
+        val eventsFromDb = logger.getEvents()
+        assertEquals(1, eventsFromDb.size)
+        val retrieved = eventsFromDb.first()
+        assertTrue(retrieved is EventVerificationDigitalCredentials)
+        assertEquals(savedEvent.identifier, retrieved.identifier)
+        assertEquals("https://example.com", retrieved.origin)
+        assertEquals("com.example.app", retrieved.appId)
+        assertEquals("""{"requests": []}""", retrieved.requestJson)
+        assertEquals("""{"response": "ok"}""", retrieved.responseJson)
+        assertEquals(350.milliseconds, retrieved.durationRequestSentToResponseReceived)
+    }
+
+    @Test
+    fun testAddAndGetEventVerificationIso18013Proximity() = runTest {
+        val fakeClock = FakeClock(Instant.fromEpochMilliseconds(3000))
+        val ephemeralStorage = EphemeralStorage(fakeClock)
+        val logger = SimpleEventLogger(storage = ephemeralStorage, partitionId = "test-partition", clock = fakeClock)
+
+        val presentmentRecord = Iso18013PresentmentRecord(
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL,
+            request = Simple.NULL,
+            eDeviceKey = null,
+            encryptionInfo = null,
+            origin = null
+        )
+        val stats = NfcHybridTransportStats(
+            numSent = 10,
+            numSentViaNfc = 8,
+            numSentViaTransport = 2,
+            numReceived = 12,
+            numReceivedFirstOnNfc = 9,
+            numReceivedFirstOnTransport = 3,
+            nfcDisconnectedDuringTransaction = false
+        )
+
+        val event = EventVerificationIso18013Proximity(
+            identifier = "",
+            timestamp = Instant.DISTANT_PAST,
+            presentmentRecord = presentmentRecord,
+            engagementType = EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT,
+            durationNfcTapToEngagement = 150.milliseconds,
+            durationEngagementReceivedToRequestSent = 50.milliseconds,
+            durationRequestSentToResponseReceived = 400.milliseconds,
+            durationScanningTime = 300.milliseconds,
+            nfcHybridTransportStats = stats
+        )
+
+        val savedEvent = logger.addEvent(event)
+        assertNotNull(savedEvent)
+        assertTrue(savedEvent is EventVerificationIso18013Proximity)
+        assertEquals(EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT, savedEvent.engagementType)
+        assertEquals(150.milliseconds, savedEvent.durationNfcTapToEngagement)
+        assertEquals(50.milliseconds, savedEvent.durationEngagementReceivedToRequestSent)
+        assertEquals(400.milliseconds, savedEvent.durationRequestSentToResponseReceived)
+        assertEquals(300.milliseconds, savedEvent.durationScanningTime)
+        assertEquals(stats, savedEvent.nfcHybridTransportStats)
+
+        val eventsFromDb = logger.getEvents()
+        assertEquals(1, eventsFromDb.size)
+        val retrieved = eventsFromDb.first()
+        assertTrue(retrieved is EventVerificationIso18013Proximity)
+        assertEquals(savedEvent.identifier, retrieved.identifier)
+        assertEquals(EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT, retrieved.engagementType)
+        assertEquals(150.milliseconds, retrieved.durationNfcTapToEngagement)
+        assertEquals(50.milliseconds, retrieved.durationEngagementReceivedToRequestSent)
+        assertEquals(400.milliseconds, retrieved.durationRequestSentToResponseReceived)
+        assertEquals(300.milliseconds, retrieved.durationScanningTime)
+        assertEquals(stats, retrieved.nfcHybridTransportStats)
+    }
+
+    @Test
+    fun testLegacyVerificationEventBackwardCompatibility() = runTest {
+        val presentmentRecord = Iso18013PresentmentRecord(
+            response = Simple.NULL,
+            sessionTranscript = Simple.NULL,
+            request = Simple.NULL,
+            eDeviceKey = null,
+            encryptionInfo = null,
+            origin = null
+        )
+        // Construct CBOR map with legacy typeId "Verification"
+        val legacyCbor = buildCborMap {
+            put("type", Tstr("Verification"))
+            put("identifier", Tstr("legacy-id-123"))
+            put("timestamp", Instant.fromEpochMilliseconds(5000).toDataItemDateTimeString())
+            put("appData", buildCborMap {})
+            put("presentmentRecord", presentmentRecord.toDataItem())
+            put("durationRequestSentToResponseReceived", Tstr("PT0.5S"))
+        }
+
+        val event = Event.fromDataItem(legacyCbor)
+        assertTrue(event is EventVerification)
+        assertTrue(event is EventVerificationDefault)
+        assertEquals("legacy-id-123", event.identifier)
+        assertEquals(Instant.fromEpochMilliseconds(5000), event.timestamp)
+        assertEquals(500.milliseconds, event.durationRequestSentToResponseReceived)
+
+        // Verify serializing EventVerificationDefault encodes with type "Verification"
+        val reEncoded = event.toDataItem()
+        assertEquals(Tstr("Verification"), reEncoded["type"])
     }
 
     // --- Fakes ---

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/CborSerializationTest.kt
@@ -5,10 +5,21 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.cbor.annotation.CborSerializationImplemented
 import org.multipaz.cbor.buildCborMap
+import org.multipaz.cbor.Tstr
+import org.multipaz.cbor.Uint
 import org.multipaz.util.fromBase64Url
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 enum class Enum1 { A, B, C }
 
@@ -204,6 +215,22 @@ data class SiInheritsB(
     val moarStuff: String,
 ): SiRoot(stuff)
 
+@CborSerializable
+data class DurationContainer(
+    val duration: Duration,
+    val optionalDuration: Duration? = null,
+) {
+    companion object
+}
+
+@CborSerializable
+data class DurationCollectionsContainer(
+    val durationList: List<Duration>,
+    val durationMap: Map<String, Duration>,
+) {
+    companion object
+}
+
 class CborSerializationTest {
     @Test
     fun structuralEquivalency() {
@@ -372,5 +399,100 @@ class CborSerializationTest {
             b,
             SiRoot.fromDataItem(b.toDataItem())
         )
+    }
+
+    @Test
+    fun durationSerialization_roundTrip() {
+        val testCases = listOf(
+            Duration.ZERO,
+            500.milliseconds,
+            123456789.nanoseconds,
+            42.seconds,
+            15.minutes,
+            2.hours,
+            5.days,
+            (-10).seconds,
+            (-250).milliseconds,
+            (-3).days,
+            Duration.INFINITE,
+            -Duration.INFINITE,
+        )
+        for (d in testCases) {
+            val container = DurationContainer(
+                duration = d,
+                optionalDuration = d,
+            )
+            val dataItem = container.toDataItem()
+            val decoded = DurationContainer.fromDataItem(dataItem)
+            assertEquals(container, decoded)
+            assertEquals(container, DurationContainer.fromCbor(container.toCbor()))
+
+            val collectionsContainer = DurationCollectionsContainer(
+                durationList = listOf(d, Duration.ZERO),
+                durationMap = mapOf("key" to d)
+            )
+            val collectionsDataItem = collectionsContainer.toDataItem()
+            val decodedCollections = DurationCollectionsContainer.fromDataItem(collectionsDataItem)
+            assertEquals(collectionsContainer, decodedCollections)
+            assertEquals(collectionsContainer, DurationCollectionsContainer.fromCbor(collectionsContainer.toCbor()))
+        }
+    }
+
+    @Test
+    fun durationSerialization_optionalNull() {
+        val container = DurationContainer(
+            duration = 10.seconds,
+            optionalDuration = null
+        )
+        val decoded = DurationContainer.fromDataItem(container.toDataItem())
+        assertEquals(container, decoded)
+        assertNull(decoded.optionalDuration)
+    }
+
+    @Test
+    fun durationSerialization_cborRepresentation() {
+        val duration = 1234.milliseconds
+        val container = DurationContainer(duration = duration)
+        val dataItem = container.toDataItem()
+        // Should be encoded as ISO-8601 string: Tstr("PT1.234S")
+        assertEquals(Tstr(duration.toIsoString()), dataItem["duration"])
+    }
+
+    @Test
+    fun durationDeserialization_fromRawIsoStrings() {
+        val cases = listOf(
+            "PT0S" to Duration.ZERO,
+            "PT1.5S" to 1500.milliseconds,
+            "PT1H30M" to 90.minutes,
+            "P1DT2H" to 26.hours,
+            "-PT10S" to (-10).seconds,
+            "PT-10S" to (-10).seconds,
+        )
+        for ((isoString, expectedDuration) in cases) {
+            val cborMap = buildCborMap {
+                put("duration", Tstr(isoString))
+            }
+            val container = DurationContainer.fromDataItem(cborMap)
+            assertEquals(expectedDuration, container.duration)
+        }
+    }
+
+    @Test
+    fun durationDeserialization_invalidValues() {
+        // Invalid ISO-8601 string
+        val invalidStringMap = buildCborMap {
+            put("duration", Tstr("not-a-valid-duration"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            DurationContainer.fromDataItem(invalidStringMap)
+        }
+
+        // Wrong CBOR type (Uint instead of Tstr)
+        val wrongTypeMap = buildCborMap {
+            put("duration", Uint(1000u))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            DurationContainer.fromDataItem(wrongTypeMap)
+        }
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/DcRequestScreen.kt
@@ -40,7 +40,7 @@ import org.multipaz.testapp.DcqlRequestDefinition
 import org.multipaz.verification.VerificationSession
 import org.multipaz.verification.VerificationUtil
 import org.multipaz.verification.VerifierIdentity
-import org.multipaz.eventlogger.EventVerification
+import org.multipaz.eventlogger.EventVerificationDigitalCredentials
 import kotlin.random.Random
 import kotlin.time.Clock
 
@@ -393,10 +393,22 @@ private suspend fun doDcRequestFlow(
     Logger.iJson(TAG, "Request", dcRequestObject)
     val t0 = Clock.System.now()
     val dcResponseObject = app.digitalCredentials.request(dcRequestObject)
+    val durationRequestSentToResponseReceived = Clock.System.now() - t0
     Logger.iJson(TAG, "Response", dcResponseObject)
 
     val presentmentRecord = session.processDcResponse(dcResponse = dcResponseObject)
-    app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
+    val requestJson = Json.encodeToString(dcRequestObject)
+    val responseJson = Json.encodeToString(dcResponseObject)
+    app.eventLogger.addEventAsync(
+        EventVerificationDigitalCredentials(
+            presentmentRecord = presentmentRecord,
+            requestJson = requestJson,
+            responseJson = responseJson,
+            durationRequestSentToResponseReceived = durationRequestSentToResponseReceived,
+            origin = origin,
+            appId = clientId
+        )
+    )
 
     val metadata = ShowResponseMetadata(
         engagementType = "OS-provided CredentialManager API",

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventLoggerScreen.kt
@@ -53,7 +53,10 @@ import org.multipaz.eventlogger.EventPresentmentUriSchemeOpenID4VP
 import org.multipaz.eventlogger.EventProvisioning
 import org.multipaz.eventlogger.EventSimple
 import org.multipaz.eventlogger.EventVerification
+import org.multipaz.eventlogger.EventVerificationDigitalCredentials
+import org.multipaz.eventlogger.EventVerificationIso18013Proximity
 import org.multipaz.eventlogger.SimpleEventLogger
+import org.multipaz.mdoc.engagement.EngagementType
 import org.multipaz.verification.Iso18013PresentmentRecord
 import org.multipaz.verification.OpenID4VPPresentmentRecord
 import org.multipaz.compose.getOutlinedImageVector
@@ -335,11 +338,29 @@ private fun EventItemVerification(
     modifier: Modifier = Modifier
 ) {
     val eventDateTimeString = event.timestamp.toLocalDateTime(timeZone = timeZone).formatLocalized()
-    val protocol = when (event.presentmentRecord) {
-        is Iso18013PresentmentRecord -> "ISO 18013-5"
-        is OpenID4VPPresentmentRecord -> "OpenID4VP"
+    val details = when (event) {
+        is EventVerificationDigitalCredentials -> {
+            val originOrApp = event.origin ?: event.appId
+            val originPart = if (originOrApp != null) " • $originOrApp" else ""
+            "Digital Credentials$originPart"
+        }
+        is EventVerificationIso18013Proximity -> {
+            val engagement = when (event.engagementType) {
+                EngagementType.QR_CODE -> "QR Code"
+                EngagementType.NFC_STATIC_HANDOVER -> "NFC Static"
+                EngagementType.NFC_NEGOTIATED_HANDOVER -> "NFC Negotiated"
+                EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT -> "NFC Concurrent Channel"
+            }
+            "ISO 18013-5 • $engagement"
+        }
+        else -> {
+            when (event.presentmentRecord) {
+                is Iso18013PresentmentRecord -> "ISO 18013-5"
+                is OpenID4VPPresentmentRecord -> "OpenID4VP"
+            }
+        }
     }
-    val text = "$eventDateTimeString • $protocol"
+    val text = "$eventDateTimeString • $details"
 
     FloatingItemText(
         modifier = modifier,

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/EventViewerScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -81,8 +82,11 @@ import org.multipaz.eventlogger.EventProvisioning
 import org.multipaz.eventlogger.EventProvisioningIssuerDataOpenID4VCI
 import org.multipaz.eventlogger.EventSimple
 import org.multipaz.eventlogger.EventVerification
+import org.multipaz.eventlogger.EventVerificationDigitalCredentials
+import org.multipaz.eventlogger.EventVerificationIso18013Proximity
 import org.multipaz.eventlogger.SimpleEventLogger
 import org.multipaz.eventlogger.toDataItem
+import org.multipaz.mdoc.engagement.EngagementType
 import org.multipaz.prompt.PromptModel
 import org.multipaz.request.MdocRequestedClaim
 import org.multipaz.request.RequestedClaim
@@ -93,7 +97,10 @@ import org.multipaz.verification.Iso18013PresentmentRecord
 import org.multipaz.verification.OpenID4VPPresentmentRecord
 import org.multipaz.compose.getOutlinedImageVector
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.text.font.FontFamily
 import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlin.time.Clock
 
 @OptIn(ExperimentalMaterial3Api::class, FormatStringsInDatetimeFormats::class)
@@ -643,6 +650,42 @@ private fun EventViewerVerification(
 
     var verifiedPresentations by remember { mutableStateOf<List<VerifiedPresentation>?>(null) }
     var verificationError by remember { mutableStateOf<Throwable?>(null) }
+    var jsonDialogTitle by remember { mutableStateOf<String?>(null) }
+    var jsonDialogContent by remember { mutableStateOf<String?>(null) }
+
+    if (jsonDialogTitle != null && jsonDialogContent != null) {
+        AlertDialog(
+            onDismissRequest = {
+                jsonDialogTitle = null
+                jsonDialogContent = null
+            },
+            title = { Text(text = jsonDialogTitle!!) },
+            text = {
+                val scrollState = rememberScrollState()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(scrollState)
+                ) {
+                    Text(
+                        text = jsonDialogContent!!,
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        jsonDialogTitle = null
+                        jsonDialogContent = null
+                    }
+                ) {
+                    Text(text = "Close")
+                }
+            }
+        )
+    }
 
     LaunchedEffect(event) {
         try {
@@ -683,10 +726,89 @@ private fun EventViewerVerification(
                 text = eventDateTimeString
             )
 
-            FloatingItemHeadingAndText(
-                heading = "Presentment protocol",
-                text = protocol
-            )
+            when (event) {
+                is EventVerificationDigitalCredentials -> {
+                    OriginAndAppIdItem(event.origin, event.appId)
+                    FloatingItemHeadingAndText(
+                        heading = "Presentment protocol",
+                        text = protocol
+                    )
+                    event.durationRequestSentToResponseReceived?.let {
+                        FloatingItemHeadingAndText(
+                            heading = "Latency",
+                            text = "${it.inWholeMilliseconds} ms"
+                        )
+                    }
+                    FloatingItemHeadingAndText(
+                        heading = "Request JSON",
+                        text = "Click to view",
+                        modifier = Modifier.clickable {
+                            jsonDialogTitle = "Request JSON"
+                            jsonDialogContent = formatJson(event.requestJson)
+                        }
+                    )
+                    FloatingItemHeadingAndText(
+                        heading = "Response JSON",
+                        text = "Click to view",
+                        modifier = Modifier.clickable {
+                            jsonDialogTitle = "Response JSON"
+                            jsonDialogContent = formatJson(event.responseJson)
+                        }
+                    )
+                }
+                is EventVerificationIso18013Proximity -> {
+                    val engagementText = when (event.engagementType) {
+                        EngagementType.QR_CODE -> "QR Code"
+                        EngagementType.NFC_STATIC_HANDOVER -> "NFC Static Handover"
+                        EngagementType.NFC_NEGOTIATED_HANDOVER -> "NFC Negotiated Handover"
+                        EngagementType.NFC_CONCURRENT_CHANNEL_ENGAGEMENT -> "NFC Concurrent Channel Engagement"
+                    }
+                    FloatingItemHeadingAndText(
+                        heading = "Engagement channel",
+                        text = engagementText
+                    )
+                    FloatingItemHeadingAndText(
+                        heading = "Presentment protocol",
+                        text = protocol
+                    )
+                    event.durationNfcTapToEngagement?.let {
+                        FloatingItemHeadingAndText(
+                            heading = "NFC tap to engagement",
+                            text = "${it.inWholeMilliseconds} ms"
+                        )
+                    }
+                    event.durationEngagementReceivedToRequestSent?.let {
+                        FloatingItemHeadingAndText(
+                            heading = "Engagement to request sent",
+                            text = "${it.inWholeMilliseconds} ms"
+                        )
+                    }
+                    event.durationRequestSentToResponseReceived?.let {
+                        FloatingItemHeadingAndText(
+                            heading = "Request sent to response received",
+                            text = "${it.inWholeMilliseconds} ms"
+                        )
+                    }
+                    event.durationScanningTime?.let {
+                        FloatingItemHeadingAndText(
+                            heading = "Transport scanning time",
+                            text = "${it.inWholeMilliseconds} ms"
+                        )
+                    }
+                    event.nfcHybridTransportStats?.let { stats ->
+                        FloatingItemHeadingAndText(
+                            heading = "NFC hybrid transport stats",
+                            text = "Sent: ${stats.numSent} (${stats.numSentViaNfc} NFC, ${stats.numSentViaTransport} transport)\nReceived: ${stats.numReceived} (${stats.numReceivedFirstOnNfc} NFC, ${stats.numReceivedFirstOnTransport} transport)"
+                        )
+                    }
+                }
+                else -> {
+                    FloatingItemHeadingAndText(
+                        heading = "Presentment protocol",
+                        text = protocol
+                    )
+                }
+            }
 
             if (verificationError != null) {
                 FloatingItemHeadingAndText(
@@ -767,5 +889,16 @@ private fun EventViewerVerification(
                 }
             }
         }
+    }
+}
+
+private val jsonPrettyPrint = Json { prettyPrint = true }
+
+private fun formatJson(jsonString: String): String {
+    return try {
+        val element = Json.parseToJsonElement(jsonString)
+        jsonPrettyPrint.encodeToString(JsonElement.serializer(), element)
+    } catch (_: Throwable) {
+        jsonString
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -82,6 +82,9 @@ import org.multipaz.util.fromHex
 import org.multipaz.utopia.knowntypes.wellKnownMultipleDocumentRequests
 import org.multipaz.verification.VerificationSession
 import org.multipaz.eventlogger.EventVerification
+import org.multipaz.eventlogger.EventVerificationIso18013Proximity
+import org.multipaz.mdoc.engagement.EngagementType
+import org.multipaz.mdoc.engagement.toEngagementType
 import kotlin.time.Clock
 import kotlin.time.Duration
 
@@ -343,7 +346,15 @@ fun IsoMdocProximityReadingScreen(
                                 val deviceResponse = Cbor.decode(readerMostRecentDeviceResponse.value!!)
                                 val session = readerSession.value!!
                                 val presentmentRecord = session.processIso18013ProximityResponse(deviceResponse = deviceResponse)
-                                app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
+                                app.eventLogger.addEventAsync(
+                                    EventVerificationIso18013Proximity(
+                                        presentmentRecord = presentmentRecord,
+                                        engagementType = EngagementType.QR_CODE,
+                                        durationEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent.value,
+                                        durationRequestSentToResponseReceived = durationRequestSentToResponseReceived.value,
+                                        durationScanningTime = readerTransport.value?.scanningTime,
+                                    )
+                                )
                                 showResponse(
                                     /* vpToken = */ null,
                                     /* deviceResponse = */ deviceResponse,
@@ -720,7 +731,17 @@ fun IsoMdocProximityReadingScreen(
                                     val deviceResponse = Cbor.decode(readerMostRecentDeviceResponse.value!!)
                                     val session = readerSession.value!!
                                     val presentmentRecord = session.processIso18013ProximityResponse(deviceResponse = deviceResponse)
-                                    app.eventLogger.addEventAsync(EventVerification(presentmentRecord = presentmentRecord))
+                                    app.eventLogger.addEventAsync(
+                                        EventVerificationIso18013Proximity(
+                                            presentmentRecord = presentmentRecord,
+                                            engagementType = scanResult.type.toEngagementType(),
+                                            durationNfcTapToEngagement = scanResult.processingDuration,
+                                            durationEngagementReceivedToRequestSent = durationEngagementReceivedToRequestSent.value,
+                                            durationRequestSentToResponseReceived = durationRequestSentToResponseReceived.value,
+                                            durationScanningTime = scanResult.transport.scanningTime,
+                                            nfcHybridTransportStats = (scanResult.transport as? NfcHybridTransportMdocReader)?.stats,
+                                        )
+                                    )
                                     showResponse(
                                         /* vpToken = */ null,
                                         /* deviceResponse = */ deviceResponse,


### PR DESCRIPTION
Enhance verification event telemetry by introducing specialized subclasses under `EventVerification` to capture complete protocol context, timing metrics, and diagnostic data:

- Add support for serializing and deserializing `Duration` values in `CborSymbolProcessor` as ISO-8601 strings, with unit test coverage in `CborSerializationTest`.
- Introduce `EngagementType` enum for ISO/IEC 18013 engagement channels (`QR_CODE`, `NFC_STATIC_HANDOVER`, `NFC_NEGOTIATED_HANDOVER`, and `NFC_CONCURRENT_CHANNEL_ENGAGEMENT`).
- Convert `EventVerification` into a sealed class and add `EventVerificationDigitalCredentials` to capture W3C Digital Credentials API request/response JSON, latency, origin, and app ID.
- Add `EventVerificationIso18013Proximity` to record proximity engagement channel, phase timings, scanning durations, and NFC hybrid transport diagnostics.
- Add `EventVerificationDefault` with typeId "Verification" to preserve backward compatibility when deserializing legacy verification events.
- Update call sites in `DcRequestScreen` and `IsoMdocProximityReadingScreen` to log these specialized verification events with timings and stats.
- Update testapp `EventLoggerScreen` and `EventViewerScreen` as well as web tools `EventDecoderComponent` to format and display the new telemetry.
- Add unit tests in `SimpleEventLoggerTests` verifying serialization and roundtrip deserialization of all verification event types.

Fixes #1985.

Test: Manually tested in Test App.
Test: ./gradlew detekt :multipaz:jvmTest :multipaz-cbor-rpc:test :multipaz-tools:web:compileKotlinJs :samples:testapp:assembleDebug
