### PR TITLE
Resolve the lokalize API key from the environment only

### DIFF
--- a/build-logic/conventions/src/main/kotlin/org/multipaz/lokalize/convention/LokalizeConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/org/multipaz/lokalize/convention/LokalizeConventionPlugin.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.multipaz.lokalize.util.LLMProvider
 import org.multipaz.lokalize.util.LLmModel
-import org.multipaz.lokalize.util.OutputFormat
 
 /**
  * Convention plugin for Lokalize configuration.
@@ -44,7 +43,6 @@ class LokalizeConventionPlugin : Plugin<Project> {
 
             ext.llmProvider.set(LLMProvider.GOOGLE)
             ext.llModel.set(LLmModel.GEMINI2_5_FLASH)
-            ext.llmApiKey.set("API_KEY")
         }
     }
 }

--- a/build-logic/lokalize/README.md
+++ b/build-logic/lokalize/README.md
@@ -49,10 +49,10 @@ lokalize {
     // Resource format: XML (Android strings.xml) or JSON
     outputFormat.set(OutputFormat.JSON)
     
-    // Optional: Configure AI translation
-    llmApiKey.set("your-api-key") // Or use environment variable
+    // Optional: Configure AI translation.
+    // Note there is no API key setting here - see "Set up your API key" below.
     llmProvider.set(LLMProvider.GOOGLE)  // GOOGLE, OPENAI, or ANTHROPIC
-    llModel.set(LLmModel.GEMINI2_0_FLASH)
+    llModel.set(LLmModel.GEMINI2_5_FLASH)
     
     // Optional: Custom resources directory.
     // For Kotlin Multiplatform JSON projects, prefer a path that is NOT a
@@ -72,16 +72,46 @@ lokalize {
 
 ### Step 3: Set up your API key (for AI translation)
 
-Option 1 - Environment variable (recommended):
+Only `lokalizeFix` needs a key; `lokalizeCheck` and the generator tasks do not.
+
+**There is no `llmApiKey` setting in the `lokalize { }` block, by design.** The key is a
+secret, and a build script that can assign one is a build script that will eventually have
+one committed to it. The plugin resolves it itself, using the first of these that is set:
+
+1. `LOKALIZE_API_KEY` environment variable (preferred)
+2. `KOOG_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY` environment
+   variables, in that order
+3. the `lokalizeApiKey` Gradle property
+
+Option 1 - environment variable (recommended):
 ```bash
 export LOKALIZE_API_KEY="your-api-key"
+./gradlew :multipaz-compose:lokalizeFix
 ```
 
-Option 2 - `local.properties` file:
+Option 2 - Gradle property in `~/.gradle/gradle.properties`, which lives outside the
+repository:
 ```properties
-lokalize.api.key=your-api-key
-lokalize.provider=GOOGLE
-lokalize.model=GEMINI2_0_FLASH
+lokalizeApiKey=your-api-key
+```
+
+> **Do not** put the key in this repository's `gradle.properties` - that file is checked in.
+> `local.properties` is git-ignored but is *not* read by this plugin.
+
+If no key is found, `lokalizeFix` does not fail. It warns and copies the base locale text
+verbatim into every target locale, so a run without a key produces resources that look
+complete but are untranslated. Check the log for `No API key found` before committing.
+
+#### The key is written to disk while the task runs
+
+`lokalizeFix` forks a worker process and passes it parameters through a file, so your key
+is written **in cleartext** to
+`<module>/build/lokalize/translations/translation_input_<locale>.json`, one file per locale,
+and stays there after the build. `build/` is git-ignored so it cannot be committed, but if
+you have used a real key, remove them afterwards:
+
+```bash
+find . -name 'translation_input_*.json' -delete
 ```
 
 ## Tasks
@@ -173,9 +203,8 @@ val languages = GeneratedTranslations.allLanguages
 | `targetLocales` | `List<String>` | `[]` | Locales to validate/translate |
 | `failOnMissing` | `Boolean` | `true` | Fail build on missing translations |
 | `outputFormat` | `OutputFormat` | `XML` | Resource format (XML or JSON) |
-| `llmApiKey` | `Property<String>` | Environment lookup | API key for translation |
 | `llmProvider` | `LLMProvider` | `GOOGLE` | LLM provider to use |
-| `llModel` | `LLmModel` | `GEMINI2_0_FLASH` | Specific model |
+| `llModel` | `LLmModel` | `GEMINI2_5_FLASH_LITE` | Specific model |
 | `resourcesDir` | `Property<String>` | `"src/commonMain/composeResources"` | Resources base path |
 | `generatedTranslationsPackageName` | `Property<String>` | `"org.multipaz.doctypes.generated"` | Package for the generated `GeneratedTranslations` and per-language `Strings_*` files |
 | `stringKeysPackageName` | `Property<String>` | `"org.multipaz.doctypes.localization"` | Package for the generated `GeneratedStringKeys` object |
@@ -228,10 +257,11 @@ JSON format is recommended when:
 ### Google (Gemini)
 
 Available models:
-- `GEMINI2_0_FLASH` - Fast, efficient (recommended)
-- `GEMINI2_0_FLASH_LITE` - Most efficient for low-latency
+- `GEMINI2_5_FLASH` - Balance of speed and capability (recommended)
+- `GEMINI2_5_FLASH_LITE` - Most efficient for low-latency; the plugin default
 - `GEMINI2_5_PRO` - Advanced capabilities
-- `GEMINI2_5_FLASH` - Balance of speed and capability
+- `GEMINI3_PRO_PREVIEW` - Advanced reasoning, preview
+- `GEMINI3_FLASH_PREVIEW` - Pro-level intelligence at Flash speed, preview
 
 ### OpenAI
 
@@ -345,6 +375,28 @@ If you see `429 Too Many Requests`:
 - Claude has different rate limits per tier
 - Check your API key's tier status
 
+### Authentication Errors
+
+`Translation failed for locale '<locale>'` followed by `API key not valid`, `401` or `403`
+means the key never reached the provider, or was rejected. Check, in order:
+
+- Is `LOKALIZE_API_KEY` exported in the shell that runs Gradle? Confirm with
+  `echo ${LOKALIZE_API_KEY:+set}`.
+- Does something assign the key in a build script? Nothing should - `lokalize { }` exposes no
+  key setting, and a `set()` call on the underlying property outranks the environment lookup
+  and is sent to the provider verbatim. This is what caused issue #2003, where a placeholder
+  `"API_KEY"` was hardcoded in the convention plugin and every run failed with
+  `400 API_KEY_INVALID`.
+- Is the key valid for the provider you selected? A Gemini key will not work with
+  `llmProvider.set(LLMProvider.OPENAI)`. Verify a Google key independently with:
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' \
+    "https://generativelanguage.googleapis.com/v1beta/models?key=$LOKALIZE_API_KEY"
+  ```
+
+The failure message includes the provider's own error and the exception chain, and the
+worker prints the full stack trace, so read those before guessing.
+
 ### Missing Translations Not Detected
 
 Ensure your resource directory structure follows standard conventions:
@@ -390,9 +442,14 @@ If `generateMultipazStrings` is skipped:
    - Cultural context
    - UI space constraints
 
-3. **Use environment variables for API keys**: Don't commit API keys to version control
+3. **Keep API keys out of the repository**: pass them by environment variable, never by
+   editing a build script. The `lokalize { }` block has no key setting for this reason.
    ```bash
    export LOKALIZE_API_KEY="your-key"
+   ```
+   After a run with a real key, clear the worker input files it leaves behind:
+   ```bash
+   find . -name 'translation_input_*.json' -delete
    ```
 
 4. **Run check before commit**: Add to pre-commit hooks:

--- a/build-logic/lokalize/build.gradle.kts
+++ b/build-logic/lokalize/build.gradle.kts
@@ -16,6 +16,10 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
 group = "org.multipaz.util.lokalize"
 version = "0.1.0"
 

--- a/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/LokalizePlugin.kt
+++ b/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/LokalizePlugin.kt
@@ -29,13 +29,15 @@ import java.io.File
  *     defaultLocale = "en"
  *     targetLocales = listOf("es", "fr", "de")
  *     failOnMissing = true
- *     llmApiKey.set("your-api-key") // or use LOKALIZE_API_KEY env var
  *     llmProvider.set(LLMProvider.GOOGLE)  // or OPENAI, ANTHROPIC
  *     llModel.set(LLmModel.GEMINI2_5_FLASH_LITE)  // see LLmModel enum for all options
  *     resourcesDir.set("src/commonMain/composeResources") // optional: custom path
  *     outputFormat.set(OutputFormat.XML) // or JSON for web/desktop projects
  * }
  * ```
+ *
+ * The translation API key is intentionally absent from that DSL; see [translationApiKey]
+ * for where `lokalizeFix` reads it from.
  *
  * Output formats:
  * - XML: Android strings.xml format with values/values-locale folders
@@ -81,12 +83,6 @@ class LokalizePlugin : Plugin<Project> {
             add("lokalizeWorker", "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
         }
 
-        ext.llmApiKey.convention(target.providers.environmentVariable("LOKALIZE_API_KEY")
-            .orElse(target.providers.environmentVariable("KOOG_API_KEY"))
-            .orElse(target.providers.environmentVariable("OPENAI_API_KEY"))
-            .orElse(target.providers.environmentVariable("GOOGLE_API_KEY"))
-            .orElse(target.providers.environmentVariable("ANTHROPIC_API_KEY")))
-
         ext.llmProvider.convention(LLMProvider.GOOGLE)
         ext.llModel.convention(LLmModel.GEMINI2_5_FLASH_LITE)
         ext.resourcesDir.convention("src/commonMain/composeResources")
@@ -127,7 +123,7 @@ class LokalizePlugin : Plugin<Project> {
             task.group = "lokalize"
 
             // Wire extension values to task inputs lazily
-            task.llmApiKey.convention(ext.llmApiKey)
+            task.llmApiKey.convention(translationApiKey(target))
             task.llmProvider.convention(ext.llmProvider)
             task.llModel.convention(ext.llModel)
             task.resourcesDir.convention(ext.resourcesDir)
@@ -238,3 +234,24 @@ class LokalizePlugin : Plugin<Project> {
         target.tasks.named("check").configure { it.dependsOn(verifyTask) }
     }
 }
+
+/**
+ * Resolves the API key used by `lokalizeFix`, in order: `LOKALIZE_API_KEY`, `KOOG_API_KEY`,
+ * `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY` from the environment, then the
+ * `lokalizeApiKey` Gradle property.
+ *
+ * The Gradle property exists so the key can live in `~/.gradle/gradle.properties`, outside
+ * any repository. Note that the root `gradle.properties` here is checked in, so it is not a
+ * safe place for one.
+ *
+ * There is deliberately no `llmApiKey` extension property to assign. A `set()` call outranks
+ * this lookup, so a key - or worse, a placeholder - assigned in a build script silently wins
+ * and gets sent to the provider verbatim, which is what broke translations in issue #2003.
+ */
+private fun translationApiKey(target: Project): Provider<String> =
+    target.providers.environmentVariable("LOKALIZE_API_KEY")
+        .orElse(target.providers.environmentVariable("KOOG_API_KEY"))
+        .orElse(target.providers.environmentVariable("OPENAI_API_KEY"))
+        .orElse(target.providers.environmentVariable("GOOGLE_API_KEY"))
+        .orElse(target.providers.environmentVariable("ANTHROPIC_API_KEY"))
+        .orElse(target.providers.gradleProperty("lokalizeApiKey"))

--- a/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/service/KoogTranslationService.kt
+++ b/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/service/KoogTranslationService.kt
@@ -38,8 +38,15 @@ class KoogTranslationService(
  */
 private sealed class TranslationResult {
     data class Success(val translations: Map<String, String>) : TranslationResult()
-    data class RateLimited(val partialResults: Map<String, String>) : TranslationResult()
-    data class Failed(val fallback: Map<String, String>) : TranslationResult()
+    data class RateLimited(
+        val partialResults: Map<String, String>,
+        val cause: Throwable
+    ) : TranslationResult()
+
+    data class Failed(
+        val fallback: Map<String, String>,
+        val cause: Throwable
+    ) : TranslationResult()
 }
 
 /**
@@ -83,13 +90,16 @@ private class BatchTranslator(
                     throw RuntimeException(
                         "API rate limit exceeded for locale '$targetLocale'. " +
                                 "${result.partialResults.size}/${batch.keys.size} translations completed. " +
-                                "Get a new API key or wait 24h for quota reset."
+                                "Get a new API key or wait 24h for quota reset.",
+                        result.cause
                     )
                 }
 
                 is TranslationResult.Failed -> {
                     throw RuntimeException(
-                        "Translation failed for locale '$targetLocale': ${batch.keys.joinToString()}"
+                        "Translation failed for locale '$targetLocale': " +
+                                "${batch.keys.joinToString()} - ${describe(result.cause)}",
+                        result.cause
                     )
                 }
             }
@@ -137,15 +147,26 @@ private class BatchTranslator(
     }
 
     private fun handleError(e: Exception, batch: TranslationBatch): TranslationResult {
-        val isRateLimit = e.message?.let { msg ->
-            msg.contains("429") || msg.contains("RESOURCE_EXHAUSTED") || msg.contains("quota")
-        } ?: false
-
         return when {
-            isRateLimit -> TranslationResult.RateLimited(batch.fallback())
-            else -> TranslationResult.Failed(batch.fallback())
+            isRateLimit(e) -> TranslationResult.RateLimited(batch.fallback(), e)
+            else -> TranslationResult.Failed(batch.fallback(), e)
         }
     }
+
+    /**
+     * Detects quota/rate-limit errors anywhere in the exception chain.
+     *
+     * Koog wraps transport errors, so the HTTP status only shows up on a nested cause and
+     * checking just [Throwable.message] misclassifies quota errors as generic failures.
+     */
+    private fun isRateLimit(e: Throwable): Boolean =
+        e.causeChain().any { throwable ->
+            val msg = throwable.message ?: return@any false
+            msg.contains("429") ||
+                    msg.contains("RESOURCE_EXHAUSTED") ||
+                    msg.contains("quota") ||
+                    msg.contains("limit: 0")
+        }
 
     private suspend fun addDelayIfNeeded(currentIndex: Int, totalBatches: Int) {
         if (currentIndex >= totalBatches - 1) return
@@ -246,3 +267,30 @@ private object ResultParser {
         } ?: fallback
     }
 }
+
+/** Upper bound on how far [causeChain] walks, so a cyclic chain cannot spin forever. */
+private const val MAX_CAUSE_DEPTH = 10
+
+/**
+ * Returns this throwable followed by its causes, stopping at [MAX_CAUSE_DEPTH] or a repeat.
+ */
+private fun Throwable.causeChain(): List<Throwable> {
+    val chain = mutableListOf<Throwable>()
+    var current: Throwable? = this
+    while (current != null && current !in chain && chain.size < MAX_CAUSE_DEPTH) {
+        chain.add(current)
+        current = current.cause
+    }
+    return chain
+}
+
+/**
+ * Renders a throwable and its causes on one line.
+ *
+ * The worker process reports failures via the exception message, so without this the
+ * underlying provider error (HTTP status, API explanation) never reaches Gradle's output.
+ */
+private fun describe(e: Throwable): String =
+    e.causeChain().joinToString(" <- ") { throwable ->
+        "${throwable::class.simpleName}: ${throwable.message ?: "(no message)"}"
+    }

--- a/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/tasks/LokalizeTranslateTask.kt
+++ b/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/tasks/LokalizeTranslateTask.kt
@@ -41,7 +41,16 @@ abstract class LokalizeTranslateTask @Inject constructor(
     @get:Internal
     abstract val extension: Property<LokalizeExtension>
 
-    @get:Input
+    /**
+     * Translation API key, supplied by the plugin from the environment or the
+     * `lokalizeApiKey` Gradle property.
+     *
+     * Marked [Internal] rather than [Input] on purpose: task inputs are fingerprinted and
+     * persisted in Gradle's task-state and configuration-cache files and can surface in build
+     * scans, so a secret does not belong there. Nothing is lost by excluding it, because this
+     * task declares `outputs.upToDateWhen { false }` and therefore always re-runs.
+     */
+    @get:Internal
     abstract val llmApiKey: Property<String>
 
     @get:Input
@@ -76,7 +85,11 @@ abstract class LokalizeTranslateTask @Inject constructor(
     @TaskAction
     fun run() {
         val apiKey = llmApiKey.orNull ?: run {
-                logger.warn("No API key configured - will use fallback mode (copying base text)")
+                logger.warn(
+                    "No API key found - set LOKALIZE_API_KEY (or the lokalizeApiKey Gradle " +
+                        "property). Falling back to copying the base locale text verbatim " +
+                        "into every target locale, which produces untranslated resources."
+                )
                 ""
             }
 

--- a/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/util/LokalizeExtension.kt
+++ b/build-logic/lokalize/src/main/kotlin/org/multipaz/lokalize/util/LokalizeExtension.kt
@@ -18,9 +18,6 @@ abstract class LokalizeExtension @Inject constructor(objects: ObjectFactory) {
     /** Whether to fail the build when missing translations are detected */
     var failOnMissing: Boolean = true
 
-    /** API key for AI translation (can also use LOKALIZE_API_KEY env var) */
-    val llmApiKey: Property<String> = objects.property(String::class.java)
-
     /** LLM provider to use for translation (OpenAI, Google, Anthropic) */
     val llmProvider: Property<LLMProvider> = objects.property(LLMProvider::class.java)
 

--- a/build-logic/lokalize/src/test/kotlin/org/multipaz/lokalize/engine/ResourceScannerTest.kt
+++ b/build-logic/lokalize/src/test/kotlin/org/multipaz/lokalize/engine/ResourceScannerTest.kt
@@ -12,7 +12,10 @@ class ResourceScannerTest {
     @Test
     fun `scan should extract simple strings`(@TempDir tempDir: File) {
         // Given
-        val xmlFile = File(tempDir, "strings.xml")
+        // The scanner derives the locale from the parent directory name, so the file has to
+        // sit in a `values` directory for it to report the base locale.
+        val valuesDir = File(tempDir, "values").apply { mkdirs() }
+        val xmlFile = File(valuesDir, "strings.xml")
         xmlFile.writeText("""
             <?xml version="1.0" encoding="utf-8"?>
             <resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ar/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ar/strings.xml
@@ -254,4 +254,6 @@
     <string name="provisioning_tx_code_fallback_prompt">أدخل عبارة المرور التي تم إبلاغك بها مسبقًا</string>
     <string name="floating_item_heading_and_date_not_set">غير محدد</string>
     <string name="floating_item_heading_and_date_time_not_set">غير محدد</string>
+    <string name="presentment_activity_removed_too_fast">تمت إزالة الجهاز قبل اكتمال المشاركة</string>
+    <string name="presentment_activity_nfc_only_tip">اجعل الجهاز قريبًا من القارئ حتى يتم نقل جميع البيانات</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-cs/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-cs/strings.xml
@@ -222,4 +222,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Zadejte heslovou frázi, která vám byla dříve sdělena</string>
     <string name="floating_item_heading_and_date_not_set">Nenastaveno</string>
     <string name="floating_item_heading_and_date_time_not_set">Nenastaveno</string>
+    <string name="presentment_activity_removed_too_fast">Zařízení bylo odebráno před dokončením sdílení</string>
+    <string name="presentment_activity_nfc_only_tip">Přidržte u čtečky, dokud se nepřenesou všechna data</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-da/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-da/strings.xml
@@ -212,4 +212,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Indtast den adgangskode, der tidligere blev meddelt dig</string>
     <string name="floating_item_heading_and_date_not_set">Ikke angivet</string>
     <string name="floating_item_heading_and_date_time_not_set">Ikke angivet</string>
+    <string name="presentment_activity_removed_too_fast">Enheden blev fjernet, før delingen blev afsluttet</string>
+    <string name="presentment_activity_nfc_only_tip">Hold tæt på læseren, indtil alle data er overført</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-de/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-de/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Geben Sie die Ihnen zuvor mitgeteilte Passphrase ein</string>
     <string name="floating_item_heading_and_date_not_set">Nicht festgelegt</string>
     <string name="floating_item_heading_and_date_time_not_set">Nicht festgelegt</string>
+    <string name="presentment_activity_removed_too_fast">Gerät wurde entfernt, bevor die Freigabe abgeschlossen war</string>
+    <string name="presentment_activity_nfc_only_tip">Halten Sie es nah an das Lesegerät, bis alle Daten übertragen sind</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-el/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-el/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Εισαγάγετε τον κωδικό πρόσβασης που σας κοινοποιήθηκε προηγουμένως</string>
     <string name="floating_item_heading_and_date_not_set">Δεν έχει οριστεί</string>
     <string name="floating_item_heading_and_date_time_not_set">Δεν έχει οριστεί</string>
+    <string name="presentment_activity_removed_too_fast">Η συσκευή απομακρύνθηκε πριν ολοκληρωθεί η κοινοποίηση</string>
+    <string name="presentment_activity_nfc_only_tip">Κρατήστε το κοντά στον αναγνώστη μέχρι να μεταφερθούν όλα τα δεδομένα</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-es/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-es/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Introduce la frase de contraseña que se te comunicó previamente</string>
     <string name="floating_item_heading_and_date_not_set">No establecido</string>
     <string name="floating_item_heading_and_date_time_not_set">No establecido</string>
+    <string name="presentment_activity_removed_too_fast">El dispositivo se retiró antes de que se completara el uso compartido</string>
+    <string name="presentment_activity_nfc_only_tip">Mantén cerca del lector hasta que se transfieran todos los datos</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-fr/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-fr/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Saisissez la phrase secrète qui vous a été communiquée précédemment</string>
     <string name="floating_item_heading_and_date_not_set">Non défini</string>
     <string name="floating_item_heading_and_date_time_not_set">Non défini</string>
+    <string name="presentment_activity_removed_too_fast">L'appareil a été retiré avant la fin du partage</string>
+    <string name="presentment_activity_nfc_only_tip">Maintenez à proximité du lecteur jusqu'à ce que toutes les données soient transférées</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-he/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-he/strings.xml
@@ -230,4 +230,6 @@
     <string name="provisioning_tx_code_fallback_prompt">הזן את מילת הקוד שנמסרה לך בעבר</string>
     <string name="floating_item_heading_and_date_not_set">לא מוגדר</string>
     <string name="floating_item_heading_and_date_time_not_set">לא מוגדר</string>
+    <string name="presentment_activity_removed_too_fast">ההתקן הוסר לפני שהשיתוף הושלם.</string>
+    <string name="presentment_activity_nfc_only_tip">החזק צמוד לקורא עד שכל הנתונים יועברו.</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-hi/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-hi/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">वह पासफ्रेज़ दर्ज करें जो आपको पहले बताया गया था</string>
     <string name="floating_item_heading_and_date_not_set">सेट नहीं</string>
     <string name="floating_item_heading_and_date_time_not_set">सेट नहीं</string>
+    <string name="presentment_activity_removed_too_fast">साझाकरण पूर्ण होने से पहले डिवाइस हटा दिया गया था</string>
+    <string name="presentment_activity_nfc_only_tip">सारा डेटा ट्रांसफर होने तक रीडर के पास रखें</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-id/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-id/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Masukkan frasa sandi yang sebelumnya telah dikomunikasikan kepada Anda</string>
     <string name="floating_item_heading_and_date_not_set">Belum diatur</string>
     <string name="floating_item_heading_and_date_time_not_set">Belum diatur</string>
+    <string name="presentment_activity_removed_too_fast">Perangkat dilepaskan sebelum berbagi selesai</string>
+    <string name="presentment_activity_nfc_only_tip">Dekatkan ke pembaca hingga semua data ditransfer</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-it/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-it/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Inserisci la passphrase che ti è stata comunicata in precedenza</string>
     <string name="floating_item_heading_and_date_not_set">Non impostato</string>
     <string name="floating_item_heading_and_date_time_not_set">Non impostato</string>
+    <string name="presentment_activity_removed_too_fast">Il dispositivo è stato rimosso prima del completamento della condivisione</string>
+    <string name="presentment_activity_nfc_only_tip">Mantieni vicino al lettore fino al completo trasferimento dei dati</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ja/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ja/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">以前にお伝えしたパスフレーズを入力してください</string>
     <string name="floating_item_heading_and_date_not_set">未設定</string>
     <string name="floating_item_heading_and_date_time_not_set">未設定</string>
+    <string name="presentment_activity_removed_too_fast">共有完了前にデバイスが離されました</string>
+    <string name="presentment_activity_nfc_only_tip">すべてのデータが転送されるまで、リーダーにかざし続けてください</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ko/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ko/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">이전에 전달된 암호를 입력하세요</string>
     <string name="floating_item_heading_and_date_not_set">미설정</string>
     <string name="floating_item_heading_and_date_time_not_set">미설정</string>
+    <string name="presentment_activity_removed_too_fast">공유가 완료되기 전에 기기가 멀어졌습니다.</string>
+    <string name="presentment_activity_nfc_only_tip">모든 데이터가 전송될 때까지 리더기에 가까이 대세요.</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-nl/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-nl/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Voer de wachtwoordzin in die eerder met u is gedeeld</string>
     <string name="floating_item_heading_and_date_not_set">Niet ingesteld</string>
     <string name="floating_item_heading_and_date_time_not_set">Niet ingesteld</string>
+    <string name="presentment_activity_removed_too_fast">Apparaat is verwijderd voordat het delen was voltooid</string>
+    <string name="presentment_activity_nfc_only_tip">Houd dicht bij de lezer totdat alle gegevens zijn overgedragen</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-pl/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-pl/strings.xml
@@ -234,4 +234,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Wprowadź hasło, które zostało wcześniej Tobie przekazane</string>
     <string name="floating_item_heading_and_date_not_set">Nie ustawiono</string>
     <string name="floating_item_heading_and_date_time_not_set">Nie ustawiono</string>
+    <string name="presentment_activity_removed_too_fast">Urządzenie zostało odłączone przed zakończeniem udostępniania</string>
+    <string name="presentment_activity_nfc_only_tip">Trzymaj blisko czytnika, aż wszystkie dane zostaną przesłane</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-pt/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-pt/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Insira a frase-passe que lhe foi comunicada anteriormente</string>
     <string name="floating_item_heading_and_date_not_set">Não definido</string>
     <string name="floating_item_heading_and_date_time_not_set">Não definido</string>
+    <string name="presentment_activity_removed_too_fast">O dispositivo foi removido antes da conclusão do compartilhamento</string>
+    <string name="presentment_activity_nfc_only_tip">Mantenha perto do leitor até que todos os dados sejam transferidos</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-ru/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-ru/strings.xml
@@ -234,4 +234,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Введите парольную фразу, которая была вам сообщена ранее</string>
     <string name="floating_item_heading_and_date_not_set">Не задано</string>
     <string name="floating_item_heading_and_date_time_not_set">Не задано</string>
+    <string name="presentment_activity_removed_too_fast">Устройство было убрано до завершения передачи</string>
+    <string name="presentment_activity_nfc_only_tip">Держите рядом со считывателем, пока все данные не будут переданы</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-th/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-th/strings.xml
@@ -206,4 +206,6 @@
     <string name="provisioning_tx_code_fallback_prompt">ป้อนรหัสผ่านที่คุณได้รับแจ้งก่อนหน้านี้</string>
     <string name="floating_item_heading_and_date_not_set">ไม่ได้ตั้งค่า</string>
     <string name="floating_item_heading_and_date_time_not_set">ไม่ได้ตั้งค่า</string>
+    <string name="presentment_activity_removed_too_fast">อุปกรณ์ถูกนำออกก่อนการแชร์เสร็จสมบูรณ์</string>
+    <string name="presentment_activity_nfc_only_tip">ถือให้อยู่ใกล้กับเครื่องอ่านจนกว่าข้อมูลทั้งหมดจะถูกถ่ายโอน</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-tr/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-tr/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Size önceden iletilen parolayı girin</string>
     <string name="floating_item_heading_and_date_not_set">Ayarlanmadı</string>
     <string name="floating_item_heading_and_date_time_not_set">Ayarlanmadı</string>
+    <string name="presentment_activity_removed_too_fast">Cihaz paylaşım tamamlanmadan uzaklaştırıldı.</string>
+    <string name="presentment_activity_nfc_only_tip">Tüm veriler aktarılana kadar okuyucuya yakın tutun.</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-uk/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-uk/strings.xml
@@ -234,4 +234,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Введіть парольну фразу, яку було вам раніше повідомлено</string>
     <string name="floating_item_heading_and_date_not_set">Не встановлено</string>
     <string name="floating_item_heading_and_date_time_not_set">Не встановлено</string>
+    <string name="presentment_activity_removed_too_fast">Пристрій було прибрано до завершення обміну</string>
+    <string name="presentment_activity_nfc_only_tip">Тримайте близько до зчитувача, доки всі дані не будуть передані</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-vi/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-vi/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">Nhập mật khẩu đã được thông báo cho bạn trước đó</string>
     <string name="floating_item_heading_and_date_not_set">Chưa đặt</string>
     <string name="floating_item_heading_and_date_time_not_set">Chưa đặt</string>
+    <string name="presentment_activity_removed_too_fast">Thiết bị đã bị di chuyển đi trước khi chia sẻ hoàn tất</string>
+    <string name="presentment_activity_nfc_only_tip">Giữ gần đầu đọc cho đến khi toàn bộ dữ liệu được chuyển</string>
 </resources>

--- a/multipaz-compose/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -214,4 +214,6 @@
     <string name="provisioning_tx_code_fallback_prompt">输入之前已告知您的通行码</string>
     <string name="floating_item_heading_and_date_not_set">未设置</string>
     <string name="floating_item_heading_and_date_time_not_set">未设置</string>
+    <string name="presentment_activity_removed_too_fast">设备在共享完成前已移开</string>
+    <string name="presentment_activity_nfc_only_tip">请靠近读卡器，直到所有数据传输完成</string>
 </resources>


### PR DESCRIPTION
Fixes #2003

`lokalizeFix` could never authenticate: the lokalize convention plugin assigned a placeholder API key with `set()`, which outranks the base plugin's environment lookup, so `LOKALIZE_API_KEY` was unreachable and the literal string `API_KEY` was sent to Gemini as a credential (`400 API_KEY_INVALID`). That error was invisible because batch translation failures discarded their exception, leaving only `Translation failed for locale '<locale>'`.

Fixed by removing the assignment and the `llmApiKey` extension property entirely, so the key can only come from the environment or the `lokalizeApiKey` Gradle property, and by propagating the provider's real error. The second commit adds the two missing `presentment_activity_*` strings for all 22 locales, generated with the now-working task.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
