### PR TITLE
Configure busy timeout on SQLite storage to prevent lock failures.

### DIFF
--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/storage/AndroidStorageTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/storage/AndroidStorageTest.kt
@@ -26,6 +26,8 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.minutes
 
 class AndroidStorageTest {
@@ -522,6 +524,63 @@ class AndroidStorageTest {
             assertEquals(setOf(key3), table.enumerate(partitionId = "C").toSet())
             assertNull(table.get(key = key1, partitionId = "B"))
             assertNull(table.get(key = key2, partitionId = "B"))
+        }
+    }
+
+    @Test
+    fun testBusyTimeout() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val dbFile = context.getDatabasePath("test_busy_timeout.db")
+        dbFile.delete()
+        try {
+            val storage1 = AndroidStorage(
+                databasePath = dbFile.absolutePath,
+                clock = TestClock,
+                keySize = 3
+            )
+            val storage2 = AndroidStorage(
+                databasePath = dbFile.absolutePath,
+                clock = TestClock,
+                keySize = 3
+            )
+            val tableSpec = StorageTableSpec("test_table", supportPartitions = false, supportExpiration = false)
+            val table1 = storage1.getTable(tableSpec)
+            val table2 = storage2.getTable(tableSpec)
+
+            table1.insert("k1", data = "v1".encodeToByteString())
+
+            // Android SQLite automatically configures a non-zero busy_timeout (typically 2500ms).
+            storage1.withDatabase { db ->
+                db.rawQuery("PRAGMA busy_timeout", null).use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val timeout = cursor.getLong(0)
+                        assertTrue(timeout >= 2000L, "Expected busy_timeout >= 2000ms, got $timeout")
+                    }
+                }
+            }
+
+            // Connection 1 holds an exclusive transaction for 200ms.
+            val lockJob = launch(Dispatchers.IO) {
+                storage1.withDatabase { db ->
+                    db.execSQL("BEGIN EXCLUSIVE TRANSACTION")
+                    try {
+                        Thread.sleep(200)
+                        db.execSQL("COMMIT")
+                    } catch (e: Throwable) {
+                        db.execSQL("ROLLBACK")
+                    }
+                }
+            }
+
+            delay(50)
+
+            // Connection 2 writes while Connection 1 holds the lock.
+            // With Android's busy timeout, this automatically waits and succeeds.
+            table2.insert("k2", data = "v2".encodeToByteString())
+            assertEquals("v2".encodeToByteString(), table2.get("k2"))
+            lockJob.join()
+        } finally {
+            dbFile.delete()
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/storage/Storage.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/storage/Storage.kt
@@ -3,6 +3,22 @@ package org.multipaz.storage
 /**
  * Storage (in most cases persistent) that holds data items. Collection of items are organized
  * in named [StorageTable]s.
+ *
+ * ## Concurrency and Multiple Instances
+ *
+ * It is safe to use multiple [Storage] instances that reference the same underlying database
+ * concurrently, whether within the same process or across different processes (for example, a mobile
+ * application and an app extension sharing an App Group container).
+ *
+ * Implementations provide concurrency guarantees through the underlying database engine:
+ * - **Atomicity:** Individual operations on [StorageTable] (such as `insert`, `update`, `delete`,
+ *   and `get`) are atomic.
+ * - **Contention Handling:** When multiple connections or processes attempt to access or modify
+ *   the database simultaneously, implementations configure appropriate lock wait mechanisms
+ *   (e.g., SQLite's `busy_timeout` on mobile platforms, transaction queues in IndexedDB, or MVCC
+ *   in relational databases). Operations will automatically wait for concurrent locks to be released
+ *   rather than immediately failing with contention errors. If contention persists longer than
+ *   the configured timeout, the operation will fail with an exception.
  */
 interface Storage {
     /**

--- a/multipaz/src/iosMain/kotlin/org/multipaz/storage/ios/IosStorage.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/storage/ios/IosStorage.kt
@@ -12,22 +12,60 @@ import org.multipaz.storage.StorageTableSpec
 import org.multipaz.storage.sqlite.SqliteStorage
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLIsExcludedFromBackupKey
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Implementation of [Storage] for iOS platform.
  *
  * @param storageFileUrl a URL with the path to the database file.
  * @param excludeFromBackup if true, the database file will be excluded from backup.
+ * @param busyTimeout timeout to wait for SQLite database locks before failing. Defaults to 5 seconds.
+ * @param clock clock to use for timestamps and expiration. Defaults to [Clock.System].
  */
 @OptIn(ExperimentalForeignApi::class, DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 class IosStorage(
     private val storageFileUrl: NSURL,
-    private val excludeFromBackup: Boolean = true
+    private val excludeFromBackup: Boolean = true,
+    busyTimeout: Duration = 5.seconds,
+    clock: Clock = Clock.System
 ): SqliteStorage(
     connection = getConnection(storageFileUrl, excludeFromBackup),
+    clock = clock,
     // Native sqlite crashes when used with Dispatchers.IO.
-    coroutineContext = newSingleThreadContext("DB")
+    coroutineContext = newSingleThreadContext("DB"),
+    busyTimeout = busyTimeout
 ) {
+    /**
+     * Constructor for backwards compatibility with Swift and Objective-C callers
+     * who do not specify [busyTimeout] or [clock].
+     */
+    constructor(
+        storageFileUrl: NSURL,
+        excludeFromBackup: Boolean
+    ) : this(
+        storageFileUrl = storageFileUrl,
+        excludeFromBackup = excludeFromBackup,
+        busyTimeout = 5.seconds,
+        clock = Clock.System
+    )
+
+    /**
+     * Constructor allowing Swift and Objective-C callers to specify a busy timeout in milliseconds.
+     */
+    constructor(
+        storageFileUrl: NSURL,
+        excludeFromBackup: Boolean,
+        busyTimeoutMs: Long
+    ) : this(
+        storageFileUrl = storageFileUrl,
+        excludeFromBackup = excludeFromBackup,
+        busyTimeout = busyTimeoutMs.milliseconds,
+        clock = Clock.System
+    )
+
     companion object {
         private fun getConnection(
             storageFileUrl: NSURL,

--- a/multipaz/src/iosMain/kotlin/org/multipaz/storage/sqlite/SqliteStorage.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/storage/sqlite/SqliteStorage.kt
@@ -1,6 +1,7 @@
 package org.multipaz.storage.sqlite
 
 import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
 import org.multipaz.storage.Storage
 import org.multipaz.storage.base.BaseStorage
 import org.multipaz.storage.base.BaseStorageTable
@@ -9,6 +10,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -31,8 +34,27 @@ open class SqliteStorage(
     private val connection: SQLiteConnection,
     clock: Clock = Clock.System,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
-    internal val keySize: Int = 9
+    internal val keySize: Int = 9,
+    val busyTimeout: Duration = 5.seconds
 ): BaseStorage(clock) {
+    init {
+        val busyTimeoutMs = busyTimeout.inWholeMilliseconds
+        require(busyTimeoutMs >= 0) { "busyTimeout must not be negative" }
+        connection.execSQL("PRAGMA busy_timeout = $busyTimeoutMs")
+    }
+
+    constructor(
+        connection: SQLiteConnection,
+        clock: Clock = Clock.System,
+        coroutineContext: CoroutineContext = Dispatchers.IO,
+        keySize: Int = 9
+    ): this(
+        connection = connection,
+        clock = clock,
+        coroutineContext = coroutineContext,
+        keySize = keySize,
+        busyTimeout = 5.seconds
+    )
     override suspend fun createTable(tableSpec: StorageTableSpec): BaseStorageTable {
         val table = SqliteStorageTable(this, tableSpec)
         table.init()

--- a/multipaz/src/iosTest/kotlin/org/multipaz/storage/IosStorageTest.kt
+++ b/multipaz/src/iosTest/kotlin/org/multipaz/storage/IosStorageTest.kt
@@ -1,29 +1,39 @@
 package org.multipaz.storage
 
+import androidx.sqlite.SQLiteException
 import androidx.sqlite.driver.NativeSQLiteDriver
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.multipaz.storage.base.BaseStorageTable
 import org.multipaz.util.toHex
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.newSingleThreadContext
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.decodeToString
 import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.storage.ios.IosStorage
 import org.multipaz.storage.sqlite.SqliteStorage
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
 import kotlin.random.Random
 import kotlin.test.BeforeTest
@@ -34,7 +44,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.minutes
 
 class IosStorageTest {
     @BeforeTest
@@ -533,6 +542,160 @@ class IosStorageTest {
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class, ExperimentalForeignApi::class)
+    @Test
+    fun testBusyTimeout() = runBlocking {
+        val paths = NSSearchPathForDirectoriesInDomains(
+            directory = NSCachesDirectory,
+            domainMask = NSUserDomainMask,
+            expandTilde = true
+        )
+        if (paths.isEmpty()) {
+            throw IllegalStateException("No caches directory")
+        }
+        val dbPath = "${paths[0]}/testBusyTimeout_${uniqueSuffix()}.db"
+        val dbUrl = NSURL.fileURLWithPath(dbPath)
+        val fileManager = NSFileManager.defaultManager
+        if (fileManager.fileExistsAtPath(dbPath)) {
+            fileManager.removeItemAtPath(dbPath, null)
+        }
+
+        try {
+            val tableSpec = StorageTableSpec(
+                name = "TestBusy",
+                supportPartitions = false,
+                supportExpiration = false
+            )
+
+            // Verify default busy_timeout pragma is 5000ms
+            val defaultStorage = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false
+            )
+            assertEquals(5.seconds, defaultStorage.busyTimeout)
+            defaultStorage.withConnection { conn ->
+                conn.prepare("PRAGMA busy_timeout").use { stmt ->
+                    assertTrue(stmt.step())
+                    assertEquals(5000L, stmt.getLong(0))
+                }
+            }
+
+            // Initialize table
+            val defaultTable = defaultStorage.getTable(tableSpec)
+            defaultTable.insert("k1", "v1".encodeToByteString())
+
+            // Test 1: With busyTimeout = Duration.ZERO, a second connection encountering
+            // contention immediately throws SQLiteException (reproducing issue #1979).
+            val zeroTimeoutStorage1 = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false,
+                busyTimeout = Duration.ZERO
+            )
+            val zeroTimeoutStorage2 = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false,
+                busyTimeout = Duration.ZERO
+            )
+            val zeroTable2 = zeroTimeoutStorage2.getTable(tableSpec)
+
+            zeroTimeoutStorage1.withConnection { conn1 ->
+                conn1.execSQL("BEGIN EXCLUSIVE TRANSACTION")
+                try {
+                    // Contended read immediately fails with SQLiteException because busy_timeout is 0
+                    assertFailsWith<SQLiteException> {
+                        zeroTable2.get("k1")
+                    }
+                } finally {
+                    conn1.execSQL("ROLLBACK")
+                }
+            }
+
+            // Test 2: With default busyTimeout (5s), connection 2 waits for connection 1
+            // to release the lock and succeeds without throwing.
+            val lockHolderStorage = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false
+            )
+            val waitingStorage = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false
+            )
+            val waitingTable = waitingStorage.getTable(tableSpec)
+
+            val lockJob = launch(Dispatchers.Default) {
+                lockHolderStorage.withConnection { conn ->
+                    conn.execSQL("BEGIN EXCLUSIVE TRANSACTION")
+                    delay(200)
+                    conn.execSQL("COMMIT")
+                }
+            }
+
+            // Give lockJob a moment to acquire the exclusive lock
+            delay(50)
+
+            // Contended read: waits until lockJob commits after 200ms, then succeeds
+            val data = waitingTable.get("k1")
+            assertEquals("v1".encodeToByteString(), data)
+            lockJob.join()
+
+            // Test 3: If lock is held longer than busyTimeout, it times out and throws SQLiteException.
+            val shortTimeoutStorage = IosStorage(
+                storageFileUrl = dbUrl,
+                excludeFromBackup = false,
+                busyTimeout = 100.milliseconds
+            )
+            val shortTable = shortTimeoutStorage.getTable(tableSpec)
+
+            val longLockJob = launch(Dispatchers.Default) {
+                lockHolderStorage.withConnection { conn ->
+                    conn.execSQL("BEGIN EXCLUSIVE TRANSACTION")
+                    delay(500)
+                    conn.execSQL("COMMIT")
+                }
+            }
+
+            delay(50)
+
+            // Lock is held for 500ms, but timeout is only 100ms -> must fail
+            assertFailsWith<SQLiteException> {
+                shortTable.get("k1")
+            }
+            longLockJob.join()
+
+        } finally {
+            if (fileManager.fileExistsAtPath(dbPath)) {
+                fileManager.removeItemAtPath(dbPath, null)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testSqliteStorageBusyTimeout() = runBlocking {
+        val paths = NSSearchPathForDirectoriesInDomains(
+            directory = NSCachesDirectory,
+            domainMask = NSUserDomainMask,
+            expandTilde = true
+        )
+        val dbPath = "${paths[0]}/testSqliteStorage_${uniqueSuffix()}.db"
+        val fileManager = NSFileManager.defaultManager
+        try {
+            val connection = NativeSQLiteDriver().open(dbPath)
+            val storage = SqliteStorage(connection)
+            assertEquals(5.seconds, storage.busyTimeout)
+            storage.withConnection { conn ->
+                conn.prepare("PRAGMA busy_timeout").use { stmt ->
+                    assertTrue(stmt.step())
+                    assertEquals(5000L, stmt.getLong(0))
+                }
+            }
+        } finally {
+            if (fileManager.fileExistsAtPath(dbPath)) {
+                fileManager.removeItemAtPath(dbPath, null)
+            }
+        }
+    }
+
     private fun withStorage(block: suspend CoroutineScope.(storage: Storage) -> Unit) {
         for (storage in transientStorageList) {
             runBlocking {
@@ -617,10 +780,9 @@ private fun createPersistentStorage(name: String, testClock: Clock): Storage? {
             NSFileManager.defaultManager.removeItemAtPath(dbPath, null)
         }
     }
-    return SqliteStorage(
-        connection = NativeSQLiteDriver().open(dbPath),
-        clock = testClock,
-        // native sqlite crashes when used with Dispatchers.IO
-        coroutineContext = newSingleThreadContext("DB")
+    return IosStorage(
+        storageFileUrl = NSURL.fileURLWithPath(dbPath),
+        excludeFromBackup = false,
+        clock = testClock
     )
 }


### PR DESCRIPTION
On iOS, the SQLite C library defaults `busy_timeout` to 0 ms. When multiple connections access the same underlying database concurrently (such as an app and an app extension sharing an App Group container), any lock contention immediately throws `SQLiteException: Error code: 5, message: database is locked`.

Configure a default busy timeout of 5 seconds for SQLite connections on iOS:
- In `SqliteStorage`, accept a `busyTimeout: Duration = 5.seconds` parameter, validate that it is non-negative, and execute `PRAGMA busy_timeout` in the `init` block. Provide backward-compatible constructors.
- In `IosStorage`, delegate `busyTimeout` configuration to `SqliteStorage`, and provide secondary constructors with `(storageFileUrl, excludeFromBackup)` and `(storageFileUrl, excludeFromBackup, busyTimeoutMs)` overloads for Swift/Objective-C compatibility.
- In `Storage`, update KDoc to document concurrency and multi-instance safety guarantees across processes.
- In `IosStorageTest`, add unit test `testBusyTimeout()` reproducing the zero-timeout failure under lock contention, verifying that the default 5-second timeout waits and succeeds, and verifying that exceeding the timeout fails. Add `testSqliteStorageBusyTimeout()` verifying standalone `SqliteStorage` instances.
- In `AndroidStorageTest`, add `testBusyTimeout()` verifying that Android SQLite automatically configures a busy timeout (>= 2000 ms) and handles contention without error.

Fixes #1979.

Test: Ran ./gradlew :multipaz:jvmTest
Test: Ran ./gradlew :multipaz:iosSimulatorArm64Test
Test: Ran ./gradlew :multipaz:connectedDebugAndroidTest (on Pixel 8 Pro)
Test: Ran ./gradlew detekt
Test: Ran xcodebuild -project samples/SwiftTestApp/SwiftTestApp.xcodeproj -scheme SwiftTestApp -sdk iphonesimulator build
