### PR TITLE
Verify processed SD-JWT payload and transaction data in presentment.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
@@ -52,14 +52,20 @@ class SdJwtKb private constructor(
     }
 
     /**
-     * Verifies a SD-JWT+KB according to Section 7.3 of the SD-JWT specification
+     * Verifies a SD-JWT+KB according to Section 7.3 of the SD-JWT specification.
+     *
+     * Note that per Section 7.3 of RFC 9901, the returned JSON object is the Processed SD-JWT
+     * Payload containing only the Issuer-signed claims (with Disclosures resolved). The
+     * device-signed claims in the Key Binding JWT (such as `nonce`, `aud`, `iat`, and any
+     * transaction response claims) are not included in this returned payload and must be
+     * retrieved separately from [jwtBody].
      *
      * @param issuerKey the issuer's key to use for verification or `null` to not perform issuer signature validation.
      * @param checkNonce a function to check that the nonce in the KB JWT is as expected.
      * @param checkAudience a function to check that the audience in the KB JWT is as expected.
      * @param checkCreationTime a function to check that the creation time in the KB JWT is as expected.
-     * @param transactionData transaction data that was sent with the request
-     * @return the processed SD-JWT payload,
+     * @param transactionData transaction data that was sent with the request.
+     * @return the processed SD-JWT payload.
      * @throws SignatureVerificationException if the issuer signature or key-binding signature failed to validate.
      * @throws IllegalStateException if [checkNonce], [checkAudience], or [checkCreationTime] returns false.
      */

--- a/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/presentment/DigitalCredentialsPresentmentTest.kt
@@ -1,6 +1,5 @@
 package org.multipaz.presentment
 
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.ByteString
@@ -21,6 +20,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.buildJsonArray
 import org.multipaz.asn1.ASN1Integer
+import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.ByteStringFormat
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Cdn
@@ -34,8 +34,6 @@ import org.multipaz.cbor.Uint
 import org.multipaz.cbor.addCborArray
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
-import org.multipaz.cbor.putCborArray
-import org.multipaz.cbor.toDataItem
 import org.multipaz.credential.Credential
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.AsymmetricKey
@@ -53,7 +51,6 @@ import org.multipaz.documenttype.ISO_18013_TRANSACTION_DATA_NAMESPACE
 import org.multipaz.documenttype.TransactionType
 import org.multipaz.documenttype.TransactionUserInput
 import org.multipaz.documenttype.knowntypes.PaymentTransaction
-import org.multipaz.mdoc.devicesigned.DeviceAuth
 import org.multipaz.mdoc.request.DeviceRequestInfo
 import org.multipaz.mdoc.request.DocRequestInfo
 import org.multipaz.mdoc.request.DocumentSet
@@ -66,7 +63,6 @@ import org.multipaz.openid.OpenID4VP
 import org.multipaz.prompt.promptModelSilentConsent
 import org.multipaz.request.RequestedClaim
 import org.multipaz.request.Requester
-import org.multipaz.request.RequesterIdentity
 import org.multipaz.request.TrustedRequesterIdentity
 import org.multipaz.sdjwt.SdJwtKb
 import org.multipaz.trustmanagement.TrustPoint
@@ -82,6 +78,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 
 class DigitalCredentialsPresentmentTest {
     internal abstract class BooleanTransaction(
@@ -1121,6 +1118,10 @@ class DigitalCredentialsPresentmentTest {
         assertEquals(DeviceResponse.STATUS_OK, deviceResponse.status)
         assertEquals(1, deviceResponse.documents.size)
         val mdocDoc = deviceResponse.documents[0]
+        assertEquals(1, mdocDoc.transactionData.size)
+        val tx = mdocDoc.transactionData[0]
+        assertEquals(PaymentTransaction, tx.type)
+        assertEquals(payload, tx.payload)
         val txElements = mdocDoc.deviceNamespaces.data[ISO_18013_TRANSACTION_DATA_NAMESPACE]!![PaymentTransaction.identifier]!!
         assertEquals(0L, txElements["docRequestId"].asNumber)
         assertEquals(123.25, txElements["amount"].asDouble)
@@ -1329,6 +1330,10 @@ class DigitalCredentialsPresentmentTest {
         assertEquals(1, deviceResponse.otherDocuments.size)
         val otherDoc = deviceResponse.otherDocuments[0]
         assertEquals("dc+sd-jwt", otherDoc.docFormat)
+        assertEquals(1, otherDoc.transactionData.size)
+        val tx = otherDoc.transactionData[0]
+        assertEquals(PaymentTransaction, tx.type)
+        assertEquals(payload, tx.payload)
 
         // Pretty-printed entire DeviceResponse (Concise Diagnostic Notation) using LENGTH_ONLY
         val responseCdn = Cdn.encode(
@@ -1349,10 +1354,42 @@ class DigitalCredentialsPresentmentTest {
         """.trimIndent()
         assertEquals(expectedResponseCdn, responseCdn.trim())
 
-        // Pretty-printed SD-JWT KB-JWT payload (JSON)
         val decompressedData = otherDoc.data.toByteArray().zlibInflate()
         val sdJwtKb = SdJwtKb.fromCompactSerialization(decompressedData.decodeToString())
         val prettyJson = Json { prettyPrint = true }
+
+        // Pretty-printed SD-JWT payload (JSON)
+        val jwtJson = prettyJson.encodeToString(sdJwtKb.sdJwt.jwtBody)
+        val jwtIat = sdJwtKb.sdJwt.jwtBody["iat"]!!.jsonPrimitive.content
+        val jwtNbf = sdJwtKb.sdJwt.jwtBody["nbf"]!!.jsonPrimitive.content
+        val jwtExp = sdJwtKb.sdJwt.jwtBody["exp"]!!.jsonPrimitive.content
+        val jwtSd = sdJwtKb.sdJwt.jwtBody["_sd"]!!.jsonArray[0].jsonPrimitive.content
+        val jwtCnfX = sdJwtKb.sdJwt.jwtBody["cnf"]!!.jsonObject["jwk"]!!.jsonObject["x"]!!.jsonPrimitive.content
+        val jwtCnfY = sdJwtKb.sdJwt.jwtBody["cnf"]!!.jsonObject["jwk"]!!.jsonObject["y"]!!.jsonPrimitive.content
+        val expectedJwtJson = """
+            {
+                "iss": "https://example-issuer.com",
+                "vct": "org.multipaz.payment.sca.1",
+                "iat": $jwtIat,
+                "nbf": $jwtNbf,
+                "exp": $jwtExp,
+                "_sd": [
+                    "$jwtSd"
+                ],
+                "_sd_alg": "sha-256",
+                "cnf": {
+                    "jwk": {
+                        "crv": "P-256",
+                        "kty": "EC",
+                        "x": "$jwtCnfX",
+                        "y": "$jwtCnfY"
+                    }
+                }
+            }
+        """.trimIndent()
+        assertEquals(expectedJwtJson, jwtJson.trim())
+
+        // Pretty-printed SD-JWT KB-JWT payload (JSON)
         val kbJwtJson = prettyJson.encodeToString(sdJwtKb.jwtBody)
         val sdHash = sdJwtKb.jwtBody["sd_hash"]!!.jsonPrimitive.content
         val iat = sdJwtKb.jwtBody["iat"]!!.jsonPrimitive.content
@@ -1372,6 +1409,41 @@ class DigitalCredentialsPresentmentTest {
             }
         """.trimIndent()
         assertEquals(expectedKbJwtJson, kbJwtJson.trim())
+
+        val sessionTranscriptBytes = Tagged(
+            tagNumber = Tagged.ENCODED_CBOR,
+            taggedItem = Bstr(Cbor.encode(sessionTranscript))
+        )
+        val expectedNonce = Crypto.digest(Algorithm.SHA256, Cbor.encode(sessionTranscriptBytes)).toBase64Url()
+
+        // Pretty-printed processed SD-JWT payload (JSON)
+        val processedJwt = sdJwtKb.verify(
+            issuerKey = documentStoreTestHarness.dsKey.publicKey,
+            checkNonce = { it == expectedNonce },
+            checkAudience = { it == "none" },
+            checkCreationTime = { (it - creationTime).absoluteValue < 5.minutes },
+            transactionData = otherDoc.transactionData
+        )
+        val processedJwtJson = prettyJson.encodeToString(processedJwt)
+        val expectedProcessedJwtJson = """
+            {
+                "iss": "https://example-issuer.com",
+                "vct": "org.multipaz.payment.sca.1",
+                "iat": $jwtIat,
+                "nbf": $jwtNbf,
+                "exp": $jwtExp,
+                "cnf": {
+                    "jwk": {
+                        "crv": "P-256",
+                        "kty": "EC",
+                        "x": "$jwtCnfX",
+                        "y": "$jwtCnfY"
+                    }
+                },
+                "account_id": "acc-12345"
+            }
+        """.trimIndent()
+        assertEquals(expectedProcessedJwtJson, processedJwtJson.trim())
     }
 
     @Test


### PR DESCRIPTION
Clarify that the processed payload returned by `verify()` in `SdJwtKb` contains only Issuer-signed claims per RFC 9901 and does not include device-signed claims from the Key Binding JWT, which must be retrieved separately from `jwtBody`.

Update ISO 18013-5 payment presentment tests to verify both raw and processed SD-JWT payloads, validate the session transcript nonce, audience, creation time, and transaction data callbacks in `verify()`, and assert that `transactionData` is populated and matches the expected payment payload on `MdocDocument` and `OtherDocument`.

Key changes:
- In `SdJwtKb`, update documentation for `verify()` explaining that device-signed claims from the Key Binding JWT are not included in the returned processed payload and must be retrieved from `jwtBody`.
- In `DigitalCredentialsPresentmentTest`, update `payment_Iso18013_SdJwtVc()` to verify the raw SD-JWT payload string, call `verify()` on `SdJwtKb` with explicit `issuerKey`, `checkNonce`, `checkAudience`, `checkCreationTime`, and `transactionData` arguments, and assert the processed SD-JWT payload string.
- In `DigitalCredentialsPresentmentTest`, assert that `transactionData` on `otherDoc` and `mdocDoc` is not empty and matches the expected `PaymentTransaction` payload in `payment_Iso18013_SdJwtVc()` and `payment_Iso18013_IsoMdoc()`.
- Remove unused imports in `DigitalCredentialsPresentmentTest`.

Fixes #1980.

Test: Ran ./gradlew detekt
Test: Ran ./gradlew :multipaz:jvmTest --tests "org.multipaz.presentment.*"
Test: Ran ./gradlew :multipaz:jvmTest --tests "org.multipaz.sdjwt.*"
