### PR TITLE
Reset NFC transceiver state and close IsoDep on NFC engagement errors

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
@@ -693,6 +693,12 @@ class VerificationHelper internal constructor(
                     reportDeviceEngagementReceived(parsedCms)
                 } catch (t: Throwable) {
                     reportError(t)
+                } finally {
+                    try {
+                        isoDep?.close()
+                    } catch (ignored: Throwable) {
+                    }
+                    nfcIsoDep = null
                 }
             }
         }


### PR DESCRIPTION
Fixes #1990 

Adds a finally block in VerificationHelper to prevent the NFC reader from getting in a wedged state where subsequent NFC taps fail to connect.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
