### PR TITLE
Accept BER-encoded BOOLEAN TRUE and preserve the content octet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Significant changes since Multipaz 0.100.0 include:
 - New `custom_head_html` server setting, injected into the `<head>` of every HTML page served
   by `serveResources()`, so a deployment can restyle the built-in pages without forking their
   markup.
+- Fixed `ASN1Boolean` rejecting a BOOLEAN whose content octet is non-zero but not `0xFF`, which
+  made X.509 extension parsing fail on certificates from devices whose KeyMint emits `0x01` and
+  so broke Android key attestation on them. Such an octet now decodes as `true` per X.690 8.2.2
+  and is preserved, so decoding and re-encoding stay byte-exact.
 
 ## [0.100.0] - 2026-07-08
 Significant changes since Multipaz 0.99.0 include:

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1Boolean.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1Boolean.kt
@@ -2,11 +2,31 @@ package org.multipaz.asn1
 
 import kotlinx.io.bytestring.ByteStringBuilder
 
-class ASN1Boolean(val value: Boolean): ASN1PrimitiveValue(tag = TAG_NUMBER) {
+class ASN1Boolean internal constructor(
+    val value: Boolean,
+    /**
+     * The content octet this value was decoded from, or the canonical octet when the value was
+     * constructed rather than decoded.
+     *
+     * X.690 8.2.2 lets a sender encode TRUE as any non-zero octet, and Android KeyMint emits
+     * `0x01`. Retaining that octet instead of normalising it to `0xFF` is what keeps
+     * `ASN1.encode(ASN1.decode(bytes))` equal to `bytes`, which this package tests as a contract
+     * and which structures signed over their decoded form — such as the entry extensions of a
+     * CRL, reached through a plain SEQUENCE — depend on.
+     */
+    val encodedValue: Byte
+): ASN1PrimitiveValue(tag = TAG_NUMBER) {
+
+    /**
+     * Constructs a boolean that encodes canonically, as `0xFF` for `true` and `0x00` for `false`.
+     *
+     * @param value the boolean value.
+     */
+    constructor(value: Boolean): this(value, if (value) 0xff.toByte() else 0x00.toByte())
 
     override fun encode(builder: ByteStringBuilder) {
         ASN1.appendUniversalTagEncodingLength(builder, TAG_NUMBER, enc, 1)
-        builder.append(if (value) 0xff.toByte() else 0x00.toByte())
+        builder.append(encodedValue)
     }
 
     override fun equals(other: Any?): Boolean = other is ASN1Boolean && value == other.value
@@ -20,16 +40,23 @@ class ASN1Boolean(val value: Boolean): ASN1PrimitiveValue(tag = TAG_NUMBER) {
     companion object {
         const val TAG_NUMBER = 0x01
 
+        /**
+         * Decodes a BOOLEAN from its content octets.
+         *
+         * Any non-zero octet decodes as `true`, per X.690 8.2.2. The requirement that TRUE be
+         * `0xFF` is a restriction clause 11 places on encoders, so it is applied when encoding
+         * values constructed through the public constructor, not here — see
+         * https://github.com/openwallet-foundation/multipaz/issues/1992 for the certificates
+         * that motivated this.
+         *
+         * @param content the content octets, which must be exactly one octet (X.690 8.2.1).
+         * @return the decoded value, carrying [encodedValue] so it re-encodes byte-exactly.
+         * @throws IllegalArgumentException if [content] is not exactly one octet.
+         */
+        @Throws(IllegalArgumentException::class)
         fun parse(content: ByteArray): ASN1Boolean {
             require(content.size == 1) { "Content size is ${content.size}, expected 1" }
-            val value = when (content[0]) {
-                0x00.toByte() -> false
-                0xff.toByte() -> true
-                else -> {
-                    throw IllegalArgumentException("Content value is ${content[0]}, expected 0x00 or 0xff")
-                }
-            }
-            return ASN1Boolean(value)
+            return ASN1Boolean(content[0] != 0x00.toByte(), content[0])
         }
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/asn1/ASN1Tests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/asn1/ASN1Tests.kt
@@ -58,8 +58,20 @@ class ASN1Tests {
 
         assertEquals(ASN1Boolean(false), ASN1.decode("010100".fromHex()))
         assertEquals(ASN1Boolean(true), ASN1.decode("0101ff".fromHex()))
+
+        // X.690 8.2.2 makes any non-zero octet TRUE, and Android KeyMint emits 0x01 in the
+        // `critical` flag of X.509 extensions, so decoding has to accept it. Note that equality
+        // is semantic and ignores the octet, so it cannot catch the octet being dropped — the
+        // re-encoding below is what pins that.
+        assertEquals(ASN1Boolean(true), ASN1.decode("010101".fromHex()))
+
+        // The octet is preserved rather than normalized to 0xff, keeping decode/encode
+        // byte-exact as testCertificate() requires.
+        assertContentEquals("010101".fromHex(), ASN1.encode(ASN1.decode("010101".fromHex())!!))
+
+        // Well-formedness is still enforced: the contents are exactly one octet (X.690 8.2.1).
         assertFailsWith(IllegalArgumentException::class) {
-            assertEquals(ASN1Boolean(false), ASN1.decode("010101".fromHex()))
+            ASN1.decode("01020000".fromHex())
         }
 
         assertEquals(
@@ -73,6 +85,21 @@ class ASN1Tests {
                 ASN1Boolean(false),
             ))).trim()
         )
+    }
+
+    @Test
+    fun testBooleanNonCanonicalInExtension() {
+        // The keyUsage extension of an Android Keystore certificate whose KeyMint encodes the
+        // `critical` flag as 0x01 — SEQUENCE { OID 2.5.29.15, BOOLEAN 01, OCTET STRING }.
+        // This nested form is the one that actually failed: a certificate's extensions live in a
+        // CONTEXT_SPECIFIC [3] whose content ASN1.decode passes through untouched, so they are
+        // only decoded when accessed, via X509Signed.getExtensionsSeq().
+        val extension = "300e0603551d0f010101040403020780".fromHex()
+
+        val decoded = ASN1.decode(extension) as ASN1Sequence
+
+        assertTrue((decoded.elements[1] as ASN1Boolean).value)
+        assertContentEquals(extension, ASN1.encode(decoded))
     }
 
     @Test


### PR DESCRIPTION
Fixes #1992

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

`ASN1Boolean.parse` accepted only `0x00` and `0xFF`. Android KeyMint encodes the `critical`
flag of X.509 extensions as `0x01` — valid BER, invalid DER — so it threw. Extensions are
decoded on access, in `X509Signed.getExtensionsSeq()`, so every extension read on those
devices failed, `AndroidAttestationExtensionParser` included. Any non-zero octet now decodes
as `true` per X.690 8.2.2; the public constructor still encodes `0xFF`.

The one thing worth reviewing: the octet is **preserved**, not normalised. That keeps
`ASN1.encode(ASN1.decode(x)) == x`, which `ASN1Tests.testCertificate` pins, and it matters
for signed structures where the boolean really is re-encoded — CRL entry extensions, since
`TBSCertList.revokedCertificates` is a plain SEQUENCE. It also matches `ASN1Integer` and
`ASN1BitString`, which already keep their raw content octets.

The two-argument constructor is `internal`, so nothing outside the module can build an
`ASN1Boolean` whose `value` contradicts its encoding — that flag is the `cA` bit
`X509CertChain` validates on. The public single-argument constructor is unchanged.

`testBoolean()` previously pinned the rejection with `assertFailsWith`; that is replaced by
stronger assertions, plus `testBooleanNonCanonicalInExtension()` covering the nested path
that actually failed, with the real bytes from an affected device.

Not general leniency (cf. #1734): valid BER in, octet preserved, encoder untouched — same
shape as #1938.